### PR TITLE
Remove old Sauce Labs token

### DIFF
--- a/functional-tests/src/main/resources/project.conf
+++ b/functional-tests/src/main/resources/project.conf
@@ -3,7 +3,7 @@
 "sauceLabs" : {
   "browser" : "chrome"
   "platform" : "Windows 8"
-  "webDriverRemoteUrl" : "http://membershipdev:629a0aa3-44d8-40a9-a4ea-d904b860d242@ondemand.saucelabs.com:80/wd/hub"
+  "webDriverRemoteUrl" : ""
   "testBaseUrl" : "https://membership.code.dev-theguardian.com/"
 }
 


### PR DESCRIPTION
This token is now obsolete. The new one will be added to Team City and passed as a command-line parameter.
