### PR TITLE
Fix mobile navigation scrolling bug

### DIFF
--- a/frontend/app/views/fragments/header.scala.html
+++ b/frontend/app/views/fragments/header.scala.html
@@ -35,7 +35,7 @@
                 </nav>
             </div>
             <div class="header__secondary">
-                <ul class="nav nav--global nav-global--mini nav--top-border-off">
+                <ul class="nav nav--external nav--brand hidden-tablet">
                     <li><a href="http://www.theguardian.com/" class="nav__link case--lower">The Guardian</a></li>
                     <li><a href="http://jobs.theguardian.com/" class="nav__link case--lower">Jobs</a></li>
                     <li><a href="https://soulmates.theguardian.com/" class="nav__link case--lower">Soulmates</a></li>
@@ -94,8 +94,8 @@
             </div>
         </div>
         <nav role="navigation" class="nav nav--global nav--global--header">
-            <div class="header__primary navigation__scroll">
-                <ul class="inline-list">
+            <div class="nav__scroll">
+                <ul class="nav__list inline-list">
                     @fragments.nav(inlineMode=true)
                 </ul>
             </div>

--- a/frontend/app/views/fragments/nav.scala.html
+++ b/frontend/app/views/fragments/nav.scala.html
@@ -8,7 +8,7 @@
 
 @if(inlineMode) {
     <li class="@navItemClass()">
-        <a href="/" class="nav__link"><i class="icon-home"></i> <span class="u-h">Home</span></a>
+        <a href="/" class="nav__link"><i class="icon icon-home"></i> <span class="u-h">Home</span></a>
     </li>
 }
 <li class="@navItemClass()">

--- a/frontend/assets/stylesheets/nav/_nav.scss
+++ b/frontend/assets/stylesheets/nav/_nav.scss
@@ -24,82 +24,28 @@
 
 }
 
+/* ==========================================================================
+   Nav - Global Navigation
+   ========================================================================== */
+
+// Semi magic-number. Height of toggle link.
+$_global-nav-height: 36px;
 .nav--global {
+
     clear: both;
     display: block;
+    height: auto;
+    padding: 0;
+
+    overflow: hidden;
+    overflow-x: scroll;
+    -webkit-overflow-scrolling: touch;
+
     @include fs-headline(2);
     font-weight: normal;
     -moz-osx-font-smoothing: auto;
     -webkit-font-smoothing: subpixel-antialiased;
     -webkit-font-feature-settings: "kern" 1;
-    padding: rem($gs-baseline / 2 0);
-    height: rem($gs-gutter * 2 + 4);
-
-    .nav__item {
-        float: left;
-    }
-
-    .nav__item--right {
-        float: right;
-    }
-
-    .nav__link {
-        position: relative;
-        color: $black;
-        display: block;
-        margin: 0 rem($gs-gutter) 0 0;
-        padding: rem(5px) 0 rem(6px);
-
-        @include mq(tablet) {
-            margin-right: rem(26px);
-        }
-    }
-
-    .nav__link {
-
-        &:focus,
-        &:active {
-            text-decoration: underline;
-        }
-
-        @include mq(desktop) {
-            &,
-            &:active {
-                text-decoration: none;
-                color: $black;
-            }
-
-            &:focus,
-            &:hover {
-                text-decoration: underline;
-            }
-        }
-    }
-
-    .nav__link--last {
-        margin-right: 0 !important;
-    }
-
-    .navigation__scroll {
-        width: rem(580px);
-
-        @include mq(tablet) {
-            width: 100%;
-        }
-    }
-}
-
-/* ==========================================================================
-   Nav Modifiers
-   ========================================================================== */
-
-.nav--global--header {
-    overflow: hidden;
-    overflow-x: scroll;
-    height: $pageOffset;
-    padding-top: rem(3px);
-    padding-bottom: 0;
-    -webkit-overflow-scrolling: touch;
 
     background-color: darken($mem-blue, 10%);
     @include side-margins-calc('padding-left');
@@ -109,27 +55,106 @@
         display: none;
     }
 
-    @include mq(tablet) {
-        overflow-x: hidden;
+    .nav__scroll {
+        display: table;
+        white-space: nowrap;
+        width: 100%;
+        vertical-align: middle;
+        height: rem($_global-nav-height);
+        padding: 0 rem($_global-nav-height * 2) 0 rem($gs-gutter / 2);
+
+        @include mq(tablet) {
+            padding-right: rem($gs-gutter / 2);
+        }
     }
-}
+    .nav__list {
+        display: table-row;
 
-.nav-global--mini {
-    display: none;
-    text-align: right;
-    font-size: rem(14px);
-    padding-top: rem(6px); // magic number, aligns with left icons
+        @include mq(desktop) {
+            display: block;
+        }
+    }
+    .nav__item {
+        display: table-cell;
+        vertical-align: middle;
 
-    > li:last-child .nav__link {
+        @include mq(desktop) {
+            display: inline-block;
+        }
+    }
+    .nav__item--right {
+        @include mq(desktop) {
+            float: right;
+        }
+    }
+    .nav__link {
+        color: $black;
+        position: relative;
+        display: block;
+        margin: 0 rem($gs-gutter) 0 0;
+        padding: 0;
+
+        &:focus,
+        &:active {
+            text-decoration: underline;
+        }
+
+        @include mq(desktop) {
+            padding: rem(8px) 0 rem(6px);
+            &, &:active {
+                text-decoration: none;
+                color: $black;
+            }
+            &:focus,
+            &:hover {
+                text-decoration: underline;
+            }
+        }
+    }
+    .nav__link--last {
         margin-right: 0;
     }
-
-    @include mq($from: tablet) {
-        display: block;
+    .icon-home {
+        vertical-align: top;
     }
 }
 
-/* Columns
+/* ==========================================================================
+   Nav - Brand Navigation
+   ========================================================================== */
+
+.nav--brand {
+    @include fs-bodyCopy(1);
+    padding-top: rem($gs-gutter/2);
+    text-align: right;
+
+    .nav__link {
+        color: $black;
+        position: relative;
+        display: block;
+        margin-left: rem($gs-gutter);
+        padding: 0;
+
+        &:focus,
+        &:active {
+            text-decoration: underline;
+        }
+
+        @include mq(desktop) {
+            &:link, &:active {
+                text-decoration: none;
+                color: $black;
+            }
+            &:focus,
+            &:hover {
+                text-decoration: underline;
+            }
+        }
+    }
+}
+
+/* ==========================================================================
+   Nav - Columns
    ========================================================================== */
 
 .nav--columns {
@@ -139,11 +164,10 @@
         width: 100%;
         display: block;
 
-        @include mq(tablet) {
+        @include mq(desktop) {
             border-right: 0;
         }
     }
-
     .nav__link {
         @include fs-bodyHeading(1);
         border-top: rem(1px) solid $mem-blue-border;
@@ -159,16 +183,18 @@
             color: $black;
             text-decoration: none;
         }
-
         &:hover {
             text-decoration: underline;
         }
 
-        @include mq(tablet) {
+        @include mq(desktop) {
             border-top: 0;
         }
     }
 }
+
+/* Mobile Menu (Toggle link)
+   ========================================================================== */
 
 .mobile-menu {
     position: absolute;
@@ -184,7 +210,6 @@
         padding: rem(3px) rem(9px) rem(9px);
         box-shadow: rem(-3px) 0 rem(4px) 0 rgba(50, 50, 50, .30);
     }
-
     .mobile-menu__button i {
         border-top: rem(2px) solid rgba(255, 255, 255, .9);
         display: block;
@@ -194,7 +219,6 @@
         -webkit-transition: opacity .1s, -webkit-transform .1s ease-in;
         transition: opacity .1s, transform .1s ease-in;
     }
-
     .close-icon-white--active i {
         @include transform-origin(43%);
 
@@ -208,6 +232,4 @@
             @include transform(translateY(rem(-4px)) rotate(-45deg));
         }
     }
-
 }
-

--- a/frontend/assets/stylesheets/state/_responsive.scss
+++ b/frontend/assets/stylesheets/state/_responsive.scss
@@ -14,6 +14,12 @@
     }
 }
 
+.hidden-tablet {
+    @include mq($until: tablet) {
+        display: none !important;
+    }
+}
+
 .mobile-only {
     @include mq(tablet) {
         display: none !important;


### PR DESCRIPTION
Fixed a small bug where the mobile navigation was collapsing so items were disappearing off the side. Removes the requirement to have a magic-number for the offset which needed updating each time the navigation changed.

**Before**
![mobile-nav-before mov](https://cloud.githubusercontent.com/assets/123386/5487703/c9171852-86ac-11e4-9e97-9b4d066b5340.gif)

**After**
![mobile-nav-after mov](https://cloud.githubusercontent.com/assets/123386/5487704/cc818d56-86ac-11e4-9f4c-8ffaf174290e.gif)
