### PR TITLE
Design refinements - Events listings

### DIFF
--- a/frontend/app/views/fragments/event/item.scala.html
+++ b/frontend/app/views/fragments/event/item.scala.html
@@ -14,7 +14,7 @@
             <a href="/event/@event.id" itemprop="url" content="@event.memUrl">
                 <h4 class="event-item__title">
                     @if(event.isSoldOut){
-                        <span class="event-status--sold-out" data-filter-key="status">Sold Out</span>
+                        <span class="event-status event-status--sold-out" data-filter-key="status">Sold out</span>
                     }
                     <span itemprop="name" data-filter-key="title">@event.name.text</span>
                 </h4>

--- a/frontend/app/views/fragments/event/itemSummary.scala.html
+++ b/frontend/app/views/fragments/event/itemSummary.scala.html
@@ -10,7 +10,7 @@
     <div class="event-item__meta">
         <h2 class="event-item__title">
             @if(event.isSoldOut){
-                <span class="event-status--sold-out">Sold Out</span>
+                <span class="event-status event-status--sold-out">Sold out</span>
             }
             @event.name.text
         </h2>

--- a/frontend/app/views/joining/tierChooser.scala.html
+++ b/frontend/app/views/joining/tierChooser.scala.html
@@ -30,7 +30,7 @@
                     </div>
                     <h2 class="event-content__name">
                         @if(event.isSoldOut){
-                            <span class="event-status--sold-out">Sold Out</span>
+                            <span class="event-status event-status--sold-out">Sold out</span>
                         }
                         @event.name.text
                     </h2>

--- a/frontend/assets/stylesheets/_vars.scss
+++ b/frontend/assets/stylesheets/_vars.scss
@@ -213,6 +213,13 @@ $action-icon-rightspace: 7px;
 // Membership
 // =============================================================================
 
+$white: #ffffff;
+$offWhite: #d6d6d6;
+$black: #000000;
+$offBlack: #666666;
+$black-trans: rgba(0, 0, 0, .25);
+$white-trans: rgba(255, 255, 255, .25);
+
 $mem-brandOrange: #ce6f14;
 $mem-brandBlue: #82c2d6;
 $mem-brandGrey: #dcddda;
@@ -230,13 +237,7 @@ $mem-button-confirm: #1a4683;
 $mem-button-cancel: #b8b8b8;
 $mem-blue-border: #6dcfe3;
 $mem-header: rgba(0, 0, 0, .7);
-
-$white: #ffffff;
-$offWhite: #d6d6d6;
-$black: #000000;
-$offBlack: #666666;
-$black-trans: rgba(0, 0, 0, .25);
-$white-trans: rgba(255, 255, 255, .25);
+$mem-sold-out: #cc2b12;
 
 $mem-live-top: #b51800;
 $mem-live-accent: #cc2b12;

--- a/frontend/assets/stylesheets/pages/_events-list.scss
+++ b/frontend/assets/stylesheets/pages/_events-list.scss
@@ -378,17 +378,24 @@ $filter-icon-size: 18px;
     @include fs-data(4);
 }
 
-// Sold-out flag
-// TODO: Refactor out into generic `flag` component
-.event-status--sold-out {
+/* Event Status
+   ========================================================================== */
+
+.event-status {
     display: inline-block;
-    color: $white;
-    background-color: $mem-live-accent;
-    @include fs-data(2);
-    position: relative;
-    top: -2px;
-    padding: 1px 3px;
-    margin-right: 4px;
+    &:after {
+        content: '/';
+        color: fade-out($c-neutral1, .8);
+        display: inline-block;
+        font-weight: normal;
+        margin-left: .2em;
+    }
+    &:hover:after {
+        text-decoration: none;
+    }
+}
+.event-status--sold-out {
+    color: $mem-sold-out;
 }
 
 /* ==========================================================================


### PR DESCRIPTION
Some design refinements to events listings from Ben W:
- Add hover effect to event items, matches next-gen
- Increase font-weight for event-items and keep font-size consistent across breakpoints

**Hover before**
![hover-before mov](https://cloud.githubusercontent.com/assets/123386/5568710/159efac2-8f5a-11e4-8fb3-5e26f94fce0f.gif)

**Hover after**
![hover-after mov](https://cloud.githubusercontent.com/assets/123386/5568711/1aa9afee-8f5a-11e4-8736-60c5a69b5488.gif)

**Font-weight before**
![screen shot 2014-12-29 at 12 58 26](https://cloud.githubusercontent.com/assets/123386/5568741/7669b70c-8f5a-11e4-9449-326e271926c6.png)

**Font-weight after**
![screen shot 2014-12-29 at 12 49 45](https://cloud.githubusercontent.com/assets/123386/5568722/561969d4-8f5a-11e4-86de-4d7223a1b113.png)

![screen shot 2014-12-29 at 12 49 57](https://cloud.githubusercontent.com/assets/123386/5568724/5848033c-8f5a-11e4-949c-22a3e4b66be4.png)
