### PR TITLE
Design update to header to match next-gen style

### DIFF
--- a/frontend/app/views/fragments/header.scala.html
+++ b/frontend/app/views/fragments/header.scala.html
@@ -19,16 +19,16 @@
                                     </span>
                                 </span>
                                 <span class="hidden-mobile js-user-detail">
-                                    <span class="identity__notice control__info">Sign in</span>
+                                    <span class="identity__notice control__info case--lower">Sign in</span>
                                     <span class="identity__account control__info u-h no-underline--override js-user-displayname"></span>
-                                    <span class="identity__tier control__info u-h no-underline--override case--capitalize js-user-tier"></span>
+                                    <span class="identity__tier control__info u-h no-underline--override js-user-tier"></span>
                                 </span>
                             </a>
                         </li>
                         <li class="menu-item menu-item--last is-hidden js-header-join-us-cta">
                             <a href="/join" role="menuitem" class="no-underline hidden-mobile control-container" title="Join us">
                                 <span class="control control--no-border"><i class="icon-g-black"></i></span>
-                                <span class="control__info no-underline--override hidden-mobile">Join us</span>
+                                <span class="control__info no-underline--override case--lower hidden-mobile">Join us</span>
                             </a>
                         </li>
                     </ul>

--- a/frontend/assets/stylesheets/layout/_header.scss
+++ b/frontend/assets/stylesheets/layout/_header.scss
@@ -84,7 +84,7 @@
 
     @include mq(tablet) {
         margin-right: rem(15px);
-        padding-top: rem(8px);
+        padding-top: rem(3px);
     }
 
     &:hover {

--- a/frontend/assets/stylesheets/nav/_control.scss
+++ b/frontend/assets/stylesheets/nav/_control.scss
@@ -1,22 +1,21 @@
-/* Control icon
+/* ==========================================================================
+   Controls
    ========================================================================== */
-.control-container {
 
-    &:hover {
+.control-container:hover {
+    color: $white;
+
+    .control {
+        border-color: $white;
+    }
+    .control__info {
         color: $white;
-
-        .control {
-            border-color: $white;
-        }
-        .control__info {
-            color: $white;
-        }
-        .icon-user-black {
-            @extend %icon-user-white;
-        }
-        .icon-g-black {
-            @extend %icon-g-white;
-        }
+    }
+    .icon-user-black {
+        @extend %icon-user-white;
+    }
+    .icon-g-black {
+        @extend %icon-g-white;
     }
 }
 
@@ -27,7 +26,29 @@
     cursor: pointer;
     outline: none;
 }
-
+.control__info {
+    @include fs-bodyHeading(1);
+    line-height: rem($gs-gutter * 1.75);
+    text-overflow: ellipsis;
+    vertical-align: top;
+    white-space: nowrap;
+    overflow: hidden;
+    text-align: left;
+    max-width: rem($gs-gutter * 10);
+    padding-left: rem($gs-gutter / 4);
+    height: rem($gs-gutter * 1.75);
+    color: $black;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}
+.control__icon {
+    display: block;
+    text-align: center;
+    height: rem($gs-baseline * 2);
+    padding-top: rem($gs-baseline / 2);
+}
 .control--faq {
     width: rem($gs-gutter + ($gs-baseline / 2));
     height: rem($gs-gutter + ($gs-baseline / 2));
@@ -38,18 +59,15 @@
         padding-top: rem(3px);
     }
 }
-
 .control--no-border {
     border: 0;
 }
-
 .control--active {
     border-color: $white;
     .control__info {
         color: $white;
     }
 }
-
 .control--cancel {
     border: 1px solid $c-neutral3;
 
@@ -57,35 +75,10 @@
         padding-top: rem(4px);
         opacity: .2;
     }
-
     &:hover {
         border: 1px solid $c-neutral1;
-
         .control__icon {
             opacity: 1;
         }
     }
-}
-
-.control__info {
-    vertical-align: top;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    text-align: left;
-    font-family: $f-serif-text;
-    font-size: rem(13px);
-    font-weight: bold;
-    line-height: rem($gs-gutter * 1.75);
-    max-width: rem($gs-gutter * 10);
-    padding-left: rem($gs-gutter / 4);
-    height: rem($gs-gutter * 1.75);
-    color: $black;
-}
-
-.control__icon {
-    display: block;
-    text-align: center;
-    height: rem($gs-baseline * 2);
-    padding-top: rem($gs-baseline / 2);
 }

--- a/frontend/assets/stylesheets/nav/_nav.scss
+++ b/frontend/assets/stylesheets/nav/_nav.scss
@@ -64,7 +64,7 @@ $_global-nav-height: 36px;
         padding: 0 rem($_global-nav-height * 2) 0 rem($gs-gutter / 2);
 
         @include mq(tablet) {
-            padding-right: rem($gs-gutter / 2);
+            padding: 0 rem($gs-gutter);
         }
     }
     .nav__list {
@@ -124,8 +124,8 @@ $_global-nav-height: 36px;
    ========================================================================== */
 
 .nav--brand {
-    @include fs-bodyCopy(1);
-    padding-top: rem($gs-gutter/2);
+    @include fs-bodyHeading(1);
+    padding-top: rem($gs-gutter / 2);
     text-align: right;
 
     .nav__link {


### PR DESCRIPTION
Design update from Ben W to make the header links match next-gen style. Lower case-text, heavier font-weight, and a minor alignment fix.

Before:
![screen shot 2014-12-30 at 12 59 03](https://cloud.githubusercontent.com/assets/123386/5578702/491bc400-9024-11e4-817d-87da6c90798e.png)

After:
![screen shot 2014-12-30 at 12 59 12](https://cloud.githubusercontent.com/assets/123386/5578704/4dcbd314-9024-11e4-83b7-b37a14922ebc.png)
