### PR TITLE
Improve external-content typographic styles

### DIFF
--- a/frontend/app/views/patterns/patterns.scala.html
+++ b/frontend/app/views/patterns/patterns.scala.html
@@ -67,8 +67,7 @@
             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Architecto, delectus. Optio sequi, aperiam obcaecati sunt minima dicta, quidem molestias adipisci deserunt consequuntur ad nostrum. Nihil voluptates aut, dolorem quidem minus!</p>
             <ol>
                 <li>This is an ordered list.</li>
-                <li>
-                    This is the second item, which contains a sub list
+                <li>This is the second item, which contains a sub list
                     <ol>
                         <li>This is the sub list, which is also ordered.</li>
                         <li>It has two items.</li>
@@ -76,11 +75,26 @@
                 </li>
                 <li>This is the final item on this list.</li>
             </ol>
-            <h3>This is a third level heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. <a href="#">Inline link</a>. Tempore iusto quam incidunt, ullam exercitationem provident beatae consectetur enim odio cum sint, praesentium nemo? Suscipit quidem explicabo quaerat, possimus eaque ipsa.</p>
+            <blockquote>
+                <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. <a href="#">Inline link</a>. Tempore iusto quam incidunt, ullam exercitationem provident beatae consectetur enim odio cum sint, praesentium nemo? Suscipit quidem explicabo quaerat, possimus eaque ipsa.</p>
+            </blockquote>
+            <p><em>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Totam repellat modi architecto iure unde possimus aliquam soluta provident commodi, eos, dicta magnam ad vero cum, labore amet odit tenetur consequatur.</em></p>
+            <h2>This is an inline second level heading</h2>
             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. <a href="#">Inline link</a>. Tempore iusto quam incidunt, ullam exercitationem provident beatae consectetur enim odio cum sint, praesentium nemo? Suscipit quidem explicabo quaerat, possimus eaque ipsa.</p>
             <p><em>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Totam repellat modi architecto iure unde possimus aliquam soluta provident commodi, eos, dicta magnam ad vero cum, labore amet odit tenetur consequatur.</em></p>
-            <h4>This is a fourth level heading</h4>
+            <h3>This is a third level heading</h3>
+            <p>Single level list:</p>
             <ul>
+                <li>England</li>
+                <li>Scotland</li>
+                <li>Wales</li>
+                <li>Northern Ireland</li>
+            </ul>
+            <h4>This is a fourth level heading</h4>
+            <p>Multi-level list:</p>
+            <ul>
+                <li>Lorem ipsum dolor sit amet, consectetur adipisicing elit. <a href="#">Inline link</a>. Tempore iusto quam incidunt, ullam exercitationem provident beatae consectetur enim odio cum sint, praesentium nemo? Suscipit quidem explicabo quaerat, possimus eaque ipsa.</li>
                 <li>
                     United Kingdom of Great Britain and Northern Ireland:
                     <ul>

--- a/frontend/assets/stylesheets/base/_type.scss
+++ b/frontend/assets/stylesheets/base/_type.scss
@@ -2,9 +2,6 @@
    Global typography settings
    ========================================================================== */
 
-/* Root base
-   ========================================================================== */
-
 html {
     font-family: $f-serif-text;
 
@@ -23,33 +20,20 @@ body {
     line-height: 1.4;
 }
 
-/* Base headings
-   ========================================================================== */
-
 h1, h2, h3, h4, h5, h6 {
-    margin: 0;
-}
-
-
-/* Default type elements
-   ========================================================================== */
-
-blockquote {
     margin: 0;
 }
 
 p {
     margin-top: 0;
-    margin-bottom: rem(($gs-baseline / 3) * 2);
+    margin-bottom: rem($gs-baseline * 1.3333);
 }
-
-/* Membership specific type elements
-   ========================================================================== */
 
 blockquote {
     font-style: italic;
     font-weight: 300;
     margin-bottom: rem(10px);
+    margin: 0;
 
     &:before {
         @extend %icon-quote-blue;
@@ -57,28 +41,6 @@ blockquote {
         display: block;
         float: left;
         margin-right: rem(5px);
-    }
-}
-
-/* Opt-in typographic styles
-   ========================================================================== */
-   // Add more readable defaults for blocks of body copy
-   // Particularly useful when copy come from a third-party (e.g., eventbrite/evently)
-   // See:
-   //   http://css-tricks.com/opt-in-typography/
-   //   http://dbushell.com/2012/04/18/scoping-typography-css/
-   //   http://anthonyshort.me/global-typographic-styles-suck/
-
-.copy {
-    a {
-        text-decoration: none;
-        border-bottom: 1px solid $c-neutral3;
-
-        &:hover,
-        &:focus {
-            text-decoration: none;
-            border-color: $c-neutral2;
-        }
     }
 }
 

--- a/frontend/assets/stylesheets/components/_from-content-api.scss
+++ b/frontend/assets/stylesheets/components/_from-content-api.scss
@@ -1,0 +1,122 @@
+/* ==========================================================================
+   Opt-in typographic styles
+   From Content API
+   ========================================================================== */
+// These are for styling HTML that we get from external sources
+// and may contain more specific selectors than we would usually like.
+// Similar in goal to _from-content-api.scss from next-gen.
+//
+// Opt-in typography
+// Particularly useful when copy come from a third-party (e.g., eventbrite/evently)
+// See:
+//     http://css-tricks.com/opt-in-typography/
+//     http://dbushell.com/2012/04/18/scoping-typography-css/
+//     http://anthonyshort.me/global-typographic-styles-suck/
+
+.copy {
+
+    > p,
+    ul,
+    ol,
+    address {
+        padding: 0;
+        margin: 0 0 rem($gs-baseline);
+
+        @include mq(tablet) {
+            margin-bottom: rem($gs-baseline * 1.3333);
+        }
+    }
+
+    h2 {
+        @include fs-header(2);
+
+        @include mq(tablet) {
+            margin-bottom: 1px;
+            @include fs-header(3, true);
+        }
+    }
+    p + h2, ol + h2, ul + h2 {
+        margin-top: rem($gs-gutter * 1.3);
+    }
+    h3 {
+        @include fs-bodyHeading(3);
+    }
+    p + h3, ol + h3, ul + h3 {
+        margin-top: rem($gs-baseline);
+    }
+    h4 {
+        @include fs-bodyHeading(2);
+    }
+    h5, h6 {
+        @include fs-bodyHeading(1);
+    }
+    h6 {
+        font-weight: normal;
+        font-style: italic;
+    }
+
+    a {
+        text-decoration: none;
+        border-bottom: 1px solid $c-neutral3;
+
+        &:hover,
+        &:focus {
+            text-decoration: none;
+            border-color: $c-neutral2;
+        }
+    }
+
+    li > ol,
+    li > ul {
+        margin-bottom: 0;
+    }
+
+    ul,
+    ol {
+        list-style: none;
+        margin-left: rem($gs-gutter);
+    }
+
+    ul > li {
+        list-style-position: outside;
+        list-style-image: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iMTMiIHZpZXdCb3g9IjAgMCAxMiAxMyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNMTIgNi44NTdjMCAxLjA4OS0uMjY4IDIuMDkzLS44MDUgMy4wMTEtLjUzNy45MTktMS4yNjUgMS42NDctMi4xODQgMi4xODQtLjkxOS41MzctMS45MjMuODA2LTMuMDExLjgwNS0xLjA4OC0uMDAxLTIuMDkyLS4yNjktMy4wMTEtLjgwNXMtMS42NDctMS4yNjQtMi4xODQtMi4xODRjLS41MzctLjkyLS44MDUtMS45MjQtLjgwNS0zLjAxMSAwLTEuMDg3LjI2OC0yLjA5MS44MDUtMy4wMTEuNTM3LS45MiAxLjI2NS0xLjY0OCAyLjE4NC0yLjE4NC45MTktLjUzNiAxLjkyMy0uODA0IDMuMDExLS44MDUgMS4wODgtLjAwMSAyLjA5Mi4yNjggMy4wMTEuODA1czEuNjQ3IDEuMjY1IDIuMTg0IDIuMTg0Yy41MzcuOTE5LjgwNSAxLjkyMi44MDUgMy4wMTF6IiBmaWxsPSIjQkRCREJEIi8+PC9zdmc+);
+    }
+
+    ol {
+        counter-reset: li;
+    }
+    ol > ol,
+    ol > ul {
+        margin-left: rem($gs-gutter * 2);
+    }
+    ol > li {
+        list-style-position: outside;
+        text-indent: -(rem($gs-gutter));
+    }
+    ol > li:before {
+        content: counter(li)'.';
+        counter-increment: li;
+        @include fs-header(1);
+        margin-right: rem($gs-baseline / 2);
+
+        @include mq(tablet) {
+            @include fs-header(2, true);
+        }
+    }
+
+    .no-style-list {
+        list-style: none;
+    }
+
+    blockquote {
+        padding-left: rem(14px);
+        border-left: rem(2px) solid #cfcfcd;
+        font-style: italic;
+        margin: 0 0 rem(16px);
+    }
+
+    blockquote p {
+        margin: 0;
+    }
+
+}

--- a/frontend/assets/stylesheets/mixins/_common.scss
+++ b/frontend/assets/stylesheets/mixins/_common.scss
@@ -46,18 +46,6 @@
     overflow: hidden;
 }
 
-@mixin faux-bullet-point($color: $c-neutral3, $right-space: 2px) {
-    &:before {
-        display: inline-block;
-        content: '';
-        @include border-radius(6px);
-        height: rem(12px);
-        width: rem(12px);
-        margin-right: rem($right-space);
-        background-color: $color;
-    }
-}
-
 // Hide content visually, still readable by screen readers
 @mixin u-h {
     border: 0 !important;

--- a/frontend/assets/stylesheets/pages/_events-detail.scss
+++ b/frontend/assets/stylesheets/pages/_events-detail.scss
@@ -315,38 +315,10 @@
         float: right;
     }
 
-    h2 {
-        @include fs-header(2);
-
-        @include mq(tablet) {
-            @include fs-header(3, true);
-        }
-    }
-
-    ol,
-    ul {
-        list-style-position: inside;
-        padding: 0;
-        margin: 0 0 rem(8px);
-    }
-    .no-style-list {
-        list-style: none;
-    }
     .section-header {
         @include fs-headline(3);
         font-weight: 900;
         margin: rem(27px) 0 rem(10px);
-    }
-
-    blockquote {
-        padding-left: rem(14px);
-        border-left: rem(2px) solid #cfcfcd;
-        font-style: italic;
-        margin: 0 0 rem(16px);
-    }
-
-    blockquote p {
-        margin: 0;
     }
 
     img {

--- a/frontend/assets/stylesheets/style.scss
+++ b/frontend/assets/stylesheets/style.scss
@@ -58,9 +58,10 @@
 @import 'nav/control';
 @import 'nav/brand-bar';
 
-/* Membership Components
+/* Components
    ========================================================================== */
 
+@import 'components/from-content-api';
 @import 'components/grid';
 @import 'components/content';
 @import 'components/action';


### PR DESCRIPTION
One more design request from Ben: improve the quality of typography for external-content/blocks of copy.
- Extracted out all opt-in typographic styles into `_from-content-api.scss`, matching next-gen. _We're not using the main Content API but it does serve the same purpose (content comes from Eventbrite API) so I thought it made sense to follow the same convention_
- Style lists to match next-gen style and to handle nested lists correctly
- Clean-out some now redundant styles from `_events-detail.scss`

**Pattern library example**
![screen shot 2014-12-30 at 17 23 52](https://cloud.githubusercontent.com/assets/123386/5580923/b8cd09b0-9049-11e4-9a3b-1df55215ba26.png)
![screen shot 2014-12-30 at 17 30 44](https://cloud.githubusercontent.com/assets/123386/5580913/a01757ea-9049-11e4-9866-a3fc16a5550f.png)

**Masterclass example**
![screen shot 2014-12-30 at 17 24 22](https://cloud.githubusercontent.com/assets/123386/5580891/548bd8be-9049-11e4-96a4-ae3eed2d4dc7.png)
