### PR TITLE
Document inline-list and add inline-list--divided modifier

### DIFF
--- a/frontend/app/views/patterns/patterns.scala.html
+++ b/frontend/app/views/patterns/patterns.scala.html
@@ -159,6 +159,22 @@
         </table>
     }
 
+    @pattern("Lists - Inline List") {
+        <ul class="inline-list">
+            <li class="inline-list__item"><a href="#">Item 1</a></li>
+            <li class="inline-list__item"><a href="#">Item 2</a></li>
+            <li class="inline-list__item"><a href="#">Item 3</a></li>
+        </ul>
+    }
+
+    @pattern("Lists - Inline List w/Dividers", "Inline list with divider modifier") {
+        <ul class="inline-list inline-list--divided">
+            <li class="inline-list__item"><a href="#">Item 1</a></li>
+            <li class="inline-list__item"><a href="#">Item 2</a></li>
+            <li class="inline-list__item"><a href="#">Item 3</a></li>
+        </ul>
+    }
+
     @pattern("Page Header") {
         @fragments.page.pageHeader("This a page headline", Some("This is a page header with a headline and intro text"))
     }

--- a/frontend/app/views/tier/change.scala.html
+++ b/frontend/app/views/tier/change.scala.html
@@ -25,11 +25,12 @@
                 </section>
             </div>
             <div class="content__container content__container--border-dark content__footer">
-                <ul class="inline-list">
+
+                <ul class="inline-list inline-list--divided">
                     <li class="inline-list__item"><a href="/help">Help</a></li>
-                    <li class="inline-list__item">&#149;</li>
                     <li class="inline-list__item"><a id="qa-cancel-membership" href="/tier/cancel">Cancel Guardian membership</a></li>
                 </ul>
+
             </div>
         </div>
   </main>

--- a/frontend/assets/stylesheets/base/_lists.scss
+++ b/frontend/assets/stylesheets/base/_lists.scss
@@ -29,7 +29,18 @@ nav ol {
 .inline-list {
     @extend %u-unstyled;
 }
-
 .inline-list__item {
     display: inline-block; // Prevent linebreak within an item
+}
+
+.inline-list--divided {
+    .inline-list__item:after {
+        display: inline-block;
+        content: ' \2022 ';
+        margin: 0 rem($gs-baseline / 2);
+    }
+    .inline-list__item:last-child:after {
+        display: none;
+        content: '';
+    }
 }


### PR DESCRIPTION
Minor thing but `inline-list` is used in quite a few places so thought it worth adding to the patterns. Also added an `inline-list--divided` modifier which adds divider bullets between each list item (this was previously being done manually)

![screen shot 2015-01-02 at 17 02 29](https://cloud.githubusercontent.com/assets/123386/5597829/8abec1e4-92a1-11e4-8d6a-4c8995cdc974.png)
