### PR TITLE
Log who the exception affected if they are logged in

### DIFF
--- a/frontend/app/Global.scala
+++ b/frontend/app/Global.scala
@@ -1,12 +1,13 @@
+import play.api.{UsefulException, Logger, Application}
+import play.api.mvc.Results.{InternalServerError, NotFound}
+import play.api.mvc.{RequestHeader, Result, WithFilters}
+import play.filters.csrf._
+
 import configuration.Config
 import controllers.Cached
 import filters.{CheckCacheHeadersFilter, Gzipper}
 import monitoring.SentryLogging
-import play.api.Application
-import play.api.mvc.Results.{InternalServerError, NotFound}
-import play.api.mvc.{RequestHeader, Result, WithFilters}
-import play.filters.csrf._
-import services.{SubscriptionService, _}
+import services._
 
 import scala.concurrent.Future
 
@@ -26,6 +27,16 @@ object Global extends WithFilters(CheckCacheHeadersFilter, CacheSensitiveCSRFFil
   }
 
   override def onError(request: RequestHeader, ex: Throwable) = {
+    // Try to associate the error with a user
+    AuthenticationService.authenticatedUserFor(request).foreach { user =>
+      val code = ex match {
+        case err: UsefulException => "@" + err.id
+        case _ => "Unknown"
+      }
+
+      Logger.error(s"$code affected user ${user.id}")
+    }
+
     if (Config.stage == "PROD") {
       Future.successful(Cached(InternalServerError(views.html.error500(ex))))
     } else {


### PR DESCRIPTION
It would be useful to know which user was affected by the exception.

Ideally this would be associated with the log entry for the exception itself, but often it is triggered in a context where we do not know about the request. In `Global.onError` the exception has been reconciled with the request.