### PR TITLE
Increase time between MC data refresh to preserve CAPI quota

### DIFF
--- a/frontend/app/services/MasterclassDataService.scala
+++ b/frontend/app/services/MasterclassDataService.scala
@@ -67,7 +67,7 @@ object MasterclassDataService extends MasterclassDataService with ScheduledTask[
   def getData(eventId: String) = masterclassData.find(mc => mc.eventId.equals(eventId))
 
   val initialValue = Nil
-  val interval = 60.seconds
+  val interval = 2.minutes
   val initialDelay = 2.seconds
 
   def refresh(): Future[Seq[MasterclassData]] = getAllContent


### PR DESCRIPTION
We are currently hitting our API quota limit at around 9-10pm each day and there is no real need to refresh the masterclass data that often.