### PR TITLE
Fix bug with booking button visited states

### DIFF
--- a/frontend/assets/stylesheets/components/_action.scss
+++ b/frontend/assets/stylesheets/components/_action.scss
@@ -31,19 +31,14 @@
 
     @extend %action;
 
-    &,
-    &:visited,
-    &:hover,
-    &:focus,
-    &:active {
-        color: $white;
-        background-color: $mem-buttonBlue;
-        text-decoration: none;
-    }
+    color: $white;
+    background-color: $mem-buttonBlue;
+    text-decoration: none;
 
     &:focus,
     &:active,
     &:hover {
+        text-decoration: none;
         background-color: darken($mem-buttonBlue, 10%);
     }
 


### PR DESCRIPTION
Spotted a minor issue with the colour of booking buttons. Only happens when the link has been visited before. Styles were a little overzealous.

**Before**
![screen shot 2015-01-06 at 10 10 34 1](https://cloud.githubusercontent.com/assets/123386/5627172/d7ded98a-958c-11e4-8b90-275b9c13e40b.png)

**After**
![screen shot 2015-01-06 at 10 10 45](https://cloud.githubusercontent.com/assets/123386/5627173/db1375a2-958c-11e4-9cd2-1c7f1c619af1.png)
