### PR TITLE
Update to latest raven-logback lib

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val identity = "3.42"
 
   //libraries
-  val sentryRavenLogback = "net.kencochrane.raven" % "raven-logback" % "5.0"
+  val sentryRavenLogback = "net.kencochrane.raven" % "raven-logback" % "6.0.0"
   val identityCookie = "com.gu.identity" %% "identity-cookie" % identity
   val identityTestUsers = "com.gu" %% "identity-test-users" % "0.4"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.1"


### PR DESCRIPTION
Each release of Sentry supports the last two version of the protocol (i.e. Sentry 6.4.2 supports both the protocol V5 and V4), for this reason, only the two last stable versions of Raven are actively maintained.

https://github.com/getsentry/raven-java#sentry-protocol-and-raven-versions

The version of sentry we're using is currently 7.1.0.dev0 (57c620a):

https://app.getsentry.com/the-guardian/membership/