### PR TITLE
AuthenticatedException to wrap user and exception

### DIFF
--- a/frontend/app/Global.scala
+++ b/frontend/app/Global.scala
@@ -1,4 +1,4 @@
-import play.api.{UsefulException, Logger, Application}
+import play.api.Application
 import play.api.mvc.Results.{InternalServerError, NotFound}
 import play.api.mvc.{RequestHeader, Result, WithFilters}
 import play.filters.csrf._
@@ -27,16 +27,6 @@ object Global extends WithFilters(CheckCacheHeadersFilter, CacheSensitiveCSRFFil
   }
 
   override def onError(request: RequestHeader, ex: Throwable) = {
-    // Try to associate the error with a user
-    AuthenticationService.authenticatedUserFor(request).foreach { user =>
-      val code = ex match {
-        case err: UsefulException => "@" + err.id
-        case _ => "Unknown"
-      }
-
-      Logger.error(s"$code affected user ${user.id}")
-    }
-
     if (Config.stage == "PROD") {
       Future.successful(Cached(InternalServerError(views.html.error500(ex))))
     } else {


### PR DESCRIPTION
PR #23 introduced an extra log message to help associate a user with an exception. With a great suggestion from @rtyley, this introduces an `AuthenticatedException` which wraps the actual exception and contains details about the user.

One problem with this approach is that it suppresses the original stack trace on Play's default error page (see below), while this doesn't matter in production, it can be useful for devs. However the stack trace is still in the logs so we'll see how annoying this is for a while.

![image](https://cloud.githubusercontent.com/assets/2084823/5629865/0009084a-95b0-11e4-84f0-5ca9b081e5e6.png)
