### PR TITLE
Simplify About/package feature  fragment

### DIFF
--- a/frontend/app/views/fragments/tier/packageFeature.scala.html
+++ b/frontend/app/views/fragments/tier/packageFeature.scala.html
@@ -1,7 +1,4 @@
-@(
-    tier: com.gu.membership.salesforce.Tier.Tier,
-    caption: String = ""
-)(action: Html)(implicit token: play.filters.csrf.CSRF.Token)
+@(tier: com.gu.membership.salesforce.Tier.Tier)
 
 @import model.Benefits
 @import com.gu.membership.salesforce.Tier
@@ -10,17 +7,17 @@
     <div class="package-feature__header">
         @fragments.tier.tierHeader(tier)
     </div>
-    @if(caption){
-        <div class="package-feature__caption">
-            @caption
-        </div>
-    }
+    <div class="package-feature__caption">
+        @Benefits.details(tier).leadin
+    </div>
     <div class="package-feature__content">
         <div class="package-feature__benefits">
             @fragments.benefits.featured(tier)
         </div>
         <div class="package-feature__action">
-            @action
+            <a class="action action--no-margin js-opt-become-member" data-link-name="@Benefits.details(tier).cta" href="/join/@tier.toString.toLowerCase/enter-details">
+                @Benefits.details(tier).cta
+            </a>
         </div>
     </div>
 </div>

--- a/frontend/app/views/info/about.scala.html
+++ b/frontend/app/views/info/about.scala.html
@@ -115,21 +115,9 @@
         <div id="whats-included" class="page-slice__inner">
             <h2 class="page-slice__headline">What's included</h2>
             <div class="page-slice-content">
-                @fragments.tier.packageFeature(Tier.Friend, "Benefits") {
-                    <a class="action action--no-margin js-opt-become-member" data-link-name="Become a Friend" href="/join/friend/enter-details">
-                        Become a Friend
-                    </a>
-                }
-                @fragments.tier.packageFeature(Tier.Partner, "All Friend benefits, plus") {
-                    <a class="action action--no-margin js-opt-become-member" data-link-name="Become a Partner" href="/join/partner/enter-details">
-                        Become a Partner
-                    </a>
-                }
-                @fragments.tier.packageFeature(Tier.Patron, "All Partner benefits, plus") {
-                    <a class="action action--no-margin js-opt-become-member" data-link-name="Become a Patron" href="/join/patron/enter-details">
-                        Become a Patron
-                    </a>
-                }
+                @fragments.tier.packageFeature(Tier.Friend)
+                @fragments.tier.packageFeature(Tier.Partner)
+                @fragments.tier.packageFeature(Tier.Patron)
             </div>
         </div>
     </div>

--- a/frontend/app/views/patterns/patterns.scala.html
+++ b/frontend/app/views/patterns/patterns.scala.html
@@ -350,9 +350,7 @@
     }
 
     @pattern("Package - Feature") {
-        @fragments.tier.packageFeature(Tier.Patron, "All Partner benefits, plus") {
-            <a class="action u-no-margin" href="#">Become a Patron</a>
-        }
+        @fragments.tier.packageFeature(Tier.Patron)
     }
 
     @pattern("Package - Stack") {


### PR DESCRIPTION
Simplify About/package feature fragment.

- Use `leadin` from model
- Build button from Tier, rather than passing HTML in

// @wpf500