### PR TITLE
Increase the timeout for fetching Masterclasses

### DIFF
--- a/frontend/app/services/EventbriteService.scala
+++ b/frontend/app/services/EventbriteService.scala
@@ -26,7 +26,7 @@ trait EventbriteService extends utils.WebServiceHelper[EBObject, EBError] {
 
   def scheduleAgentRefresh[T](agent: Agent[T], refresher: => Future[T], intervalPeriod: FiniteDuration) = {
     Akka.system.scheduler.schedule(1.second, intervalPeriod) {
-      agent.sendOff(_ => Await.result(refresher, 15.seconds))
+      agent.sendOff(_ => Await.result(refresher, 25.seconds))
     }
   }
   val refreshTimeAllEvents = new FiniteDuration(Config.eventbriteRefreshTime, SECONDS)


### PR DESCRIPTION
We're seeing errors fetching Masterclasses locally as it looks like they added a bunch (there's ~140 now, but it was only ~110 or so a month or so back) and now it times out. We haven't seen this in prod yet but just in case, this ups the timeout to give them space to return.

cc @wpf500 / @jamesoram  / @rtyley 