### PR TITLE
Track eventbrite iframe impressions

### DIFF
--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -29,12 +29,7 @@ trait Event extends Controller {
 
   val memberService: MemberService
 
-  private def metrics(event: RichEvent) = {
-    event match {
-      case _: GuLiveEvent => guLiveEvents.wsMetrics
-      case _: MasterclassEvent => masterclassEvents.wsMetrics
-    }
-  }
+  private def metrics(event: RichEvent) = EventbriteService.getService(event).wsMetrics
 
   private def recordBuyIntention(eventId: String) = new ActionBuilder[Request] {
     override def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]): Future[Result] = {

--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -120,7 +120,7 @@ trait Event extends Controller {
   private def eventCookie(event: RichEvent) = s"mem-event-${event.id}"
 
   private def redirectToEventbrite(request: AnyMemberTierRequest[AnyContent], event: RichEvent): Future[Result] =
-    Timing.record(metrics(event), "user-sent-to-eventbrite") {
+    Timing.record(metrics(event), s"user-sent-to-eventbrite-${request.member.tier}") {
       for {
         discountOpt <- memberService.createDiscountForMember(request.member, event)
       } yield Found(event.url ? ("discount" -> discountOpt.map(_.code)))

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -138,6 +138,7 @@ trait Joiner extends Controller {
         eventId <- PreMembershipJoiningEventFromSessionExtractor.eventIdFrom(request)
         event <- EventbriteService.getBookableEvent(eventId)
       } yield {
+        EventbriteService.getService(event).wsMetrics.put("user-sent-to-eventbrite", 1)
         MemberService.createDiscountForMember(request.member, event).map { discountOpt =>
           (event, (Config.eventbriteApiIframeUrl ? ("eid" -> event.id) & ("discount" -> discountOpt.map(_.code))).toString)
         }

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -138,10 +138,12 @@ trait Joiner extends Controller {
         eventId <- PreMembershipJoiningEventFromSessionExtractor.eventIdFrom(request)
         event <- EventbriteService.getBookableEvent(eventId)
       } yield {
-        EventbriteService.getService(event).wsMetrics.put("user-sent-to-eventbrite", 1)
+        EventbriteService.getService(event).wsMetrics.put(s"user-sent-to-eventbrite-iframe-$tier", 1)
+
         MemberService.createDiscountForMember(request.member, event).map { discountOpt =>
           (event, (Config.eventbriteApiIframeUrl ? ("eid" -> event.id) & ("discount" -> discountOpt.map(_.code))).toString)
         }
+
       }
 
       Future.sequence(optFuture.toSeq).map(_.headOption)

--- a/frontend/app/services/EventbriteService.scala
+++ b/frontend/app/services/EventbriteService.scala
@@ -168,4 +168,10 @@ object EventbriteService {
 
   def getEvent(id: String): Option[RichEvent] =
     GuardianLiveEventService.getAllEvents(id) orElse MasterclassEventService.getAllEvents(id)
+
+  def getService(event: RichEvent): EventbriteService =
+    event match {
+      case _: GuLiveEvent => GuardianLiveEventService
+      case _: MasterclassEvent => MasterclassEventService
+    }
 }

--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -109,10 +109,7 @@ trait MemberService extends LazyLogging {
   }
 
   def createDiscountForMember(member: Member, event: RichEvent): Future[Option[EBCode]] = {
-    val eventService = event match {
-      case _: GuLiveEvent => GuardianLiveEventService
-      case _: MasterclassEvent => MasterclassEventService
-    }
+    val eventService = EventbriteService.getService(event)
 
     member.tier match {
       case Tier.Friend => Future.successful(None)

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -93,4 +93,4 @@ GET            /user/me/details                   controllers.User.meDetails
 GET            /founder                           controllers.VanityUrl.redirect
 
 # Styleguide
-GET            /patterns                        controllers.PatternLibrary.patterns
+GET            /patterns                          controllers.PatternLibrary.patterns


### PR DESCRIPTION
It turns out that the radiator app only shows when users are sent to EventBrite when they're already signed in – if a user signs up for Membership while trying to buy tickets, we don't run the code which redirects them to EventBrite – instead they see this screen:

![screen shot 2015-01-07 at 11 58 59](https://cloud.githubusercontent.com/assets/394376/5645217/9f2d413e-9664-11e4-9644-77149dfa3bff.png)

This update adds the same CloudWatch tracking string (`user-sent-to-eventbrite`) to this use case, so our radiator totals will now include this flow too.




