### PR TITLE
Clean up scss _vars

### DIFF
--- a/frontend/assets/stylesheets/_vars.scss
+++ b/frontend/assets/stylesheets/_vars.scss
@@ -17,14 +17,20 @@ $browser-supports-flexbox: true !default;
 // Layout dimensions
 // =============================================================================
 
-$gutter: 16px;
-$gutter-width-fluid: 2.5%;
-$unitHeight: 36px;
-$inArticleInlineImgWidth: 114px;
-$trailblockImgWidth: 100%;
-$trailblockImgWidthLarge: 140px;
+$gutter-width-fluid: 2%;
+$gutter: 16px; // TODO: Remove this, only used in _joiner.scss
+$trailblockImgWidth: 100%; // TOOD: Remove this?
+$trailblockImgWidthLarge: 140px; // TODO: Remove this? Only used in events listings
 $mobilePopupOffset: 43px;
 $pageOffset: 36px;
+$side-margins-top-magic-number: 114px;
+
+// Animation Settings
+// =============================================================================
+
+$transition-duration-short: .25s;
+$transition-duration-medium: .5s;
+$transition-duration-long: 1s;
 
 // Guss defaults overrides
 // =============================================================================
@@ -118,106 +124,11 @@ $font-scale: (
 
 // Colours
 // =============================================================================
-// TODO - clean up the colours in this file, potentially abstract into own file and use guss-colour() mixin and
-// TODO - new way of doing things
+// TODO - Clean up the colours in this file, potentially abstract into own file and use guss-colour() mixin and
+
 @import 'components/bower-components/guss-colours/_colours.scss';
 @import 'components/bower-components/pasteup-palette/src/_palette';
 @import 'components/bower-components/guss-colours/_colours.helpers.scss';
-
-$error: guss-colour(error, $pasteup-palette);
-
-
-$c-brandBlue: #214583;
-$c-brandLightBlue: #94b1ca;
-$c-error: #d61d00;
-
-$c-body: #333333; // Changed from #545454
-$c-body-transparent: rgba(51, 51, 51, .05);
-$c-background: #ffffff;
-
-$c-neutral1: #333333;
-$c-neutral2: #767676;
-// Enhance contrast of grey text on light grey background
-$c-neutral2-contrasted: darken($c-neutral2, 3%);
-$c-neutral3: #bdbdbd;
-$c-neutral4: #dcdcdc;
-$c-neutral5: guss-colour('neutral-5', $pasteup-palette);
-$c-neutral6: #eaeaea;
-$c-neutral7: #f1f1f1;
-$c-neutral8: #f6f6f6;
-$c-neutral9: #fdfdfd;
-
-$c-live: #e81818;
-$c-media-icon: #fbba0f;
-
-// Tones
-// =============================================================================
-
-$c-newsDefault: #005689;
-$c-newsAccent: #4bc6df;
-
-$c-featureDefault: #951c55;
-$c-featureAccent: #f66980;
-$c-featuresVariant: #7d0068;
-
-$c-commentDefault: #e6711b;
-$c-commentAccent: #ffbb00;
-
-// Zones
-// =============================================================================
-
-// Note: try to at least alphabetise these within sections
-
-$articleOrange: #e47a39;
-//Used for live-blogging
-$businessBlue: #004179;
-$commentBlue: #004179;
-$culturePink: #d1008b;
-$environmentGreen: #4a7801;
-$lifeandstyleOrange: #ea721e;
-$moneyPurple: #7d0068;
-$newsRed: #d61d00;
-$travelBlue: #066ec9;
-
-// Football
-// =============================================================================
-
-$c-sportBright: #70d2e6;
-$c-sportMid: #005689;
-$c-sportDark: #003f64;
-
-$c-sportHome: $c-sportBright;
-$c-sportAway: $c-sportDark;
-
-// Stati
-// =============================================================================
-
-$c-statusPositive: #6ca843;
-$c-statusNeutral: $c-neutral2;
-$c-statusNegative: #da1d1d;
-
-// MPU
-// =============================================================================
-
-$mpu-original-width: 300px;
-$mpu-original-height: 250px;
-$mpu-align-offset: 20px;
-// Align bottom of ad with text on desktop
-$mpu-ad-label-height: 34px;
-
-// Scale the ad down on tablet
-$mpu-target-width: gs-span(3) + $gs-gutter/2;
-$mpu-scale-ratio: $mpu-target-width/$mpu-original-width;
-$mpu-resulting-height: ceil($mpu-original-height*$mpu-scale-ratio);
-
-// Dimensions
-// =============================================================================
-
-$action-icon-width: 23px;
-$action-icon-rightspace: 7px;
-
-// Membership
-// =============================================================================
 
 $white: #ffffff;
 $offWhite: #d6d6d6;
@@ -226,6 +137,29 @@ $offBlack: #666666;
 $black-trans: rgba(0, 0, 0, .25);
 $white-trans: rgba(255, 255, 255, .25);
 
+$c-brandBlue: #214583;
+$c-brandLightBlue: #94b1ca;
+
+$c-newsDefault: #005689;
+$c-newsAccent: #4bc6df;
+
+$c-body: #333333;
+$c-link: $c-newsDefault;
+$c-error: #d61d00;
+$c-background-transparent: rgba(51, 51, 51, .05);
+$c-background: #ffffff;
+
+$c-neutral1: #333333;
+$c-neutral2: #767676;
+$c-neutral3: #bdbdbd;
+$c-neutral4: #dcdcdc;
+$c-neutral5: #dfdfdf;
+$c-neutral6: #eaeaea;
+$c-neutral7: #f1f1f1;
+$c-neutral8: #f6f6f6;
+$c-neutral9: #fdfdfd;
+
+// Membership paletts
 $mem-brandOrange: #ce6f14;
 $mem-brandBlue: #82c2d6;
 $mem-brandGrey: #dcddda;
@@ -254,8 +188,6 @@ $mem-mc-accent: #fcdd03;
 $mem-underline-white-trans: rgba(229, 208, 212, .5);
 $mem-event-button-hover: rgba(0, 0, 0, .65);
 
-$side-margins-top-magic-number: 114px;
-
 $c-border-brand: $mem-blue;
 $c-border-neutral: $c-neutral3;
 
@@ -265,7 +197,3 @@ $flash-error-background: #fdf4f3;
 $flash-success-color: #1c6326;
 $flash-success-border: #33a22b;
 $flash-success-background: #faffe5;
-
-$transition-duration-short: .25s;
-$transition-duration-medium: .5s;
-$transition-duration-long: 1s;

--- a/frontend/assets/stylesheets/base/_forms.scss
+++ b/frontend/assets/stylesheets/base/_forms.scss
@@ -185,18 +185,18 @@
 
 .form-field--error {
     .label {
-        color: $newsRed;
+        color: $c-error;
     }
 
     .text-input,
     .text-input:focus {
-        border-color: $newsRed;
+        border-color: $c-error;
     }
 }
 
 .form-field__error-message {
     @include fs-data(3);
-    color: $newsRed;
+    color: $c-error;
     margin-top: rem(2px);
 }
 
@@ -212,7 +212,7 @@
 }
 
 .form-field__error {
-    color: $newsRed;
+    color: $c-error;
     margin-top: rem($gs-baseline / 2);
 }
 

--- a/frontend/assets/stylesheets/base/_links.scss
+++ b/frontend/assets/stylesheets/base/_links.scss
@@ -5,7 +5,7 @@
 a,
 .fake-link {
     overflow: hidden;
-    color: $c-newsDefault;
+    color: $c-link;
     cursor: pointer;
     text-decoration: none;
 
@@ -14,7 +14,7 @@ a,
         text-decoration: underline;
     }
     &:active {
-        color: $c-newsAccent;
+        color: $c-link;
         text-decoration: none;
     }
 }

--- a/frontend/assets/stylesheets/base/_tables.scss
+++ b/frontend/assets/stylesheets/base/_tables.scss
@@ -70,7 +70,7 @@ td {
 }
 
 .table-column--sub {
-    color: $c-statusNeutral;
+    color: $c-neutral2;
 }
 
 .table-column--main {

--- a/frontend/assets/stylesheets/layout/_layout.scss
+++ b/frontend/assets/stylesheets/layout/_layout.scss
@@ -86,7 +86,7 @@ body {
         content: '';
         position: absolute;
         z-index: 1;
-        background: $c-body-transparent;
+        background: $c-background-transparent;
 
         /**
          * Magic number: we shift these margins up to skip the header gap


### PR DESCRIPTION
- Removed any variables that we are not using. Mostly copied from next-gen, we're a bit behind how they handle colours anyway so if we're not using them they should go
- Also cleaned up a couple of places that variables were being used accidentally (e.g., using `newsRed` instead of a dedicated error colour for form errors)