### PR TITLE
Use new version of membership-common for failed timing logging

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val identityCookie = "com.gu.identity" %% "identity-cookie" % identity
   val identityTestUsers = "com.gu" %% "identity-test-users" % "0.4"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.1"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.42"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.43"
   val playGoogleAuth = "com.gu" %% "play-googleauth" % "0.1.10"
   val contentAPI = "com.gu" %% "content-api-client" % "3.5"
   val playWS = PlayImport.ws


### PR DESCRIPTION
This version of `membership-common` will log failed `Future`s that are wrapped in `Timing.record`, useful for seeing when requests are failing and also how long failed requests took.

![image](https://cloud.githubusercontent.com/assets/2084823/5662419/b65890ee-9730-11e4-8e17-aaaf8a5d014f.png)
