### PR TITLE
Add diagnostics for the ID-API IdentityServiceErrors we saw today

### DIFF
--- a/frontend/app/services/IdentityService.scala
+++ b/frontend/app/services/IdentityService.scala
@@ -1,22 +1,20 @@
 package services
 
-import scala.concurrent.Future
-import scala.concurrent.ExecutionContext.Implicits.global
-
-import play.api.Logger
-import play.api.Play.current
-import play.api.libs.json._
-import play.api.libs.ws.{WS, WSResponse}
-
 import com.gu.membership.util.Timing
 import com.gu.membership.zuora.Address
-
 import configuration.Config
 import controllers.IdentityRequest
 import forms.MemberForm._
-import model.{IdMinimalUser, IdUser}
 import model.UserDeserializer._
+import model.{IdMinimalUser, IdUser}
 import monitoring.IdentityApiMetrics
+import play.api.Logger
+import play.api.Play.current
+import play.api.libs.json._
+import play.api.libs.ws.WS
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 case class IdentityServiceError(s: String) extends Throwable {
   override def getMessage: String = s
@@ -109,9 +107,13 @@ trait IdentityApi {
 
   def get(endpoint: String, headers:List[(String, String)], parameters: List[(String, String)]) : Future[Option[IdUser]] = {
     Timing.record(IdentityApiMetrics, "get-user") {
-      WS.url(s"${Config.idApiUrl}/$endpoint").withHeaders(headers: _*).withQueryString(parameters: _*).withRequestTimeout(1000).get().map { response =>
+      val url = s"${Config.idApiUrl}/$endpoint"
+      WS.url(url).withHeaders(headers: _*).withQueryString(parameters: _*).withRequestTimeout(1000).get().map { response =>
+        println("AX"+response.body)
         recordAndLogResponse(response.status, "GET user", endpoint)
-        (response.json \ "user").asOpt[IdUser]
+        val jsResult = (response.json \ "user").validate[IdUser]
+        if (jsResult.isError) Logger.error(s"Id Api response on $url : $jsResult")
+        jsResult.asOpt
       }.recover {
         case _ => None
       }


### PR DESCRIPTION
There was a burst of these at lunchtime today:

```
services.IdentityServiceError: Couldn't find user with ID 1280xxxx
```

The logged error implies that the user doesn't exist in Identity, but that is not the case. I think we're expecting there to be fields on this user that do not exist - this logging should make it clearer how the parsing fails.