### PR TITLE
Remove need for isCurrent flag in slideshow

### DIFF
--- a/frontend/app/views/fragments/media/slideshowItem.scala.html
+++ b/frontend/app/views/fragments/media/slideshowItem.scala.html
@@ -1,15 +1,15 @@
-@(imgSrc: String, description: String, isCurrent: Boolean = false)
+@(imgSrc: String, description: String)
 
 @import views.support.Asset
 
-<figure class="slideshow__element@if(isCurrent == true){ is-current} js-slideshow-item">
+<figure class="slideshow__element js-slideshow-item">
     <figcaption class="slideshow__detail">
         <div class="progress-indicator">
             <span class="progress-indicator__index js-slideshow-position"></span>
             <span class="progress-indicator__separator">/ </span>
             <span class="progress-indicator__count js-slideshow-total"></span>
         </div>
-        <h2 class="slideshow__description">@description</h2>
+        <span class="slideshow__description">@description</span>
     </figcaption>
     <div data-src="@imgSrc" data-alt="@description" data-class="responsive-img slideshow__image" class="js-image-slideshow"></div>
 </figure>

--- a/frontend/app/views/index.scala.html
+++ b/frontend/app/views/index.scala.html
@@ -5,7 +5,7 @@
     @* ===== Slideshow ===== *@
     <section class="slideshow js-slideshow" data-slideshow-duration="5000">
         @fragments.media.slideshowItem("https://media.guim.co.uk/eab86e9c81414932e0d50a1cd609dccfc20ca5d2/0_0_2279_1368/{width}.jpg", "Guardian Live event: Pussy Riot - art, sex and disobedience")
-        @fragments.media.slideshowItem("https://media.guim.co.uk/da867c363957d748bd04cfd9d4890033203a58c6/0_0_2279_1368/{width}.jpg", "Guardian Live with Russell Brand", true)
+        @fragments.media.slideshowItem("https://media.guim.co.uk/da867c363957d748bd04cfd9d4890033203a58c6/0_0_2279_1368/{width}.jpg", "Guardian Live with Russell Brand")
         @fragments.media.slideshowItem("https://media.guim.co.uk/733834b0b9f84e4367cf676919008bfd88007f25/0_0_2279_1368/{width}.jpg", "A life in music: Jimmy Page")
         @fragments.media.slideshowItem("https://media.guim.co.uk/e736acb945406974844bea77ca49b2c1e450013e/0_0_2279_1368/{width}.jpg", "Guardian Live event: Russell Brand")
         @fragments.media.slideshowItem("https://media.guim.co.uk/1e687530a52ef14cd9c1eacb1e8757600c382f86/0_0_2279_1368/{width}.jpg", "Observer Ideas - Stories that inspire: Tinie Tempah")


### PR DESCRIPTION
Spotted an issue with the slideshow that was causing the second slide to flash in before showing the first one. This was due to the `isCurrent` flag being passed on the second item, we can actually remove the flag.