### PR TITLE
Use flexbox for sticky footer

### DIFF
--- a/frontend/assets/stylesheets/_vars.scss
+++ b/frontend/assets/stylesheets/_vars.scss
@@ -21,7 +21,6 @@ $gutter-width-fluid: 2%;
 $gutter: 16px; // TODO: Remove this, only used in _joiner.scss
 $trailblock-img-width: 140px;
 $mobilePopupOffset: 43px;
-$pageOffset: 36px;
 $side-margins-top-magic-number: 114px;
 
 // Animation Settings

--- a/frontend/assets/stylesheets/layout/_footer.scss
+++ b/frontend/assets/stylesheets/layout/_footer.scss
@@ -3,15 +3,12 @@
    ========================================================================== */
 
 .global-footer {
-    position: absolute;
-    bottom: 0;
     width: 100%;
-    z-index: 1;
-    margin: rem($pageOffset/2) 0 0;
+    margin: rem($gs-baseline) 0 0;
     background-color: $c-neutral8;
 
     @include mq(mobileLandscape) {
-        margin-top: rem($pageOffset);
+        margin-top: rem($gs-baseline * 3);
     }
 }
 .global-footer__banner {

--- a/frontend/assets/stylesheets/layout/_header.scss
+++ b/frontend/assets/stylesheets/layout/_header.scss
@@ -4,10 +4,7 @@
 
 .header {
     position: relative;
-    margin-bottom: rem($pageOffset/2);
-    @include mq(tablet) {
-        margin-bottom: rem($pageOffset);
-    }
+    margin-bottom: rem($gs-baseline);
 
     .header__inner--popup {
         padding: 0;

--- a/frontend/assets/stylesheets/layout/_layout.scss
+++ b/frontend/assets/stylesheets/layout/_layout.scss
@@ -26,19 +26,17 @@ html.patron-page {
     }
 }
 
-// TODO: Can magic numbers be removed?
-// Magic numbers refer to footer height
+/**
+ * Use flexbox for sticky footer
+ * @see http://philipwalton.github.io/solved-by-flexbox/demos/sticky-footer/
+ */
 body {
-    min-height: 100%;
-    margin-bottom: rem(280px);
-
-    @include mq(mobileLandscape) {
-        margin-bottom: rem(260px);
-    }
-
-    @include mq(tablet) {
-        margin-bottom: rem(220px);
-    }
+    @include flex-display();
+    @include flex-direction(column);
+    min-height: 100vh;
+}
+.container-global {
+    @include flex(1);
 }
 
 /* Layout Helpers


### PR DESCRIPTION
The sticky footer currently requires quite a few magic number / fixed heights. It's a good candidate for flexbox which lets us do this without all the positioning.

http://philipwalton.github.io/solved-by-flexbox/demos/sticky-footer/

Only downside is that if you are on IE 9 and you are on a short page (probably only signup) and you have a deep enough viewport you'll see a gap underneath the footer.

Given IE9 is ~2% of traffic and the number of conditions in the previous sentence mean it will only affect a fraction of that % means that this feels OK to me…