### PR TITLE
Update choose tier title to be contextual to type of event

### DIFF
--- a/frontend/app/model/RichEvent.scala
+++ b/frontend/app/model/RichEvent.scala
@@ -12,13 +12,39 @@ object RichEvent {
     eventListUrl: String,
     termsUrl: String,
     largeImg: Boolean,
-    highlightsUrlOpt: Option[String]
+    highlightsUrlOpt: Option[String],
+    chooseTier: ChooseTierMetadata
   )
 
-  val guLiveMetadata = Metadata("guardian-live", "Guardian Live events", "Events", controllers.routes.Event.list.url,
-    Config.guardianLiveEventsTermsUrl, largeImg=true, Some(Config.guardianMembershipUrl + "#video"))
-  val masterclassMetadata = Metadata("masterclasses", "Guardian Masterclasses", "Masterclasses",
-    controllers.routes.Event.masterclasses.url, Config.guardianMasterclassesTermsUrl, largeImg=false, None)
+  case class ChooseTierMetadata(title: String, sectionTitle: String)
+
+  val guLiveMetadata = Metadata(
+    identifier="guardian-live",
+    title="Guardian Live events",
+    shortTitle="Events",
+    eventListUrl=controllers.routes.Event.list.url,
+    termsUrl=Config.guardianLiveEventsTermsUrl,
+    largeImg=true,
+    highlightsUrlOpt=Some(Config.guardianMembershipUrl + "#video"),
+    chooseTier=ChooseTierMetadata(
+      "Guardian Live events are exclusively for Guardian members",
+      "Choose a membership tier to continue with your booking"
+    )
+  )
+
+  val masterclassMetadata = Metadata(
+    identifier="masterclasses",
+    title="Guardian Masterclasses",
+    shortTitle="Masterclasses",
+    eventListUrl=controllers.routes.Event.masterclasses.url,
+    termsUrl=Config.guardianMasterclassesTermsUrl,
+    largeImg=false,
+    highlightsUrlOpt=None,
+    chooseTier=ChooseTierMetadata(
+      "Choose a membership tier to continue with your booking",
+      "Become a Partner or Patron to save 20% on your masterclass"
+    )
+  )
 
   case class EventImage(assets: List[Grid.Asset], metadata: Grid.Metadata)
 

--- a/frontend/app/views/joining/tierChooser.scala.html
+++ b/frontend/app/views/joining/tierChooser.scala.html
@@ -8,8 +8,17 @@
     eventOpt.fold {
         "Choose a membership tier"
     } {
-        case _: MasterclassEvent => "Become a member of the Guardian to buy your masterclass"
+        case _: MasterclassEvent => "Choose a membership tier to continue with your booking"
         case _: GuLiveEvent => "Guardian Live events are exclusively for Guardian members"
+    }
+}
+
+@sectionTitle = @{
+    eventOpt.fold {
+        "Choose a membership tier to continue with your booking"
+    } {
+        case _: MasterclassEvent => "Become a Partner or Patron to save 20% on your masterclass"
+        case _: GuLiveEvent => "Choose a membership tier to continue with your booking"
     }
 }
 
@@ -24,7 +33,7 @@
                 @fragments.joiner.joinStepCounter(1, 3)
             </div>
             <div class="page-section__content">
-                <h2 class="h-section h-section--lead">Choose a membership tier to continue with your booking</h2>
+                <h2 class="h-section h-section--lead">@sectionTitle</h2>
                 <ul class="grid grid--single-row grid--bordered grid--3up-stacked">
                     <li class="grid__item">
                         @fragments.tier.packagePromo(Tier.Friend, Some("#package-benefits-friend"))

--- a/frontend/app/views/joining/tierChooser.scala.html
+++ b/frontend/app/views/joining/tierChooser.scala.html
@@ -1,39 +1,19 @@
 @(eventOpt: Option[model.RichEvent.RichEvent], pageInfo: model.PageInfo)(implicit token: play.filters.csrf.CSRF.Token)
 
 @import com.gu.membership.salesforce.Tier
-@import model.Eventbrite.GuLiveEvent
-@import model.Eventbrite.MasterclassEvent
-
-@title = @{
-    eventOpt.fold {
-        "Choose a membership tier"
-    } {
-        case _: MasterclassEvent => "Choose a membership tier to continue with your booking"
-        case _: GuLiveEvent => "Guardian Live events are exclusively for Guardian members"
-    }
-}
-
-@sectionTitle = @{
-    eventOpt.fold {
-        "Choose a membership tier to continue with your booking"
-    } {
-        case _: MasterclassEvent => "Become a Partner or Patron to save 20% on your masterclass"
-        case _: GuLiveEvent => "Choose a membership tier to continue with your booking"
-    }
-}
 
 @main("Join Choose Tier", pageInfo=pageInfo) {
 
     <main role="main" class="page-content">
 
-        @fragments.page.pageHeader(title)
+        @fragments.page.pageHeader(eventOpt.fold("Choose a membership tier")(_.metadata.chooseTier.title))
 
         <section class="page-section page-section--no-padding">
             <div class="page-section__lead-in">
                 @fragments.joiner.joinStepCounter(1, 3)
             </div>
             <div class="page-section__content">
-                <h2 class="h-section h-section--lead">@sectionTitle</h2>
+                <h2 class="h-section h-section--lead">@eventOpt.fold("Choose a membership tier to continue with your booking")(_.metadata.chooseTier.sectionTitle)</h2>
                 <ul class="grid grid--single-row grid--bordered grid--3up-stacked">
                     <li class="grid__item">
                         @fragments.tier.packagePromo(Tier.Friend, Some("#package-benefits-friend"))

--- a/frontend/app/views/joining/tierChooser.scala.html
+++ b/frontend/app/views/joining/tierChooser.scala.html
@@ -1,13 +1,23 @@
 @(eventOpt: Option[model.RichEvent.RichEvent], pageInfo: model.PageInfo)(implicit token: play.filters.csrf.CSRF.Token)
 
 @import com.gu.membership.salesforce.Tier
-@import views.support.Dates._
-@import configuration.Config
+@import model.Eventbrite.GuLiveEvent
+@import model.Eventbrite.MasterclassEvent
+
+@title = @{
+    eventOpt.fold {
+        "Choose a membership tier"
+    } {
+        case _: MasterclassEvent => "Become a member of the Guardian to buy your masterclass"
+        case _: GuLiveEvent => "Guardian Live events are exclusively for Guardian members"
+    }
+}
 
 @main("Join Choose Tier", pageInfo=pageInfo) {
 
     <main role="main" class="page-content">
-        @fragments.page.pageHeader("Guardian Live events are exclusively for Guardian members")
+
+        @fragments.page.pageHeader(title)
 
         <section class="page-section page-section--no-padding">
             <div class="page-section__lead-in">

--- a/frontend/test/services/EventbriteServiceTest.scala
+++ b/frontend/test/services/EventbriteServiceTest.scala
@@ -3,7 +3,7 @@ package services
 import model.EventbriteTestObjects
 import play.api.test.PlaySpecification
 import model.Eventbrite.{EBEvent, EBError, EBObject}
-import model.RichEvent.{Metadata, RichEvent}
+import model.RichEvent.{ChooseTierMetadata, Metadata, RichEvent}
 import scala.concurrent.{Await, Future}
 import play.api.libs.json.Reads
 import utils.Resource
@@ -42,7 +42,7 @@ class EventbriteServiceTest extends PlaySpecification {
     val imageMetadata = None
     val tags = Nil
 
-    val metadata = Metadata("", "", "", "", "", false, None)
+    val metadata = Metadata("", "", "", "", "", false, None, ChooseTierMetadata("", ""))
   }
 
 


### PR DESCRIPTION
Updates the choose tier title to be contextual to type of event that is being booked.

**When booking a Guardian Live event**
![screen shot 2015-01-13 at 14 58 14](https://cloud.githubusercontent.com/assets/123386/5722547/fa785c20-9b34-11e4-9691-10c826f0d10d.png)

**When booking a Masterclass**
![screen shot 2015-01-13 at 14 57 53](https://cloud.githubusercontent.com/assets/123386/5722556/0495bf2c-9b35-11e4-9503-df151100f5c4.png)

**Default / fallback title when there is no event**
![screen shot 2015-01-13 at 14 58 26](https://cloud.githubusercontent.com/assets/123386/5722562/0fd2f9ae-9b35-11e4-9474-47cc3fec2e26.png)
