### PR TITLE
Fix bug with nav wrapping on tablet breakpoints

### DIFF
--- a/frontend/assets/stylesheets/components/nav/_nav.scss
+++ b/frontend/assets/stylesheets/components/nav/_nav.scss
@@ -58,13 +58,16 @@ $_global-nav-height: 36px;
     .nav__scroll {
         display: table;
         white-space: nowrap;
-        width: 100%;
+        width: auto;
         vertical-align: middle;
         height: rem($_global-nav-height);
         padding: 0 rem($_global-nav-height * 2) 0 rem($gs-gutter / 2);
 
         @include mq(tablet) {
             padding: 0 rem($gs-gutter);
+        }
+        @include mq(desktop) {
+            width: 100%;
         }
     }
     .nav__list {


### PR DESCRIPTION
Fix bug with nav wrapping on tablet breakpoints, also improves spacing.

**Before**
![screen shot 2015-01-13 at 15 13 49](https://cloud.githubusercontent.com/assets/123386/5722791/1adecd12-9b37-11e4-8f51-0d2b005c4c44.png)

**After**
![screen shot 2015-01-13 at 15 14 33](https://cloud.githubusercontent.com/assets/123386/5722792/1eb76944-9b37-11e4-9bbe-955c38a4001b.png)
