### PR TITLE
Too many blues

### DIFF
--- a/frontend/assets/stylesheets/_vars.scss
+++ b/frontend/assets/stylesheets/_vars.scss
@@ -18,7 +18,6 @@ $browser-supports-flexbox: true !default;
 // =============================================================================
 
 $gutter-width-fluid: 2%;
-$gutter: 16px; // TODO: Remove this, only used in _joiner.scss
 $trailblock-img-width: 140px;
 $mobilePopupOffset: 43px;
 $pageOffset: 36px;
@@ -124,76 +123,65 @@ $font-scale: (
 
 // Colours
 // =============================================================================
-// TODO - Clean up the colours in this file, potentially abstract into own file and use guss-colour() mixin and
 
 @import 'components/bower-components/guss-colours/_colours.scss';
 @import 'components/bower-components/pasteup-palette/src/_palette';
 @import 'components/bower-components/guss-colours/_colours.helpers.scss';
 
+// Shorthands
 $white: #ffffff;
-$offWhite: #d6d6d6;
 $black: #000000;
-$offBlack: #666666;
 $black-trans: rgba(0, 0, 0, .25);
 $white-trans: rgba(255, 255, 255, .25);
 
-$c-brandBlue: #214583;
-$c-brandLightBlue: #94b1ca;
+// Neutrals
+$c-neutral1: map-get($pasteup-palette, neutral-1);
+$c-neutral2: map-get($pasteup-palette, neutral-2);
+$c-neutral3: map-get($pasteup-palette, neutral-3);
+$c-neutral4: map-get($pasteup-palette, neutral-4);
+$c-neutral5: map-get($pasteup-palette, neutral-5);
+$c-neutral6: map-get($pasteup-palette, neutral-6);
+$c-neutral7: map-get($pasteup-palette, neutral-7);
+$c-neutral8: map-get($pasteup-palette, neutral-8);
 
-$c-newsDefault: #005689;
-$c-newsAccent: #4bc6df;
-
-$c-body: #333333;
-$c-link: $c-newsDefault;
-$c-error: #d61d00;
+$c-body: $c-neutral1;
+$c-background: $white;
 $c-background-transparent: rgba(51, 51, 51, .05);
-$c-background: #ffffff;
+$c-link: map-get($pasteup-palette, news-main-1);
+$c-error: map-get($pasteup-palette, error);
+$c-soldOut: #cc2b12;
 
-$c-neutral1: #333333;
-$c-neutral2: #767676;
-$c-neutral3: #bdbdbd;
-$c-neutral4: #dcdcdc;
-$c-neutral5: #dfdfdf;
-$c-neutral6: #eaeaea;
-$c-neutral7: #f1f1f1;
-$c-neutral8: #f6f6f6;
-$c-neutral9: #fdfdfd;
+// Tone colours
+// TODO: Could masterclass colours go into pasteup-palette?
+// Currently uses `multimedia` in pasteup and our accent is not defined
+$c-tone-live: map-get($pasteup-palette, live-main-1);
+$c-tone-live-accent: map-get($pasteup-palette, live-main-2);
+$c-tone-masterclass: #ffbb00;
+$c-tone-masterclass-accent: #fcdd03;
+$c-tone-friend: $c-neutral1;
+$c-tone-partner: map-get($pasteup-palette, news-main-2);
+$c-tone-patron: map-get($pasteup-palette, news-main-1);
+$c-tone-tint: $c-neutral7;
 
-// Membership paletts
-$mem-brandOrange: #ce6f14;
-$mem-brandBlue: #82c2d6;
-$mem-brandGrey: #dcddda;
-$mem-brandDarkBlue: $c-newsDefault;
-$mem-brandLightblue: #02c7e1;
-$mem-trans-white: rgba(255, 255, 255, .95);
-$mem-trans-red: rgba(180, 24, 0, .95);
-$mem-trans-green: rgba(170, 216, 1, .95);
-$mem-black: #333333;
-$mem-blue: #4bc6df;
-$mem-blue-dark: #197caa;
+// Membership palette
+$mem-brandBlue: map-get($pasteup-palette, news-main-2);
+$mem-brandBlueDark: #197caa;
+// TODO: This is going to come out when brochure pages are revisited,
+// only used on /about page for Space.
 $mem-green: #aad802;
-$mem-buttonBlue: $mem-blue-dark;
-$mem-darkGrey: #999999;
-$mem-button-confirm: #1a4683;
-$mem-button-cancel: #b8b8b8;
-$mem-blue-border: #6dcfe3;
-$mem-header: rgba(0, 0, 0, .7);
-$mem-sold-out: #cc2b12;
 
-$mem-live-top: #b51800;
-$mem-live-accent: #cc2b12;
-$mem-mc-top: #ffbb00;
-$mem-mc-accent: #fcdd03;
+// Buttons
+$c-button: $mem-brandBlueDark;
+$c-button-cancel: #b8b8b8;
 
-$mem-underline-white-trans: rgba(229, 208, 212, .5);
-$mem-event-button-hover: rgba(0, 0, 0, .65);
-
-$c-border-brand: $mem-blue;
+// Borders
+$c-border-brand: $mem-brandBlue;
 $c-border-neutral: $c-neutral3;
 
-$flash-error-color: #d61d00;
-$flash-error-border: #ff998a;
-$flash-error-background: #fdf4f3;
-$flash-success-color: #1c6326;
-$flash-success-border: #33a22b;
-$flash-success-background: #faffe5;
+// Messages
+$c-flash-error: #d61d00;
+$c-flash-error-border: #ff998a;
+$c-flash-error-background: #fdf4f3;
+$c-flash-success: #1c6326;
+$c-flash-success-border: #33a22b;
+$c-flash-success-background: #faffe5;

--- a/frontend/assets/stylesheets/base/_form.scss
+++ b/frontend/assets/stylesheets/base/_form.scss
@@ -6,7 +6,7 @@
    ========================================================================== */
 .form {
     @include mq(desktop) {
-        border-top: 1px solid $mem-blue;
+        border-top: 1px solid $mem-brandBlue;
     }
 }
 
@@ -139,8 +139,8 @@
 
 .input-text,
 .input-textarea {
-    border: 1px solid $c-neutral4;
     color: $c-body;
+    border: 1px solid $c-neutral4;
     @include fs-textSans(5);
     padding: rem(8px) rem(8px) rem(7px);
     outline: none;
@@ -148,7 +148,7 @@
     -webkit-appearance: none;
 
     &:focus {
-        border-color: $mem-brandLightblue;
+        border-color: $c-border-brand;
     }
 
     @include mq(tablet) {
@@ -215,7 +215,7 @@
 }
 
 input[type=radio]:checked + .psuedo-radio {
-    border-color: $mem-brandLightblue;
+    border-color: $c-border-brand;
 
     &:before {
         @include radio-circle();
@@ -291,6 +291,8 @@ $card-icon-offset: 1px;
 /* ==========================================================================
    Password Strength indicator
    ========================================================================== */
+
+// TODO: Can these colours be moved into pasteup / shared w/ Identity?
 $password-strength-score-0: #e31f26;
 $password-strength-score-1: #e6711b;
 $password-strength-score-2: #ffbb00;

--- a/frontend/assets/stylesheets/components/_action.scss
+++ b/frontend/assets/stylesheets/components/_action.scss
@@ -32,14 +32,14 @@
     @extend %action;
 
     color: $white;
-    background-color: $mem-buttonBlue;
+    background-color: $c-button;
     text-decoration: none;
 
     &:focus,
     &:active,
     &:hover {
         text-decoration: none;
-        background-color: darken($mem-buttonBlue, 10%);
+        background-color: darken($c-button, 10%);
     }
 
     &:after {
@@ -129,7 +129,7 @@
     background-position: center center;
 
     @include border-radius(50px);
-    border: 1px solid $mem-buttonBlue;
+    border: 1px solid $c-button;
 
     &:focus {
         outline: 0;
@@ -142,9 +142,9 @@
 
 .action--secondary,
 .action--toggle {
-    color: $mem-buttonBlue;
+    color: $c-button;
     background-color: transparent;
-    border: 1px solid transparentize($mem-buttonBlue, 0.5);
+    border: 1px solid transparentize($c-button, 0.5);
 
     &:focus,
     &:active,
@@ -153,7 +153,7 @@
     }
 
     &:hover {
-        border-color: $mem-buttonBlue;
+        border-color: $c-button;
     }
 
 }
@@ -186,24 +186,24 @@
     &:active,
     &:focus {
         color: $black;
-        background-color: $offWhite;
+        background-color: $c-neutral4;
     }
     &:hover {
         color: $black;
-        background-color: darken($offWhite, 15%);
+        background-color: darken($c-neutral4, 15%);
     }
 }
 
 // TODO: These classes are only used inside the staff email change modal.
 // Should be made more generic, or into clearer modfiers.
 .action-secondary-small {
-    color: $mem-buttonBlue;
+    color: $c-button;
     border: 1px solid rgba(24, 104, 153, .25);
     background-color: $white;
     @extend %action;
 
     &:hover {
-        border: 1px solid $mem-buttonBlue;
+        border: 1px solid $c-button;
     }
 }
 .action-secondary-small--modal {
@@ -250,17 +250,17 @@
     min-width: 100%;
 
     .theme--guardian-live & {
-        background-color: $mem-live-top;
+        background-color: $c-tone-live;
 
         &:hover {
-            background-color: darken($mem-live-top, 5%);
+            background-color: darken($c-tone-live, 5%);
         }
     }
     .theme--masterclasses & {
         color: $c-neutral1;
-        background-color: $mem-mc-top;
+        background-color: $c-tone-masterclass;
         &:hover {
-            background-color: darken($mem-mc-top, 5%);
+            background-color: darken($c-tone-masterclass, 5%);
         }
         &:after {
             @extend .icon-arrow-right-black;
@@ -272,10 +272,10 @@
     min-width: 100%;
 
     .theme--guardian-live & {
-        background-color: $mem-live-top;
+        background-color: $c-tone-live;
     }
     .theme--masterclasses & {
-        background-color: $mem-mc-top;
+        background-color: $c-tone-masterclass;
     }
     &:hover {
         cursor: default;
@@ -288,18 +288,18 @@
 .action--join,
 .action--logged-in {
     text-align: left;
-    background-color: $mem-buttonBlue;
+    background-color: $c-button;
     color: $white;
     padding: rem(8px) rem(8px) rem(8px) rem(18px);
 
     &:visited,
     &:active,
     &:focus {
-        background-color: $mem-buttonBlue;
+        background-color: $c-button;
         color: $white;
     }
     &:hover {
-        background-color: darken($mem-buttonBlue, 15%);
+        background-color: darken($c-button, 15%);
     }
     i {
         float: right;
@@ -320,13 +320,13 @@
 }
 
 .action-cta--confirm {
-    background-color: $mem-buttonBlue;
+    background-color: $c-button;
 }
 
 .action-cta--cancel {
     &,
     &:hover {
-      background-color: $mem-button-cancel;
+      background-color: $c-button-cancel;
     }
 }
 
@@ -371,21 +371,21 @@
 // Currently not styled when used outside of a theme
 .action--search {
     .theme--guardian-live & {
-        background-color: $mem-live-top;
+        background-color: $c-tone-live;
         color: $white;
         &:hover,
         &:focus,
         &:active {
-            background-color: $mem-live-accent;
+            background-color: $c-tone-live-accent;
         }
     }
     .theme--masterclasses & {
-        background-color: $mem-mc-top;
+        background-color: $c-tone-masterclass;
         color: $c-neutral1;
         &:hover,
         &:focus,
         &:active {
-            background-color: $mem-mc-accent;
+            background-color: $c-tone-masterclass-accent;
         }
     }
 }

--- a/frontend/assets/stylesheets/components/_content.scss
+++ b/frontend/assets/stylesheets/components/_content.scss
@@ -37,7 +37,7 @@
     max-width: rem(gs-span(8));
 
     .content__headline {
-        border-top: 1px solid $c-newsAccent;
+        border-top: 1px solid $mem-brandBlue;
         margin-bottom: rem($gs-baseline);
         padding-top: rem($gs-baseline / 2 - 1px);
     }

--- a/frontend/assets/stylesheets/components/_event-detail.scss
+++ b/frontend/assets/stylesheets/components/_event-detail.scss
@@ -163,7 +163,7 @@
     }
 }
 .event-status--sold-out {
-    color: $mem-sold-out;
+    color: $c-soldOut;
 }
 
 

--- a/frontend/assets/stylesheets/components/_event-items.scss
+++ b/frontend/assets/stylesheets/components/_event-items.scss
@@ -296,7 +296,7 @@
     .event-status--sold-out {
         display: inline-block;
         color: $white;
-        background-color: $mem-live-accent;
+        background-color: $c-tone-live-accent;
         @include fs-data(2);
         position: relative;
         top: rem(-3px);

--- a/frontend/assets/stylesheets/components/_form-layout.scss
+++ b/frontend/assets/stylesheets/components/_form-layout.scss
@@ -126,6 +126,6 @@
 }
 
 .form-detail {
-    border-top: 1px solid $mem-blue;
+    border-top: 1px solid $mem-brandBlue;
     padding-top: rem($gs-baseline / 2);
 }

--- a/frontend/assets/stylesheets/components/_help.scss
+++ b/frontend/assets/stylesheets/components/_help.scss
@@ -6,7 +6,7 @@
 }
 
 .help-list {
-    border-top: 1px solid $mem-blue;
+    border-top: 1px solid $mem-brandBlue;
     margin-bottom: rem($gs-baseline);
 }
 

--- a/frontend/assets/stylesheets/components/_messages.scss
+++ b/frontend/assets/stylesheets/components/_messages.scss
@@ -12,13 +12,13 @@
 }
 
 .flash-message--error {
-    background-color: $flash-error-background;
-    border-color: $flash-error-border;
-    color: $flash-error-color;
+    background-color: $c-flash-error-background;
+    border-color: $c-flash-error-border;
+    color: $c-flash-error;
 }
 
 .flash-message--success {
-    background-color: $flash-success-background;
-    border-color: $flash-success-border;
-    color: $flash-success-color;
+    background-color: $c-flash-success-background;
+    border-color: $c-flash-success-border;
+    color: $c-flash-success;
 }

--- a/frontend/assets/stylesheets/components/_packages.scss
+++ b/frontend/assets/stylesheets/components/_packages.scss
@@ -298,11 +298,6 @@
         margin-bottom: 0;
     }
 }
-    .package-feature__intro {
-        position: relative;
-        padding: rem($gs-gutter/2) 0 rem($gs-gutter);
-        border-top: 1px solid $mem-blue-border;
-    }
     .package-feature__caption {
         font-weight: bold;
         margin: rem($gs-gutter/2) 0;

--- a/frontend/assets/stylesheets/components/_page.scss
+++ b/frontend/assets/stylesheets/components/_page.scss
@@ -191,7 +191,7 @@ $_page-offset: rem(gs-span(2) + $gs-gutter);
     }
 
     .page-section__lead-in {
-        border-top: 1px solid $mem-blue;
+        border-top: 1px solid $mem-brandBlue;
     }
 
     @include mq(desktop) {
@@ -199,7 +199,7 @@ $_page-offset: rem(gs-span(2) + $gs-gutter);
             border-top: none;
         }
         .page-section__content {
-            border-top: 1px solid $mem-blue;
+            border-top: 1px solid $mem-brandBlue;
         }
     }
 }

--- a/frontend/assets/stylesheets/components/_patterns.scss
+++ b/frontend/assets/stylesheets/components/_patterns.scss
@@ -24,6 +24,6 @@
     width: 100%;
     z-index: 10000;
     padding: .5em 1em;
-    background: $mem-trans-white;
+    background: transparentize($white, .95);
     text-align: center;
 }

--- a/frontend/assets/stylesheets/components/_payment.scss
+++ b/frontend/assets/stylesheets/components/_payment.scss
@@ -8,7 +8,7 @@
 
 .steps {
     @include fs-header(2);
-    color: $mem-blue-dark;
+    color: $mem-brandBlueDark;
     border-top: 1px solid $c-border-brand;
     padding-top: rem($gs-baseline / 2);
     margin-bottom: rem($gs-gutter);

--- a/frontend/assets/stylesheets/components/_text-helpers.scss
+++ b/frontend/assets/stylesheets/components/_text-helpers.scss
@@ -40,7 +40,7 @@
 }
 
 .text-highlight {
-    color: $mem-buttonBlue;
+    color: $mem-brandBlueDark;
 }
 
 /* Text Helpers - Case

--- a/frontend/assets/stylesheets/components/_tier.scss
+++ b/frontend/assets/stylesheets/components/_tier.scss
@@ -68,10 +68,10 @@
 }
 .tier-header--partner {
     color: $black;
-    background-color: $mem-brandLightblue;
+    background-color: $c-tone-partner;
 }
 .tier-header--patron {
-    background-color: $mem-brandDarkBlue;
+    background-color: $c-tone-patron;
 }
 
 /* Tier Header - Stacked modifier

--- a/frontend/assets/stylesheets/components/nav/_control.scss
+++ b/frontend/assets/stylesheets/components/nav/_control.scss
@@ -52,7 +52,7 @@
 .control--faq {
     width: rem($gs-gutter + ($gs-baseline / 2));
     height: rem($gs-gutter + ($gs-baseline / 2));
-    border-color: $mem-blue;
+    border-color: $mem-brandBlue;
     position: absolute;
 
     .control__icon {

--- a/frontend/assets/stylesheets/components/nav/_nav.scss
+++ b/frontend/assets/stylesheets/components/nav/_nav.scss
@@ -47,7 +47,7 @@ $_global-nav-height: 36px;
     -webkit-font-smoothing: subpixel-antialiased;
     -webkit-font-feature-settings: "kern" 1;
 
-    background-color: darken($mem-blue, 10%);
+    background-color: darken($mem-brandBlue, 10%);
     @include side-margins-calc('padding-left');
     @include side-margins-calc('padding-right');
 
@@ -170,7 +170,7 @@ $_global-nav-height: 36px;
     }
     .nav__link {
         @include fs-bodyHeading(1);
-        border-top: 1px solid $mem-blue-border;
+        border-top: 1px solid lighten($mem-brandBlue, 5%);
         display: block;
         background-color: transparent;
         -webkit-font-smoothing: subpixel-antialiased;

--- a/frontend/assets/stylesheets/components/nav/_pop-up.scss
+++ b/frontend/assets/stylesheets/components/nav/_pop-up.scss
@@ -9,7 +9,7 @@
     padding: rem(($gs-baseline / 3) * 2) 0;
     list-style: none;
     margin-bottom: rem(-4px);
-    background-color: darken($mem-blue, 10%);
+    background-color: darken($mem-brandBlue, 10%);
     width: 100%;
 }
 

--- a/frontend/assets/stylesheets/layout/_footer.scss
+++ b/frontend/assets/stylesheets/layout/_footer.scss
@@ -14,18 +14,14 @@
         margin-top: rem($pageOffset);
     }
 }
-.global-footer__banner {
-    border-top: rem(2px) solid $c-brandBlue;
-    margin-bottom: rem(($gs-baseline / 3) * 2);
-}
 .global-footer__primary {
     position: relative;
     overflow: hidden;
-    background-color: darken($mem-blue, 12%);
+    background-color: darken($mem-brandBlue, 5%);
 }
 .global-footer__brand {
     @include clearfix;
-    background-color: darken($mem-blue, 10%);
+    background-color: $mem-brandBlue;
     padding-left: rem($gs-gutter / 4);
     padding-right: rem($gs-gutter / 4);
 

--- a/frontend/assets/stylesheets/layout/_header.scss
+++ b/frontend/assets/stylesheets/layout/_header.scss
@@ -17,7 +17,7 @@
         // move the logo area above side margins
         z-index: 2;
         position: relative;
-        background-color: transparentize($mem-blue, .1);
+        background-color: transparentize($mem-brandBlue, .1);
         padding-top: rem(5px);
         padding-bottom: rem(5px);
         height: rem(48px);

--- a/frontend/assets/stylesheets/layout/_homeslice.scss
+++ b/frontend/assets/stylesheets/layout/_homeslice.scss
@@ -119,7 +119,7 @@
             width: 100%;
             min-height: rem(104px);
             padding: rem($gs-gutter) rem($gs-gutter / 2);
-            background-color: transparentize($mem-blue, .1);
+            background-color: transparentize($mem-brandBlue, .1);
 
             margin-top: -webkit-calc(((100%/5)*3) - #{$gs-gutter/2});
             margin-top: -moz-calc(((100%/5)*3) - #{$gs-gutter/2});
@@ -196,7 +196,7 @@
     // Title block colour modifiers ======================================== //
 
     &.home-slice--red .home-slice__headline-block {
-        background-color: transparentize($mem-live-accent, .1);
+        background-color: transparentize($c-tone-live-accent, .1);
         .home-slice__headline {
             color: $white;
         }
@@ -217,7 +217,7 @@
 
         .home-slice__headline-block {
             width: 100%;
-            background-color: transparentize($mem-blue, .1);
+            background-color: transparentize($mem-brandBlue, .1);
             position: relative;
             z-index: 2;
             margin-top: rem(-$gs-gutter/2);
@@ -457,7 +457,7 @@
 
 .join-today__join-box {
     position: relative;
-    background-color: $c-neutral9;
+    background-color: $c-neutral8;
     border: 1px solid $c-neutral5;
     margin-bottom: rem($gs-gutter);
     padding: rem(68px) rem($gs-gutter / 2) rem($gs-gutter / 2);
@@ -562,12 +562,12 @@
     }
 
     &.join-today__join-box--header--partner {
-        background-color: $mem-brandLightblue;
+        background-color: $c-tone-partner;
         color: $black;
     }
 
     &.join-today__join-box--header--patron {
-        background-color: $mem-brandDarkBlue;
+        background-color: $c-tone-patron;
         color: $white;
     }
 }

--- a/frontend/assets/stylesheets/mixins/_mixins-utils.scss
+++ b/frontend/assets/stylesheets/mixins/_mixins-utils.scss
@@ -99,7 +99,7 @@
     }
 }
 
-@mixin radio-circle($colour: $mem-brandLightblue) {
+@mixin radio-circle($colour: $mem-brandBlue) {
     @include border-radius (50%);
     content: ' ';
     background-color: $colour;

--- a/frontend/assets/stylesheets/theme/_tones.scss
+++ b/frontend/assets/stylesheets/theme/_tones.scss
@@ -3,7 +3,7 @@
    ========================================================================== */
 
 .tone-masterclasses {
-    background-color: $mem-mc-top;
+    background-color: $c-tone-masterclass;
 
     a {
         border-bottom-color: transparentize($c-neutral3, .5);
@@ -14,7 +14,7 @@
 }
 .tone-guardian-live {
     color: $white;
-    background-color: $mem-live-top;
+    background-color: $c-tone-live;
 
     a {
         border-bottom-color: transparentize($white, .5);
@@ -25,49 +25,49 @@
 }
 
 .tone-masterclasses--accent {
-    background-color: $mem-mc-accent;
+    background-color: $c-tone-masterclass-accent;
 }
 .tone-guardian-live--accent {
     color: $white;
-    background-color: $mem-live-accent;
+    background-color: $c-tone-live-accent;
 }
 
 .tone-masterclasses--border {
-    border-color: $mem-mc-top;
+    border-color: $c-tone-masterclass;
 }
 .tone-guardian-live--border {
-    border-color: $mem-live-top;
+    border-color: $c-tone-live;
 }
 
 .tone-masterclasses--trans {
-    background-color: transparentize($mem-mc-top, .1);
+    background-color: transparentize($c-tone-masterclass, .1);
 }
 .tone-guardian-live--trans {
     color: $white;
-    background-color: transparentize($mem-live-top, .1);
+    background-color: transparentize($c-tone-live, .1);
 }
 
 .tone-friend {
     color: $white;
-    background-color: $c-neutral1;
+    background-color: $c-tone-friend;
 }
 .tone-partner {
-    background-color: $mem-brandLightblue;
+    background-color: $c-tone-partner;
 }
 .tone-patron {
-    background-color: $mem-brandDarkBlue;
+    background-color: $c-tone-patron;
 }
 
 .tone-friend--border {
-    border-color: $c-neutral1;
+    border-color: $c-tone-friend;
 }
 .tone-partner--border {
-    border-color: $mem-brandLightblue;
+    border-color: $c-tone-partner;
 }
 .tone-patron--border {
-    border-color: $mem-brandDarkBlue;
+    border-color: $c-tone-patron;
 }
 
 .tone-tint {
-    background-color: $c-neutral7;
+    background-color: $c-tone-tint;
 }


### PR DESCRIPTION
Spotted chatting to Ben W that our membership brand colours were a bit all over the place, with some blues being defined but never used and others being defined incorrectly. This PR:

- Rationalises the different blues we have, now clearly defined
- Remove a load of dead variable colours
- Use pasteup-palette where possible for any core brand colours
- Fixes a bug where the Partner level blue was incorrect
- Adds dedicated tone variables to make these a little clearer

There's some future tweaks to be consistent with `camelCase` vs `hyphenated-names` but I'm going to look to see if it makes sense for use to use Sass maps for colours in a later PR anyway.