### PR TITLE
Don't add padding when base64 encoding

### DIFF
--- a/frontend/app/controllers/User.scala
+++ b/frontend/app/controllers/User.scala
@@ -1,17 +1,14 @@
 package controllers
 
-import org.apache.commons.codec.binary.Base64
-
-import org.joda.time.format.ISODateTimeFormat
+import com.gu.membership.salesforce.{FreeMember, Member, PaidMember}
 import org.joda.time.Instant
+import org.joda.time.format.ISODateTimeFormat
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import play.api.libs.json._
+import play.api.mvc.{Controller, Cookie}
+import utils.GuMemCookie
 
 import scala.concurrent.Future
-
-import play.api.mvc.{Cookie, Controller}
-import play.api.libs.json._
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
-
-import com.gu.membership.salesforce.{Member, FreeMember, PaidMember}
 
 trait User extends Controller {
   val standardFormat = ISODateTimeFormat.dateTime.withZoneUTC
@@ -19,8 +16,10 @@ trait User extends Controller {
 
   def me = AjaxMemberAction { implicit request =>
     val json = basicDetails(request.member)
-    Ok(json).withCookies(Cookie("GU_MEM", Base64.encodeBase64String(Json.stringify(json).getBytes), secure = true, httpOnly = false))
+    Ok(json).withCookies(Cookie("GU_MEM", GuMemCookie.encodeUserJson(json), secure = true, httpOnly = false))
   }
+
+
 
   def meDetails = AjaxMemberAction.async { implicit request =>
     def futureCardDetails = request.member match {

--- a/frontend/app/utils/GuMemCookie.scala
+++ b/frontend/app/utils/GuMemCookie.scala
@@ -1,0 +1,12 @@
+package utils
+
+import org.apache.commons.codec.binary.Base64
+import play.api.libs.json.{JsObject, Json}
+
+object GuMemCookie {
+
+  def encodeUserJson(json: JsObject): String = {
+    Base64.encodeBase64URLSafeString(Json.stringify(json).getBytes)
+  }
+
+}

--- a/frontend/test/utils/GuMemCookieTest.scala
+++ b/frontend/test/utils/GuMemCookieTest.scala
@@ -1,0 +1,23 @@
+package utils
+
+import org.specs2.mutable.Specification
+import play.api.libs.json.Json
+import utils.GuMemCookie.encodeUserJson
+
+class GuMemCookieTest extends Specification {
+
+  val userTestData = Json.obj(
+    "userId" -> 123456,
+    "regNumber" -> "",
+    "firstName" -> "test",
+    "tier" -> "Friend",
+    "joinDate" -> 1421252372000L
+  )
+
+  "encodeUserJson" should {
+    "encode json to base64 without padding" in {
+      encodeUserJson(userTestData) mustEqual "eyJ1c2VySWQiOjEyMzQ1NiwicmVnTnVtYmVyIjoiIiwiZmlyc3ROYW1lIjoidGVzdCIsInRpZXIiOiJGcmllbmQiLCJqb2luRGF0ZSI6MTQyMTI1MjM3MjAwMH0"
+    }
+  }
+
+}


### PR DESCRIPTION
After base64 encoding the `GU_MEM` cookie we were still seeing issues with the cookie value getting quoted. This was due to padding on the `base64` value. Comparing with Identity we should be using `encodeBase64URLSafeString` which does not add padding.

**See:** http://commons.apache.org/proper/commons-codec/apidocs/org/apache/commons/codec/binary/Base64.html#encodeBase64URLSafeString(byte[])

With assistance from @rtyley extracted out the encoding method and added a test.