### PR TITLE
Don't throw an exception on encountering an ex-member

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val identityCookie = "com.gu.identity" %% "identity-cookie" % "3.44"
   val identityTestUsers = "com.gu" %% "identity-test-users" % "0.4"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.4"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.45"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.46"
   val playGoogleAuth = "com.gu" %% "play-googleauth" % "0.1.10"
   val contentAPI = "com.gu" %% "content-api-client" % "3.5"
   val playWS = PlayImport.ws


### PR DESCRIPTION
This is just publishing the updated membership-common lib from https://github.com/guardian/membership-common/pull/47 - the fix stops these:

https://app.getsentry.com/the-guardian/membership/group/50506635/

...which started https://github.com/guardian/membership-common/pull/45 went out - we were throwing an exception when encountering `null` for `Membership_Tier__c` - but as ex-members can have this state, it's not actually an error.