### PR TITLE
Use working mixin

### DIFF
--- a/frontend/assets/stylesheets/layout/_layout.scss
+++ b/frontend/assets/stylesheets/layout/_layout.scss
@@ -31,7 +31,7 @@ html.patron-page {
  * @see http://philipwalton.github.io/solved-by-flexbox/demos/sticky-footer/
  */
 body {
-    @include flex-display();
+    @include flexbox();
     @include flex-direction(column);
     min-height: 100vh;
 }


### PR DESCRIPTION
We had a rendering issue on FF19 which was admittedly not affecting many people, but stems from what I suspect is [an issue](https://github.com/guardian/guss-css3/issues/11) with guss-css3. 

#### Before:
![screen shot 2015-01-19 at 11 38 52](https://cloud.githubusercontent.com/assets/394376/5799981/e164d600-9fd0-11e4-9917-9dcff412faed.png)

#### After:
![screen shot 2015-01-19 at 11 39 41](https://cloud.githubusercontent.com/assets/394376/5799982/e167748c-9fd0-11e4-878e-2ec7b833babe.png)
