### PR TITLE
Show discounts for guardian membership events only

### DIFF
--- a/frontend/app/model/Eventbrite.scala
+++ b/frontend/app/model/Eventbrite.scala
@@ -119,6 +119,7 @@ object Eventbrite {
 
     val generalReleaseTicket = ticket_classes.find(!_.isHidden)
     val memberTickets = ticket_classes.filter { t => t.isHidden && t.name.toLowerCase.startsWith("guardian member")}
+    val hasMemberTicket = memberTickets.nonEmpty
 
     val mainImageUrl: Option[String] = description.flatMap(desc => "<!--\\s*main-image: (.*?)\\s*-->".r.findFirstMatchIn(desc.html).map(_.group(1)) )
 

--- a/frontend/app/services/EventbriteService.scala
+++ b/frontend/app/services/EventbriteService.scala
@@ -97,21 +97,6 @@ trait EventbriteService extends utils.WebServiceHelper[EBObject, EBError] {
     } yield discount
   }
 
-  def createOrGetDiscount(event: RichEvent, code: String): Future[EBDiscount] = {
-    val uri = s"events/${event.id}/discounts"
-
-    for {
-      discounts <- getPaginated[EBDiscount](uri)
-      discount <- discounts.find(_.code == code).map(Future.successful).getOrElse {
-        post[EBDiscount](uri, Map(
-          "discount.code" -> Seq(code),
-          "discount.percent_off" -> Seq("20"),
-          "discount.quantity_available" -> Seq(maxDiscountQuantityAvailable.toString)
-        ))
-      }
-    } yield discount
-  }
-
   def getOrder(id: String): Future[EBOrder] = get[EBOrder](s"orders/$id")
 }
 
@@ -168,10 +153,6 @@ object MasterclassEventService extends EventbriteService {
 
   override def getEventsOrdering: Seq[String] = Nil
   override def getEventsTagged(tag: String): Seq[RichEvent] = events.filter(_.tags.contains(tag.toLowerCase))
-
-  // This should never happen as we only display masterclasses with access codes enabled
-  override def createOrGetDiscount(event: RichEvent, code: String): Future[EBDiscount] =
-    Future.failed(MasterclassEventServiceError(s"Masterclasses aren't allowed discount codes, attempted on event ${event.id}"))
 }
 
 object MasterclassEventServiceHelpers {

--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -111,17 +111,11 @@ trait MemberService extends LazyLogging {
 
   def createDiscountForMember(member: Member, event: RichEvent): Future[Option[EBCode]] = {
     member.tier match {
-      case Tier.Friend => Future.successful(None)
-
-      case _ =>
-        if (event.memberTickets.nonEmpty) {
+      case Tier.Partner | Tier.Patron if event.hasMemberTicket =>
           // Add a "salt" to make access codes different to discount codes
           val code = DiscountCode.generate(s"A_${member.identityId}_${event.id}")
           event.service.createOrGetAccessCode(event, code, event.memberTickets).map(Some(_))
-        } else {
-          val code = DiscountCode.generate(s"${member.identityId}_${event.id}")
-          event.service.createOrGetDiscount(event, code).map(Some(_))
-        }
+      case _ => Future.successful(None)
     }
   }
 

--- a/frontend/app/views/event/page.scala.html
+++ b/frontend/app/views/event/page.scala.html
@@ -172,19 +172,35 @@
                                         </div>
                                     } else {
                                         @for(pricing <- ticket.cost) {
-                                            <div class="js-event-price event-content__item">
-                                                <div class="event-content__price event-content--line-divider js-event-price-value" data-discount-text="@pricing.discountPrice" itemprop="highPrice">
-                                                    @pricing.formattedPrice
+
+                                            @if(event.hasMemberTicket) {
+                                                <div class="js-event-price event-content__item">
+                                                    <div class="event-content__price event-content--line-divider js-event-price-value"
+                                                         data-discount-text="@pricing.discountPrice"
+                                                         itemprop="highPrice">
+                                                        @pricing.formattedPrice
+                                                    </div>
+
+                                                    <div class="event-content__trail">
+                                                        <span class="event-content__trail-tag js-event-price-discount"
+                                                              data-discount-text="Full price @pricing.formattedPrice"
+                                                              itemprop="lowPrice">
+                                                            Partners/Patrons @pricing.discountPrice
+                                                        </span>
+                                                        <span class="event-content__trail-saving js-event-price-saving"
+                                                              data-discount-text="(you save @pricing.savingPrice)">
+                                                            (Save @pricing.savingPrice)
+                                                        </span>
+                                                    </div>
                                                 </div>
-                                                <div class="event-content__trail">
-                                                    <span class="event-content__trail-tag js-event-price-discount" data-discount-text="Full price @pricing.formattedPrice" itemprop="lowPrice">
-                                                        Partners/Patrons @pricing.discountPrice
-                                                    </span>
-                                                    <span class="event-content__trail-saving js-event-price-saving" data-discount-text="(you save @pricing.savingPrice)">
-                                                        (save @pricing.savingPrice)
-                                                    </span>
+                                            } else {
+                                                <div class="event-content__item">
+                                                    <div class="event-content__price event-content--line-divider"
+                                                         itemprop="highPrice">
+                                                        @pricing.formattedPrice
+                                                    </div>
                                                 </div>
-                                            </div>
+                                            }
                                         }
                                     }
                                     @if(event.isBookable) {

--- a/frontend/app/views/fragments/event/itemMetaAvailability.scala.html
+++ b/frontend/app/views/fragments/event/itemMetaAvailability.scala.html
@@ -18,17 +18,30 @@
                     </span>
                 } else {
                     @for(pricing <- ticket.cost) {
-                        <div class="js-event-price">
-                            <span class="event-item__price-amount js-event-price-value" data-discount-text="@pricing.discountPrice" itemprop="highPrice">
+                        @if(event.hasMemberTicket) {
+                            <div class="js-event-price">
+                                <span class="event-item__price-amount js-event-price-value"
+                                      data-discount-text="@pricing.discountPrice"
+                                      itemprop="highPrice">
+                                @pricing.formattedPrice
+                                </span>
+
+                                <span class="event-item__price-amount-discount js-event-price-discount"
+                                      data-discount-text="Full price @pricing.formattedPrice"
+                                      itemprop="lowPrice" content="@pricing.discountPrice">
+                                    Partners/Patrons: @pricing.discountPrice
+                                </span>
+                                <span class="event-item__price-amount-discount js-event-price-saving"
+                                      data-discount-text="You save @pricing.savingPrice">
+                                    (Save @pricing.savingPrice)
+                                </span>
+                            </div>
+                        } else {
+                            <span class="event-item__price-amount"
+                                  itemprop="highPrice">
                                 @pricing.formattedPrice
                             </span>
-                            <span class="event-item__price-amount-discount js-event-price-discount" data-discount-text="Full price @pricing.formattedPrice" itemprop="lowPrice" content="@pricing.discountPrice">
-                               Partners/Patrons: @pricing.discountPrice
-                            </span>
-                            <span class="event-item__price-amount-discount js-event-price-saving" data-discount-text="You save @pricing.savingPrice">
-                                Save @pricing.savingPrice
-                            </span>
-                        </div>
+                        }
                     }
                 }
             }

--- a/frontend/test/services/EventbriteServiceTest.scala
+++ b/frontend/test/services/EventbriteServiceTest.scala
@@ -12,29 +12,6 @@ import monitoring.EventbriteMetrics
 
 class EventbriteServiceTest extends PlaySpecification {
 
-  def testEvent = TestRichEvent(EventbriteTestObjects.eventWithName("test"))
-
-  "EventbriteService" should {
-
-    "reuses an existing discount code" in TestEventbriteService { service =>
-      Await.ready(service.createOrGetDiscount(testEvent, "5ZCYERL5"), 5.seconds)
-      service.lastRequest mustEqual RequestInfo.empty
-    }
-
-    "creates a new discount code" in TestEventbriteService { service =>
-      Await.ready(service.createOrGetDiscount(testEvent, "NEW"), 5.seconds)
-
-      service.lastRequest mustEqual RequestInfo(
-        url = s"http://localhost:9999/v1/events/test/discounts",
-        body = Map(
-          "discount.code" -> Seq("NEW"),
-          "discount.quantity_available" -> Seq("2"),
-          "discount.percent_off" -> Seq("20")
-        )
-      )
-    }
-  }
-
   case class TestRichEvent(event: EBEvent) extends RichEvent {
     val imgUrl = ""
     val availableWidths = ""


### PR DESCRIPTION
- If an event has a "Guardian Member" ticket on an event we allow this event to discounted for all users as it is currently.
- If there is no "Guardian Member" ticket on an event then the event will not be discounted for any user.

This pull request is connected with [this one](https://github.com/guardian/membership-frontend/pull/90)

# List page (no discount event on the right)
![screen shot 2015-01-19 at 12 10 16](https://cloud.githubusercontent.com/assets/2305016/5800297/b4d85af4-9fd4-11e4-874c-cab9140ec258.png)

# Event page (discounted event)
![screen shot 2015-01-19 at 12 12 53](https://cloud.githubusercontent.com/assets/2305016/5800316/ec1d3f66-9fd4-11e4-9c56-af7bc4794918.png)

# Event page (no discount event)
![screen shot 2015-01-19 at 12 13 07](https://cloud.githubusercontent.com/assets/2305016/5800321/f8960d68-9fd4-11e4-8214-e0ba7e7f4a07.png)
