### PR TITLE
Show better event URLs

### DIFF
--- a/frontend/app/model/Eventbrite.scala
+++ b/frontend/app/model/Eventbrite.scala
@@ -9,7 +9,7 @@ import org.joda.time.format.ISODateTimeFormat
 import play.api.data.validation.ValidationError
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
-import utils.StringUtils.truncateToWordBoundary
+import utils.StringUtils._
 
 object Eventbrite {
 
@@ -122,13 +122,17 @@ object Eventbrite {
 
     val mainImageUrl: Option[String] = description.flatMap(desc => "<!--\\s*main-image: (.*?)\\s*-->".r.findFirstMatchIn(desc.html).map(_.group(1)) )
 
-    lazy val memUrl = Config.membershipUrl + controllers.routes.Event.details(id)
+    val slug = slugify(name.text) + "-" + id
+
+    lazy val memUrl = Config.membershipUrl + controllers.routes.Event.details(slug)
   }
 
   object EBEvent {
     val providerWhitelist = Seq(
       "birkbeck"
     )
+
+    def slugToId(slug: String): Option[String] = "-?(\\d+)$".r.findFirstMatchIn(slug).map(_.group(1))
   }
 
   trait EBCode extends EBObject {

--- a/frontend/app/utils/StringUtils.scala
+++ b/frontend/app/utils/StringUtils.scala
@@ -1,5 +1,7 @@
 package utils
 
+import java.text.Normalizer
+
 object StringUtils {
 
   def truncateToWordBoundary(text: String, length: Int) = {
@@ -8,6 +10,13 @@ object StringUtils {
       val index = text.lastIndexWhere(_.isSpaceChar, length + 1)
       text.take(if (index>= 0) index else length) + " …"
     }
+  }
+
+  def slugify(text: String): String = {
+    Normalizer.normalize(text, Normalizer.Form.NFKD)
+      .toLowerCase
+      .replaceAll("[^0-9a-z ]", "")
+      .trim.replaceAll(" +", "-")
   }
 
 }

--- a/frontend/app/views/fragments/event/item.scala.html
+++ b/frontend/app/views/fragments/event/item.scala.html
@@ -6,13 +6,13 @@
 <div class="event-item" itemscope itemtype="http://schema.org/Event">
     <div class="event-item__container">
         <div class="event-item__media">
-            <a href="/event/@event.id" itemprop="image" content="@event.socialImgUrl">
+            <a href="@routes.Event.details(event.slug)" itemprop="image" content="@event.socialImgUrl">
                 @fragments.event.image(event)
             </a>
         </div>
         <div class="event-item__content">
             <div class="event-item__meta">
-                <a href="/event/@event.id" itemprop="url" content="@event.memUrl">
+                <a href="@routes.Event.details(event.slug)" itemprop="url" content="@event.memUrl">
                     @fragments.event.itemMetaTitle(event)
                     <div class="event-item__time" itemprop="startDate" content="@event.start">@event.start.pretty</div>
                     <div class="event-item__location" itemprop="location" itemscope itemtype="http://schema.org/Place">

--- a/frontend/app/views/fragments/event/itemHero.scala.html
+++ b/frontend/app/views/fragments/event/itemHero.scala.html
@@ -8,7 +8,7 @@
     <div class="event-item__container">
         <div class="event-item__content">
             <div class="event-item__meta">
-                <a href="/event/@event.id" itemprop="url" content="@event.memUrl">
+                <a href="@routes.Event.details(event.slug)" itemprop="url" content="@event.memUrl">
                     @fragments.event.itemMetaTitle(event)
                     <div class="event-item__time" itemprop="startDate" content="@event.start">@event.start.pretty</div>
                     <div class="event-item__location" itemprop="location" itemscope itemtype="http://schema.org/Place">
@@ -27,7 +27,7 @@
             </div>
         </div>
         <div class="event-item__media">
-            <a href="/event/@event.id" itemprop="image" content="@event.socialImgUrl">
+            <a href="@routes.Event.details(event.slug)" itemprop="image" content="@event.socialImgUrl">
                 @fragments.event.image(event)
             </a>
         </div>

--- a/frontend/app/views/fragments/event/itemMinimal.scala.html
+++ b/frontend/app/views/fragments/event/itemMinimal.scala.html
@@ -3,13 +3,13 @@
 <div class="event-item @if(isCard){ event-item--card} else { event-item--minimal}" itemscope itemtype="http://schema.org/Event">
     <div class="event-item__container">
         <div class="event-item__media">
-            <a href="/event/@event.id" itemprop="image" content="@event.socialImgUrl">
+            <a href="@routes.Event.details(event.slug)" itemprop="image" content="@event.socialImgUrl">
                 @fragments.event.image(event)
             </a>
         </div>
         <div class="event-item__content">
             <div class="event-item__meta">
-                <a href="/event/@event.id" itemprop="url" content="@event.memUrl">
+                <a href="@routes.Event.details(event.slug)" itemprop="url" content="@event.memUrl">
                     @fragments.event.itemMetaTitle(event)
                 </a>
             </div>

--- a/frontend/test/model/EBEventTest.scala
+++ b/frontend/test/model/EBEventTest.scala
@@ -140,4 +140,14 @@ class EBEventTest extends PlaySpecification {
       event.providerOpt must beNone
     }
   }
+
+  "slugToId" should {
+    "return the id for a normal slug" in {
+      EBEvent.slugToId("this-is-a-slug-1234") must beSome("1234")
+    }
+
+    "return a standalone id not in a slug" in {
+      EBEvent.slugToId("1234") must beSome("1234")
+    }
+  }
 }

--- a/frontend/test/utils/StringUtilsTest.scala
+++ b/frontend/test/utils/StringUtilsTest.scala
@@ -1,7 +1,7 @@
 package utils
 
 import org.specs2.mutable.Specification
-import StringUtils.truncateToWordBoundary
+import StringUtils._
 
 class StringUtilsTest extends Specification {
 
@@ -18,6 +18,22 @@ class StringUtilsTest extends Specification {
       truncateToWordBoundary("this is a test string", 13) mustEqual "this is a test …"
       truncateToWordBoundary("this is a test string", 14) mustEqual "this is a test …"
       truncateToWordBoundary("this is a test string", 15) mustEqual "this is a test …"
+    }
+  }
+
+  "slugify" should {
+    "normalize accented characters" in {
+      slugify("ÀÁÂÃÄÅÇÈÉÊËÌÍÎÏÑÒÓÔÕÖÙÚÛÜÝß") mustEqual "aaaaaaceeeeiiiinooooouuuuy"
+      slugify("àáâãäåçèéêëìíîïñòóôõöùúûüýÿ") mustEqual "aaaaaaceeeeiiiinooooouuuuyy"
+    }
+
+    "remove symbols" in {
+      slugify("Something & something else") mustEqual "something-something-else"
+      slugify("****£20 event name /|/|/|/| @blah ^^^") mustEqual "20-event-name-blah"
+    }
+
+    "never have multiple hyphens consecutively" in {
+      slugify("blah  +  blah") mustEqual "blah-blah"
     }
   }
 


### PR DESCRIPTION
Add a nice slug to the event URLs so they look nicer and have better SEO.

e.g.
`/event/15327407689` becomes `/event/guardian-live-guantanamo-diary-15327407689`

URLs without slugs or with invalid slugs (e.g. after an event name change) redirect to the correct URL.