### PR TITLE
Event overview staff page

### DIFF
--- a/frontend/app/controllers/Staff.scala
+++ b/frontend/app/controllers/Staff.scala
@@ -1,0 +1,16 @@
+package controllers
+
+import play.api.mvc.Controller
+import services.GuardianLiveEventService
+
+import scala.concurrent.Future
+
+trait Staff extends Controller {
+  val guLiveEvents = GuardianLiveEventService
+
+  def eventOverview = PermanentStaffNonMemberAction.async { implicit request =>
+     Future.successful(Ok(views.html.staff.eventOverview(guLiveEvents.events)))
+  }
+}
+
+object Staff extends Staff

--- a/frontend/app/model/Eventbrite.scala
+++ b/frontend/app/model/Eventbrite.scala
@@ -119,6 +119,7 @@ object Eventbrite {
 
     val generalReleaseTicket = ticket_classes.find(!_.isHidden)
     val memberTickets = ticket_classes.filter { t => t.isHidden && t.name.toLowerCase.startsWith("guardian member")}
+    val hasMemberTicket = memberTickets.nonEmpty;
 
     val mainImageUrl: Option[String] = description.flatMap(desc => "<!--\\s*main-image: (.*?)\\s*-->".r.findFirstMatchIn(desc.html).map(_.group(1)) )
 

--- a/frontend/app/views/fragments/header.scala.html
+++ b/frontend/app/views/fragments/header.scala.html
@@ -2,7 +2,7 @@
 
 @import configuration.Config
 
-<header class="header hidden-print" role="banner">
+<header class="header hidden-print js-header" role="banner">
     <div class="js-warning">
         <p>Please enable JavaScript &ndash; we use it to enhance behaviour for Guardian Membership. <a href="http://www.enable-javascript.com/">Click here for instructions to do so in your browser</a>.</p>
     </div>

--- a/frontend/app/views/fragments/oauth/staffAccessError.scala.html
+++ b/frontend/app/views/fragments/oauth/staffAccessError.scala.html
@@ -1,0 +1,12 @@
+@(flashMessage: Option[model.FlashMessage])
+
+@import configuration.Config
+
+@for(flashMsg <- flashMessage) {
+    @fragments.notifications.flashMessage(flashMsg)
+}
+
+<p>
+    You need to be added to the right Google Group to view the events overview - contact
+    <a href="mailto:@Config.membershipDevEmail">@Config.membershipDevEmail</a> if you definitely need access.
+</p>

--- a/frontend/app/views/mainBasic.scala.html
+++ b/frontend/app/views/mainBasic.scala.html
@@ -1,0 +1,35 @@
+@(
+    title: String,
+    pageInfo: model.PageInfo = model.PageInfo.default
+)(content: Html)
+
+@import configuration.Config
+@import views.support.Asset
+
+<!DOCTYPE html>
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport"                     content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
+        <meta name="HandheldFriendly"             content="true"/>
+        <meta name="apple-touch-fullscreen"       content="yes" />
+        <meta name="apple-mobile-web-app-capable" content="yes">
+
+        <title>@(title + " | " + Config.siteTitle)</title>
+
+        @fragments.javaScriptFirstSteps(pageInfo)
+
+            <!--[if (gt IE 9) | (IEMobile)]><!-->
+        <link rel="stylesheet" media="all" href="@Asset.at("stylesheets/style.css")">
+            <!--<![endif]-->
+
+        @fragments.javaScriptLaterSteps()
+    </head>
+    <body>
+        <div>
+            @content
+        </div>
+        @fragments.javaScriptRequireJS()
+    </body>
+</html>

--- a/frontend/app/views/staff/eventOverview.scala.html
+++ b/frontend/app/views/staff/eventOverview.scala.html
@@ -1,0 +1,68 @@
+@(events: Seq[model.RichEvent.RichEvent])
+
+@import model.RichEvent._
+@import configuration.Config
+@import views.support.Event
+
+@eventTrait(title: String, hasTrait: Boolean, isLast: Boolean = false) = {
+    <li class="event-trait@if(isLast){ event-trait--last}">
+        <h4 class="event-trait_header">@title</h4>
+        <div class="event-trait_detail@if(hasTrait){ has-trait}"></div>
+    </li>
+}
+
+@mainBasic("Event Overview") {
+
+    <main role="main" class="page-content">
+
+        <section class="utils-page-header l-constrained">
+            <h1 class="page-headline">Events Overview</h1>
+            <p class="page-intro">A breakdown of Live events currently displayed on Membership</p>
+        </section>
+
+        <section class="l-constrained">
+
+            @for(event <- events) {
+                @defining(Event.eventDetail(event)) { eventDetail =>
+
+                    <div class="event-detail-container">
+
+                        <div class="event-detail u-cf">
+
+                            <div class="event-detail_image">
+                                <a href="/event/@event.id" target="_blank">
+                                @fragments.event.image(event)
+                                </a>
+                            </div>
+
+                            <div class="event-detail_info copy">
+                                <a href="/event/@event.id" target="_blank">@event.name.text</a>
+                                <div>
+                                    <a href="@(s"${Config.membershipUrl}/preview-event/${event.id}")"
+                                    target="_blank"
+                                    class="event-sub-detail">Preview</a>
+                                </div>
+                                <div>
+                                    <a href="@(s"https://dashboard.ophan.co.uk/info?url=${Config.membershipUrl}/event/${event.id}")"
+                                    target="_blank"
+                                    class="event-sub-detail">Ophan</a>
+                                </div>
+                            </div>
+                        </div>
+
+                        <ul class="event-trait-container u-unstyled">
+                            @eventTrait("Free", eventDetail.isFree)
+                            @eventTrait("Discounted", eventDetail.isDiscounted)
+                            @eventTrait("noTicketEvent", eventDetail.isNoTicketEvent)
+                            @eventTrait("Sold out", eventDetail.isSoldOut)
+                            @eventTrait("Member Ticket", eventDetail.hasMemberTicket, true)
+                        </ul>
+
+                    </div>
+                }
+            }
+
+        </section>
+
+    </main>
+}

--- a/frontend/app/views/support/Event.scala
+++ b/frontend/app/views/support/Event.scala
@@ -1,0 +1,23 @@
+package views.support
+
+object Event {
+
+  case class Detail(
+    isFree: Boolean,
+    isDiscounted: Boolean,
+    isNoTicketEvent: Boolean,
+    isSoldOut: Boolean,
+    hasMemberTicket: Boolean
+  )
+
+  def eventDetail(event: model.RichEvent.RichEvent) = {
+
+      val isFree = !event.isNoTicketEvent && event.generalReleaseTicket.exists(_.free)
+      val isDiscounted = !event.isNoTicketEvent && event.generalReleaseTicket.exists(!_.free && !event.hasMemberTicket)
+      val isNoTicketEvent = event.isNoTicketEvent
+      val isSoldOut = event.isSoldOut
+      val hasMemberTicket = event.hasMemberTicket
+
+      Detail(isFree, isDiscounted, isNoTicketEvent, isSoldOut, hasMemberTicket)
+  }
+}

--- a/frontend/assets/javascripts/src/modules/Header.js
+++ b/frontend/assets/javascripts/src/modules/Header.js
@@ -7,6 +7,7 @@ define([
 
     //TODO-ben refactor this file
 
+    var HEADER_SELECTOR = '.js-header';
     var config = {
         classes: {
             DOCUMENT_ELEMENT: 'html',
@@ -33,11 +34,13 @@ define([
     function Header() {}
 
     Header.prototype.init = function() {
-        this.cacheDomElements();
-        this.appendLocationDetailToIdentityReturnUrl();
-        this.populateUserDetails();
-        this.showMembersArea();
-        this.addListeners();
+        if (document.querySelector(HEADER_SELECTOR)) {
+            this.cacheDomElements();
+            this.appendLocationDetailToIdentityReturnUrl();
+            this.populateUserDetails();
+            this.showMembersArea();
+            this.addListeners();
+        }
     };
 
     Header.prototype.user = userUtil.getUserFromCookie();

--- a/frontend/assets/stylesheets/components/_util-page.scss
+++ b/frontend/assets/stylesheets/components/_util-page.scss
@@ -1,0 +1,72 @@
+.utils-page-header {
+    padding: rem(10px);
+}
+
+.event-detail-container {
+    margin-bottom: rem(40px);
+    background-color: $c-neutral8;
+    padding: rem(20px);
+    @include border-radius(4px);
+}
+
+.event-detail {
+    margin-bottom: rem(10px);
+}
+
+.event-detail_image {
+
+    @include mq(mobileLandscape) {
+        width: 40%;
+        padding-right: rem(10px);
+        float: left;
+    }
+
+    @include mq(tablet) {
+        width: 30%;
+    }
+}
+
+.event-sub-detail {
+    color: $c-neutral2;
+    @include fs-data(2);
+}
+
+.event-trait-container {
+    display: table;
+    width: 100%;
+}
+
+.event-trait {
+    margin-bottom: rem(10px);
+
+    @include mq(tablet) {
+        display: table-cell;
+        width: 20%;
+        padding-right: rem(4px);
+        margin-bottom: 0;
+    }
+}
+
+.event-trait--last {
+    padding-right: 0;
+}
+
+.event-trait_header {
+    color: $c-neutral1;
+    font-weight: normal;
+    @include fs-bodyCopy(1);
+
+    @include mq(tablet) {
+        text-align: center;
+    }
+}
+
+.event-trait_detail {
+    @include border-radius(4px);
+    min-height: rem(20px);
+    background-color: #e31f26;
+}
+
+.has-trait {
+    background-color: #aad801;
+}

--- a/frontend/assets/stylesheets/style.scss
+++ b/frontend/assets/stylesheets/style.scss
@@ -99,6 +99,7 @@
 @import 'components/features';
 @import 'components/messages';
 @import 'components/warnings';
+@import 'components/util-page';
 
 // Dev modules:
 // - Pattern library

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -39,6 +39,9 @@ GET            /staff/login                       controllers.OAuth.login
 GET            /staff/loginAction                 controllers.OAuth.loginAction
 GET            /oauth2callback                    controllers.OAuth.oauth2Callback
 
+# Staff event page to show discounted events
+GET            /staff/event-overview              controllers.Staff.eventOverview
+
 GET            /choose-tier                       controllers.Joining.tierChooser()
 
 # Subscription


### PR DESCRIPTION
This is a page that gives easy to check information on all live events on membership and can be found ``/staff/event-overview``

- behind staff oauth,
- shows live events and displays if they are 
  - free, 
  - discounted, 
  - have the &lt;!-- noTicketEvent --&gt; comment, 
  - are sold out, 
  - contain a "Guardian Member" ticket

It also shows the:
  - current main image,
  - title of the event and links to,
  - ophan,
  - event preview

A number of things worth mentioning:
- I have created a mainBasic.scala.html file as we had a lot of markup in the main.scala.html that is not needed here. 
- This mainBasic.scala.html brings in our CSS and JS. Not a lot of this is being used, currently it is just the Imager work and some styles so potentially a utils stylesheet and js file could be made or not as this is for staff only.

# Desktop
![event overview the guardian membership](https://cloud.githubusercontent.com/assets/2305016/5805140/5538089e-a004-11e4-96ca-83c944e2fb5c.png)

# Mobile
![event overview the guardian membership 1](https://cloud.githubusercontent.com/assets/2305016/5805174/86fdb518-a004-11e4-9378-ce487cbe7ef0.png)




