### PR TITLE
wrapped the price in the header with the hasMemberTicket conditional

### DIFF
--- a/frontend/app/views/fragments/event/ticketDetails.scala.html
+++ b/frontend/app/views/fragments/event/ticketDetails.scala.html
@@ -9,19 +9,29 @@
                 </div>
             } else {
                 @for(pricing <- ticket.cost) {
-                    <div class="js-event-price">
+
+                    @if(event.hasMemberTicket) {
+                        <div class="js-event-price">
+                            <div class="event-ticket__price">
+                                <span class="event-ticket__price-amount js-event-price-value"
+                                      data-discount-text="@pricing.discountPrice">@pricing.formattedPrice</span>
+                            </div>
+                            <div class="event-ticket__trail">
+                                <span class="event-ticket__trail-tag js-event-price-discount"
+                                      data-discount-text="Full price @pricing.formattedPrice">
+                                    Partners/Patrons @pricing.discountPrice
+                                </span>
+                                <span class="event-ticket__trail-saving js-event-price-saving"
+                                      data-discount-text="(you save @pricing.savingPrice)">
+                                    (save @pricing.savingPrice)
+                                </span>
+                            </div>
+                        </div>
+                    } else {
                         <div class="event-ticket__price">
-                            <span class="event-ticket__price-amount js-event-price-value" data-discount-text="@pricing.discountPrice">@pricing.formattedPrice</span>
+                            <span class="event-ticket__price-amount">@pricing.formattedPrice</span>
                         </div>
-                        <div class="event-ticket__trail">
-                            <span class="event-ticket__trail-tag js-event-price-discount" data-discount-text="Full price @pricing.formattedPrice">
-                                Partners/Patrons @pricing.discountPrice
-                            </span>
-                            <span class="event-ticket__trail-saving js-event-price-saving" data-discount-text="(you save @pricing.savingPrice)">
-                                (save @pricing.savingPrice)
-                            </span>
-                        </div>
-                    </div>
+                    }
                 }
             }
         </div>


### PR DESCRIPTION
The price in the header also needs to not be discounted when an event does not have a "Guardian Member" ticket. Connected with [this](https://github.com/guardian/membership-frontend/pull/91) pull request

## No Discount
![screen shot 2015-01-20 at 16 29 10](https://cloud.githubusercontent.com/assets/2305016/5821104/8f637cca-a0c1-11e4-9bcb-6ceb4813592b.png)

## With Discount
![screen shot 2015-01-20 at 16 29 17](https://cloud.githubusercontent.com/assets/2305016/5821106/95581550-a0c1-11e4-8af2-0e71bedaf196.png)