### PR TITLE
use secure image for social url

### DIFF
--- a/frontend/app/model/RichEvent.scala
+++ b/frontend/app/model/RichEvent.scala
@@ -75,7 +75,9 @@ object RichEvent {
 
     val imageMetadata = image.map(_.metadata)
 
-    val socialImgUrl = image.flatMap(_.assets.find(_.dimensions.width == widths.max)).fold(fallbackImage)(_.file)
+    val socialImgUrl = image.flatMap(_.assets.find(_.dimensions.width == widths.max)).fold(fallbackImage){ asset =>
+      asset.secureUrl.getOrElse(asset.file)
+    }
 
     val tags = Nil
 

--- a/frontend/test/model/GuLiveEventTest.scala
+++ b/frontend/test/model/GuLiveEventTest.scala
@@ -23,7 +23,7 @@ class GuLiveEventTest extends PlaySpecification with Mockito {
       guEvent.imageMetadata.flatMap(_.description) mustEqual Some("It's Chris!")
       guEvent.imageMetadata.map(_.photographer) mustEqual Some("Joe Bloggs/Guardian Images")
       guEvent.availableWidths mustEqual "1000,500"
-      guEvent.socialImgUrl mustEqual "//some-media-thing/aede0da05506d0d8cb993558b7eb9ad1d2d3e675/294_26_1584_950/1000.jpg"
+      guEvent.socialImgUrl mustEqual "https://some-media-thing/aede0da05506d0d8cb993558b7eb9ad1d2d3e675/294_26_1584_950/1000.jpg"
     }
 
     "use file url, metadata, socialUrl for image when no secure url is present" in {
@@ -35,7 +35,7 @@ class GuLiveEventTest extends PlaySpecification with Mockito {
       guEvent.imageMetadata.map(_.photographer) mustEqual Some("Joe Bloggs/Guardian Images")
 
       guEvent.availableWidths mustEqual "1000,500,140"
-      guEvent.socialImgUrl mustEqual "//some-media-thing/aede0da05506d0d8cb993558b7eb9ad1d2d3e675/0_130_1703_1022/1000.jpg"
+      guEvent.socialImgUrl mustEqual "http://some-media-thing/aede0da05506d0d8cb993558b7eb9ad1d2d3e675/0_130_1703_1022/1000.jpg"
     }
 
     "use fallback image when no image is found from the Grid" in {

--- a/frontend/test/model/GuLiveEventTest.scala
+++ b/frontend/test/model/GuLiveEventTest.scala
@@ -23,7 +23,7 @@ class GuLiveEventTest extends PlaySpecification with Mockito {
       guEvent.imageMetadata.flatMap(_.description) mustEqual Some("It's Chris!")
       guEvent.imageMetadata.map(_.photographer) mustEqual Some("Joe Bloggs/Guardian Images")
       guEvent.availableWidths mustEqual "1000,500"
-      guEvent.socialImgUrl mustEqual "http://some-media-thing/aede0da05506d0d8cb993558b7eb9ad1d2d3e675/294_26_1584_950/1000.jpg"
+      guEvent.socialImgUrl mustEqual "//some-media-thing/aede0da05506d0d8cb993558b7eb9ad1d2d3e675/294_26_1584_950/1000.jpg"
     }
 
     "use file url, metadata, socialUrl for image when no secure url is present" in {
@@ -35,7 +35,7 @@ class GuLiveEventTest extends PlaySpecification with Mockito {
       guEvent.imageMetadata.map(_.photographer) mustEqual Some("Joe Bloggs/Guardian Images")
 
       guEvent.availableWidths mustEqual "1000,500,140"
-      guEvent.socialImgUrl mustEqual "http://some-media-thing/aede0da05506d0d8cb993558b7eb9ad1d2d3e675/0_130_1703_1022/1000.jpg"
+      guEvent.socialImgUrl mustEqual "//some-media-thing/aede0da05506d0d8cb993558b7eb9ad1d2d3e675/0_130_1703_1022/1000.jpg"
     }
 
     "use fallback image when no image is found from the Grid" in {


### PR DESCRIPTION
I noticed that the social image url is not https as these are used directly on the [event overview page](https://github.com/guardian/membership-frontend/pull/100). 
- Use secure image
- Update to tests