### PR TITLE
Fix layout issues in Safari 6

### DIFF
--- a/frontend/assets/stylesheets/base/_base.scss
+++ b/frontend/assets/stylesheets/base/_base.scss
@@ -33,6 +33,7 @@ html {
     // This is used as a baseline for rem (root ems) values
     // Calc needed for IE11 to do the math properly
     // See http://bit.ly/1g4X0bX — thanks @7studio and @dawitti
+    font-size: -webkit-calc(1em * .625);
     font-size: calc(1em * .625);
 }
 

--- a/frontend/assets/stylesheets/layout/_layout.scss
+++ b/frontend/assets/stylesheets/layout/_layout.scss
@@ -105,6 +105,7 @@ body {
          */
         top: rem($side-margins-top-magic-number);
         height: 100%;
+        height: -webkit-calc(100% - #{$side-margins-top-magic-number});
         height: calc(100% - #{$side-margins-top-magic-number});
         width: 0;
 

--- a/frontend/assets/stylesheets/mixins/_mixins-layout.scss
+++ b/frontend/assets/stylesheets/mixins/_mixins-layout.scss
@@ -60,10 +60,12 @@ $gs-max-columns: 16;
     $offset: ($gs-gutter * 2);
     @include mq(tablet) {
         $width: map-get($max-widths, max-tablet);
+        #{$property}: -webkit-calc((100% - #{rem($width + $offset)}) / 2);
         #{$property}: calc((100% - #{rem($width + $offset)}) / 2);
     }
     @include mq(mem-full) {
         $width: map-get($max-widths, max-desktop);
+        #{$property}: -webkit-calc((100% - #{rem($width + $offset)}) / 2);
         #{$property}: calc((100% - #{rem($width + $offset)}) / 2);
     }
 }


### PR DESCRIPTION
Safari before 6.1 needs [webkit prefix for calc ](http://caniuse.com/#feat=calc)

**Before**
![safari-before](https://cloud.githubusercontent.com/assets/123386/5854913/8da28bbe-a22a-11e4-9b62-0a4fcca23119.png)

**After**
![safari-after](https://cloud.githubusercontent.com/assets/123386/5854915/92216d72-a22a-11e4-9972-6b1dc32a0655.png)

(Note web-fonts are not present in the after screenshot because this was pointing to my dev version on the internal network which doesn't have permission)

If we want to support Safari 5 as well we should look into not relying on `calc` for critical layout styles (mostly just using px for the `html` reset and refactoring the header layout a bit).