### PR TITLE
Update to use the latest version of the membership-common library

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,16 +8,17 @@ object Dependencies {
   val identityCookie = "com.gu.identity" %% "identity-cookie" % "3.44"
   val identityTestUsers = "com.gu" %% "identity-test-users" % "0.4"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.4"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.47"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.48"
   val playGoogleAuth = "com.gu" %% "play-googleauth" % "0.1.10"
   val contentAPI = "com.gu" %% "content-api-client" % "3.5"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache
   val playFilters = PlayImport.filters
+  val awsSimpleEmail = "com.amazonaws" % "aws-java-sdk-ses" % "1.9.16"
 
   //projects
 
   val frontendDependencies = Seq(identityCookie, playGoogleAuth, identityTestUsers, scalaUri, membershipCommon,
-    contentAPI, playWS, playCache, playFilters,sentryRavenLogback)
+    contentAPI, playWS, playCache, playFilters,sentryRavenLogback, awsSimpleEmail)
 
 }


### PR DESCRIPTION
...which doesn't include the whole AWS sdk anymore, so we need to explicitly include awsSimpleEmail (the overall deployable artifact size should reduce).