### PR TITLE
more event overview events on a page

### DIFF
--- a/frontend/assets/stylesheets/tools/_tools-page.scss
+++ b/frontend/assets/stylesheets/tools/_tools-page.scss
@@ -10,28 +10,56 @@
 
     @include mq(mobileLandscape) {
         width: 100% + $gutter-width-fluid;
-        margin-left: -$gutter-width-fluid;
+        margin-left: -$gutter-width-fluid *.75;
     }
 
     .event-item {
 
         @include mq(mobileLandscape) {
             float: left;
-            margin-left: $gutter-width-fluid / 2;
-            padding-left: $gutter-width-fluid / 2;
+            margin-left: $gutter-width-fluid / 4;
+            padding-left: $gutter-width-fluid / 4;
             margin-bottom: rem($gs-baseline);
-            width: 50% - ($gutter-width-fluid / 2);
-            &:nth-of-type(2n+1) {
-                clear: left;
-            }
+            width: 50% - ($gutter-width-fluid / 4);
+
+            &:nth-of-type(2n+1) { clear: left; }
         }
 
         @include mq(tablet) {
-            width: 25% - ($gutter-width-fluid / 2);
-            &:nth-of-type(2n+1) {
-                clear: none;
+            width: 33.3% - ($gutter-width-fluid / 4);
+
+            &:nth-of-type(2n+1) { clear: none; }
+            &:nth-of-type(3n+1) {
+                clear: left;
+                border-left: 0;
             }
+        }
+
+        @include mq(desktop) {
+            width: 25% - ($gutter-width-fluid / 4);
+
+            &:nth-of-type(3n+1) { clear: none; }
             &:nth-of-type(4n+1) {
+                clear: left;
+                border-left: 0;
+            }
+        }
+
+        @include mq(mem-full) {
+            width: 20% - ($gutter-width-fluid / 4);
+
+            &:nth-of-type(4n+1) { clear: none; }
+            &:nth-of-type(5n+1) {
+                clear: left;
+                border-left: 0;
+            }
+        }
+
+        @include mq(wide) {
+            width: 16.6% - ($gutter-width-fluid / 4);
+
+            &:nth-of-type(5n+1) { clear: none; }
+            &:nth-of-type(6n+1) {
                 clear: left;
                 border-left: 0;
             }


### PR DESCRIPTION
- Improvements to the amount of overview events displayed on the page

## Wide query
![event overview the guardian membership 2](https://cloud.githubusercontent.com/assets/2305016/5861101/3b9ccfa8-a25e-11e4-94ee-b0637112bf12.png)


## Desktop query
![event overview the guardian membership 3](https://cloud.githubusercontent.com/assets/2305016/5861095/3766acec-a25e-11e4-8da8-67f903b72bf5.png)


## Mobile query
![event overview the guardian membership 4](https://cloud.githubusercontent.com/assets/2305016/5861123/544acadc-a25e-11e4-8793-a6de7f2bc7d9.png)

