### PR TITLE
Fix issue with SVG icons occasionally not showing in IE 9

### DIFF
--- a/frontend/app/views/fragments/javaScriptFirstSteps.scala.html
+++ b/frontend/app/views/fragments/javaScriptFirstSteps.scala.html
@@ -93,13 +93,10 @@
          * Insert SVG sprite into document
          */
         function inlineSvg(data) {
-            var div = document.createElement('div');
-            div.className = 'icon-sprite';
-            div.innerHTML = data;
-            /* We need to wait for DOMContentLoaded before inserting SVG */
-            document.addEventListener('DOMContentLoaded', function(){
-                document.body.insertBefore(div, document.body.childNodes[0]);
-            },false);
+            var el = document.createElement('div');
+            el.innerHTML = data;
+            var ref = document.getElementsByTagName('script')[0];
+            ref.parentNode.insertBefore(el, ref);
         }
 
         function loadSvgIcons() {

--- a/frontend/assets/stylesheets/components/_icons.scss
+++ b/frontend/assets/stylesheets/components/_icons.scss
@@ -61,10 +61,6 @@
 /* Inline Icons
    ========================================================================== */
 
-.icon-sprite {
-   display: none;
-}
-
 .icon-inline {
    width: 16px;
    height: 16px;


### PR DESCRIPTION
As part of this PR https://github.com/guardian/membership-frontend/pull/101 , @jamesoram spotted an issue where inline SVG icons would occasionally not show up. We managed to narrow it down to an issue with `DOMContentLoaded` not always firing (and checking `readyState` first didn't reliably resolve the problem).

Thankfully Paul Irish documented a more reliable approach (used in Modernizr) which in testing with James seems to be working for us and avoids the need to wait for a ready event: http://www.paulirish.com/2011/surefire-dom-element-insertion/ 

![screen shot 2015-01-22 at 17 31 23](https://cloud.githubusercontent.com/assets/123386/5860881/85357400-a25c-11e4-8b79-9bec1a99cfeb.png)
