### PR TITLE
Remove dead join/choose-tier IE9 styles

### DIFF
--- a/frontend/assets/stylesheets/_ie9.scss
+++ b/frontend/assets/stylesheets/_ie9.scss
@@ -25,38 +25,11 @@
     }
 }
 
-// Join page - fix height of tier boxes
-.join,
-.change-tier {
-    .package {
-        @include mq(desktop) {
-            height: rem(1400px);
-            margin-bottom: rem($gs-gutter * 3);
-        }
-
-        @include mq(mem-full) {
-            height: rem(1350px);
-            margin-bottom: rem($gs-gutter * 3);
-        }
-    }
-}
-
 // Homepage & Patron page - fix height of tier boxes
 .home-page,
 .patron-page {
     .package {
         height: auto;
-    }
-}
-
-// general page - fix height of tier boxes
-.package {
-    @include mq(desktop) {
-        margin-bottom: rem($gs-gutter * 3);
-    }
-
-    @include mq(mem-full) {
-        margin-bottom: rem($gs-gutter * 3);
     }
 }
 


### PR DESCRIPTION
Found some dead styles in `_ie9.scss` which caused this interesting bug:

**Before**
![screen shot 2015-01-22 at 17 38 52](https://cloud.githubusercontent.com/assets/123386/5861062/fa4664b0-a25d-11e4-83cb-13acf96a90c9.png)

(It keeps going…)

**After**
![screen shot 2015-01-22 at 17 39 31](https://cloud.githubusercontent.com/assets/123386/5861067/06805eac-a25e-11e4-9146-72783461ec35.png)
