### PR TITLE
IE9 cleanup and patrons pricing update

### DIFF
--- a/frontend/app/views/info/about.scala.html
+++ b/frontend/app/views/info/about.scala.html
@@ -111,10 +111,10 @@
         </div>
     </div>
 
-    <div class="page-slice">
-        <div id="whats-included" class="page-slice__inner">
+    <div class="page-slice l-side-margins">
+        <div id="whats-included" class="l-constrained">
             <h2 class="page-slice__headline">What's included</h2>
-            <div class="page-slice-content">
+            <div class="page-slice__content">
                 @fragments.tier.packageFeature(Tier.Friend)
                 @fragments.tier.packageFeature(Tier.Partner)
                 @fragments.tier.packageFeature(Tier.Patron)

--- a/frontend/app/views/joiner/tier/patron.scala.html
+++ b/frontend/app/views/joiner/tier/patron.scala.html
@@ -92,12 +92,18 @@
 
     @* ===== Join Today ===== *@
 
-    <div class="home-slice home-slice--join-today">
-        <div class="home-slice__inner u-cf">
-            <h2 class="home-slice__headline">Not ready to become a Patron yet?<br />Join as a Friend or a Partner</h2>
-            <div class="join-today__join-boxes package-list package-list--flex-box package-list--bordered">
-                @fragments.tier.benefits(currentTier=None, tier=Tier.Friend, showBenefitDetails=false, mode="promo", showLearnMore=true)
-                @fragments.tier.benefits(currentTier=None, tier=Tier.Partner, showBenefitDetails=false, mode="promo", showLearnMore=true)
+    <div class="page-slice page-slice--split tone-tint">
+        <div class="page-slice__inner l-constrained">
+            <h2 class="page-slice__headline">Not ready to become a Patron yet? Join as a Friend or a Partner</h2>
+            <div class="page-slice__content">
+                <ul class="grid grid--bordered grid--2up-stacked">
+                    <li class="grid__item">
+                        @fragments.tier.packagePromo(Tier.Friend, isReversed=true)
+                    </li>
+                    <li class="grid__item">
+                        @fragments.tier.packagePromo(Tier.Partner, isReversed=true)
+                    </li>
+                </ul>
             </div>
         </div>
     </div>

--- a/frontend/assets/stylesheets/_ie9.scss
+++ b/frontend/assets/stylesheets/_ie9.scss
@@ -1,67 +1,6 @@
-.nav--global--header {
-    overflow-x: hidden!important;
-    @include side-margins-calc('padding-left');
-    @include side-margins-calc('padding-right');
-}
-
-.icon-wrapper {
-    display: inline;
-}
-
-.event-content {
-    padding-bottom: rem(70px)!important;
-}
-
-
-/* Tier ie9 fix
-   ========================================================================== */
-
 // Patron page - fix height of tier boxes
-.patron-page {
-    .package__inner {
-        @include mq(desktop) {
-            height: rem(125px);
-        }
-    }
-}
-
-// Homepage & Patron page - fix height of tier boxes
-.home-page,
 .patron-page {
     .package {
         height: auto;
-    }
-}
-
-.content__footer {
-    clear: both;
-}
-
-/* Footer ie9 fix
-   ========================================================================== */
-
-.colophon {
-    margin-bottom: rem($gs-gutter);
-    overflow: hidden;
-
-    @include mq(tablet) {
-        width: rem(gs-span(8));
-    }
-
-    @include mq(desktop) {
-        width: rem(gs-span(10));
-    }
-
-    li {
-        width: 50%;
-
-        @include mq(tablet) {
-            width: 33.333%;
-        }
-    }
-
-    .colophon__item {
-        float: left;
-        display: inline;
     }
 }

--- a/frontend/assets/stylesheets/_ie9.scss
+++ b/frontend/assets/stylesheets/_ie9.scss
@@ -1,6 +1,0 @@
-// Patron page - fix height of tier boxes
-.patron-page {
-    .package {
-        height: auto;
-    }
-}

--- a/frontend/assets/stylesheets/components/_content.scss
+++ b/frontend/assets/stylesheets/components/_content.scss
@@ -55,4 +55,5 @@
     color: #1a4683;
     text-align: center;
     @include fs-bodyCopy(3);
+    clear: both;
 }

--- a/frontend/assets/stylesheets/components/_grid.scss
+++ b/frontend/assets/stylesheets/components/_grid.scss
@@ -64,7 +64,26 @@
 .grid--2up {
     .grid__item {
         @include mq(tablet) {
-            &:nth-of-type(2n+1) { border-left: none; }
+            &:nth-of-type(2n+1) { clear: left; border-left: none; }
+        }
+    }
+}
+
+.grid--2up-stacked {
+    @include mq(desktop) {
+        width: 100% + $gutter-width-fluid;
+        margin-left: -$gutter-width-fluid;
+    }
+    .grid__item {
+        @include mq(desktop) {
+            float: left;
+            border-style: solid;
+            border-width: 0 0 0 1px;
+            margin-left: $gutter-width-fluid / 2;
+            padding-left: $gutter-width-fluid / 2;
+            margin-bottom: rem($gs-baseline);
+            width: 50% - ($gutter-width-fluid / 2);
+            &:nth-of-type(2n+1) { clear: left; border-left: none; }
         }
     }
 }

--- a/frontend/assets/stylesheets/components/_packages.scss
+++ b/frontend/assets/stylesheets/components/_packages.scss
@@ -72,9 +72,6 @@
             .no-flexbox & {
                 width: 31%;
                 float: left;
-                .patron-page & {
-                    width: 45%;
-                }
             }
             // override button widths for flexbox
             .action {

--- a/frontend/assets/stylesheets/components/_page.scss
+++ b/frontend/assets/stylesheets/components/_page.scss
@@ -17,44 +17,40 @@ $_page-offset: rem(gs-span(2) + $gs-gutter);
     background-color: $white;
     padding-bottom: rem($gs-gutter * 3);
 }
-.page-slice__inner {
-    width: 100%;
+    .page-slice__headline {
+        @include fs-headline(4);
+        padding: rem($gs-gutter / 2);
+        border-top: 2px solid $c-neutral6;
+        @include mq(tablet) {
+            @include fs-headline(7);
+            padding: rem($gs-baseline) rem($gs-gutter);
+        }
+    }
+    .page-slice__content {
+        padding: rem($gs-gutter / 2);
 
+        @include mq(tablet) {
+            padding: rem($gs-gutter);
+        }
+        @include mq(mem-full) {
+            padding-left: rem($gs-gutter * 9);
+        }
+    }
+
+.page-slice--split {
+    padding-bottom: 0;
     @include mq(desktop) {
-        width: rem(gs-span(12) + $gs-gutter * 2);
-        margin: 0 auto;
-    }
-
-    @include mq(mem-full) {
-        width: rem(gs-span(14) + $gs-gutter * 2);
-    }
-}
-.page-slice__headline {
-    @include fs-headline(6);
-    padding: rem($gs-gutter/2);
-    border-top: 2px solid $c-neutral6;
-    @include mq(tablet) {
-        @include fs-headline(7);
-        padding: rem($gs-baseline) rem($gs-gutter);
+        .page-slice__headline {
+            width: 30%;
+            float: left;
+        }
+        .page-slice__content {
+            float: right;
+            width: 58%;
+            padding: rem($gs-gutter);
+        }
     }
 }
-
-/* Page Slice Content
-   - Inner content for a page slice (pushed to right)
-   ========================================================================== */
-
-.page-slice-content {
-
-    padding: rem($gs-gutter / 2);
-
-    @include mq(tablet) {
-        padding: rem($gs-gutter);
-    }
-    @include mq(mem-full) {
-        padding-left: rem($gs-gutter * 9);
-    }
-}
-
 
 /* ==========================================================================
    Functional Page Layout Components

--- a/frontend/assets/stylesheets/components/_pricing.scss
+++ b/frontend/assets/stylesheets/components/_pricing.scss
@@ -7,7 +7,7 @@
 
 .price-info {
     position: relative;
-    max-width: rem(gs-span(4) - $gs-gutter);
+    max-width: rem(gs-span(4));
 
     @include mq(tablet) {
         display: table;

--- a/frontend/assets/stylesheets/components/nav/_nav.scss
+++ b/frontend/assets/stylesheets/components/nav/_nav.scss
@@ -41,6 +41,10 @@ $_global-nav-height: 36px;
     overflow-x: scroll;
     -webkit-overflow-scrolling: touch;
 
+    @include mq(desktop) {
+        overflow-x: hidden;
+    }
+
     @include fs-headline(2);
     font-weight: normal;
     -moz-osx-font-smoothing: auto;

--- a/frontend/assets/stylesheets/ie9.style.scss
+++ b/frontend/assets/stylesheets/ie9.style.scss
@@ -2,8 +2,4 @@
 
 $browser-supports-flexbox: false;
 
-// Import global styles
 @import 'style';
-
-// Import IE9 overrides
-@import '_ie9';

--- a/frontend/assets/stylesheets/layout/_footer.scss
+++ b/frontend/assets/stylesheets/layout/_footer.scss
@@ -64,20 +64,15 @@
    ========================================================================== */
 
 .colophon {
+    @include clearfix();
     @include fs-bodyHeading(1);
     list-style: none;
     margin: 0;
     padding-top: rem($gs-baseline * 2);
     padding-bottom: rem($gs-baseline / 2);
 
-    @include columns(2);
-
-    @include mq(tablet) {
-        @include columns(3);
-    }
-
-    @include mq(wide) {
-        @include columns(4);
+    @include mq(desktop) {
+        max-width: 75%;
     }
 
     a {
@@ -86,7 +81,14 @@
     }
 }
 .colophon__item {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
+    float: left;
+    display: block;
+    width: 50%;
+
+    @include mq(tablet) {
+        width: 33.333%;
+    }
 }
 
 .really-serious-copyright {

--- a/frontend/assets/stylesheets/layout/_homeslice.scss
+++ b/frontend/assets/stylesheets/layout/_homeslice.scss
@@ -457,8 +457,6 @@
 
 .join-today__join-box {
     position: relative;
-    background-color: $c-neutral8;
-    border: 1px solid $c-neutral5;
     margin-bottom: rem($gs-gutter);
     padding: rem(68px) rem($gs-gutter / 2) rem($gs-gutter / 2);
 


### PR DESCRIPTION
Did some cleanup of the IE9 specific styles which means we can now remove the IE9 override stylesheet!

- **Updated patrons page to use new style package promos (Agreed with Ben W). Removes need for remaining IE9 overrides**
- Cleanup of footer to use floats throughout (no more CSS columns)
- Bugfix to the main navigation to remove overflow IE9 fix

![screen shot 2015-01-23 at 13 52 00](https://cloud.githubusercontent.com/assets/123386/5875703/fa5df184-a307-11e4-97be-c01da8e1ad1b.png)

![screen shot 2015-01-23 at 12 46 08](https://cloud.githubusercontent.com/assets/123386/5875707/020dac30-a308-11e4-87c0-c4eacd9596bb.png)