### PR TITLE
Enable multiple ticket classes for events

### DIFF
--- a/frontend/app/services/EventbriteService.scala
+++ b/frontend/app/services/EventbriteService.scala
@@ -101,7 +101,7 @@ trait EventbriteService extends utils.WebServiceHelper[EBObject, EBError] {
         post[EBAccessCode](uri, Map(
           "access_code.code" -> Seq(code),
           "access_code.quantity_available" -> Seq(maxDiscountQuantityAvailable.toString),
-          "access_code.ticket_ids" -> Seq(ticketClasses.head.id) // TODO: support multiple ticket classes when Eventbrite fix their API
+          "access_code.ticket_ids" -> Seq(ticketClasses.map(_.id).mkString(","))
         ))
       }(Future.successful)
     } yield discount


### PR DESCRIPTION
Eventbrite have fixed their API, so we can now associate multiple ticket classes with an access code!

![image](https://cloud.githubusercontent.com/assets/2084823/5877417/5bf5b6f2-a317-11e4-92d4-89b50e05cf66.png)

Note that the access code still only has a maximum usage of 2 so a user can't buy 2 of each member ticket class