### PR TITLE
Use MemberId over String

### DIFF
--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -158,7 +158,7 @@ trait Joiner extends Controller {
     }
 
     for {
-      subscription <- request.touchpointBackend.subscriptionService.getCurrentSubscriptionDetails(request.member.salesforceAccountId)
+      subscription <- request.touchpointBackend.subscriptionService.getCurrentSubscriptionDetails(request.member)
       customerOpt <- futureCustomerOpt
       eventDetailsOpt <- futureEventDetailsOpt
     } yield Ok(views.html.joiner.thankyou(request.member, subscription, customerOpt.map(_.card), eventDetailsOpt, upgrade))

--- a/frontend/app/controllers/TierController.scala
+++ b/frontend/app/controllers/TierController.scala
@@ -32,7 +32,7 @@ trait DowngradeTier {
   def downgradeToFriendSummary() = PaidMemberAction.async { implicit request =>
     val subscriptionService = request.touchpointBackend.subscriptionService
     for {
-      subscriptionStatus <- subscriptionService.getSubscriptionStatus(request.member.salesforceAccountId)
+      subscriptionStatus <- subscriptionService.getSubscriptionStatus(request.member)
       currentSubscription <- subscriptionService.getSubscriptionDetails(subscriptionStatus.current)
       futureSubscription <- subscriptionService.getSubscriptionDetails(subscriptionStatus.future.get)
     } yield Ok(views.html.tier.downgrade.summary(currentSubscription, futureSubscription))
@@ -94,7 +94,7 @@ trait CancelTier {
   def cancelTierSummary() = AuthenticatedAction.async { implicit request =>
     def subscriptionDetailsFor(memberOpt: Option[Member]) = {
       memberOpt.collect { case paidMember: PaidMember =>
-        request.touchpointBackend.subscriptionService.getCurrentSubscriptionDetails(paidMember.salesforceAccountId)
+        request.touchpointBackend.subscriptionService.getCurrentSubscriptionDetails(paidMember)
       }
     }
 

--- a/frontend/app/controllers/User.scala
+++ b/frontend/app/controllers/User.scala
@@ -34,7 +34,7 @@ trait User extends Controller {
 
     val futurePaymentDetails = for {
       cardDetails <- futureCardDetails
-      subscriptionStatus <- request.touchpointBackend.subscriptionService.getSubscriptionStatus(request.member.salesforceAccountId)
+      subscriptionStatus <- request.touchpointBackend.subscriptionService.getSubscriptionStatus(request.member)
       subscriptionDetails <- request.touchpointBackend.subscriptionService.getSubscriptionDetails(subscriptionStatus.current)
     } yield Json.obj(
       "optIn" -> !subscriptionStatus.cancelled,

--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -74,7 +74,7 @@ trait MemberService extends LazyLogging {
     )
   }.getOrElse(Json.obj())
 
-  def createMember(user: IdMinimalUser, formData: JoinForm, identityRequest: IdentityRequest): Future[String] = {
+  def createMember(user: IdMinimalUser, formData: JoinForm, identityRequest: IdentityRequest): Future[MemberId] = {
     val touchpointBackend = TouchpointBackend.forUser(user)
     val identityService = IdentityService(IdentityApi)
 
@@ -98,7 +98,7 @@ trait MemberService extends LazyLogging {
         identityService.updateUserFieldsBasedOnJoining(user, formData, identityRequest)
 
         touchpointBackend.memberRepository.metrics.putSignUp(formData.plan)
-        memberId.salesforceAccountId
+        memberId
       }
     }.andThen {
       case Success(memberAccount) => logger.debug(s"createMember() success user=${user.id} memberAccount=$memberAccount")
@@ -120,7 +120,7 @@ trait MemberService extends LazyLogging {
   }
 
   // TODO: this currently only handles free -> paid
-  def upgradeSubscription(member: FreeMember, user: IdMinimalUser, newTier: Tier.Tier, form: PaidMemberChangeForm, identityRequest: IdentityRequest): Future[String] = {
+  def upgradeSubscription(member: FreeMember, user: IdMinimalUser, newTier: Tier.Tier, form: PaidMemberChangeForm, identityRequest: IdentityRequest): Future[MemberId] = {
     val touchpointBackend = TouchpointBackend.forUser(user)
     val newPaidPlan = PaidTierPlan(newTier, form.payment.annual)
     for {
@@ -131,7 +131,7 @@ trait MemberService extends LazyLogging {
     } yield {
       IdentityService(IdentityApi).updateUserFieldsBasedOnUpgrade(user, form, identityRequest)
       touchpointBackend.memberRepository.metrics.putUpgrade(newTier)
-      memberId.salesforceAccountId
+      memberId
     }
   }
 }

--- a/frontend/app/services/TouchpointBackend.scala
+++ b/frontend/app/services/TouchpointBackend.scala
@@ -53,7 +53,7 @@ case class TouchpointBackend(
 
   def cancelSubscription(member: Member): Future[String] = {
     for {
-      subscription <- subscriptionService.cancelSubscription(member.salesforceAccountId, member.tier == Tier.Friend)
+      subscription <- subscriptionService.cancelSubscription(member, member.tier == Tier.Friend)
     } yield {
       memberRepository.metrics.putCancel(member.tier)
       ""
@@ -62,7 +62,7 @@ case class TouchpointBackend(
 
   def downgradeSubscription(member: Member, tierPlan: TierPlan): Future[String] = {
     for {
-      _ <- subscriptionService.downgradeSubscription(member.salesforceAccountId, FriendTierPlan)
+      _ <- subscriptionService.downgradeSubscription(member, FriendTierPlan)
     } yield {
       memberRepository.metrics.putDowngrade(tierPlan.tier)
       ""

--- a/frontend/app/services/zuora/ZuoraActions.scala
+++ b/frontend/app/services/zuora/ZuoraActions.scala
@@ -1,5 +1,7 @@
 package services.zuora
 
+import com.gu.membership.salesforce.MemberId
+
 import scala.xml.{Elem, Null}
 
 import org.joda.time.DateTime
@@ -88,8 +90,8 @@ case class Query(query: String) extends ZuoraAction[QueryResult] {
     </ns1:query>
 }
 
-case class Subscribe(sfAccountId: String, sfContactId: String, customerOpt: Option[Stripe.Customer],
-                     ratePlanId: String, name: NameForm, address: Address) extends ZuoraAction[SubscribeResult] {
+case class Subscribe(memberId: MemberId, customerOpt: Option[Stripe.Customer], ratePlanId: String, name: NameForm,
+                     address: Address) extends ZuoraAction[SubscribeResult] {
 
   val body = {
     val now = formatDateTime(DateTime.now)
@@ -111,11 +113,11 @@ case class Subscribe(sfAccountId: String, sfContactId: String, customerOpt: Opti
           <ns2:BcdSettingOption>AutoSet</ns2:BcdSettingOption>
           <ns2:BillCycleDay>0</ns2:BillCycleDay>
           <ns2:Currency>GBP</ns2:Currency>
-          <ns2:Name>{sfAccountId}</ns2:Name>
+          <ns2:Name>{memberId.salesforceAccountId}</ns2:Name>
           <ns2:PaymentTerm>Due Upon Receipt</ns2:PaymentTerm>
           <ns2:Batch>Batch1</ns2:Batch>
-          <ns2:CrmId>{sfAccountId}</ns2:CrmId>
-          <ns2:sfContactId__c>{sfContactId}</ns2:sfContactId__c>
+          <ns2:CrmId>{memberId.salesforceAccountId}</ns2:CrmId>
+          <ns2:sfContactId__c>{memberId.salesforceContactId}</ns2:sfContactId__c>
         </ns1:Account>
         {payment}
         <ns1:BillToContact xsi:type="ns2:Contact">

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val identityCookie = "com.gu.identity" %% "identity-cookie" % "3.44"
   val identityTestUsers = "com.gu" %% "identity-test-users" % "0.4"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.4"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.48"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.49"
   val playGoogleAuth = "com.gu" %% "play-googleauth" % "0.1.10"
   val contentAPI = "com.gu" %% "content-api-client" % "3.5"
   val playWS = PlayImport.ws


### PR DESCRIPTION
Use the type system to enforce that these methods need a member's Salesforce contact/account ID, rather than just letting them take arbitrary `String`s