### PR TITLE
Remove need for duplicate navigation markup

### DIFF
--- a/frontend/app/views/fragments/header.scala.html
+++ b/frontend/app/views/fragments/header.scala.html
@@ -75,28 +75,19 @@
                         </ul>
                     </nav>
                 </div>
-                <div class="mobile-menu mobile-only">
-                    <a href="#" role="menuitem" class="mobile-menu__button js-menu-icon" title="Menu">
-                        <span class="control__icon">
-                            <i></i>
-                            <i></i>
-                            <i></i>
-                        </span>
-                    </a>
-                </div>
-                <div class="nav-popup--sections nav-popup nav-popup--small is-hidden js-sections-nav-popup">
-                    <nav role="navigation" aria-label="@Config.siteTitle sections">
-                        <ul class="nav nav--columns nav--top-border-off u-cf js-sections-nav-popup-page-list">
-                            @fragments.nav()
-                        </ul>
-                    </nav>
-                </div>
             </div>
         </div>
-        <nav role="navigation" class="nav nav--global nav--global--header">
+        <button role="menuitem" class="mobile-menu mobile-only js-menu-icon" title="Menu">
+            <span class="control__icon">
+                <i></i>
+                <i></i>
+                <i></i>
+            </span>
+        </button>
+        <nav role="navigation" class="nav nav--global nav--global--header js-global-nav">
             <div class="nav__scroll">
                 <ul class="nav__list inline-list">
-                    @fragments.nav(inlineMode=true)
+                    @fragments.nav()
                 </ul>
             </div>
         </nav>

--- a/frontend/app/views/fragments/header.scala.html
+++ b/frontend/app/views/fragments/header.scala.html
@@ -12,7 +12,7 @@
                 <nav>
                     <ul class="inline-list u-cf" role="menubar">
                         <li class="menu-item">
-                            <a href="@Config.idWebAppSigninUrl("")" role="menuitem" class="no-underline icon-wrapper js-identity-icon control-container" title="Your account" id="qa-identity-control">
+                            <a href="@Config.idWebAppSigninUrl("")" role="menuitem" class="control-container no-underline js-identity-icon" title="Your account" id="qa-identity-control">
                                 <span class="control js-user-icon">
                                     <span class="control__icon">
                                         <i class="icon-user-black"></i>
@@ -44,7 +44,7 @@
 
             <div class="header__secondary header__logo">
                 <span itemscope itemtype="http://schema.org/Organization">
-                    <a href="/" itemprop="url" class="icon-wrapper" id="qa-header-logo">
+                    <a href="/" itemprop="url" class="header__logo__link" id="qa-header-logo">
                         <span class="u-h" itemprop="name">@Config.siteTitle</span>
                         <i class="icon-membership_beta_mobile mobile-only"></i>
                         <i class="icon-logo-beta hidden-mobile"></i>

--- a/frontend/app/views/fragments/header.scala.html
+++ b/frontend/app/views/fragments/header.scala.html
@@ -7,7 +7,7 @@
         <p>Please enable JavaScript &ndash; we use it to enhance behaviour for Guardian Membership. <a href="http://www.enable-javascript.com/">Click here for instructions to do so in your browser</a>.</p>
     </div>
     <div class="header__inner">
-        <div class="u-cf header__branding">
+        <div class="header__branding l-constrained">
             <div class="header__primary">
                 <nav>
                     <ul class="inline-list u-cf" role="menubar">
@@ -84,12 +84,6 @@
                 <i></i>
             </span>
         </button>
-        <nav role="navigation" class="nav nav--global nav--global--header js-global-nav">
-            <div class="nav__scroll">
-                <ul class="nav__list inline-list">
-                    @fragments.nav()
-                </ul>
-            </div>
-        </nav>
+        @fragments.nav()
     </div>
 </header>

--- a/frontend/app/views/fragments/nav.scala.html
+++ b/frontend/app/views/fragments/nav.scala.html
@@ -2,33 +2,39 @@
 
 @import configuration.Config
 
-<li class="nav__item nav__item--home">
-    <a href="/" class="nav__link">
-        @fragments.inlineIcon("home")
-        <span class="u-h">Home</span>
-    </a>
-</li>
-<li class="nav__item">
-    <a href="/events" class="nav__link" id="qa-nav-events">Events</a>
-</li>
-<li class="nav__item">
-    <a href="/masterclasses" class="nav__link" id="qa-nav-masterclasses">Masterclasses</a>
-</li>
-<li class="nav__item">
-    <a href="/about" class="nav__link" id="qa-nav-about">About membership</a>
-</li>
-<li class="nav__item">
-    <a href="/patrons" class="nav__link" id="qa-nav-patrons">Patrons</a>
-</li>
-<li class="nav__item">
-    <a href="/join" class="nav__link" id="qa-nav-pricing">Pricing</a>
-</li>
-<li class="nav__item">
-    <a href="/help" class="nav__link" id="qa-nav-help">Help</a>
-</li>
-<li class="nav__item">
-    <a href="/feedback" class="nav__link" id="qa-nav-feedback">Feedback</a>
-</li>
-<li class="nav__item nav__item--right">
-    <a href="@Config.guardianMembershipUrl" class="nav__link nav__link--last js-members-area is-hidden">Members' Area</a>
-</li>
+<nav role="navigation" class="nav nav--global nav--global--header js-global-nav">
+    <div class="nav__scroll l-constrained">
+        <ul class="nav__list inline-list">
+            <li class="nav__item nav__item--home">
+                <a href="/" class="nav__link">
+                    @fragments.inlineIcon("home")
+                    <span class="u-h">Home</span>
+                </a>
+            </li>
+            <li class="nav__item">
+                <a href="/events" class="nav__link" id="qa-nav-events">Events</a>
+            </li>
+            <li class="nav__item">
+                <a href="/masterclasses" class="nav__link" id="qa-nav-masterclasses">Masterclasses</a>
+            </li>
+            <li class="nav__item">
+                <a href="/about" class="nav__link" id="qa-nav-about">About membership</a>
+            </li>
+            <li class="nav__item">
+                <a href="/patrons" class="nav__link" id="qa-nav-patrons">Patrons</a>
+            </li>
+            <li class="nav__item">
+                <a href="/join" class="nav__link" id="qa-nav-pricing">Pricing</a>
+            </li>
+            <li class="nav__item">
+                <a href="/help" class="nav__link" id="qa-nav-help">Help</a>
+            </li>
+            <li class="nav__item">
+                <a href="/feedback" class="nav__link" id="qa-nav-feedback">Feedback</a>
+            </li>
+            <li class="nav__item nav__item--right">
+                <a href="@Config.guardianMembershipUrl" class="nav__link nav__link--last js-members-area is-hidden">Members' Area</a>
+            </li>
+        </ul>
+    </div>
+</nav>

--- a/frontend/app/views/fragments/nav.scala.html
+++ b/frontend/app/views/fragments/nav.scala.html
@@ -1,40 +1,34 @@
-@(inlineMode: Boolean = false)
+@()
 
 @import configuration.Config
 
-@navItemClass() = @{
-    if (inlineMode) "inline-list__item nav__item" else "nav__item"
-}
-
-@if(inlineMode) {
-    <li class="@navItemClass()">
-        <a href="/" class="nav__link" id="qa-nav-home">
-            @fragments.inlineIcon("home")
-            <span class="u-h">Home</span>
-        </a>
-    </li>
-}
-<li class="@navItemClass()">
-    <a href="/events" class="nav__link case--lower" @if(inlineMode) { id="qa-nav-events"}>Events</a>
+<li class="nav__item nav__item--home">
+    <a href="/" class="nav__link">
+        @fragments.inlineIcon("home")
+        <span class="u-h">Home</span>
+    </a>
 </li>
-<li class="@navItemClass()">
-    <a href="/masterclasses" class="nav__link case--lower">Masterclasses</a>
+<li class="nav__item">
+    <a href="/events" class="nav__link" id="qa-nav-events">Events</a>
 </li>
-<li class="@navItemClass()">
-    <a href="/about" class="nav__link case--lower">About membership</a>
+<li class="nav__item">
+    <a href="/masterclasses" class="nav__link" id="qa-nav-masterclasses">Masterclasses</a>
 </li>
-<li class="@navItemClass()">
-    <a href="/patrons" class="nav__link case--lower">Patrons</a>
+<li class="nav__item">
+    <a href="/about" class="nav__link" id="qa-nav-about">About membership</a>
 </li>
-<li class="@navItemClass()">
-    <a href="/join" class="nav__link case--lower" @if(inlineMode) { id="qa-nav-pricing"}>Pricing</a>
+<li class="nav__item">
+    <a href="/patrons" class="nav__link" id="qa-nav-patrons">Patrons</a>
 </li>
-<li class="@navItemClass()">
-    <a href="/help" class="nav__link case--lower">Help</a>
+<li class="nav__item">
+    <a href="/join" class="nav__link" id="qa-nav-pricing">Pricing</a>
 </li>
-<li class="@navItemClass()">
-    <a href="/feedback" class="nav__link nav__link case--lower">Feedback</a>
+<li class="nav__item">
+    <a href="/help" class="nav__link" id="qa-nav-help">Help</a>
 </li>
-<li class="@navItemClass() nav__item--right">
-    <a href="@Config.guardianMembershipUrl" class="nav__link nav__link--last case--lower js-members-area">Members' Area</a>
+<li class="nav__item">
+    <a href="/feedback" class="nav__link" id="qa-nav-feedback">Feedback</a>
+</li>
+<li class="nav__item nav__item--right">
+    <a href="@Config.guardianMembershipUrl" class="nav__link nav__link--last js-members-area is-hidden">Members' Area</a>
 </li>

--- a/frontend/assets/javascripts/src/main.js
+++ b/frontend/assets/javascripts/src/main.js
@@ -13,6 +13,7 @@ require([
     'src/modules/images',
     'src/modules/sticky',
     'src/modules/Header',
+    'src/modules/navigation',
     'src/modules/UserDetails',
     'src/modules/tier/choose',
     'src/modules/events/eventPriceEnhance',
@@ -38,6 +39,7 @@ require([
     images,
     sticky,
     Header,
+    navigation,
     UserDetails,
     choose,
     eventPriceEnhance,
@@ -69,6 +71,7 @@ require([
     sticky.init();
     var header = new Header();
     header.init();
+    navigation.init();
     (new UserDetails()).init();
 
     // Events

--- a/frontend/assets/javascripts/src/modules/Header.js
+++ b/frontend/assets/javascripts/src/modules/Header.js
@@ -13,7 +13,7 @@ define([
             DOCUMENT_ELEMENT: 'html',
             HEADER_JOIN_US_CTA: '.js-header-join-us-cta',
             SECTIONS_POP_UP_JOIN_US_CTA: '.js-sections-nav-join-us',
-            SECTIONS_POP_UP_NAV: '.js-sections-nav-popup',
+            SECTIONS_POP_UP_NAV: '.js-global-nav',
             SECTIONS_POP_UP_PAGE_LIST: '.js-sections-nav-popup-page-list',
             MENU_ICON: '.js-menu-icon',
             IDENTITY_NOTICE: '.identity__notice',
@@ -64,8 +64,7 @@ define([
             e.preventDefault();
             e.stopImmediatePropagation();
 
-            config.DOM.IDENTITY_POP_UP_NAV.addClass('is-hidden');
-            config.DOM.SECTIONS_POP_UP_NAV.toggleClass('is-hidden');
+            config.DOM.SECTIONS_POP_UP_NAV.toggleClass('is-active');
             config.DOM.MENU_ICON.toggleClass('close-icon-white--active');
             self.setMenuListener.call(self, config.DOM.SECTIONS_POP_UP_NAV);
         });
@@ -75,7 +74,7 @@ define([
                 e.preventDefault();
                 e.stopImmediatePropagation();
 
-                config.DOM.SECTIONS_POP_UP_NAV.addClass('is-hidden');
+                config.DOM.SECTIONS_POP_UP_NAV.removeClass('is-active');
                 config.DOM.IDENTITY_POP_UP_NAV.toggleClass('is-hidden');
                 config.DOM.IDENTITY_ICON.toggleClass('menu-item--active');
                 config.DOM.USER_ICON.toggleClass('control--active');
@@ -101,7 +100,7 @@ define([
     Header.prototype.addCloseMenuListener = function () {
         bean.on(config.DOM.DOCUMENT_ELEMENT[0], 'click', function () {
             config.DOM.IDENTITY_POP_UP_NAV.addClass('is-hidden');
-            config.DOM.SECTIONS_POP_UP_NAV.addClass('is-hidden');
+            config.DOM.SECTIONS_POP_UP_NAV.removeClass('is-active');
         });
     };
 

--- a/frontend/assets/javascripts/src/modules/Header.js
+++ b/frontend/assets/javascripts/src/modules/Header.js
@@ -13,15 +13,12 @@ define([
             DOCUMENT_ELEMENT: 'html',
             HEADER_JOIN_US_CTA: '.js-header-join-us-cta',
             SECTIONS_POP_UP_JOIN_US_CTA: '.js-sections-nav-join-us',
-            SECTIONS_POP_UP_NAV: '.js-global-nav',
             SECTIONS_POP_UP_PAGE_LIST: '.js-sections-nav-popup-page-list',
-            MENU_ICON: '.js-menu-icon',
             IDENTITY_NOTICE: '.identity__notice',
             IDENTITY_ICON: '.js-identity-icon',
             IDENTITY_POP_UP_NAV: '.js-profile-nav-popup',
             COMMENT_ACTIVITY_LINK: '.js-comment-activity',
             EDIT_PROFILE_LINK: '.js-edit-profile',
-            MEMBERS_AREA: '.js-members-area',
             USER_ICON: '.js-user-icon',
             USER_DETAIL: '.js-user-detail'
         },
@@ -38,7 +35,6 @@ define([
             this.cacheDomElements();
             this.appendLocationDetailToIdentityReturnUrl();
             this.populateUserDetails();
-            this.showMembersArea();
             this.addListeners();
         }
     };
@@ -60,21 +56,11 @@ define([
         var self = this;
         var user = this.user;
 
-        bean.on(config.DOM.MENU_ICON[0], 'click', function (e) {
-            e.preventDefault();
-            e.stopImmediatePropagation();
-
-            config.DOM.SECTIONS_POP_UP_NAV.toggleClass('is-active');
-            config.DOM.MENU_ICON.toggleClass('close-icon-white--active');
-            self.setMenuListener.call(self, config.DOM.SECTIONS_POP_UP_NAV);
-        });
-
         bean.on(config.DOM.IDENTITY_ICON[0], 'click', function (e) {
             if (user) {
                 e.preventDefault();
                 e.stopImmediatePropagation();
 
-                config.DOM.SECTIONS_POP_UP_NAV.removeClass('is-active');
                 config.DOM.IDENTITY_POP_UP_NAV.toggleClass('is-hidden');
                 config.DOM.IDENTITY_ICON.toggleClass('menu-item--active');
                 config.DOM.USER_ICON.toggleClass('control--active');
@@ -100,7 +86,6 @@ define([
     Header.prototype.addCloseMenuListener = function () {
         bean.on(config.DOM.DOCUMENT_ELEMENT[0], 'click', function () {
             config.DOM.IDENTITY_POP_UP_NAV.addClass('is-hidden');
-            config.DOM.SECTIONS_POP_UP_NAV.removeClass('is-active');
         });
     };
 
@@ -140,11 +125,6 @@ define([
         config.DOM.IDENTITY_ICON.attr('href', config.DOM.IDENTITY_ICON.attr('href') + utilsHelper.getLocationDetail());
     };
 
-    Header.prototype.showMembersArea = function () {
-        if (!this.user) {
-            config.DOM.MEMBERS_AREA.addClass('is-hidden');
-        }
-    };
-
     return Header;
+
 });

--- a/frontend/assets/javascripts/src/modules/navigation.js
+++ b/frontend/assets/javascripts/src/modules/navigation.js
@@ -1,0 +1,37 @@
+define(['src/utils/user'], function (userUtil) {
+
+    var MENU_ICON = '.js-menu-icon';
+    var NAVIGATION ='.js-global-nav';
+    var MEMBERS_AREA = '.js-members-area';
+    var ACTIVE_CLASS = 'is-active';
+    var HIDDEN_CLASS = 'is-hidden';
+
+    function addListeners(menuEl, navigationEl) {
+        menuEl.addEventListener('click', function(event) {
+            event.preventDefault();
+            menuEl.classList.toggle(ACTIVE_CLASS);
+            navigationEl.classList.toggle(ACTIVE_CLASS);
+        });
+    }
+
+    function showMembersArea() {
+        var membersAreaLink = document.querySelector(MEMBERS_AREA);
+        if (userUtil.getUserFromCookie() && membersAreaLink) {
+            membersAreaLink.classList.remove(HIDDEN_CLASS);
+        }
+    }
+
+    function init() {
+        var menuEl = document.querySelector(MENU_ICON),
+            navigationEl = document.querySelector(NAVIGATION);
+        if (menuEl) {
+            addListeners(menuEl, navigationEl);
+            showMembersArea();
+        }
+    }
+
+    return {
+        init: init
+    };
+
+});

--- a/frontend/assets/stylesheets/_vars.scss
+++ b/frontend/assets/stylesheets/_vars.scss
@@ -20,7 +20,6 @@ $browser-supports-flexbox: true !default;
 $gutter-width-fluid: 2%;
 $trailblock-img-width: 140px;
 $mobilePopupOffset: 43px;
-$side-margins-top-magic-number: 114px;
 
 // Animation Settings
 // =============================================================================

--- a/frontend/assets/stylesheets/components/_icons.scss
+++ b/frontend/assets/stylesheets/components/_icons.scss
@@ -53,11 +53,6 @@
     }
 }
 
-// TODO: Only used in global header, can this be made more explicit? Or documented
-.icon-wrapper {
-    display: block;
-}
-
 /* Inline Icons
    ========================================================================== */
 

--- a/frontend/assets/stylesheets/components/nav/_control.scss
+++ b/frontend/assets/stylesheets/components/nav/_control.scss
@@ -2,6 +2,9 @@
    Controls
    ========================================================================== */
 
+.control-container {
+    display: block;
+}
 .control-container:hover {
     color: $white;
 

--- a/frontend/assets/stylesheets/components/nav/_nav.scss
+++ b/frontend/assets/stylesheets/components/nav/_nav.scss
@@ -30,6 +30,7 @@ $global-nav-height: 36px;
 
 .nav--global {
 
+    @include clearfix();
     clear: both;
     display: block;
     height: auto;
@@ -85,7 +86,8 @@ $global-nav-height: 36px;
         text-transform: lowercase;
 
         @include mq(desktop) {
-            display: inline-block;
+            display: block;
+            float: left;
         }
     }
     .nav__item--right {

--- a/frontend/assets/stylesheets/components/nav/_nav.scss
+++ b/frontend/assets/stylesheets/components/nav/_nav.scss
@@ -9,27 +9,25 @@
  * The root component nav and >li>a selectors should not be modified directly,
  * instead use modifier classes such as "nav--columns"
  */
-
 .nav {
     list-style: none;
     margin: 0;
     padding: 0;
-    z-index: 100; //To ensure it sits above anything else
 
     > li,
     > li > a {
         display: inline-block;
         zoom: 1;
     }
-
 }
 
 /* ==========================================================================
    Nav - Global Navigation
    ========================================================================== */
 
-// Semi magic-number. Height of toggle link.
-$_global-nav-height: 36px;
+// Height of toggle link.
+$global-nav-height: 36px;
+
 .nav--global {
 
     clear: both;
@@ -64,8 +62,8 @@ $_global-nav-height: 36px;
         white-space: nowrap;
         width: auto;
         vertical-align: middle;
-        height: rem($_global-nav-height);
-        padding: 0 rem($_global-nav-height * 2) 0 rem($gs-gutter / 2);
+        height: rem($global-nav-height);
+        padding: 0 rem($global-nav-height * 2) 0 rem($gs-gutter / 2);
 
         @include mq(tablet) {
             padding: 0 rem($gs-gutter);
@@ -84,6 +82,7 @@ $_global-nav-height: 36px;
     .nav__item {
         display: table-cell;
         vertical-align: middle;
+        text-transform: lowercase;
 
         @include mq(desktop) {
             display: inline-block;
@@ -123,6 +122,61 @@ $_global-nav-height: 36px;
     }
     .icon-home {
         vertical-align: top;
+    }
+}
+
+@include mq($until: tablet) {
+    .nav--global.is-active {
+
+        display: block;
+        height: auto;
+        padding: 0;
+        padding-top: rem($global-nav-height);
+        position: absolute;
+        z-index: 2;
+        top: 100%;
+        width: 100%;
+        background: darken($mem-brandBlue, 10%);
+
+        .nav__scroll,
+        .nav__list,
+        .nav__item {
+            display: block;
+            height: auto;
+            padding: 0;
+        }
+
+        .nav__item {
+            width: 100%;
+        }
+        .nav__item--home {
+            display: none;
+        }
+
+        .nav__link {
+            @include fs-bodyHeading(1);
+            margin: 0;
+            border-top: 1px solid lighten($mem-brandBlue, 5%);
+            display: block;
+            background-color: transparent;
+            -webkit-font-smoothing: subpixel-antialiased;
+            text-decoration: none;
+            padding: rem($gs-baseline / 2) 0 rem($gs-baseline) rem($gs-baseline);
+
+            &,
+            &:active,
+            &:focus {
+                color: $black;
+                text-decoration: none;
+            }
+            &:hover {
+                text-decoration: underline;
+            }
+
+            @include mq(desktop) {
+                border-top: 0;
+            }
+        }
     }
 }
 
@@ -204,20 +258,22 @@ $_global-nav-height: 36px;
    ========================================================================== */
 
 .mobile-menu {
+
     position: absolute;
     right: 0;
-    background-color: lighten($black, 20%);
+    bottom: 0;
     z-index: 3;
-    top: rem(43px);
 
-    a.mobile-menu__button {
-        color: $white;
-        display: block;
-        text-decoration: none;
-        padding: rem(3px) rem(9px) rem(9px);
-        box-shadow: rem(-3px) 0 rem(4px) 0 rgba(50, 50, 50, .30);
-    }
-    .mobile-menu__button i {
+    color: $white;
+    display: block;
+    height: rem($global-nav-height);
+    border: 0 none;
+    padding: rem(3px) rem(9px) rem(9px);
+    box-shadow: rem(-3px) 0 rem(4px) 0 rgba(50, 50, 50, .30);
+    background-color: lighten($black, 20%);
+    text-decoration: none;
+
+    i {
         border-top: rem(2px) solid rgba(255, 255, 255, .9);
         display: block;
         width: rem(20px);
@@ -226,17 +282,21 @@ $_global-nav-height: 36px;
         -webkit-transition: opacity .1s, -webkit-transform .1s ease-in;
         transition: opacity .1s, transform .1s ease-in;
     }
-    .close-icon-white--active i {
-        @include transform-origin(43%);
 
-        &:nth-child(1) {
-            @include transform(translateY(rem(4px)) rotate(45deg));
-        }
-        &:nth-child(2) {
-            opacity: 0;
-        }
-        &:nth-child(3) {
-            @include transform(translateY(rem(-4px)) rotate(-45deg));
+    &.is-active {
+        top: 100%;
+        i {
+            @include transform-origin(43%);
+
+            &:nth-child(1) {
+                @include transform(translateY(rem(4px)) rotate(45deg));
+            }
+            &:nth-child(2) {
+                opacity: 0;
+            }
+            &:nth-child(3) {
+                @include transform(translateY(rem(-4px)) rotate(-45deg));
+            }
         }
     }
 }

--- a/frontend/assets/stylesheets/components/nav/_nav.scss
+++ b/frontend/assets/stylesheets/components/nav/_nav.scss
@@ -50,9 +50,7 @@ $global-nav-height: 36px;
     -webkit-font-smoothing: subpixel-antialiased;
     -webkit-font-feature-settings: "kern" 1;
 
-    background-color: darken($mem-brandBlue, 10%);
-    @include side-margins-calc('padding-left');
-    @include side-margins-calc('padding-right');
+    background-color: darken($mem-brandBlue, 12%);
 
     &::-webkit-scrollbar {
         display: none;
@@ -65,6 +63,7 @@ $global-nav-height: 36px;
         vertical-align: middle;
         height: rem($global-nav-height);
         padding: 0 rem($global-nav-height * 2) 0 rem($gs-gutter / 2);
+        background-color: darken($mem-brandBlue, 10%);
 
         @include mq(tablet) {
             padding: 0 rem($gs-gutter);

--- a/frontend/assets/stylesheets/components/nav/_pop-up.scss
+++ b/frontend/assets/stylesheets/components/nav/_pop-up.scss
@@ -5,6 +5,7 @@
 .nav-popup {
     position: absolute;
     top: 0;
+    z-index: 10;
     clear: both;
     padding: rem(($gs-baseline / 3) * 2) 0;
     list-style: none;

--- a/frontend/assets/stylesheets/layout/_footer.scss
+++ b/frontend/assets/stylesheets/layout/_footer.scss
@@ -6,6 +6,8 @@
     width: 100%;
     margin: rem($gs-baseline) 0 0;
     background-color: $c-neutral8;
+    position: relative;
+    z-index: 2;
 
     @include mq(mobileLandscape) {
         margin-top: rem($gs-baseline * 3);

--- a/frontend/assets/stylesheets/layout/_header.scss
+++ b/frontend/assets/stylesheets/layout/_header.scss
@@ -11,12 +11,9 @@
         position: relative;
     }
     .header__branding {
-        // move the logo area above side margins
-        z-index: 2;
-        position: relative;
         background-color: transparentize($mem-brandBlue, .1);
-        padding-top: rem(5px);
-        padding-bottom: rem(5px);
+        padding-top: rem($gs-gutter / 4);
+        padding-bottom: rem($gs-gutter / 4);
         height: rem(48px);
 
         @include mq(tablet) {

--- a/frontend/assets/stylesheets/layout/_header.scss
+++ b/frontend/assets/stylesheets/layout/_header.scss
@@ -3,26 +3,23 @@
    ========================================================================== */
 
 .header {
-    position: relative;
+    background-color: transparentize($mem-brandBlue, .1);
     margin-bottom: rem($gs-baseline);
+    position: relative;
+    z-index: 2;
 
     .header__inner--popup {
         padding: 0;
         position: relative;
     }
     .header__branding {
-        background-color: transparentize($mem-brandBlue, .1);
+        @include clearfix();
         padding-top: rem($gs-gutter / 4);
         padding-bottom: rem($gs-gutter / 4);
         height: rem(48px);
 
         @include mq(tablet) {
             height: auto;
-        }
-
-        @include mq($from: desktop) {
-            @include side-margins-calc('padding-left');
-            @include side-margins-calc('padding-right');
         }
     }
     .header__primary {

--- a/frontend/assets/stylesheets/layout/_header.scss
+++ b/frontend/assets/stylesheets/layout/_header.scss
@@ -57,6 +57,9 @@
             height: rem(50px);
         }
     }
+    .header__logo__link {
+        display: block;
+    }
 }
 
 .identity__tier {

--- a/frontend/assets/stylesheets/layout/_layout.scss
+++ b/frontend/assets/stylesheets/layout/_layout.scss
@@ -94,21 +94,13 @@ body {
 .page-side-margins {
     &:before,
     &:after {
+        background: $c-background-transparent;
         content: '';
         position: absolute;
         z-index: 1;
-        background: $c-background-transparent;
-
-        /**
-         * Magic number: we shift these margins up to skip the header gap
-         * and the (fixed) height of the nav bar
-         */
-        top: rem($side-margins-top-magic-number);
+        top: 0;
         height: 100%;
-        height: -webkit-calc(100% - #{$side-margins-top-magic-number});
-        height: calc(100% - #{$side-margins-top-magic-number});
         width: 0;
-
         @include side-margins-calc('width');
     }
     &:before {


### PR DESCRIPTION
Noticed this whilst working through refactoring functional tests with @jamesoram . Currently the global navigation works by including two versions of the nav on the page and toggling between them.

Whilst the nav is based on the guardian.com responsive nav, we don't have the same behaviour when toggling so we can happily handle the nav toggle with CSS, rather than duplicate markup.

- Removes need for duplicate navigation markup
- Removes need for magic numbers in layout / side-margin styles / Centralises layout for header, footer etc.
- Extracts navigation toggle JS out from `Header.js` and into a standalone component

Also fixes a firefox layout bug for the signed in members link:

![screen shot 2015-01-26 at 12 59 30](https://cloud.githubusercontent.com/assets/123386/5901166/2bd1cf9e-a568-11e4-9c7e-e622dea53b95.png)

![screen shot 2015-01-26 at 12 59 41](https://cloud.githubusercontent.com/assets/123386/5901170/2e2b5abc-a568-11e4-8613-19f9e1fd4ac0.png)

