### PR TITLE
Update downgrade summary template to use page layout

### DIFF
--- a/frontend/app/views/fragments/tier/summary.scala.html
+++ b/frontend/app/views/fragments/tier/summary.scala.html
@@ -14,7 +14,7 @@
     </tr>
     <tr role="row">
         <th role="rowheader">
-            End Date
+            End date
         </th>
         <td id="qa-tier-summary-end">
             @currentSubscription.endDate.pretty
@@ -30,7 +30,7 @@
     </tr>
     <tr role="row">
         <th role="rowheader">
-            Last Payment
+            Last payment
         </th>
         <td id="qa-tier-summary-start">
             @currentSubscription.startDate.pretty

--- a/frontend/app/views/tier/downgrade/summary.scala.html
+++ b/frontend/app/views/tier/downgrade/summary.scala.html
@@ -7,60 +7,54 @@
 @main("Change Tier Summary | " + futureSubscription.planName + " from " + currentSubscription.planName) {
 
     <main role="main" class="page-content">
-        <div class="content__container">
-            <section>
-                @fragments.layout.sectionHeader("Sorry to see you go&hellip;")
-                <p>You will continue to receive all the great Membership benefits until @currentSubscription.endDate.pretty</p>
-            </section>
-        </div>
-        <div class="content__container content__container--border">
-            <section class="l-row l-row--items-2">
-                <div class="l-row__item">
-                    <h2 class="content__headline">Current Membership Summary</h2>
-                </div>
-                <div class="l-row__item l-row__item--boost-2 secondary-content">
-                    @fragments.tier.summary(currentSubscription)
-                </div>
-            </section>
-        </div>
-        <div class="content__container content__container--border">
-            <section class="l-row l-row--items-2">
-                <div class="l-row__item">
-                    <h2 class="content__headline">New Membership Summary</h2>
-                </div>
-                <div class="l-row__item l-row__item--boost-2 secondary-content">
-                    <table class="table table--responsive-font table--striped" role="grid">
-                        <tr role="row">
-                            <th role="rowheader">
-                                Tier
-                            </th>
-                            <td id="qa-downgrade-summary-tier">
-                                Friend
-                            </td>
-                        </tr>
-                        <tr role="row">
-                            <th role="rowheader">
-                                Start Date
-                            </th>
-                            <td id="qa-downgrade-summary-start">
-                                @futureSubscription.startDate.pretty
-                            </td>
-                        </tr>
-                        <tr role="row">
-                            <th role="rowheader">
-                                @if(futureSubscription.annual){ Annual } else { Monthly } Payment
-                            </th>
-                            <td>
-                                @futureSubscription.planAmount.pretty
-                            </td>
-                        </tr>
-                    </table>
-                </div>
-            </section>
-        </div>
-        <section class="content__container u-align-right">
-            <a href="@Config.idWebAppUrl/membership/edit" class="action action-cta action-cta--confirm" id="qa-downgrade-profile-link">My Profile</a>
+
+        @fragments.page.pageHeader("Sorry to see you go…", Some("You will continue to receive all the great Membership benefits until " + currentSubscription.endDate.pretty))
+
+        <section class="page-section page-section--bordered">
+            <div class="page-section__lead-in">
+                <h2 class="page-section__headline">Current Membership summary</h2>
+            </div>
+            <div class="page-section__content">
+                @fragments.tier.summary(currentSubscription)
+            </div>
         </section>
+
+        <section class="page-section page-section--bordered">
+            <div class="page-section__lead-in">
+                <h2 class="page-section__headline">New Membership summary</h2>
+            </div>
+            <div class="page-section__content">
+                <table class="table table--responsive-font table--striped" role="grid">
+                    <tr role="row">
+                        <th role="rowheader">
+                            Tier
+                        </th>
+                        <td id="qa-downgrade-summary-tier">
+                            Friend
+                        </td>
+                    </tr>
+                    <tr role="row">
+                        <th role="rowheader">
+                            Start date
+                        </th>
+                        <td id="qa-downgrade-summary-start">
+                            @futureSubscription.startDate.pretty
+                        </td>
+                    </tr>
+                    <tr role="row">
+                        <th role="rowheader">
+                            @if(futureSubscription.annual){ Annual } else { Monthly } payment
+                        </th>
+                        <td>
+                            @futureSubscription.planAmount.pretty
+                        </td>
+                    </tr>
+                </table>
+
+                <a href="@Config.idWebAppUrl/membership/edit" class="action u-align-right" id="qa-downgrade-profile-link">My profile</a>
+            </div>
+        </section>
+
     </main>
 
 }

--- a/frontend/assets/stylesheets/layout/_layout.scss
+++ b/frontend/assets/stylesheets/layout/_layout.scss
@@ -68,12 +68,6 @@ body {
     }
 }
 
-// TOOD: Code smell. This is related to generated classes from guss-layout,
-// do we really need this? If so, document usage clearly.
-.l-row__item {
-    padding-bottom: rem($gs-gutter * 2);
-}
-
 .u-align-middle {
     vertical-align: middle;
 }
@@ -139,15 +133,5 @@ body {
 .page-content--padded {
     @include mq(tablet) {
         padding: 0 rem($gs-gutter * 4) rem($gs-gutter * 8);
-    }
-}
-
-// TODO: Too broad. What is this affecting?
-// Only on downgrade page??
-.secondary-content {
-    flex-basis: 16em;
-    order: 2;
-    @if $old-ie {
-        float: left;
     }
 }


### PR DESCRIPTION
Update downgrade summary template to use functional page markup. Also lets us remove some thorny css from `_layout.scss`. Have run this past Ben W who is happy with the layout change.

**New**
![screen shot 2015-01-26 at 14 52 34](https://cloud.githubusercontent.com/assets/123386/5901514/f945ce92-a56a-11e4-8aeb-85092cd2a8b9.png)

**Old**
![screen shot 2015-01-26 at 14 41 25](https://cloud.githubusercontent.com/assets/123386/5901503/e5f30814-a56a-11e4-9343-84cd09a7399a.png)
