### PR TITLE
Use a Membership-specific Ophan script that identifies us as our own platform

### DIFF
--- a/frontend/app/views/fragments/javaScriptLaterSteps.scala.html
+++ b/frontend/app/views/fragments/javaScriptLaterSteps.scala.html
@@ -8,7 +8,7 @@
         apiName: 'require',
         paths: {
             zxcvbn: '@Asset.at("javascripts/lib/zxcvbn/zxcvbn.js")',
-            'ophan/ng': '@Config.ophanJsUrl',
+            ophan: '@Config.ophanJsUrl',
             omniture: '@Asset.at("javascripts/lib/omniture/omniture.js")'
         }
     };

--- a/frontend/assets/javascripts/src/utils/analytics/setup.js
+++ b/frontend/assets/javascripts/src/utils/analytics/setup.js
@@ -13,7 +13,7 @@ define([
         }
 
         if (guardian.analyticsEnabled) {
-            require('ophan/ng', function () {});
+            require('ophan', function () {});
             omnitureAnalytics.init();
             googleAnalytics.init();
         }

--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -164,4 +164,4 @@ guardian.membership.contact.us.url ="http://www.theguardian.com/help/contact-us#
 guardian.membership.building.blog.url="http://theguardian.com/membership/midland-goods-shed-progress/"
 guardian.membership.building.space.url="http://www.theguardian.com/membership/midland-goods-shed-progress/2014/sep/10/-sp-midland-goods-shed-guardian-events-membership-building-space"
 
-ophan.js.url="//j.ophan.co.uk/ophan.ng"
+ophan.js.url="//j.ophan.co.uk/ophan.membership"


### PR DESCRIPTION
See https://github.com/guardian/ophan/pull/821 for the generation of the Membership-specifc Ophan script.

The 'ophan/ng' to just 'ophan' change is not strictly necessary, I just made it because 'ng' is what the Ophan project calls the www.theguardian.com (formerly NGW) platform.

cc @davidrapson