### PR TITLE
Fix bug with active state on links + clean up disabled styles

### DIFF
--- a/frontend/assets/javascripts/src/modules/events/Cta.js
+++ b/frontend/assets/javascripts/src/modules/events/Cta.js
@@ -117,7 +117,7 @@ define([
     };
 
     Cta.prototype.upgradeComingSoonMemberCtaButton = function () {
-        $(this.getElem('MEMBER_CTA')).text(TICKETS_AVAILABLE_SOON).addClass('action--disabled').removeAttr('href');
+        $(this.getElem('MEMBER_CTA')).text(TICKETS_AVAILABLE_SOON).addClass('is-disabled').removeAttr('href');
     };
 
     Cta.prototype.upgradeMemberCtaButton = function () {

--- a/frontend/assets/stylesheets/components/_action.scss
+++ b/frontend/assets/stylesheets/components/_action.scss
@@ -44,8 +44,9 @@
     &:focus,
     &:active,
     &:hover {
-        text-decoration: none;
+        color: $white;
         background-color: darken($c-button, 10%);
+        text-decoration: none;
     }
 
     &:after {
@@ -56,12 +57,6 @@
         content: '';
         float: right;
         margin: rem(2px) rem(-$gs-gutter / 2) 0 rem(30px);
-    }
-
-    &[disabled],
-    &[disabled]:hover,
-    &[disabled]:focus {
-        background-color: $c-neutral5;
     }
 
     .action__icon {
@@ -78,6 +73,15 @@
         margin-left: rem($gs-gutter / 2);
     }
 
+}
+
+/**
+ * Disabled state
+ */
+.action.is-disabled,
+.action[disabled],
+.action[disabled]:hover {
+    background-color: $c-neutral5;
 }
 
 // TODO: Specificy issues
@@ -202,20 +206,6 @@
    }
 }
 
-// TODO: Only used in cta.js.
-// Refactor to add disabled attribute
-.action--disabled {
-    &,
-    &:visited,
-    &:hover,
-    &:focus,
-    &:active {
-        background-color: #cccccc;
-        color: #ffffff;
-    }
-    border: 0;
-    cursor: default;
-}
 
 .action--snap {
     min-width: 0;


### PR DESCRIPTION
Fix up an annoying visual bug with the active state for buttons, and simplify disabled states for buttons.

**Before** (no text-colour when active)
![screen shot 2015-01-30 at 11 01 38](https://cloud.githubusercontent.com/assets/123386/5974746/c785015e-a86f-11e4-9c8f-ee2abdb7adf7.png)

**After**
![screen shot 2015-01-30 at 11 02 52](https://cloud.githubusercontent.com/assets/123386/5974749/d2637358-a86f-11e4-939e-e81c3647ce82.png)
