### PR TITLE
Stop Twitter cards derailing users into the mobile apps

### DIFF
--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -143,10 +143,6 @@ object Config {
   }
 
   val twitterUsername = config.getString("twitter.username")
-  val twitterIphoneAppName = config.getString("twitter.app.iphone.name")
-  val twitterIphoneAppId = config.getString("twitter.app.iphone.id")
-  val twitterGoogleplayAppName = config.getString("twitter.app.googleplay.name")
-  val twitterGoogleplayAppId = config.getString("twitter.app.googleplay.id")
 
   val googleAnalyticsTrackingId = config.getString("google.analytics.tracking.id")
 

--- a/frontend/app/views/main.scala.html
+++ b/frontend/app/views/main.scala.html
@@ -28,10 +28,6 @@
         <meta property="og:type" content="website"/>
         <meta property="fb:app_id" content="@Config.facebookAppId"/>
         <meta name="twitter:site" content="@@@Config.twitterUsername"/>
-        <meta name="twitter:app:name:iphone" content="@Config.twitterIphoneAppName"/>
-        <meta name="twitter:app:id:iphone" content="@Config.twitterIphoneAppId"/>
-        <meta name="twitter:app:name:googleplay" content="@Config.twitterGoogleplayAppName"/>
-        <meta name="twitter:app:id:googleplay" content="@Config.twitterGoogleplayAppId"/>
         <meta name="twitter:card" content="summary"/>
 
         <title>@(title + " | " + Config.siteTitle )</title>

--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -53,10 +53,6 @@ membership.home.images.widths=[500, 1000, 2000]
 membership.home.images.ratios=[1]
 
 twitter.username="gdnmembership"
-twitter.app.iphone.name="The Guardian"
-twitter.app.iphone.id=409128287
-twitter.app.googleplay.name="The Guardian"
-twitter.app.googleplay.id="com.guardian"
 
 stripe.api.url="https://api.stripe.com/v1"
 


### PR DESCRIPTION
Unfortunately the mobile apps don't understand Membership urls, and so when a user clicks 'Open in the Guardian app', they just get taken to the 'homepage' of the app - not to Membership.

![](https://cloud.githubusercontent.com/assets/52038/5958317/398506b0-a7bb-11e4-8764-af5d403c8058.gif)

While it's nice to promote the apps, until they open the links in a way that's helpful to the user, we should remove the 'Open in the Guardian app' functionality from our Twitter cards.

https://dev.twitter.com/cards/mobile

cc @mattandrews
