### PR TITLE
added prevent default to toggle

### DIFF
--- a/frontend/assets/javascripts/src/modules/events/toggle.js
+++ b/frontend/assets/javascripts/src/modules/events/toggle.js
@@ -16,7 +16,8 @@ define(['$', 'bean', 'src/utils/analytics/ga'], function ($, bean, googleAnalyti
         ELEMENTS_TO_TOGGLE  = '[data-toggle-hidden]';
 
     var toggleElm = function ($elem) {
-        return function () {
+        return function (e) {
+            e.preventDefault();
             var toggleElmId = $elem.data(TOGGLE_DATA_ELM);
 
             $(document.getElementById(toggleElmId)).toggle();


### PR DESCRIPTION
added a prevent default to toggle to stop screen moving when hash is in the toggle url when using an anchor for a toggle elem