### PR TITLE
change ophan module name to stop define() curl.js error

### DIFF
--- a/frontend/app/views/fragments/javaScriptLaterSteps.scala.html
+++ b/frontend/app/views/fragments/javaScriptLaterSteps.scala.html
@@ -8,7 +8,7 @@
         apiName: 'require',
         paths: {
             zxcvbn: '@Asset.at("javascripts/lib/zxcvbn/zxcvbn.js")',
-            ophan: '@Config.ophanJsUrl',
+            'ophan/membership': '@Config.ophanJsUrl',
             omniture: '@Asset.at("javascripts/lib/omniture/omniture.js")'
         }
     };

--- a/frontend/assets/javascripts/src/utils/analytics/setup.js
+++ b/frontend/assets/javascripts/src/utils/analytics/setup.js
@@ -13,7 +13,7 @@ define([
         }
 
         if (guardian.analyticsEnabled) {
-            require('ophan', function () {});
+            require('ophan/membership', function () {});
             omnitureAnalytics.init();
             googleAnalytics.init();
         }


### PR DESCRIPTION
<h3>before</h3>
We have been seeing the following error when curl loads the Membership Ophan script. 
Note the Membership Ophan script loads.

![screen shot 2015-02-04 at 12 05 12](https://cloud.githubusercontent.com/assets/2305016/6040126/4b38bc4e-ac66-11e4-9ba9-785c00573d84.png)

<h3>after</h3>
Changing the module name to 'ophan/membership' 

<i>curl.js expects a named module to use its true name. There are no single-word module names in a package. All module names in packages take the form "[package-name]/[module-path]".<i> [ref](https://github.com/cujojs/curl/issues/256#issuecomment-35163242)

The error goes away and the Membership Ophan script loads. 

![screen shot 2015-02-04 at 12 17 36](https://cloud.githubusercontent.com/assets/2305016/6040274/d0e423b4-ac67-11e4-9c18-f972ea8ab6d4.png)
