### PR TITLE
Updating to latest version of common, so that when I change common I know what broke it

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val identityCookie = "com.gu.identity" %% "identity-cookie" % "3.44"
   val identityTestUsers = "com.gu" %% "identity-test-users" % "0.4"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.4"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.50"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.51"
   val playGoogleAuth = "com.gu" %% "play-googleauth" % "0.1.10"
   val contentAPI = "com.gu" %% "content-api-client" % "5.1"
   val playWS = PlayImport.ws


### PR DESCRIPTION
Note this is the only change going 0.51 to 0.52: https://github.com/guardian/membership-common/commit/fc9f87d376118953c93a755e1ef5fa835a961c4a

cc @wpf500 