### PR TITLE
Improvements to feedback form validation

### DIFF
--- a/frontend/app/views/fragments/form/feedback.scala.html
+++ b/frontend/app/views/fragments/form/feedback.scala.html
@@ -64,7 +64,8 @@
             @fragments.form.errorMessage("Please enter your name")
         </div>
 
-        @* email regex taken from http://www.w3.org/TR/html-markup/input.email.html#input.email.attrs.value.single *@
+        @* //TODO this email check needs to be done on the server
+        email regex taken from http://www.w3.org/TR/html-markup/input.email.html#input.email.attrs.value.single *@
         <div class="form-field">
             <label class="label" for="email">Email address</label>
             <input name="email"

--- a/frontend/app/views/fragments/form/feedback.scala.html
+++ b/frontend/app/views/fragments/form/feedback.scala.html
@@ -64,12 +64,14 @@
             @fragments.form.errorMessage("Please enter your name")
         </div>
 
+        @* email regex taken from http://www.w3.org/TR/html-markup/input.email.html#input.email.attrs.value.single *@
         <div class="form-field">
             <label class="label" for="email">Email address</label>
             <input name="email"
                    id="email"
                    class="input-text"
                    type="email"
+                   pattern="^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$"
                    required
                    aria-required="true"/>
             @fragments.form.errorMessage("Please enter your email address")

--- a/frontend/app/views/fragments/form/feedback.scala.html
+++ b/frontend/app/views/fragments/form/feedback.scala.html
@@ -25,7 +25,7 @@
         </div>
 
         <div class="form-field">
-            <label class="label" for="page">Which page on the web site are you referring to?</label>
+            <label class="label optional-marker" for="page">Which page on the web site are you referring to?</label>
             <input class="input-text" name="page" id="page" type="text"/>
             <div class="form-note">e.g. about membership</div>
         </div>

--- a/frontend/assets/stylesheets/base/_form.scss
+++ b/frontend/assets/stylesheets/base/_form.scss
@@ -91,7 +91,9 @@
     }
 
     .input-text,
-    .input-text:focus {
+    .input-text:focus,
+    .input-textarea,
+    .input-textarea:focus {
         border-color: $c-error;
     }
 }


### PR DESCRIPTION
- added (optional) marker to the optional "Which page on the web site are you referring to?" input
- added styles for textarea to add error border-styles to highlight when it has an error
- added email regex from [w3c](http://www.w3.org/TR/html-markup/input.email.html#input.email.attrs.value.single)

<h4>Before</h4>
 ![old](https://cloud.githubusercontent.com/assets/2305016/6059034/22cc493c-ad25-11e4-935b-e08a0dc00925.gif)

<h4>After</h4>
![new](https://cloud.githubusercontent.com/assets/2305016/6059047/39e8f818-ad25-11e4-947a-46c8401aa0b7.gif)
