### PR TITLE
Add lodash-amd

### DIFF
--- a/frontend/Gruntfile.js
+++ b/frontend/Gruntfile.js
@@ -73,6 +73,7 @@ module.exports = function (grunt) {
                     paths: {
                         '$': 'src/utils/$',
                         'modernizr': 'lib/modernizr',
+                        'lodash': 'lib/bower-components/lodash-amd/modern',
                         'bean': 'lib/bower-components/bean/bean',
                         'bonzo': 'lib/bower-components/bonzo/bonzo',
                         'qwery': 'lib/bower-components/qwery/qwery',

--- a/frontend/assets/javascripts/bower.json
+++ b/frontend/assets/javascripts/bower.json
@@ -10,6 +10,7 @@
     "zxcvbn": "*",
     "curl": "~0.8.10",
     "imager.js": "~0.3.0",
-    "raven-js": "~1.1.16"
+    "raven-js": "~1.1.16",
+    "lodash-amd": "~3.1.0"
   }
 }

--- a/frontend/assets/javascripts/src/modules/form/helper/serializer.js
+++ b/frontend/assets/javascripts/src/modules/form/helper/serializer.js
@@ -1,4 +1,4 @@
-define(['src/utils/helper'], function (utilsHelper) {
+define(['lodash/object/extend'], function (extend) {
 
     /**
      * serialize form elements
@@ -8,10 +8,7 @@ define(['src/utils/helper'], function (utilsHelper) {
      * @returns {{}}
      */
     var serializer = function (elems, mixin) {
-        var data = {};
-
-        if (mixin) { utilsHelper.extend(data, mixin); }
-
+        var data = extend({}, mixin);
         elems.filter(function (elem) {
             return elem.name !== '' && elem.type && (elem.type !== 'checkbox' && elem.type !== 'radio' || elem.checked);
         }).map(function (elem) {

--- a/frontend/assets/javascripts/src/modules/form/payment/processing.js
+++ b/frontend/assets/javascripts/src/modules/form/payment/processing.js
@@ -52,13 +52,14 @@ define([
      * @param response
      */
     var stripeResponseHandler = function (status, response) {
+        var data, errMsg;
         if (response.error) {
-            var errMsg = paymentErrorMessages.getMessage(response.error);
+            errMsg = paymentErrorMessages.getMessage(response.error);
             if (errMsg) {
                 handleError(errMsg);
             }
         } else {
-            var data = serializer(utilsHelper.toArray(form.elem.elements), { 'payment.token': response.id });
+            data = serializer(utilsHelper.toArray(form.elem.elements), { 'payment.token': response.id });
 
             loader.setProcessingMessage('Making payment...');
 

--- a/frontend/assets/javascripts/src/utils/helper.js
+++ b/frontend/assets/javascripts/src/utils/helper.js
@@ -42,20 +42,12 @@ define(function () {
         return height;
     };
 
+    // TODO: Replace with lodash-amd
     var toArray = function (nodeList) {
         return Array.prototype.slice.call(nodeList);
     };
 
-    var extend = function (target, source) {
-        for (var prop in source) {
-            if (source.hasOwnProperty(prop)) {
-                target[prop] = source[prop];
-            }
-        }
-    };
-
     return {
-        extend: extend,
         toArray: toArray,
         getLocationDetail: getLocationDetail,
         getSpecifiedParent: getSpecifiedParent,


### PR DESCRIPTION
Wanted to use some more functional helpers in another piece of work around improving client-side metrics. Noticed we had our own implementation of `extend` as well so have pulled in `lodash-amd` to avoid us re-implementing this kind of thing.

Main benefit of `lodash-amd` is that we can require just a single function so only the functions we actually use get included in the build.

Can also potentially replace `toArray` in helpers with the lodash version but going to do that as a separate PR.

// @feedmypixel 