### PR TITLE
fix for edge case month/year input bug

### DIFF
--- a/frontend/assets/javascripts/src/modules/form/payment/validationProfiles.js
+++ b/frontend/assets/javascripts/src/modules/form/payment/validationProfiles.js
@@ -1,4 +1,7 @@
-define(['stripe'], function (stripe) {
+define([
+    'stripe',
+    'src/modules/form/validation/display'
+], function (stripe, display) {
     'use strict';
 
     /**
@@ -20,25 +23,41 @@ define(['stripe'], function (stripe) {
     };
 
     /**
-     * use stripe lib utility to check for a valid looking month value pre fill year with current year as the
-     * select will give us a >= currentYear so here we only want to check the month is >= currentMonth
+     * use stripe lib utility to check for a valid looking date.
+     * If the date is valid then flush errors for both the month and year when month input is validated as we need
+     * to treat month/year inputs as a pair for validation
      * @param monthElem
      * @returns {*}
      */
     var validCreditCardMonth = function (monthElem) {
-        var now = new Date();
-        return stripe.card.validateExpiry(monthElem.value, now.getFullYear().toString());
+        var yearElem = document.querySelector('.js-credit-card-exp-year');
+        var isValid = stripe.card.validateExpiry(monthElem.value, yearElem.value);
+
+        if (isValid) {
+            // treat month/year inputs as a pair if month validates both month and year are valid so flush errors
+            display.flushErrIds([monthElem.id, yearElem.id]);
+        }
+
+        return isValid;
     };
 
     /**
-     * use stripe lib utility to check for a valid looking year value pre fill month with monthElem.value here we only
-     * want to check the year is >= currentYear
+     * use stripe lib utility to check for a valid looking date.
+     * If the date is valid then flush errors for both the month and year when year input is validated as we need
+     * to treat month/year inputs as a pair for validation
      * @param yearElem
      * @returns {*}
      */
     var validCreditCardYear = function (yearElem) {
         var monthElem = document.querySelector('.js-credit-card-exp-month');
-        return stripe.card.validateExpiry(monthElem.value, yearElem.value);
+        var isValid = stripe.card.validateExpiry(monthElem.value, yearElem.value);
+
+        if (isValid) {
+            // treat month/year inputs as a pair if year validates both year and month are valid so flush errors
+            display.flushErrIds([monthElem.id, yearElem.id]);
+        }
+
+        return isValid;
     };
 
     return {


### PR DESCRIPTION
<h4>bug</h4>
There is a bug with the validation for month/year expiry in the new form work. If you have a valid year but not a valid month then there is an error recorded in the form but this error is not communicated in red to the user so you cant submit the form. The only way to get around this is to blur the month and year elements to flush the errors out.

<h4>fix</h4>
This pull request fixes this by treating the validation profile of the month/year inputs as a pair.
The change I have made means that if the month is reporting it is valid this then means that year is also valid so flush both month and year errors. Visa versa if the year is not valid then the month is also not valid so keep the errors.