### PR TITLE
Minor layout fix for patron page

### DIFF
--- a/frontend/app/views/joiner/tier/patron.scala.html
+++ b/frontend/app/views/joiner/tier/patron.scala.html
@@ -45,8 +45,8 @@
     </div>
 
     @* ===== Join Today ===== *@
-    <div class="page-slice page-slice--split tone-tint">
-        <div class="page-slice__inner l-constrained">
+    <div class="page-slice page-slice--split tone-tint l-constrained">
+        <div class="page-slice__inner">
             <h2 class="page-slice__headline">Not ready to become a Patron yet? Join as a Friend or a Partner</h2>
             <div class="page-slice__content">
                 <ul class="grid grid--bordered grid--2up-stacked">


### PR DESCRIPTION
Spotted a minor layout issue with the Patron page. Joining panel was going full width, should be constrained

![screen shot 2015-02-06 at 10 35 25](https://cloud.githubusercontent.com/assets/123386/6078007/8b8d2dca-adec-11e4-99d1-2ceb562ced91.png)

![screen shot 2015-02-06 at 10 35 50](https://cloud.githubusercontent.com/assets/123386/6078008/8e345d82-adec-11e4-9ba1-fe8f84088901.png)

