### PR TITLE
Add form events to metrics tracker

### DIFF
--- a/frontend/assets/javascripts/src/main.js
+++ b/frontend/assets/javascripts/src/main.js
@@ -17,6 +17,7 @@ require([
     'src/utils/modal',
     'src/utils/form/processSubmit',
     'src/modules/form',
+    'src/modules/metrics',
     // Add new dependencies ABOVE this
     'raven',
     'modernizr'
@@ -38,7 +39,8 @@ require([
     modal,
     patterns,
     processSubmit,
-    form
+    form,
+    metrics
 ) {
     'use strict';
 
@@ -80,5 +82,8 @@ require([
 
     // Pattern library
     patterns.init();
+
+    // Metrics
+    metrics.init();
 
 });

--- a/frontend/assets/javascripts/src/modules/metrics.js
+++ b/frontend/assets/javascripts/src/modules/metrics.js
@@ -1,91 +1,11 @@
-/* global ga */
 define([
-    'lodash/object/extend',
-    'lodash/function/debounce',
-    'src/utils/url'
-], function (extend, debounce, urlHelper) {
-
-    var METRIC_ATTRS = {
-        'trigger': 'data-metric-trigger',
-        'category': 'data-metric-category',
-        'action': 'data-metric-action',
-        'label': 'data-metric-label' // Optional
-    };
-
-    function init() {
-        var trackingElems = document.querySelectorAll('[' + METRIC_ATTRS.trigger + ']');
-        if (window.ga && trackingElems) {
-            configureListeners(trackingElems);
-        }
-    }
-
-    function logMetric(options) {
-        var event = false;
-        if (window.ga) {
-            event = ga('send', extend({
-                'hitType': 'event'
-            }, options));
-        }
-        return event;
-    }
-
-    function configureListeners(trackingElems) {
-        var TRACKING_EVENTS = {
-            'click' : clickListener,
-            'keyup' : keyupListener
-        };
-        [].forEach.call(trackingElems, function(elem) {
-            var key = elem.getAttribute(METRIC_ATTRS.trigger);
-            var metricEvent = TRACKING_EVENTS[key];
-            if (metricEvent) {
-                metricEvent.call(this, elem);
-            }
-        });
-    }
-
-    function extractMetricsFromListener(elem, label, extras) {
-
-        var category = elem.getAttribute(METRIC_ATTRS.category);
-        var action = elem.getAttribute(METRIC_ATTRS.action);
-
-        if (category && action) {
-            logMetric(extend({
-                'eventCategory': category,
-                'eventAction': action,
-                'eventLabel': label || false // Label is optional
-            }, extras));
-        }
-    }
-
-    function clickListener(elem) {
-        elem.addEventListener('click', function(e) {
-            var url, label, extra;
-
-            url = elem.getAttribute('href');
-            label = elem.getAttribute(METRIC_ATTRS.label) || elem.textContent;
-            label += ' | ' + window.location.pathname;
-
-            if (urlHelper.isExternal(url)) {
-                e.preventDefault();
-                extra = {
-                    'hitCallback': function () {
-                        document.location = url;
-                    }
-                };
-            }
-            extractMetricsFromListener(elem, label, extra);
-        });
-    }
-
-    function keyupListener(elem) {
-        elem.addEventListener('keyup', debounce(function() {
-            var label = elem.value.toLowerCase();
-            extractMetricsFromListener(elem, label);
-        }, 500));
-    }
-
+    'src/modules/metrics/triggers',
+    'src/modules/metrics/forms'
+], function (metricsTriggers, metricsForms) {
     return {
-        init: init,
-        logMetric: logMetric
+        init: function() {
+            metricsTriggers.init();
+            metricsForms.init();
+        }
     };
 });

--- a/frontend/assets/javascripts/src/modules/metrics/forms.js
+++ b/frontend/assets/javascripts/src/modules/metrics/forms.js
@@ -1,0 +1,80 @@
+define([
+    'bean',
+    'src/modules/metrics/logger',
+    'src/modules/form/helper/formUtil'
+], function (bean, logMetric, formUtil) {
+
+    function init() {
+        if (window.ga && formUtil) {
+            trackForms();
+        }
+    }
+
+    function trackForms() {
+
+        var formAction = formUtil.elem.getAttribute('action');
+        var formSubmit = formUtil.elem.querySelector('[type="submit"]');
+
+        bean.on(window, 'beforeunload.formMetrics', function() {
+
+            logMetric({
+                'eventCategory': 'form',
+                'eventAction': 'abandoned',
+                'eventLabel': formAction,
+                'eventValue': formUtil.errs.length
+            });
+
+            formUtil.errs.forEach(function(er) {
+                logMetric({
+                    'eventCategory': 'form',
+                    'eventAction': 'abandoned:error',
+                    'eventLabel': er + ' | ' + formAction
+                });
+            });
+
+            formUtil.elems
+                .filter(function(el) { return !el.value; })
+                .map(function(el) {
+                    logMetric({
+                        'eventCategory': 'form',
+                        'eventAction': 'abandoned:empty',
+                        'eventLabel': (el.name || el.id) + ' | ' + formAction
+                    });
+                });
+
+        });
+
+        bean.on(formSubmit, 'click', function() {
+
+            bean.off(window, 'beforeunload.formMetrics');
+
+            if (formUtil.errs.length) {
+                logMetric({
+                    'eventCategory': 'form',
+                    'eventAction': 'submit:failure',
+                    'eventLabel': formAction,
+                    'eventValue': formUtil.errs.length
+                });
+
+                formUtil.errs.forEach(function(er) {
+                    logMetric({
+                        'eventCategory': 'form',
+                        'eventAction': 'submit:error',
+                        'eventLabel': er + ' | ' + formAction
+                    });
+                });
+            } else {
+                logMetric({
+                    'eventCategory': 'form',
+                    'eventAction': 'submit:success',
+                    'eventLabel': formAction
+                });
+            }
+        });
+
+    }
+
+    return {
+        init: init
+    };
+});

--- a/frontend/assets/javascripts/src/modules/metrics/forms.js
+++ b/frontend/assets/javascripts/src/modules/metrics/forms.js
@@ -4,74 +4,90 @@ define([
     'src/modules/form/helper/formUtil'
 ], function (bean, logMetric, formUtil) {
 
-    function init() {
-        if (window.ga && formUtil) {
-            trackForms();
-        }
+    /**
+     * Successful submission: Form was submitted without errors
+     *
+     * Sends a single success events
+     */
+    function recordFormSuccess(formAction) {
+        logMetric({
+            'eventCategory': 'form',
+            'eventAction': 'submit:success',
+            'eventLabel': formAction
+        });
     }
 
-    function trackForms() {
+    /**
+     * Failed submission: Form was submitted but has errors
+     *
+     * Sends an error event with a count of the number of errors and one event per field that has errors
+     */
+    function recordFormWithErrors(formAction) {
+        logMetric({
+            'eventCategory': 'form',
+            'eventAction': 'submit:failure',
+            'eventLabel': formAction,
+            'eventValue': formUtil.errs.length
+        });
 
-        var formAction = formUtil.elem.getAttribute('action');
-        var formSubmit = formUtil.elem.querySelector('[type="submit"]');
-
-        bean.on(window, 'beforeunload.formMetrics', function() {
-
+        formUtil.errs.forEach(function(er) {
             logMetric({
                 'eventCategory': 'form',
-                'eventAction': 'abandoned',
-                'eventLabel': formAction,
-                'eventValue': formUtil.errs.length
+                'eventAction': 'submit:error',
+                'eventLabel': er + ' | ' + formAction
             });
+        });
+    }
 
-            formUtil.errs.forEach(function(er) {
-                logMetric({
-                    'eventCategory': 'form',
-                    'eventAction': 'abandoned:error',
-                    'eventLabel': er + ' | ' + formAction
-                });
-            });
-
-            formUtil.elems
-                .filter(function(el) { return !el.value; })
-                .map(function(el) {
-                    logMetric({
-                        'eventCategory': 'form',
-                        'eventAction': 'abandoned:empty',
-                        'eventLabel': (el.name || el.id) + ' | ' + formAction
-                    });
-                });
-
+    /**
+     * Abandoned form: Form was left/not-submitted
+     *
+     * Sends an abandoned event and one event per empty field (for required fields only)
+     */
+    function recordAbandonedForm(formAction) {
+        logMetric({
+            'eventCategory': 'form',
+            'eventAction': 'abandoned',
+            'eventLabel': formAction,
+            'eventValue': formUtil.errs.length
         });
 
-        bean.on(formSubmit, 'click', function() {
-
-            bean.off(window, 'beforeunload.formMetrics');
-
-            if (formUtil.errs.length) {
-                logMetric({
-                    'eventCategory': 'form',
-                    'eventAction': 'submit:failure',
-                    'eventLabel': formAction,
-                    'eventValue': formUtil.errs.length
-                });
-
-                formUtil.errs.forEach(function(er) {
-                    logMetric({
-                        'eventCategory': 'form',
-                        'eventAction': 'submit:error',
-                        'eventLabel': er + ' | ' + formAction
-                    });
-                });
-            } else {
-                logMetric({
-                    'eventCategory': 'form',
-                    'eventAction': 'submit:success',
-                    'eventLabel': formAction
-                });
-            }
+        formUtil.errs.forEach(function(er) {
+            logMetric({
+                'eventCategory': 'form',
+                'eventAction': 'abandoned:error',
+                'eventLabel': er + ' | ' + formAction
+            });
         });
 
+        formUtil.elems
+            .filter(function(el) { return !el.value; })
+            .map(function(el) {
+                logMetric({
+                    'eventCategory': 'form',
+                    'eventAction': 'abandoned:empty',
+                    'eventLabel': (el.name || el.id) + ' | ' + formAction
+                });
+            });
+    }
+
+    function init() {
+        var formAction;
+        if (window.ga && formUtil) {
+            formAction = formUtil.elem.getAttribute('action');
+            bean.on(window, 'beforeunload.formMetrics', function() {
+                recordAbandonedForm(formAction);
+            });
+            bean.on(formUtil.elem.querySelector('[type="submit"]'), 'click', function() {
+                // Unbind `beforeunload` listener as form submission counts as `beforeunload`
+                bean.off(window, 'beforeunload.formMetrics');
+                if (formUtil.errs.length) {
+                    recordFormWithErrors(formAction);
+                } else {
+                    recordFormSuccess(formAction);
+                }
+            });
+        }
     }
 
     return {

--- a/frontend/assets/javascripts/src/modules/metrics/logger.js
+++ b/frontend/assets/javascripts/src/modules/metrics/logger.js
@@ -1,0 +1,12 @@
+/* global ga */
+define(['lodash/object/extend'], function (extend) {
+    return function(options) {
+        var metricData;
+        if (window.ga) {
+            metricData = extend({
+                'hitType': 'event'
+            }, options);
+            ga('send', metricData);
+        }
+    };
+});

--- a/frontend/assets/javascripts/src/modules/metrics/triggers.js
+++ b/frontend/assets/javascripts/src/modules/metrics/triggers.js
@@ -34,13 +34,12 @@ define([
     function extractMetricsFromListener(elem, label) {
         var category = elem.getAttribute(METRIC_ATTRS.category);
         var action = elem.getAttribute(METRIC_ATTRS.action);
-
         if (category && action) {
-            logMetric(extend({
+            logMetric({
                 'eventCategory': category,
                 'eventAction': action,
                 'eventLabel': label || false // Label is optional
-            }, extras));
+            });
         }
     }
 

--- a/frontend/assets/javascripts/src/modules/metrics/triggers.js
+++ b/frontend/assets/javascripts/src/modules/metrics/triggers.js
@@ -43,18 +43,21 @@ define([
         }
     }
 
+    function getLabel(elem) {
+        var label = elem.getAttribute(METRIC_ATTRS.label) || elem.textContent;
+        label += ' | ' + window.location.pathname;
+        return label;
+    }
+
     function clickListener(elem) {
         elem.addEventListener('click', function() {
-            var label = elem.getAttribute(METRIC_ATTRS.label) || elem.textContent;
-            label += ' | ' + window.location.pathname;
-            extractMetricsFromListener(elem, label);
+            extractMetricsFromListener(elem, getLabel(elem));
         });
     }
 
     function keyupListener(elem) {
         elem.addEventListener('keyup', debounce(function() {
-            var label = elem.value.toLowerCase();
-            extractMetricsFromListener(elem, label);
+            extractMetricsFromListener(elem, elem.value.toLowerCase());
         }, 500));
     }
 

--- a/frontend/assets/javascripts/src/modules/metrics/triggers.js
+++ b/frontend/assets/javascripts/src/modules/metrics/triggers.js
@@ -1,0 +1,65 @@
+define([
+    'lodash/function/debounce',
+    'src/modules/metrics/logger'
+], function (debounce, logMetric) {
+
+    var METRIC_ATTRS = {
+        'trigger': 'data-metric-trigger',
+        'category': 'data-metric-category',
+        'action': 'data-metric-action',
+        'label': 'data-metric-label' // Optional
+    };
+
+    function init() {
+        var trackingElems = document.querySelectorAll('[' + METRIC_ATTRS.trigger + ']');
+        if (window.ga && trackingElems) {
+            configureListeners(trackingElems);
+        }
+    }
+
+    function configureListeners(trackingElems) {
+        var TRACKING_EVENTS = {
+            'click' : clickListener,
+            'keyup' : keyupListener
+        };
+        [].forEach.call(trackingElems, function(elem) {
+            var key = elem.getAttribute(METRIC_ATTRS.trigger);
+            var metricEvent = TRACKING_EVENTS[key];
+            if (metricEvent) {
+                metricEvent.call(this, elem);
+            }
+        });
+    }
+
+    function extractMetricsFromListener(elem, label) {
+        var category = elem.getAttribute(METRIC_ATTRS.category);
+        var action = elem.getAttribute(METRIC_ATTRS.action);
+
+        if (category && action) {
+            logMetric(extend({
+                'eventCategory': category,
+                'eventAction': action,
+                'eventLabel': label || false // Label is optional
+            }, extras));
+        }
+    }
+
+    function clickListener(elem) {
+        elem.addEventListener('click', function() {
+            var label = elem.getAttribute(METRIC_ATTRS.label) || elem.textContent;
+            label += ' | ' + window.location.pathname;
+            extractMetricsFromListener(elem, label);
+        });
+    }
+
+    function keyupListener(elem) {
+        elem.addEventListener('keyup', debounce(function() {
+            var label = elem.value.toLowerCase();
+            extractMetricsFromListener(elem, label);
+        }, 500));
+    }
+
+    return {
+        init: init
+    };
+});


### PR DESCRIPTION
Expands on PR https://github.com/guardian/membership-frontend/pull/164 to add metrics for forms.

This tracks the following events for all forms:

- **Successful submission**: Sends a single success events
- **Failed submission**: Sends an error event with a count of the number of errors and one event per field that has errors
- **Abandoned form**: Sends an abandoned event and one event per empty field (for required fields only)

Should give us some insight into how many forms are abandoned, which fields are most frequently left, which fields have the most errors etc.

Thanks to @feedmypixel for his form refactoring work which has let me piggy back on the information the forms js exposes.