### PR TITLE
Remove isBrochure flag

### DIFF
--- a/frontend/app/views/error404.scala.html
+++ b/frontend/app/views/error404.scala.html
@@ -1,4 +1,4 @@
-@main("Page not found", isBrochure=true) {
+@main("Page not found") {
     <main role="main" class="page-content l-constrained">
         <h1>Error 404 - Page not found</h1>
         <p>Sorry, this page does not exist.</p>

--- a/frontend/app/views/error404.scala.html
+++ b/frontend/app/views/error404.scala.html
@@ -1,5 +1,5 @@
-@main("Page not found") {
-    <main role="main" class="page-content">
+@main("Page not found", isBrochure=true) {
+    <main role="main" class="page-content l-constrained">
         <h1>Error 404 - Page not found</h1>
         <p>Sorry, this page does not exist.</p>
     </main>

--- a/frontend/app/views/error500.scala.html
+++ b/frontend/app/views/error500.scala.html
@@ -1,5 +1,5 @@
 @(ex: Throwable)
-@main("Internal Server Error", isBrochure=true) {
+@main("Internal Server Error") {
     <main role="main" class="page-content l-constrained">
         @fragments.page.pageHeader("Error 500 – Internal server error")
         <section class="page-section">

--- a/frontend/app/views/error500.scala.html
+++ b/frontend/app/views/error500.scala.html
@@ -1,6 +1,6 @@
 @(ex: Throwable)
-@main("Internal Server Error") {
-    <main role="main" class="page-content">
+@main("Internal Server Error", isBrochure=true) {
+    <main role="main" class="page-content l-constrained">
         @fragments.page.pageHeader("Error 500 – Internal server error")
         <section class="page-section">
             <div class="page-section__content copy">

--- a/frontend/app/views/event/guardianLive.scala.html
+++ b/frontend/app/views/event/guardianLive.scala.html
@@ -1,11 +1,12 @@
 @(eventPortfolio: model.EventPortfolio, pageInfo: model.PageInfo)(implicit token: play.filters.csrf.CSRF.Token)
 
-@main("Events", htmlClass="events-bg theme--guardian-live", pageInfo=pageInfo) {
+@main("Events", pageInfo=pageInfo, isBrochure=true) {
+    <main role="main" class="l-constrained">
+        @fragments.event.headerBar(
+            "Events, discussions, debates, interviews, keynote speeches and festivals exclusively for Guardian Members",
+            "guardian-live"
+        )
 
-    @fragments.event.headerBar(
-        "Events, discussions, debates, interviews, keynote speeches and festivals exclusively for Guardian Members",
-        "guardian-live"
-    )
-
-    @views.html.event.list(eventPortfolio, "Sorry, no matching events were found.", showPastEvents=true)
+        @views.html.event.list(eventPortfolio, "Sorry, no matching events were found.", showPastEvents=true)
+    </main>
 }

--- a/frontend/app/views/event/guardianLive.scala.html
+++ b/frontend/app/views/event/guardianLive.scala.html
@@ -1,6 +1,6 @@
 @(eventPortfolio: model.EventPortfolio, pageInfo: model.PageInfo)(implicit token: play.filters.csrf.CSRF.Token)
 
-@main("Events", pageInfo=pageInfo, isBrochure=true) {
+@main("Events", pageInfo=pageInfo) {
     <main role="main" class="l-constrained">
         @fragments.event.headerBar(
             "Events, discussions, debates, interviews, keynote speeches and festivals exclusively for Guardian Members",

--- a/frontend/app/views/event/masterclass.scala.html
+++ b/frontend/app/views/event/masterclass.scala.html
@@ -7,7 +7,9 @@
 
 @import model.RichEvent.MasterclassEvent
 
-@main("Masterclasses", htmlClass="events-bg theme--masterclasses", pageInfo=pageInfo) {
+@main("Masterclasses", pageInfo=pageInfo, isBrochure=true) {
+
+    <main role="main" class="l-constrained">
 
     @fragments.event.headerBar(
         "Courses and workshops taught by award-winning professionals, with discounts for Partners and Patrons",
@@ -71,5 +73,7 @@
     </div>
 
     @views.html.event.list(eventPortfolio, "Sorry, no matching Masterclasses were found.", isFilterable=true)
+
+    </main>
 
 }

--- a/frontend/app/views/event/masterclass.scala.html
+++ b/frontend/app/views/event/masterclass.scala.html
@@ -7,7 +7,7 @@
 
 @import model.RichEvent.MasterclassEvent
 
-@main("Masterclasses", pageInfo=pageInfo, isBrochure=true) {
+@main("Masterclasses", pageInfo=pageInfo) {
 
     <main role="main" class="l-constrained">
 

--- a/frontend/app/views/event/page.scala.html
+++ b/frontend/app/views/event/page.scala.html
@@ -8,7 +8,7 @@
 @import model.Eventbrite._
 @import model.RichEvent._
 
-@main("Event Detail | " + event.name.text, pageInfo=pageInfo, isBrochure = true, htmlClass = "js-event") {
+@main("Event Detail | " + event.name.text, pageInfo=pageInfo, htmlClass = "js-event") {
 
     <div class="event-header tone-@event.metadata.identifier">
         <div class="event-header__container">

--- a/frontend/app/views/event/thankyou.scala.html
+++ b/frontend/app/views/event/thankyou.scala.html
@@ -3,7 +3,7 @@
 @import configuration.Config
 @import views.support.Social.eventThankyou
 
-@main("Event Thankyou - " + event.name.text + " (" + event.id + ")", isBrochure=true) {
+@main("Event Thankyou - " + event.name.text + " (" + event.id + ")") {
 
     <main role="main" class="page-content l-constrained">
 

--- a/frontend/app/views/event/thankyou.scala.html
+++ b/frontend/app/views/event/thankyou.scala.html
@@ -3,9 +3,9 @@
 @import configuration.Config
 @import views.support.Social.eventThankyou
 
-@main("Event Thankyou - " + event.name.text + " (" + event.id + ")") {
+@main("Event Thankyou - " + event.name.text + " (" + event.id + ")", isBrochure=true) {
 
-    <main role="main" class="page-content">
+    <main role="main" class="page-content l-constrained">
 
         @fragments.page.pageHeader("Thanks " + order.first_name + ", See you there!")
 

--- a/frontend/app/views/index.scala.html
+++ b/frontend/app/views/index.scala.html
@@ -2,7 +2,7 @@
 
 @import configuration.Config
 
-@main("Home Page", isBrochure=true) {
+@main("Home Page") {
 
 <main role="main" class="l-constrained">
 

--- a/frontend/app/views/index.scala.html
+++ b/frontend/app/views/index.scala.html
@@ -2,7 +2,9 @@
 
 @import configuration.Config
 
-@main("Home Page") {
+@main("Home Page", isBrochure=true) {
+
+<main role="main" class="l-constrained">
 
     @* ===== Slideshow ===== *@
     <section class="slideshow js-slideshow" data-slideshow-duration="5000">
@@ -61,5 +63,7 @@
             </ul>
         </div>
     </section>
+
+</main>
 
 }

--- a/frontend/app/views/info/about.scala.html
+++ b/frontend/app/views/info/about.scala.html
@@ -4,7 +4,7 @@
 @import views.support.Asset
 @import com.gu.membership.salesforce.Tier
 
-@main("About", isBrochure=true, pageInfo=pageInfo) {
+@main("About", pageInfo=pageInfo) {
 
     @* ===== About Membership ===== *@
     <div class="page-slice l-constrained l-side-margins">

--- a/frontend/app/views/info/feedback.scala.html
+++ b/frontend/app/views/info/feedback.scala.html
@@ -2,7 +2,7 @@
 
 @import helper.CSRF
 
-@main("Feedback", isBrochure=true) {
+@main("Feedback") {
 
     <main role="main" class="page-content l-constrained">
 

--- a/frontend/app/views/info/feedback.scala.html
+++ b/frontend/app/views/info/feedback.scala.html
@@ -2,9 +2,9 @@
 
 @import helper.CSRF
 
-@main("Feedback", htmlClass = "feedback") {
+@main("Feedback", isBrochure=true) {
 
-    <main role="main" class="page-content">
+    <main role="main" class="page-content l-constrained">
 
         <section class="form-header">
             <h1 class="form-headline">Feedback</h1>

--- a/frontend/app/views/info/feedbackThankyou.scala.html
+++ b/frontend/app/views/info/feedbackThankyou.scala.html
@@ -1,6 +1,6 @@
 @()
 
-@main("Feedback Thankyou", isBrochure=true) {
+@main("Feedback Thankyou") {
 
     <main role="main" class="page-content l-constrained">
         @fragments.page.pageHeader("Thank you for contacting us")

--- a/frontend/app/views/info/feedbackThankyou.scala.html
+++ b/frontend/app/views/info/feedbackThankyou.scala.html
@@ -1,8 +1,8 @@
 @()
 
-@main("Feedback Thankyou") {
+@main("Feedback Thankyou", isBrochure=true) {
 
-    <main role="main" class="page-content">
+    <main role="main" class="page-content l-constrained">
         @fragments.page.pageHeader("Thank you for contacting us")
         <div class="page-section">
             <div class="page-section__content">

--- a/frontend/app/views/info/giftingPlaceholder.scala.html
+++ b/frontend/app/views/info/giftingPlaceholder.scala.html
@@ -1,6 +1,6 @@
 @import configuration.Config
 
-@main("Gifting", isBrochure=true) {
+@main("Gifting") {
     <main role="main" class="page-content l-constrained">
         @fragments.page.pageHeader("Gifting")
         <section class="page-section page-section--bordered">

--- a/frontend/app/views/info/giftingPlaceholder.scala.html
+++ b/frontend/app/views/info/giftingPlaceholder.scala.html
@@ -1,7 +1,7 @@
 @import configuration.Config
 
-@main("Gifting", htmlClass="help") {
-    <main role="main" class="page-content">
+@main("Gifting", isBrochure=true) {
+    <main role="main" class="page-content l-constrained">
         @fragments.page.pageHeader("Gifting")
         <section class="page-section page-section--bordered">
             <div class="page-section__lead-in">

--- a/frontend/app/views/info/help.scala.html
+++ b/frontend/app/views/info/help.scala.html
@@ -1,7 +1,7 @@
 @import configuration.Config
 @import model.Faq
 
-@main("Help", isBrochure=true) {
+@main("Help") {
     <main role="main" class="page-content l-constrained">
         @fragments.page.pageHeader("FAQ", Some("Common questions about Guardian Membership"))
         <section class="page-section">

--- a/frontend/app/views/info/help.scala.html
+++ b/frontend/app/views/info/help.scala.html
@@ -1,8 +1,8 @@
 @import configuration.Config
 @import model.Faq
 
-@main("Help") {
-    <main role="main" class="page-content">
+@main("Help", isBrochure=true) {
+    <main role="main" class="page-content l-constrained">
         @fragments.page.pageHeader("FAQ", Some("Common questions about Guardian Membership"))
         <section class="page-section">
             <div class="page-section__content">

--- a/frontend/app/views/joiner/form/address.scala.html
+++ b/frontend/app/views/joiner/form/address.scala.html
@@ -7,7 +7,7 @@
 @import com.gu.membership.salesforce.Tier.Friend
 @import helper._
 
-@main("Address details | Friend", isBrochure=true) {
+@main("Address details | Friend") {
 
     <main role="main" class="page-content l-constrained">
 

--- a/frontend/app/views/joiner/form/address.scala.html
+++ b/frontend/app/views/joiner/form/address.scala.html
@@ -7,9 +7,9 @@
 @import com.gu.membership.salesforce.Tier.Friend
 @import helper._
 
-@main("Address details | Friend") {
+@main("Address details | Friend", isBrochure=true) {
 
-    <main role="main" class="page-content">
+    <main role="main" class="page-content l-constrained">
 
         <section class="form-header">
             <h1 class="form-headline">Location</h1>

--- a/frontend/app/views/joiner/form/addressWithWelcomePack.scala.html
+++ b/frontend/app/views/joiner/form/addressWithWelcomePack.scala.html
@@ -7,7 +7,7 @@
 
 @import helper._
 
-@main("Enter Details | Staff", isBrochure=true) {
+@main("Enter Details | Staff") {
 
     <main role="main" class="page-content l-constrained">
 

--- a/frontend/app/views/joiner/form/addressWithWelcomePack.scala.html
+++ b/frontend/app/views/joiner/form/addressWithWelcomePack.scala.html
@@ -7,9 +7,9 @@
 
 @import helper._
 
-@main("Enter Details | Staff") {
+@main("Enter Details | Staff", isBrochure=true) {
 
-    <main role="main" class="page-content">
+    <main role="main" class="page-content l-constrained">
 
         <section class="form-header">
             <h1 class="form-headline">Address</h1>

--- a/frontend/app/views/joiner/form/payment.scala.html
+++ b/frontend/app/views/joiner/form/payment.scala.html
@@ -8,9 +8,9 @@
 
 @import helper._
 
-@main("Payment | " + tier, pageInfo = pageInfo) {
+@main("Payment | " + tier, pageInfo=pageInfo, isBrochure=true) {
 
-    <main role="main" class="page-content">
+    <main role="main" class="page-content l-constrained">
 
         <section class="form-header">
             <h1 class="form-headline">Address & billing</h1>

--- a/frontend/app/views/joiner/form/payment.scala.html
+++ b/frontend/app/views/joiner/form/payment.scala.html
@@ -8,7 +8,7 @@
 
 @import helper._
 
-@main("Payment | " + tier, pageInfo=pageInfo, isBrochure=true) {
+@main("Payment | " + tier, pageInfo=pageInfo) {
 
     <main role="main" class="page-content l-constrained">
 

--- a/frontend/app/views/joiner/staff.scala.html
+++ b/frontend/app/views/joiner/staff.scala.html
@@ -23,9 +23,9 @@
     </li>
 }
 
-@main("Staff Membership") {
+@main("Staff Membership", isBrochure=true) {
 
-    <main class="page-content" role="main">
+    <main class="page-content l-constrained" role="main">
 
         @for(flashMsg <- flashMessage) {
             @fragments.notifications.flashMessage(flashMsg)

--- a/frontend/app/views/joiner/staff.scala.html
+++ b/frontend/app/views/joiner/staff.scala.html
@@ -23,7 +23,7 @@
     </li>
 }
 
-@main("Staff Membership", isBrochure=true) {
+@main("Staff Membership") {
 
     <main class="page-content l-constrained" role="main">
 

--- a/frontend/app/views/joiner/thankyou.scala.html
+++ b/frontend/app/views/joiner/thankyou.scala.html
@@ -25,9 +25,9 @@
     }
 }
 
-@main(title) {
+@main(title, isBrochure=true) {
 
-    <main role="main" class="page-content">
+    <main role="main" class="page-content l-constrained">
 
         @fragments.page.pageHeader(personalisedWelcome + "Welcome to Guardian Membership",
             Some("You're the newest member of the Guardian Membership community and we're thrilled to have you on board. We've sent confirmation of your membership to " + member.email))

--- a/frontend/app/views/joiner/thankyou.scala.html
+++ b/frontend/app/views/joiner/thankyou.scala.html
@@ -25,7 +25,7 @@
     }
 }
 
-@main(title, isBrochure=true) {
+@main(title) {
 
     <main role="main" class="page-content l-constrained">
 

--- a/frontend/app/views/joiner/tier/patron.scala.html
+++ b/frontend/app/views/joiner/tier/patron.scala.html
@@ -5,7 +5,7 @@
 @import model.Benefits
 @import com.gu.membership.salesforce.Tier
 
-@main("Patrons", isBrochure = true, pageInfo=pageInfo) {
+@main("Patrons", pageInfo=pageInfo) {
 
     @* ===== About Patronage ===== *@
     <div class="page-slice l-constrained l-side-margins">

--- a/frontend/app/views/joiner/tierList.scala.html
+++ b/frontend/app/views/joiner/tierList.scala.html
@@ -4,9 +4,9 @@
 @import model.Benefits
 @import com.gu.membership.salesforce.Tier
 
-@main("Join", pageInfo=pageInfo, htmlClass = "join") {
+@main("Join", pageInfo=pageInfo, isBrochure=true) {
 
-    <main role="main" class="page-content">
+    <main role="main" class="page-content l-constrained">
         @fragments.page.pageHeader("Become a member", Some("Join as a founding Partner or Patron and the price you pay today will never rise"))
 
         <section class="page-section">

--- a/frontend/app/views/joiner/tierList.scala.html
+++ b/frontend/app/views/joiner/tierList.scala.html
@@ -4,7 +4,7 @@
 @import model.Benefits
 @import com.gu.membership.salesforce.Tier
 
-@main("Join", pageInfo=pageInfo, isBrochure=true) {
+@main("Join", pageInfo=pageInfo) {
 
     <main role="main" class="page-content l-constrained">
         @fragments.page.pageHeader("Become a member", Some("Join as a founding Partner or Patron and the price you pay today will never rise"))

--- a/frontend/app/views/joining/tierChooser.scala.html
+++ b/frontend/app/views/joining/tierChooser.scala.html
@@ -2,9 +2,9 @@
 
 @import com.gu.membership.salesforce.Tier
 
-@main("Join Choose Tier", pageInfo=pageInfo) {
+@main("Join Choose Tier", pageInfo=pageInfo, isBrochure=true) {
 
-    <main role="main" class="page-content">
+    <main role="main" class="page-content l-constrained">
 
         @fragments.page.pageHeader(eventOpt.fold("Choose a membership tier")(_.metadata.chooseTier.title))
 

--- a/frontend/app/views/joining/tierChooser.scala.html
+++ b/frontend/app/views/joining/tierChooser.scala.html
@@ -2,7 +2,7 @@
 
 @import com.gu.membership.salesforce.Tier
 
-@main("Join Choose Tier", pageInfo=pageInfo, isBrochure=true) {
+@main("Join Choose Tier", pageInfo=pageInfo) {
 
     <main role="main" class="page-content l-constrained">
 

--- a/frontend/app/views/login/signin.scala.html
+++ b/frontend/app/views/login/signin.scala.html
@@ -2,7 +2,7 @@
 
 @import configuration.Config
 
-@main("Sign in/Register", isBrochure=true) {
+@main("Sign in/Register") {
 
     <main role="main" class="page-content l-constrained">
 

--- a/frontend/app/views/login/signin.scala.html
+++ b/frontend/app/views/login/signin.scala.html
@@ -2,9 +2,9 @@
 
 @import configuration.Config
 
-@main("Sign in/Register") {
+@main("Sign in/Register", isBrochure=true) {
 
-    <main role="main" class="page-content">
+    <main role="main" class="page-content l-constrained">
 
         @fragments.page.pageHeader("Sign in / Register")
 

--- a/frontend/app/views/main.scala.html
+++ b/frontend/app/views/main.scala.html
@@ -1,6 +1,5 @@
 @(
     title: String,
-    isBrochure: Boolean = false,
     htmlClass: String = "",
     pageInfo: model.PageInfo = model.PageInfo.default
 )(content: Html)
@@ -9,7 +8,6 @@
 @import views.support.Asset
 
 <!DOCTYPE html>
-
 <html class="js-off id--signed-out @htmlClass">
     <head>
         <meta charset="utf-8">
@@ -62,15 +60,7 @@
         <div class="container-global">
             @fragments.header()
             <div class="l-side-margins" id="container">
-            @if(isBrochure != true) {
-                <div class="page-container">
-            }
-
                 @content
-
-            @if(isBrochure != true) {
-                </div>
-            }
             </div>
         </div>
 

--- a/frontend/app/views/main.scala.html
+++ b/frontend/app/views/main.scala.html
@@ -61,7 +61,7 @@
         @* ===== Anything in here will be hidden for old browsers ===== *@
         <div class="container-global">
             @fragments.header()
-            <div class="page-side-margins" id="container">
+            <div class="l-side-margins" id="container">
             @if(isBrochure != true) {
                 <div class="page-container">
             }

--- a/frontend/app/views/patterns/patterns.scala.html
+++ b/frontend/app/views/patterns/patterns.scala.html
@@ -17,7 +17,7 @@
     </div>
 }
 
-@main("Pattern Library", isBrochure=true) {
+@main("Pattern Library") {
 
     <main class="page-content l-constrained">
 

--- a/frontend/app/views/patterns/patterns.scala.html
+++ b/frontend/app/views/patterns/patterns.scala.html
@@ -17,9 +17,9 @@
     </div>
 }
 
-@main("Pattern Library") {
+@main("Pattern Library", isBrochure=true) {
 
-    <main class="page-content">
+    <main class="page-content l-constrained">
 
     <div class="pattern-nav js-pattern-nav"></div>
 

--- a/frontend/app/views/staff/unauthorised.scala.html
+++ b/frontend/app/views/staff/unauthorised.scala.html
@@ -2,9 +2,9 @@
 
 @import configuration.Config
 
-@main("Unauthorised Staff") {
+@main("Unauthorised Staff", isBrochure=true) {
 
-    <main class="page-content">
+    <main class="page-content l-constrained" role="main">
 
         @fragments.page.pageHeader("Sorry, we are having problems authenticating your email address")
 

--- a/frontend/app/views/staff/unauthorised.scala.html
+++ b/frontend/app/views/staff/unauthorised.scala.html
@@ -2,7 +2,7 @@
 
 @import configuration.Config
 
-@main("Unauthorised Staff", isBrochure=true) {
+@main("Unauthorised Staff") {
 
     <main class="page-content l-constrained" role="main">
 

--- a/frontend/app/views/testing/testUsers.scala.html
+++ b/frontend/app/views/testing/testUsers.scala.html
@@ -2,9 +2,9 @@
 
 @import configuration.Config
 
-@main("Test Users") {
+@main("Test Users", isBrochure=true) {
 
-    <main role="main" class="page-content">
+    <main role="main" class="page-content l-constrained">
 
         @fragments.page.pageHeader("Test Users")
 

--- a/frontend/app/views/testing/testUsers.scala.html
+++ b/frontend/app/views/testing/testUsers.scala.html
@@ -2,7 +2,7 @@
 
 @import configuration.Config
 
-@main("Test Users", isBrochure=true) {
+@main("Test Users") {
 
     <main role="main" class="page-content l-constrained">
 

--- a/frontend/app/views/tier/cancel/confirm.scala.html
+++ b/frontend/app/views/tier/cancel/confirm.scala.html
@@ -4,9 +4,9 @@
 @import helper._
 @import views.support.Asset
 
-@main("Cancel Tier") {
+@main("Cancel Tier", isBrochure=true) {
 
-    <main role="main" class="page-content page-content--padded">
+    <main role="main" class="page-content page-content--padded l-constrained">
 
         @fragments.layout.sectionHeader("We don't like goodbyes&hellip;")
 

--- a/frontend/app/views/tier/cancel/confirm.scala.html
+++ b/frontend/app/views/tier/cancel/confirm.scala.html
@@ -4,7 +4,7 @@
 @import helper._
 @import views.support.Asset
 
-@main("Cancel Tier", isBrochure=true) {
+@main("Cancel Tier") {
 
     <main role="main" class="page-content page-content--padded l-constrained">
 

--- a/frontend/app/views/tier/cancel/summary.scala.html
+++ b/frontend/app/views/tier/cancel/summary.scala.html
@@ -3,9 +3,9 @@
 @import configuration.Config
 @import views.support.Dates._
 
-@main("Cancel Tier summary") {
+@main("Cancel Tier summary", isBrochure=true) {
 
-    <main role="main" class="page-content">
+    <main role="main" class="page-content l-constrained">
 
         @fragments.page.pageHeader("Sorry to see you go…", subscriptionDetailsOpt.map("You will continue to receive all the great Membership benefits until " + _.endDate.pretty))
 

--- a/frontend/app/views/tier/cancel/summary.scala.html
+++ b/frontend/app/views/tier/cancel/summary.scala.html
@@ -3,7 +3,7 @@
 @import configuration.Config
 @import views.support.Dates._
 
-@main("Cancel Tier summary", isBrochure=true) {
+@main("Cancel Tier summary") {
 
     <main role="main" class="page-content l-constrained">
 

--- a/frontend/app/views/tier/change.scala.html
+++ b/frontend/app/views/tier/change.scala.html
@@ -4,9 +4,9 @@
 @import com.gu.membership.salesforce.Tier
 @import helper._
 
-@main("Change Tier", htmlClass = "change-tier") {
+@main("Change Tier", htmlClass = "change-tier", isBrochure=true) {
 
-    <main role="main" class="page-content page-content--padded">
+    <main role="main" class="page-content page-content--padded l-constrained">
         <div class="content__container">
             <section class="content__section">
                 <a href="@Config.idWebAppUrl/membership/edit" class="action action--arrow-left action-cta--confirm">Edit profile</a>

--- a/frontend/app/views/tier/change.scala.html
+++ b/frontend/app/views/tier/change.scala.html
@@ -4,7 +4,7 @@
 @import com.gu.membership.salesforce.Tier
 @import helper._
 
-@main("Change Tier", htmlClass = "change-tier", isBrochure=true) {
+@main("Change Tier", htmlClass = "change-tier") {
 
     <main role="main" class="page-content page-content--padded l-constrained">
         <div class="content__container">

--- a/frontend/app/views/tier/downgrade/confirm.scala.html
+++ b/frontend/app/views/tier/downgrade/confirm.scala.html
@@ -4,7 +4,7 @@
 @import model.Benefits
 @import helper._
 
-@main("Change Tier | Friend from " + currentTier, isBrochure=true) {
+@main("Change Tier | Friend from " + currentTier) {
 
     <main role="main" class="page-content l-constrained">
 

--- a/frontend/app/views/tier/downgrade/confirm.scala.html
+++ b/frontend/app/views/tier/downgrade/confirm.scala.html
@@ -4,9 +4,9 @@
 @import model.Benefits
 @import helper._
 
-@main("Change Tier | Friend from " + currentTier) {
+@main("Change Tier | Friend from " + currentTier, isBrochure=true) {
 
-    <main role="main" class="page-content">
+    <main role="main" class="page-content l-constrained">
 
         @fragments.layout.sectionHeader("Are you sure?")
         <p>You will no longer receive all the great benefits</p>

--- a/frontend/app/views/tier/downgrade/summary.scala.html
+++ b/frontend/app/views/tier/downgrade/summary.scala.html
@@ -4,9 +4,9 @@
 @import views.support.Dates._
 @import views.support.Prices._
 
-@main("Change Tier Summary | " + futureSubscription.planName + " from " + currentSubscription.planName) {
+@main("Change Tier Summary | " + futureSubscription.planName + " from " + currentSubscription.planName, isBrochure=true) {
 
-    <main role="main" class="page-content">
+    <main role="main" class="page-content l-constrained">
 
         @fragments.page.pageHeader("Sorry to see you go…", Some("You will continue to receive all the great Membership benefits until " + currentSubscription.endDate.pretty))
 

--- a/frontend/app/views/tier/downgrade/summary.scala.html
+++ b/frontend/app/views/tier/downgrade/summary.scala.html
@@ -4,7 +4,7 @@
 @import views.support.Dates._
 @import views.support.Prices._
 
-@main("Change Tier Summary | " + futureSubscription.planName + " from " + currentSubscription.planName, isBrochure=true) {
+@main("Change Tier Summary | " + futureSubscription.planName + " from " + currentSubscription.planName) {
 
     <main role="main" class="page-content l-constrained">
 

--- a/frontend/app/views/tier/upgrade/upgradeForm.scala.html
+++ b/frontend/app/views/tier/upgrade/upgradeForm.scala.html
@@ -8,7 +8,7 @@
 
 @import helper._
 
-@main("Change Tier | " + targetTier + " from " + currentTier, pageInfo = pageInfo, isBrochure=true) {
+@main("Change Tier | " + targetTier + " from " + currentTier, pageInfo = pageInfo) {
 
     <main role="main" class="page-content l-constrained">
 

--- a/frontend/app/views/tier/upgrade/upgradeForm.scala.html
+++ b/frontend/app/views/tier/upgrade/upgradeForm.scala.html
@@ -8,9 +8,9 @@
 
 @import helper._
 
-@main("Change Tier | " + targetTier + " from " + currentTier, pageInfo = pageInfo) {
+@main("Change Tier | " + targetTier + " from " + currentTier, pageInfo = pageInfo, isBrochure=true) {
 
-    <main role="main" class="page-content">
+    <main role="main" class="page-content l-constrained">
 
         <section class="page-header">
             <h1 class="page-headline">Payment</h1>

--- a/frontend/assets/stylesheets/components/_packages.scss
+++ b/frontend/assets/stylesheets/components/_packages.scss
@@ -105,7 +105,6 @@
         float: right;
     }
 
-    .join &,
     .change-tier & {
         @include mq (desktop) {
             position: absolute;
@@ -156,7 +155,6 @@
     min-height: rem($gs-gutter * 4);
 
     // TODO: Remove this
-    .join &,
     .change-tier & {
         @include mq(desktop) {
             margin-bottom: rem($gs-gutter * 3);


### PR DESCRIPTION
This PR removes the need for the isBrochure flag and moves all layout constraints into individual templates (no global constraints on layout).

This frees us up to have much more flexible layouts, treating pages as vertical slices of content rather than a big rectangle to fill in.

Feels good to clean this out. This is a bit of a big PR, but I'm not sure there's a better way to do it other than dozens of identical PRs.

It touches nearly every template, but I've gone through each template to test that nothing has changed visually.

How do people feel about this? Better to rip the plaster off?