### PR TITLE
Fix "signed in as link" on join forms

### DIFF
--- a/frontend/assets/stylesheets/components/_form-layout.scss
+++ b/frontend/assets/stylesheets/components/_form-layout.scss
@@ -26,7 +26,7 @@
 
     @include mq(desktop) {
         width: rem(gs-span(11));
-        float: left;
+        margin-left: 0;
         padding-left: rem(gs-span(2) + $gs-gutter);
     }
 }


### PR DESCRIPTION
- remove the float as this wasn't needed and was causing problems with being able to click the signed in as link

@davidrapson fix for the above you mentioned earlier