### PR TITLE
Fix styling regressions on event pages

### DIFF
--- a/frontend/app/views/event/page.scala.html
+++ b/frontend/app/views/event/page.scala.html
@@ -124,7 +124,7 @@
                     </div>
                 }
                 @if(!event.isBookable) {
-                    <a class="action action--secondary u-fullwidth u-no-top-margin" href="@event.metadata.eventListUrl">
+                    <a class="action action--secondary u-fullwidth" href="@event.metadata.eventListUrl">
                         Find other @event.metadata.pluralTitle
                         @fragments.actionIcon("arrow-right")
                     </a>

--- a/frontend/assets/stylesheets/components/_pricing.scss
+++ b/frontend/assets/stylesheets/components/_pricing.scss
@@ -136,6 +136,7 @@
 
 .price-info-inline {
     @include clearfix;
+    color: inherit;
 }
 .price-info-inline__value {
     padding-bottom: 0;
@@ -156,8 +157,6 @@
 }
 
 .price-info-inline--primary {
-    color: $white;
-
     .price-info-inline__value {
         @include fs-header(4);
         font-weight: bold;


### PR DESCRIPTION
I managed to introduce a couple of annoying styling regressions to event pages yesterday. This PR fixes them.

**White pricing text on Masterclasses**

![screen shot 2015-02-11 at 14 19 50](https://cloud.githubusercontent.com/assets/123386/6148573/b0684366-b1fa-11e4-9ec7-d5f8f6dbf480.png)

![screen shot 2015-02-11 at 14 32 28](https://cloud.githubusercontent.com/assets/123386/6148586/c138a08c-b1fa-11e4-82ce-a23ab74fd5f8.png)

**No spacing between event info panel and button**

![screen shot 2015-02-11 at 14 30 39](https://cloud.githubusercontent.com/assets/123386/6148590/cf18d4a6-b1fa-11e4-9a5b-a5428ad4fa07.png)

![screen shot 2015-02-11 at 14 30 53](https://cloud.githubusercontent.com/assets/123386/6148591/d12e77e6-b1fa-11e4-9ed9-e6e1a26c0463.png)

