### PR TITLE
Mark which tier the downgrade is from 

### DIFF
--- a/frontend/app/controllers/TierController.scala
+++ b/frontend/app/controllers/TierController.scala
@@ -24,7 +24,7 @@ trait DowngradeTier {
 
   def downgradeToFriendConfirm() = PaidMemberAction.async { implicit request => // POST
     for {
-      cancelledSubscription <- request.touchpointBackend.downgradeSubscription(request.member, FriendTierPlan)
+      cancelledSubscription <- request.touchpointBackend.downgradeSubscription(request.member)
     } yield Redirect("/tier/change/friend/summary")
   }
 

--- a/frontend/app/services/TouchpointBackend.scala
+++ b/frontend/app/services/TouchpointBackend.scala
@@ -65,11 +65,11 @@ case class TouchpointBackend(
     }
   }
 
-  def downgradeSubscription(member: Member, tierPlan: TierPlan): Future[String] = {
+  def downgradeSubscription(member: Member): Future[String] = {
     for {
       _ <- subscriptionService.downgradeSubscription(member, FriendTierPlan)
     } yield {
-      memberRepository.metrics.putDowngrade(tierPlan.tier)
+      memberRepository.metrics.putDowngrade(member.tier)
       ""
     }
   }


### PR DESCRIPTION
For metrics to AWS we are marking all downgrades under Friend (which is the only possibility for downgrades). We could instead mark which tier the downgrade is coming from. @mattandrews this will change the radiator stats so let me know your thoughts on in if it is worth changing this. We could have two metrics (the one downgraded from and one downgraded to) but I'm hoping the Events tracking tool will cover this.