### PR TITLE
Refactor ticketing model for InternalTicketing & DiscountBenefitTicketing

### DIFF
--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -1,25 +1,21 @@
 package controllers
 
+import actions.AnyMemberTierRequest
+import actions.Fallbacks._
+import actions.Functions._
+import com.gu.membership.salesforce.Tier
+import com.gu.membership.util.Timing
+import com.netaporter.uri.dsl._
+import configuration.{Config, CopyConfig}
 import model.Eventbrite.EBEvent
+import model.RichEvent._
+import model.{EventPortfolio, Eventbrite, PageInfo}
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import play.api.mvc._
+import services.{EventbriteService, GuardianLiveEventService, MasterclassEventService, MemberService}
+import services.EventbriteService._
 
 import scala.concurrent.Future
-
-import play.api.mvc._
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
-
-import com.netaporter.uri.dsl._
-
-import com.gu.membership.salesforce.Member
-import com.gu.membership.util.Timing
-
-import actions.AnyMemberTierRequest
-import actions.Functions._
-import actions.Fallbacks._
-import services.{MasterclassEventService, GuardianLiveEventService, MemberService, EventbriteService}
-import services.EventbriteService._
-import configuration.{Config, CopyConfig}
-import model.RichEvent._
-import model.{TicketSaleDates, Eventbrite, EventPortfolio, PageInfo}
 
 trait Event extends Controller {
   val guLiveEvents: EventbriteService
@@ -112,7 +108,7 @@ trait Event extends Controller {
     EventbriteService.getEvent(id).map { event =>
       event match {
         case _: GuLiveEvent =>
-          if (memberCanBuyTicket(event, request.member)) redirectToEventbrite(request, event)
+          if (tierCanBuyTickets(event, request.member.tier)) redirectToEventbrite(request, event)
           else Future.successful(Redirect(routes.TierController.change()))
 
         case _: MasterclassEvent =>
@@ -121,10 +117,8 @@ trait Event extends Controller {
     }.getOrElse(Future.successful(NotFound))
   }
 
-  private def memberCanBuyTicket(event: Eventbrite.EBEvent, member: Member): Boolean =
-    event.generalReleaseTicket.exists { ticket =>
-      TicketSaleDates.datesFor(event.times, ticket).tierCanBuyTicket(member.tier)
-    }
+  private def tierCanBuyTickets(event: Eventbrite.EBEvent, tier: Tier): Boolean =
+    event.internalTicketing.exists(_.salesDates.tierCanBuyTicket(tier))
 
   private def eventCookie(event: RichEvent) = s"mem-event-${event.id}"
 

--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -123,7 +123,7 @@ trait Event extends Controller {
 
   private def memberCanBuyTicket(event: Eventbrite.EBEvent, member: Member): Boolean =
     event.generalReleaseTicket.exists { ticket =>
-      TicketSaleDates.datesFor(event, ticket).tierCanBuyTicket(member.tier)
+      TicketSaleDates.datesFor(event.times, ticket).tierCanBuyTicket(member.tier)
     }
 
   private def eventCookie(event: RichEvent) = s"mem-event-${event.id}"

--- a/frontend/app/model/Benefits.scala
+++ b/frontend/app/model/Benefits.scala
@@ -1,8 +1,11 @@
 package model
 
 import com.gu.membership.salesforce.Tier
+import com.gu.membership.salesforce.Tier.{Partner, Patron}
 
 object Benefits {
+
+  val DiscountTicketTiers = Set[Tier](Partner, Patron)
 
   case class Benefits(
     leadin: String,
@@ -65,14 +68,14 @@ object Benefits {
 
   val details = Map[Tier, Benefits](
     Tier.Friend -> friendBenefits,
-    Tier.Partner -> partnerBenefits,
-    Tier.Patron -> patronBenefits
+    Partner -> partnerBenefits,
+    Patron -> patronBenefits
   )
 
   val detailsLimited = Map[Tier, Seq[BenefitItem]](
     Tier.Friend -> friendsWithBenefitsLimited,
-    Tier.Partner -> partnerWithBenefitsLimited,
-    Tier.Patron -> patronWithBenefitsLimited
+    Partner -> partnerWithBenefitsLimited,
+    Patron -> patronWithBenefitsLimited
   )
 
 }

--- a/frontend/app/model/Eventbrite.scala
+++ b/frontend/app/model/Eventbrite.scala
@@ -1,6 +1,7 @@
 package model
 
 import com.github.nscala_time.time.Imports._
+import com.gu.membership.salesforce.Tier
 import com.netaporter.uri.Uri
 import com.netaporter.uri.dsl._
 import configuration.Config
@@ -60,15 +61,13 @@ object Eventbrite {
       addressLine.map(al => googleMapsUri ? ("q" -> (name.map(_ + ", ").mkString + al)))
   }
 
-  case class EBPricing(value: Int) extends EBObject {
-    def priceFormat(priceInPence: Double) = {
-      val priceInPounds = priceInPence.round / 100f
-      if (priceInPounds.isWhole) f"£$priceInPounds%.0f" else f"£$priceInPounds%.2f"
-    }
+  def formatPrice(priceInPence: Double): String = {
+    val priceInPounds = priceInPence.round / 100f
+    if (priceInPounds.isWhole) f"£$priceInPounds%.0f" else f"£$priceInPounds%.2f"
+  }
 
-    lazy val formattedPrice = priceFormat(value)
-    lazy val discountPrice = priceFormat(value * Config.discountMultiplier)
-    lazy val savingPrice = priceFormat(value * (1 - Config.discountMultiplier))
+  case class EBPricing(value: Int) extends EBObject {
+    lazy val formattedPrice = formatPrice(value)
   }
 
 
@@ -86,7 +85,78 @@ object Eventbrite {
                            sales_end: Instant,
                            sales_start: Option[Instant],
                            hidden: Option[Boolean]) extends EBObject {
-    val isHidden = hidden.exists(_ == true)
+    val isHidden = hidden.contains(true)
+
+    val isMemberBenefit = isHidden && name.toLowerCase.startsWith("guardian member")
+
+    val isSoldOut = quantity_sold >= quantity_total
+
+    val priceInPence = cost.map(_.value).getOrElse(0)
+
+    val priceText = cost.map(_.formattedPrice).getOrElse("Free")
+  }
+
+  sealed trait Ticketing
+
+  case object ExternalTicketing extends Ticketing
+
+  object InternalTicketing {
+    def optFrom(event: EBEvent): Option[InternalTicketing] = {
+      val allTickets = event.ticket_classes
+
+      val generalReleaseTicketOpt = allTickets.find(!_.isHidden)
+      val memberBenefitTickets = allTickets.filter(_.isMemberBenefit)
+
+      for (primaryTicket <- (generalReleaseTicketOpt ++ memberBenefitTickets).headOption) yield {
+        InternalTicketing(event.times, primaryTicket, memberBenefitTickets, allTickets, event.capacity)
+      }
+    }
+  }
+
+  case class InternalTicketing(
+    eventTimes: EventTimes,
+    primaryTicket: EBTicketClass,
+    memberBenefitTickets: Seq[EBTicketClass],
+    allTickets: Seq[EBTicketClass],
+    capacity: Int) extends Ticketing {
+
+    require(allTickets.contains(primaryTicket))
+    require(memberBenefitTickets.forall(allTickets.contains))
+
+    val generalReleaseTicketOpt = Some(primaryTicket).filterNot(_.isMemberBenefit)
+
+    val memberBenefitTicketOpt = memberBenefitTickets.headOption
+
+    val ticketsSold = allTickets.map(_.quantity_sold).sum
+
+    val isSoldOut = ticketsSold >= capacity
+
+    val isFree = primaryTicket.free
+
+    val salesDates = TicketSaleDates.datesFor(eventTimes, primaryTicket)
+
+    val salesEnd = primaryTicket.sales_end
+
+    val isCurrentlyAvailableToPaidMembersOnly =
+      generalReleaseTicketOpt.map(!TicketSaleDates.datesFor(eventTimes, _).tierCanBuyTicket(Tier.Friend)).getOrElse(true)
+
+    val memberDiscountOpt = for {
+      generalReleaseTicket <- generalReleaseTicketOpt
+      memberTicket <- memberBenefitTicketOpt
+    } yield DiscountBenefitTicketing(generalReleaseTicket, memberTicket)
+
+    val isPossiblyMissingDiscount = !isFree && memberDiscountOpt.isEmpty
+
+  }
+
+  case class DiscountBenefitTicketing(generalRelease: EBTicketClass, member: EBTicketClass) {
+    val saving = generalRelease.priceInPence - member.priceInPence
+
+    val savingText = formatPrice(saving)
+
+    val isSoldOut = member.isSoldOut
+
+    val fewerMembersTicketsThanGeneralTickets = member.quantity_total < generalRelease.quantity_total
   }
 
   case class EBEvent(name: EBRichText,
@@ -103,8 +173,14 @@ object Eventbrite {
 
     val times = EventTimes(created, start)
 
-    val isSoldOut = ticket_classes.map(_.quantity_sold).sum >= capacity
-    val isSoldThruEventbrite = !description.exists(_.html.contains("<!-- noTicketEvent -->"))
+    val ticketing: Option[Ticketing] =
+      if (description.exists(_.html.contains("<!-- noTicketEvent -->"))) Some(ExternalTicketing) else InternalTicketing.optFrom(this)
+
+    val internalTicketing: Option[InternalTicketing] = ticketing collect {
+      case t: InternalTicketing => t
+    }
+
+    val isSoldOut = internalTicketing.exists(_.isSoldOut)
     val isBookable = status == "live" && !isSoldOut
     val isPastEvent = status != "live" && status != "draft"
 
@@ -120,13 +196,6 @@ object Eventbrite {
       provider = m.group(1)
       if EBEvent.providerWhitelist.contains(provider)
     } yield provider
-
-    val generalReleaseTicket = ticket_classes.find(!_.isHidden)
-    val memberTickets = ticket_classes.filter { t => t.isHidden && t.name.toLowerCase.startsWith("guardian member")}
-    val hasMemberTicket = memberTickets.nonEmpty
-    val hasFreeGeneralReleaseTicket = generalReleaseTicket.exists(_.free)
-    val isFree = isSoldThruEventbrite && hasFreeGeneralReleaseTicket
-    val possiblyMissingDiscount = !hasFreeGeneralReleaseTicket && !hasMemberTicket
 
     val mainImageUrl: Option[String] = description.flatMap(desc => "<!--\\s*main-image: (.*?)\\s*-->".r.findFirstMatchIn(desc.html).map(_.group(1)) )
 

--- a/frontend/app/model/Eventbrite.scala
+++ b/frontend/app/model/Eventbrite.scala
@@ -72,6 +72,8 @@ object Eventbrite {
   }
 
 
+  case class EventTimes(created: Instant, start: DateTime)
+
   /**
    * https://developer.eventbrite.com/docs/ticket-class-object/
    */
@@ -98,6 +100,8 @@ object Eventbrite {
                      capacity: Int,
                      ticket_classes: Seq[EBTicketClass],
                      status: String) extends EBObject {
+
+    val times = EventTimes(created, start)
 
     val isSoldOut = ticket_classes.map(_.quantity_sold).sum >= capacity
     val isSoldThruEventbrite = !description.exists(_.html.contains("<!-- noTicketEvent -->"))

--- a/frontend/app/model/TicketSaleDates.scala
+++ b/frontend/app/model/TicketSaleDates.scala
@@ -1,15 +1,13 @@
 package model
 
-import scala.collection.immutable.SortedMap
-
-import org.joda.time.Instant
-import org.joda.time.DateTimeZone.UTC
 import com.github.nscala_time.time.Imports._
-
 import com.gu.membership.salesforce.Tier
-import com.gu.membership.salesforce.Tier.{Patron, Partner}
+import com.gu.membership.salesforce.Tier.{Partner, Patron}
+import model.Eventbrite.{EBTicketClass, EventTimes}
+import org.joda.time.DateTimeZone.UTC
+import org.joda.time.Instant
 
-import model.Eventbrite.{EBEvent, EBTicketClass}
+import scala.collection.immutable.SortedMap
 
 case class TicketSaleDates(generalAvailability: Instant, memberAdvanceTicketSales: Option[Map[Tier, Instant]] = None, needToDistinguishTimes: Boolean = false) {
 
@@ -39,10 +37,10 @@ object TicketSaleDates {
     6.weeks.standardDuration -> Map(Patron -> 2.weeks, Partner -> 1.week)
   )
 
-  def datesFor(event: EBEvent, tickets: EBTicketClass): TicketSaleDates = {
-    val effectiveSaleStart = tickets.sales_start.getOrElse(event.created)
+  def datesFor(eventTimes: EventTimes, tickets: EBTicketClass): TicketSaleDates = {
+    val effectiveSaleStart = tickets.sales_start.getOrElse(eventTimes.created)
 
-    val saleStartLeadTimeOnEvent = (effectiveSaleStart to event.start).duration
+    val saleStartLeadTimeOnEvent = (effectiveSaleStart to eventTimes.start).duration
 
     memberLeadTimeOverGeneralRelease.until(saleStartLeadTimeOnEvent).values.lastOption match {
       case Some(memberLeadTimes) =>

--- a/frontend/app/views/event/page.scala.html
+++ b/frontend/app/views/event/page.scala.html
@@ -34,20 +34,18 @@
                     @fragments.event.addressSummary(event)
                 </div>
             </div>
-            @if(event.isSoldThruEventbrite) {
-                @for(ticket <- event.generalReleaseTicket) {
-                    <div class="event-ticket@if(ticket.free) { event-ticket--free }u-cf">
-                        <div class="event-ticket__details">
-                            @fragments.pricing.priceInfoEvent(event, isPrimary=true)
-                        </div>
-                        @if(event.isBookable) {
-                            <div class="event-ticket__action">
-                                @fragments.event.ticketCta(event, List("action--booking"))
-                                @fragments.event.terms(event)
-                            </div>
-                        }
+            @for(internalTicketing <- event.internalTicketing) {
+                <div class="event-ticket@if(internalTicketing.isFree) { event-ticket--free }u-cf">
+                    <div class="event-ticket__details">
+                        @fragments.pricing.priceInfoEvent(event, isPrimary=true) <!-- internalTicketing -->
                     </div>
-                }
+                    @if(event.isBookable) {
+                        <div class="event-ticket__action">
+                            @fragments.event.ticketCta(event, List("action--booking"))
+                            @fragments.event.terms(event)
+                        </div>
+                    }
+                </div>
             }
             <img class="event-header__logo" src="@Asset.at("images/providers/" + event.providerOpt.getOrElse(event.metadata.identifier) + ".svg")">
         </div>
@@ -72,10 +70,12 @@
                                    data-metric-category="events"
                                    data-metric-action="highlights">@highlight.title</a>
                             }
+                        } else {
+                            @if(event.isSoldOut) {
+                                @fragments.event.waitlist(event, List("u-no-margin"))
+                            }
                         }
-                        @if(event.isSoldOut && !event.isPastEvent) {
-                            @fragments.event.waitlist(event, List("u-no-margin"))
-                        }
+
                     </div>
                 </div>
             </div>

--- a/frontend/app/views/fragments/event/infoPanel.scala.html
+++ b/frontend/app/views/fragments/event/infoPanel.scala.html
@@ -4,7 +4,7 @@
 @import model.Eventbrite.EBTicketClass
 
 @paidMembersOnly(ticket: EBTicketClass) = @{
-    val ticketSaleDates = model.TicketSaleDates.datesFor(event, ticket)
+    val ticketSaleDates = model.TicketSaleDates.datesFor(event.times, ticket)
     !ticketSaleDates.tierCanBuyTicket(Tier.Friend)
 }
 

--- a/frontend/app/views/fragments/event/infoPanel.scala.html
+++ b/frontend/app/views/fragments/event/infoPanel.scala.html
@@ -3,11 +3,6 @@
 @import com.gu.membership.salesforce.Tier
 @import model.Eventbrite.EBTicketClass
 
-@paidMembersOnly(ticket: EBTicketClass) = @{
-    val ticketSaleDates = model.TicketSaleDates.datesFor(event.times, ticket)
-    !ticketSaleDates.tierCanBuyTicket(Tier.Friend)
-}
-
 <div class="event-info@if(event.isBookable && event.metadata.largeImg) { event-info--bordered tone-border-@event.metadata.identifier } @if(!event.isBookable) { event-info--unavailable}">
 
     @if(!event.isBookable) {
@@ -30,24 +25,18 @@
         <div class="stats-listing">
             @fragments.event.stats(event)
             @* TODO: Make part of event stats *@
-            @if(event.isSoldThruEventbrite && event.isBookable) {
-                @for(ticket <- event.generalReleaseTicket) {
-                    @fragments.event.ticketSales(event, ticket)
-                }
+            @for(ticketing <- event.internalTicketing if event.isBookable) {
+                @fragments.event.ticketSales(event, ticketing)
             }
         </div>
 
-        @if(event.isSoldThruEventbrite) {
-
+         @for(ticketing <- event.internalTicketing) {
             @fragments.pricing.priceInfoEvent(event)
-
-            @for(ticket <- event.generalReleaseTicket) {
-                @if(event.isBookable) {
-                    @fragments.event.ticketCta(event)
-                    @fragments.event.terms(event, List("event-info__terms"))
-                    @if(paidMembersOnly(ticket)) {
-                        <a class="action js-member-cta" href="@routes.Joiner.tierList">Become a member</a>
-                    }
+            @if(event.isBookable) {
+                @fragments.event.ticketCta(event)
+                @fragments.event.terms(event, List("event-info__terms"))
+                @if(ticketing.isCurrentlyAvailableToPaidMembersOnly) {
+                    <a class="action js-member-cta" href="@routes.Joiner.tierList">Become a member</a>
                 }
             }
         }

--- a/frontend/app/views/fragments/event/ticketSales.scala.html
+++ b/frontend/app/views/fragments/event/ticketSales.scala.html
@@ -25,7 +25,7 @@
                 <div class="event-info__second">
                     <div class="sale-dates__header">Ticket release dates</div>
 
-                    @defining(model.TicketSaleDates.datesFor(event, ticket)) { ticketSaleDates =>
+                    @defining(model.TicketSaleDates.datesFor(event.times, ticket)) { ticketSaleDates =>
 
                         @if(ticketSaleDates.anyoneCanBuyTicket) {
                             <button class="js-toggle fake-link u-align-right sales-dates-toggle"

--- a/frontend/app/views/fragments/event/ticketSales.scala.html
+++ b/frontend/app/views/fragments/event/ticketSales.scala.html
@@ -1,4 +1,4 @@
-@(event: model.RichEvent.RichEvent, ticket: model.Eventbrite.EBTicketClass)
+@(event: model.RichEvent.RichEvent, ticketing: model.Eventbrite.InternalTicketing)
 
 @import views.support.Dates._
 @import com.github.nscala_time.time.Imports._
@@ -25,36 +25,33 @@
                 <div class="event-info__second">
                     <div class="sale-dates__header">Ticket release dates</div>
 
-                    @defining(model.TicketSaleDates.datesFor(event.times, ticket)) { ticketSaleDates =>
-
-                        @if(ticketSaleDates.anyoneCanBuyTicket) {
-                            <button class="js-toggle fake-link u-align-right sales-dates-toggle"
-                                    data-toggle-label="Hide"
-                                    data-toggle="js-event-ticket-dates-@event.id">
-                                Show
-                            </button>
-                        }
-
-                        <ul class="sale-dates__list u-unstyled u-cf"
-                            id="js-event-ticket-dates-@event.id"@if(ticketSaleDates.anyoneCanBuyTicket == true) { data-toggle-hidden}>
-                            @for(tier <- Seq(Tier.Patron, Tier.Partner, Tier.Friend)) {
-                                <li class="sale-dates__item" itemscope itemtype="http://schema.org/Offer">
-                                    <meta itemprop="eligibleCustomerType" content="@tier">
-                                    <meta itemprop="availabilityEnds" content="@ticketSaleDates.datesByTier(tier)">
-                                    <span class="sale-dates__item--left">@(tier + "s")</span>
-                                    @ticketDateForTier(tier, ticketSaleDates.datesByTier(tier), ticketSaleDates.needToDistinguishTimes)
-                                </li>
-                            }
-                        </ul>
-
-                        <ul class="sale-dates__list u-unstyled u-cf">
-                            <li class="sale-dates__item">
-                                <span class="sale-dates__item--left">Sale ends</span>
-
-                                @ticketEndSaleDate(ticket.sales_end, ticketSaleDates.needToDistinguishTimes)
-                            </li>
-                        </ul>
+                    @if(ticketing.salesDates.anyoneCanBuyTicket) {
+                        <button class="js-toggle fake-link u-align-right sales-dates-toggle"
+                                data-toggle-label="Hide"
+                                data-toggle="js-event-ticket-dates-@event.id">
+                            Show
+                        </button>
                     }
+
+                    <ul class="sale-dates__list u-unstyled u-cf"
+                        id="js-event-ticket-dates-@event.id"@if(ticketing.salesDates.anyoneCanBuyTicket) { data-toggle-hidden}>
+                        @for(tier <- Seq(Tier.Patron, Tier.Partner, Tier.Friend)) {
+                            <li class="sale-dates__item" itemscope itemtype="http://schema.org/Offer">
+                                <meta itemprop="eligibleCustomerType" content="@tier">
+                                <meta itemprop="availabilityEnds" content="@ticketing.salesDates.datesByTier(tier)">
+                                <span class="sale-dates__item--left">@(tier + "s")</span>
+                                @ticketDateForTier(tier, ticketing.salesDates.datesByTier(tier), ticketing.salesDates.needToDistinguishTimes)
+                            </li>
+                        }
+                    </ul>
+
+                    <ul class="sale-dates__list u-unstyled u-cf">
+                        <li class="sale-dates__item">
+                            <span class="sale-dates__item--left">Sale ends</span>
+
+                            @ticketEndSaleDate(ticketing.salesEnd, ticketing.salesDates.needToDistinguishTimes)
+                        </li>
+                    </ul>
                 </div>
             </div>
         </div>

--- a/frontend/app/views/fragments/pricing/priceInfoEvent.scala.html
+++ b/frontend/app/views/fragments/pricing/priceInfoEvent.scala.html
@@ -1,38 +1,36 @@
 @(event: model.RichEvent.RichEvent, isPrimary: Boolean = false)
 
-@for(ticket <- event.generalReleaseTicket) {
+@for(ticketing <- event.internalTicketing) {
     <div class="price-info-inline@if(isPrimary){ price-info-inline--primary}" itemprop="offers" itemscope itemtype="http://schema.org/AggregateOffer">
 
         <meta itemprop="url" content="@event.memUrl">
-        @if(event.isSoldOut) {
+        @if(ticketing.isSoldOut) {
             <meta itemprop="availability" content="http://schema.org/SoldOut">
         } else {
             <meta itemprop="availability" content="http://schema.org/InStock">
         }
 
-        @if(ticket.free) {
+        @if(ticketing.isFree) {
             <div class="price-info-inline__value">Free</div>
         } else {
-            @for(pricing <- ticket.cost) {
-                @if(event.hasMemberTicket) {
-                    <div class="js-event-price">
-                        <div class="price-info-inline__value js-event-price-value" data-discount-text="@pricing.discountPrice" itemprop="highPrice">
-                            @pricing.formattedPrice
-                        </div>
-                        <div class="price-info-inline__trail">
-                            <span class="js-event-price-discount" data-discount-text="Full price @pricing.formattedPrice" itemprop="lowPrice">
-                                Partners/Patrons @pricing.discountPrice
-                            </span>
-                            <span class="js-event-price-saving" data-discount-text="(you save @pricing.savingPrice)">
-                                (save @pricing.savingPrice)
-                            </span>
-                        </div>
+            @ticketing.memberDiscountOpt.fold {
+                <div class="price-info-inline__value" itemprop="highPrice">
+                    @ticketing.generalReleaseTicketOpt.map(_.priceText)
+                </div>
+            } { discountTicketing =>
+                <div class="js-event-price">
+                    <div class="price-info-inline__value js-event-price-value" data-discount-text="@discountTicketing.member.priceText" itemprop="highPrice">
+                    @discountTicketing.generalRelease.cost.get.formattedPrice
                     </div>
-                } else {
-                    <div class="price-info-inline__value" itemprop="highPrice">
-                        @pricing.formattedPrice
+                    <div class="price-info-inline__trail">
+                        <span class="js-event-price-discount" data-discount-text="Full price @discountTicketing.generalRelease.priceText" itemprop="lowPrice">
+                            Partners/Patrons @discountTicketing.member.priceText
+                        </span>
+                        <span class="js-event-price-saving" data-discount-text="(you save @discountTicketing.savingText)">
+                            (save @discountTicketing.savingText)
+                        </span>
                     </div>
-                }
+                </div>
             }
         }
     </div>

--- a/frontend/app/views/staff/eventOverview.scala.html
+++ b/frontend/app/views/staff/eventOverview.scala.html
@@ -1,9 +1,11 @@
 @(liveEvents: Seq[model.RichEvent.RichEvent], draftEvents: Seq[model.RichEvent.RichEvent])
 
+@import model.Eventbrite.InternalTicketing
+@import model.Eventbrite.ExternalTicketing
 @import configuration.Config
 
-@eventTrait(text: String, displayTrait: Boolean, identifier: String = "") = {
-    <li class="event-trait@if(identifier){ @(s"event-trait--$identifier")}@if(!displayTrait){ is-hidden}">
+@eventTrait(text: String, identifier: String = "") = {
+    <li class="event-trait@if(identifier){ @(s"event-trait--$identifier")}">
         @text
     </li>
 }
@@ -37,21 +39,23 @@
                         </div>
                     </div>
                     <ul class="event-trait-container u-unstyled">
+                        @event.ticketing.collect {
+                            case ExternalTicketing => {
+                                @eventTrait("Not Sold though Eventbrite", "noteworthy")
+                            }
+                            case ticketing: InternalTicketing => {
+                                @if(ticketing.isFree) {
+                                    @eventTrait("Free Event", "moderate")
+                                }
 
-                        @if(event.isFree) {
-                            @eventTrait("Free Event", event.isFree, "moderate")
-                        }
+                                @if(ticketing.isPossiblyMissingDiscount) {
+                                    @eventTrait("No Discount", "important")
+                                }
 
-                        @if(event.possiblyMissingDiscount) {
-                            @eventTrait("No Discount", event.possiblyMissingDiscount, "important")
-                        }
-
-                        @if(!event.isSoldThruEventbrite) {
-                            @eventTrait("Not Sold though Eventbrite", !event.isSoldThruEventbrite, "noteworthy")
-                        }
-
-                        @if(event.isSoldOut) {
-                            @eventTrait("Sold out", event.isSoldOut)
+                                @if(ticketing.isSoldOut) {
+                                    @eventTrait("Sold out")
+                                }
+                            }
                         }
                     </ul>
                 </article>

--- a/frontend/test/model/EventbriteDeserializerTest.scala
+++ b/frontend/test/model/EventbriteDeserializerTest.scala
@@ -11,14 +11,14 @@ class EventbriteDeserializerTest extends PlaySpecification {
 
   "EventbriteDeserializer" should {
 
-    "should deserialize event json" in {
+    "deserialize event json" in {
       val event = Resource.getJson("model/eventbrite/owned-events.2014-10-24.PROD.page-1.json")
       val ebResponse = event.as[EBResponse[EBEvent]]
 
       ebResponse.data.head.name.text === "Born that way: Is there a gay gene and should it matter?"
     }
 
-    "should deserialize event location" in {
+    "deserialize event location" in {
       val event = Resource.getJson("model/eventbrite/owned-events.2014-10-24.PROD.page-1.json")
       val ebResponse = event.as[EBResponse[EBEvent]]
 
@@ -34,10 +34,6 @@ class EventbriteDeserializerTest extends PlaySpecification {
     "deserialize a really complicated ticket class structure" in {
       val event = Resource.getJson("model/eventbrite/event-ticket-classes.json").as[EBEvent]
       event.ticket_classes.length mustEqual 5
-
-      event.generalReleaseTicket.get.id mustEqual "30292989"
-
-      event.memberTickets.map(_.id) mustEqual Seq("30292991", "30338645")
     }
 
     "remove leading/trailing space from strings" in {

--- a/frontend/test/model/TicketSaleDatesTest.scala
+++ b/frontend/test/model/TicketSaleDatesTest.scala
@@ -1,27 +1,25 @@
 package model
 
-import org.specs2.mutable.Specification
-import org.specs2.time.NoTimeConversions
-
 import com.github.nscala_time.time.Imports.{richDateTime, _}
 import com.gu.membership.salesforce.Tier.{Friend, Partner, Patron}
-
-import model.Eventbrite.{EBEvent, EBResponse, EBTicketClass}
+import model.Eventbrite.{EBEvent, EBResponse}
 import model.EventbriteDeserializer._
+import model.EventbriteTestObjects._
+import org.specs2.mutable.Specification
+import org.specs2.time.NoTimeConversions
 import utils.Resource
-import EventbriteTestObjects._
 
 class TicketSaleDatesTest extends Specification with NoTimeConversions {
 
   val eventDate = new DateTime(2014, 6, 1, 18, 23)
-  val testEvent = eventWithName().copy(created = (eventDate - 2.months).toInstant)
+  val testEventTimes = eventWithName().copy(created = (eventDate - 2.months).toInstant).times
 
   "Ticket Sales Dates" should {
 
     "give general availability immediately if there's very little time until the event " in {
-      val saleStart = (testEvent.start - 2.hours).toInstant
+      val saleStart = (testEventTimes.start - 2.hours).toInstant
 
-      val datesByTier = TicketSaleDates.datesFor(testEvent, eventTicketClass.copy(sales_start = Some(saleStart))).datesByTier
+      val datesByTier = TicketSaleDates.datesFor(testEventTimes, eventTicketClass.copy(sales_start = Some(saleStart))).datesByTier
 
       datesByTier(Friend) must be(saleStart)
       datesByTier(Partner) must be(saleStart)
@@ -29,21 +27,21 @@ class TicketSaleDatesTest extends Specification with NoTimeConversions {
     }
 
     "give patrons and partners advance tickets if there's enough lead time" in {
-      val saleStart = (testEvent.start - 7.weeks).toInstant
+      val saleStart = (testEventTimes.start - 7.weeks).toInstant
 
-      val datesByTier = TicketSaleDates.datesFor(testEvent, eventTicketClass.copy(sales_start = Some(saleStart))).datesByTier
+      val datesByTier = TicketSaleDates.datesFor(testEventTimes, eventTicketClass.copy(sales_start = Some(saleStart))).datesByTier
 
       datesByTier(Patron) must be_==(saleStart)
       datesByTier(Patron) must be_<=(datesByTier(Partner))
       datesByTier(Partner) must be_<=(datesByTier(Friend))
-      datesByTier(Friend) must be_<=(testEvent.start)
+      datesByTier(Friend) must be_<=(testEventTimes.start)
       (datesByTier(Patron) to datesByTier(Friend)).duration must be_>=(7.days.standardDuration)
     }
 
     "give set advance tickets to be available to start of the day if sale dates between tiers is more than a day" in {
-      val saleStart = (testEvent.start - 10.days).toInstant
+      val saleStart = (testEventTimes.start - 10.days).toInstant
 
-      val datesByTier = TicketSaleDates.datesFor(testEvent, eventTicketClass.copy(sales_start = Some(saleStart))).datesByTier
+      val datesByTier = TicketSaleDates.datesFor(testEventTimes, eventTicketClass.copy(sales_start = Some(saleStart))).datesByTier
 
       datesByTier(Patron) must be_==(saleStart)
 
@@ -55,9 +53,9 @@ class TicketSaleDatesTest extends Specification with NoTimeConversions {
     }
 
     "give set advance tickets to be available a specific time if sale dates between tiers is less than a day" in {
-      val saleStart = (testEvent.start - 36.hours).toInstant
+      val saleStart = (testEventTimes.start - 36.hours).toInstant
 
-      val datesByTier = TicketSaleDates.datesFor(testEvent, eventTicketClass.copy(sales_start = Some(saleStart))).datesByTier
+      val datesByTier = TicketSaleDates.datesFor(testEventTimes, eventTicketClass.copy(sales_start = Some(saleStart))).datesByTier
 
       datesByTier(Patron) must be_==(saleStart)
 
@@ -70,9 +68,8 @@ class TicketSaleDatesTest extends Specification with NoTimeConversions {
 
     "not die if sales_start is missing" in {
       val event = Resource.getJson("model/eventbrite/event.long-lead-time.missing-sales-start.json").as[EBEvent]
-      val created = event.created.toDateTime
 
-      TicketSaleDates.datesFor(event, event.ticket_classes.head).memberAdvanceTicketSales must beSome
+      TicketSaleDates.datesFor(event.times, event.ticket_classes.head).memberAdvanceTicketSales must beSome
     }
 
     "be sensible given a recent snapshot of PROD Eventbrite events" in {
@@ -83,7 +80,7 @@ class TicketSaleDatesTest extends Specification with NoTimeConversions {
         val tickets = event.ticket_classes.head
         val effectiveStartDate = tickets.sales_start.getOrElse(event.created)
 
-        val ticketSaleDates = TicketSaleDates.datesFor(event, tickets)
+        val ticketSaleDates = TicketSaleDates.datesFor(event.times, tickets)
         val datesByTier = ticketSaleDates.datesByTier
 
         datesByTier(Patron) must be_==(effectiveStartDate)

--- a/frontend/test/resources/model/eventbrite/event-guardian-members-discount.json
+++ b/frontend/test/resources/model/eventbrite/event-guardian-members-discount.json
@@ -1,0 +1,180 @@
+{
+    "resource_uri": "https://www.eventbriteapi.com/v3/events/14906128632/",
+    "name": {
+        "text": "Guardian Live: A Life in Music - George Clinton",
+        "html": "Guardian Live: A Life in Music - George Clinton"
+    },
+    "description": {
+        "text": "Join the Guardian's Alexis Petridis as he discusses an extraordinary life and career with Music Hall of Famer, Dr Funkenstein himself, George Clinton. In partnership with Convergence. \n  \nThe multi-award winning George Clinton revolutionised R&B during the \u201970s, twisting soul music into funk by adding influences from late-\u201960s icons such as Jimi Hendrix, Frank Zappa, and Sly Stone. Clinton\u2019s Parliament/Funkadelic machine ruled black music during the \u201970s, heavily influenced the birth of 90\u2019s rap, as artists from LL Cool J to Snoop Doggy Dogg sampled his work and later went on to work with artists ranging from Red Hot Chili Peppers and Tupac to Ice Cube and Carlos Santana. \u00a0 \nA Life in Music is our series of live interviews with some of the most extraordinary talent from the world of music.  \nFor more Convergence events see www.convergence-london.com \n",
+        "html": "<P STYLE=\"margin: 0cm; margin-bottom: .0001pt;\"><SPAN STYLE=\"font-family: Arial; font-size: 15px; line-height: 19.418672561645508px; white-space: pre-wrap;\">Join the Guardian's Alexis Petridis as he discusses an extraordinary life and career with Music Hall of Famer, Dr Funkenstein himself, George Clinton. In partnership with Convergence.<\/SPAN><\/P>\r\n<P STYLE=\"margin: 0cm; margin-bottom: .0001pt;\"><SPAN STYLE=\"font-size: 15px; font-family: Arial; vertical-align: baseline; white-space: pre-wrap;\"><SPAN STYLE=\"font-family: Arial; font-size: 15px; line-height: 19.418672561645508px; white-space: pre-wrap;\"><BR><\/SPAN><\/SPAN><\/P>\r\n<P STYLE=\"margin: 0cm; margin-bottom: .0001pt;\"><SPAN STYLE=\"font-size: 15px; font-family: Arial; vertical-align: baseline; white-space: pre-wrap;\">The multi-award winning <\/SPAN><SPAN STYLE=\"font-size: 15px; font-family: Arial; font-weight: bold; vertical-align: baseline; white-space: pre-wrap;\">George Clinton<\/SPAN><SPAN STYLE=\"font-size: 15px; font-family: Arial; vertical-align: baseline; white-space: pre-wrap;\"> revolutionised R&B during the \u201970s, twisting soul music into funk by adding influences from late-\u201960s icons such as <\/SPAN><SPAN STYLE=\"font-size: 15px; font-family: Arial; font-weight: bold; vertical-align: baseline; white-space: pre-wrap;\">Jimi Hendrix<\/SPAN><SPAN STYLE=\"font-size: 15px; font-family: Arial; vertical-align: baseline; white-space: pre-wrap;\">, <\/SPAN><SPAN STYLE=\"font-size: 15px; font-family: Arial; font-weight: bold; vertical-align: baseline; white-space: pre-wrap;\">Frank Zappa<\/SPAN><SPAN STYLE=\"font-size: 15px; font-family: Arial; vertical-align: baseline; white-space: pre-wrap;\">, and <\/SPAN><SPAN STYLE=\"font-size: 15px; font-family: Arial; font-weight: bold; vertical-align: baseline; white-space: pre-wrap;\">Sly Stone<\/SPAN><SPAN STYLE=\"font-size: 15px; font-family: Arial; vertical-align: baseline; white-space: pre-wrap;\">. Clinton\u2019s <\/SPAN><SPAN STYLE=\"font-size: 15px; font-family: Arial; font-weight: bold; vertical-align: baseline; white-space: pre-wrap;\">Parliament/Funkadelic <\/SPAN><SPAN STYLE=\"font-size: 15px; font-family: Arial; vertical-align: baseline; white-space: pre-wrap;\">machine ruled black music during the \u201970s, heavily influenced the birth of 90\u2019s rap, as artists from <\/SPAN><SPAN STYLE=\"font-size: 15px; font-family: Arial; font-weight: bold; vertical-align: baseline; white-space: pre-wrap;\">LL Cool J<\/SPAN><SPAN STYLE=\"font-size: 15px; font-family: Arial; vertical-align: baseline; white-space: pre-wrap;\"> to <\/SPAN><SPAN STYLE=\"font-size: 15px; font-family: Arial; font-weight: bold; vertical-align: baseline; white-space: pre-wrap;\">Snoop Doggy Dogg<\/SPAN><SPAN STYLE=\"font-size: 15px; font-family: Arial; vertical-align: baseline; white-space: pre-wrap;\"> sampled his work and later went on to work with artists ranging from Red Hot Chili Peppers and Tupac to Ice Cube and Carlos Santana.<BR>\u00a0<\/SPAN><\/P>\r\n<P STYLE=\"line-height: 1.294578032060103; margin-top: 0pt; margin-bottom: 10pt;\" DIR=\"ltr\"><SPAN><SPAN STYLE=\"font-size: 15px; font-family: Arial; vertical-align: baseline; white-space: pre-wrap;\"><SPAN STYLE=\"font-size: 15px; font-family: Arial; color: #222222; vertical-align: baseline; white-space: pre-wrap;\">A Life in Music is our<\/SPAN><SPAN STYLE=\"color: #222222; font-family: Arial; font-size: 15px; white-space: pre-wrap; line-height: 1.6em;\"> series of live interviews with some of the most extraordinary talent from the world of music. <\/SPAN><\/SPAN><\/SPAN><\/P>\r\n<P STYLE=\"line-height: 1.294578032060103; margin-top: 0pt; margin-bottom: 10pt;\" DIR=\"ltr\"><SPAN STYLE=\"font-size: 15px; font-family: Arial; vertical-align: baseline; white-space: pre-wrap;\"><SPAN STYLE=\"color: #222222; font-family: Arial; font-size: 15px; white-space: pre-wrap; line-height: 1.6em;\">For more Convergence events see <A HREF=\"http://www.convergence-london.com\" REL=\"nofollow\">www.convergence-london.com<\/A><\/SPAN><\/SPAN><\/P>\r\n<!-- main-image: https://media.gutools.co.uk/images/e51a6cfe9fcd6e80f306810d35293ec8f816dcfc?crop=0_139_1460_876 -->"
+    },
+    "logo": {
+        "id": "11911391",
+        "url": "http://cdn.evbuc.com/images/11911391/104062388105/1/logo.jpg"
+    },
+    "id": "14906128632",
+    "url": "http://www.eventbrite.co.uk/e/guardian-live-a-life-in-music-george-clinton-tickets-14906128632",
+    "logo_url": "http://cdn.evbuc.com/images/11911391/104062388105/1/logo.jpg",
+    "start": {
+        "timezone": "Europe/London",
+        "local": "2015-03-16T19:00:00",
+        "utc": "2015-03-16T19:00:00Z"
+    },
+    "end": {
+        "timezone": "Europe/London",
+        "local": "2015-03-16T20:30:00",
+        "utc": "2015-03-16T20:30:00Z"
+    },
+    "created": "2014-12-11T11:13:13Z",
+    "changed": "2015-02-02T20:44:16Z",
+    "capacity": 230,
+    "status": "live",
+    "currency": "GBP",
+    "listed": false,
+    "shareable": false,
+    "invite_only": false,
+    "online_event": false,
+    "show_remaining": false,
+    "organizer_id": "6693856275",
+    "venue_id": "9399243",
+    "category_id": null,
+    "subcategory_id": null,
+    "format_id": null,
+    "category": null,
+    "subcategory": null,
+    "format": null,
+    "organizer": {
+        "description": null,
+        "logo": {
+            "id": "8559825",
+            "url": "http://cdn.evbuc.com/images/8559825/104062388105/2/logo.jpg"
+        },
+        "resource_uri": "https://www.eventbriteapi.com/v3/organizers/6693856275/",
+        "id": "6693856275",
+        "name": "Guardian Live events",
+        "url": "http://www.eventbrite.com/o/guardian-live-events-6693856275",
+        "num_past_events": 11,
+        "num_future_events": 0
+    },
+    "venue": {
+        "address": {
+            "address_1": "25 New Inn Yard",
+            "address_2": null,
+            "city": "London",
+            "region": "Greater London",
+            "postal_code": "EC2A 3EA",
+            "country": "GB",
+            "latitude": "51.524572",
+            "longitude": "-0.07927500000005239"
+        },
+        "resource_uri": "https://www.eventbriteapi.com/v3/venues/9399243/",
+        "id": "9399243",
+        "name": "Amnesty International UK",
+        "latitude": "51.524572",
+        "longitude": "-0.07927500000005239"
+    },
+    "ticket_classes": [
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/14906128632/ticket_classes/32044310/",
+            "id": "32044310",
+            "name": "Standard ticket",
+            "description": null,
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a315.00",
+                "value": 1500
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a313.45",
+                "value": 1345
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a31.55",
+                "value": 155
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "quantity_total": 230,
+            "quantity_sold": 218,
+            "sales_start": "2014-12-18T15:00:00Z",
+            "sales_end": "2015-03-16T18:00:00Z",
+            "hidden": false,
+            "include_fee": true,
+            "split_fee": false,
+            "hide_description": true,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "14906128632"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/14906128632/ticket_classes/32044312/",
+            "id": "32044312",
+            "name": "Guardian Members",
+            "description": null,
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a312.00",
+                "value": 1200
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a310.63",
+                "value": 1063
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a31.37",
+                "value": 137
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "quantity_total": 230,
+            "quantity_sold": 10,
+            "sales_start": "2014-12-18T15:00:00Z",
+            "sales_end": "2015-03-16T18:00:00Z",
+            "hidden": true,
+            "include_fee": true,
+            "split_fee": false,
+            "hide_description": true,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "14906128632"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/14906128632/ticket_classes/32044313/",
+            "id": "32044313",
+            "name": "Guestlist",
+            "description": null,
+            "donation": false,
+            "free": true,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "quantity_total": 10,
+            "quantity_sold": 4,
+            "sales_start": "2014-12-06T18:00:00Z",
+            "sales_end": "2014-12-10T18:00:00Z",
+            "hidden": true,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": true,
+            "auto_hide": false,
+            "event_id": "14906128632"
+        }
+    ]
+}

--- a/frontend/test/services/EventbriteServiceHelpersTest.scala
+++ b/frontend/test/services/EventbriteServiceHelpersTest.scala
@@ -3,26 +3,10 @@ package services
 import model.Eventbrite.{EBEvent, EBResponse}
 import model.EventbriteDeserializer._
 import model.EventbriteTestObjects.TestRichEvent
-import model.RichEvent.MasterclassEvent
 import org.specs2.mutable.Specification
 import utils.Resource
 
 class EventbriteServiceHelpersTest extends Specification {
-  "availableEvents" should {
-    "only show events which have tickets available for members" in {
-      val response = Resource.getJson("model/eventbrite/events-with-member-tickets.json").as[EBResponse[EBEvent]]
-
-      val events = response.data.map { event => MasterclassEvent(event, None) }
-
-      events(0).memberTickets.map(_.id) mustEqual Seq("31250189")
-      events(1).memberTickets.map(_.id) mustEqual Seq("31250231")
-      events(2).memberTickets.map(_.id) mustEqual Seq()
-
-      val availableEvents = EventbriteServiceHelpers.availableEvents(events)
-
-      availableEvents.map(_.id) mustEqual Seq(availableEvents(0).id)
-    }
-  }
 
   "getEventsOrdering" should {
     val events = Resource.getJson("model/eventbrite/owned-events.2014-10-24.PROD.page-1.json").as[EBResponse[EBEvent]].data.map(TestRichEvent)

--- a/frontend/test/services/MasterclassEventsProviderTest.scala
+++ b/frontend/test/services/MasterclassEventsProviderTest.scala
@@ -1,0 +1,24 @@
+package services
+
+import model.Eventbrite.{EBEvent, EBResponse}
+import model.EventbriteDeserializer._
+import model.RichEvent.MasterclassEvent
+import org.specs2.mutable.Specification
+import services.MasterclassEventsProvider.MasterclassesWithAvailableMemberDiscounts
+import utils.Resource
+
+class MasterclassEventsProviderTest extends Specification {
+
+  "service" should {
+    "only show masterclasses which have discount tickets available for members" in {
+      val response = Resource.getJson("model/eventbrite/events-with-member-tickets.json").as[EBResponse[EBEvent]]
+
+      val events = response.data.map { event => MasterclassEvent(event, None) }
+
+      val availableEvents = events.filter(MasterclassesWithAvailableMemberDiscounts)
+
+      availableEvents.map(_.id) mustEqual Seq("13675207915")
+    }
+  }
+
+}


### PR DESCRIPTION
Some questions only make sense for certain events - eg "What's the member discount for this ticket?". Events can be broken down like this:

* **Internal** vs **External** ticketing - Russell Brannd cinema tickets were externally ticketed, by the cinemas involved - all other events, sold thru our Eventbrite, were _Internally_ ticketed.
* **Discounted Events** with a discount for certain tiers (Partner, Patron) - which covers most events - and events with _no_ discount, like the Charlie Hebdo charity event. We can _only_ display information around discounts for Internally ticketed events

There's a lot of conditional logic around how to display this ticket-pricing information, but rather than relying on devs surrounding the relevant code with 'if' statements, it's better to use optional fields and surround with for-comprehensions instead - this way, displaying `salesDates` for an externally-ticketed event can be enforced as a compile error - rather than relying on devs to remember to use the right `if` statement.

So now there's a nesting of optional fields, that goes like this:

```
event --> internalTicketing --> memberDiscountOpt
```

As an additional benefit of this work, we actually correctly display the discount offered based on consideration of both the general-release ticket and the members-benefit ticket - previously, **we were just assuming that the discount was indeed 20% all the time** - I'd rather the discount displayed correlates with what the user actually sees when they go to Eventbrite:

![image](https://cloud.githubusercontent.com/assets/52038/6149998/82d83898-b204-11e4-8d92-ba179128028e.png)

cc @jamesoram @jennysivapalan @davidrapson @feedmypixel 