### PR TITLE
[DO NOT MERGE] Remove code to stop partners from upgrading from events

### DIFF
--- a/frontend/app/model/Eventbrite.scala
+++ b/frontend/app/model/Eventbrite.scala
@@ -135,6 +135,7 @@ object Eventbrite {
 
     val salesDates = TicketSaleDates.datesFor(eventTimes, primaryTicket)
 
+    val salesStart = primaryTicket.sales_start
     val salesEnd = primaryTicket.sales_end
 
     val isCurrentlyAvailableToPaidMembersOnly =

--- a/frontend/app/views/event/page.scala.html
+++ b/frontend/app/views/event/page.scala.html
@@ -42,6 +42,9 @@
                     @if(event.isBookable) {
                         <div class="event-ticket__action">
                             @fragments.event.ticketCta(event, List("action--booking"))
+                            @if(internalTicketing.isCurrentlyAvailableToPaidMembersOnly) {
+                                <a class="action action--booking js-member-cta" href="@routes.Joiner.tierList">Become a member</a>
+                            }
                             @fragments.event.terms(event)
                         </div>
                     }

--- a/frontend/app/views/fragments/event/infoPanel.scala.html
+++ b/frontend/app/views/fragments/event/infoPanel.scala.html
@@ -26,14 +26,14 @@
             @fragments.event.stats(event, showTicketSales=true)
         </div>
 
-         @for(ticketing <- event.internalTicketing) {
+        @for(ticketing <- event.internalTicketing) {
             @fragments.pricing.priceInfoEvent(event)
             @if(event.isBookable) {
                 @fragments.event.ticketCta(event)
-                @fragments.event.terms(event, List("event-info__terms"))
                 @if(ticketing.isCurrentlyAvailableToPaidMembersOnly) {
                     <a class="action js-member-cta" href="@routes.Joiner.tierList">Become a member</a>
                 }
+                @fragments.event.terms(event, List("event-info__terms"))
             }
         }
     </div>

--- a/frontend/app/views/fragments/event/ticketSales.scala.html
+++ b/frontend/app/views/fragments/event/ticketSales.scala.html
@@ -14,6 +14,11 @@
 }
 
 <div class="ticket-sales" itemprops="offers" itemscope itemtype="http://schema.org/AggregateOffer">
+
+    @for(salesStart <- ticketing.salesStart) {
+        <time class="js-ticket-sale-start u-h" datetime="@salesStart">@salesStart.pretty(true)</time>
+    }
+
     <span class="ticket-sales__header">Ticket release dates</span>
     @if(ticketing.salesDates.anyoneCanBuyTicket) {
         <button class="ticket-sales__toggle u-button-reset u-align-right js-toggle"

--- a/frontend/assets/javascripts/src/modules/events/Cta.js
+++ b/frontend/assets/javascripts/src/modules/events/Cta.js
@@ -127,20 +127,16 @@ define([
     };
 
     Cta.prototype.init = function () {
-        var self = this;
         this.elem = this.elem || this.getElem('EVENT');
 
-        /* buttons are either both not here, both here, or only one is here */
         if (this.getElem('MEMBER_CTA') || this.getElem('BUY_TICKET_CTA')) {
-
             this.userIsLoggedIn = user.isLoggedIn();
-
             user.getMemberDetail(function (memberDetail) {
-                self.memberTier = memberDetail && memberDetail.tier;
-                self.parseDates();
-                self.buyTicketCta();
-                self.memberCta();
-            });
+                this.memberTier = memberDetail && memberDetail.tier;
+                this.parseDates();
+                this.buyTicketCta();
+                this.memberCta();
+            }.bind(this));
         }
     };
 

--- a/frontend/assets/javascripts/src/modules/events/Cta.js
+++ b/frontend/assets/javascripts/src/modules/events/Cta.js
@@ -11,7 +11,6 @@ define([
     var PATRON = 'Patron';
     var TIER_CHANGE_URL = '/tier/change';
     var UPGRADE = 'Upgrade membership';
-    var TICKETS_AVAILABLE_SOON = 'Tickets available soon';
 
     var Cta = function (containerElem) {
         this.elem = containerElem;
@@ -86,38 +85,28 @@ define([
         var now = Date.now();
         var $memberCtaElement = $(this.getElem('MEMBER_CTA'));
 
-        if ($memberCtaElement.length) {
-            if (this.userIsLoggedIn) {
-                if (memberTier) {
-                    // tickets not yet on sale
-                    if (salesStart > now) {
-                        this.removeMemberCtaButton();
-                    }
-                    // tickets on sale < 7 days
-                    if (salesStart < now && partnerSaleStart > now) {
-                        if (memberTier === PARTNER) {
-                            this.upgradeComingSoonMemberCtaButton();
-                        } else if (memberTier === FRIEND) {
-                            this.upgradeMemberCtaButton();
-                        } else if (memberTier === PATRON) {
-                            this.removeMemberCtaButton();
-                        }
-                    }
-                    // tickets on sale > 8 days < 14 days
-                    if (partnerSaleStart < now && friendSaleStart > now) {
-                        if (memberTier === FRIEND) {
-                            this.upgradeMemberCtaButton();
-                        } else if (memberTier === PARTNER || memberTier === PATRON) {
-                            this.removeMemberCtaButton();
-                        }
-                    }
+        if ($memberCtaElement.length && this.userIsLoggedIn && memberTier) {
+            // tickets not yet on sale
+            if (salesStart > now) {
+                this.removeMemberCtaButton();
+            }
+            // tickets on sale < 7 days
+            if (salesStart < now && partnerSaleStart > now) {
+                if (memberTier === FRIEND || memberTier === PARTNER) {
+                    this.upgradeMemberCtaButton();
+                } else if (memberTier === PATRON) {
+                    this.removeMemberCtaButton();
+                }
+            }
+            // tickets on sale > 8 days < 14 days
+            if (partnerSaleStart < now && friendSaleStart > now) {
+                if (memberTier === FRIEND) {
+                    this.upgradeMemberCtaButton();
+                } else if (memberTier === PARTNER || memberTier === PATRON) {
+                    this.removeMemberCtaButton();
                 }
             }
         }
-    };
-
-    Cta.prototype.upgradeComingSoonMemberCtaButton = function () {
-        $(this.getElem('MEMBER_CTA')).text(TICKETS_AVAILABLE_SOON).addClass('is-disabled').removeAttr('href');
     };
 
     Cta.prototype.upgradeMemberCtaButton = function () {

--- a/frontend/test/js/spec/Cta.spec.js
+++ b/frontend/test/js/spec/Cta.spec.js
@@ -94,7 +94,6 @@ define([
             });
 
             spyOn(cta, 'disableBuyTicketsCtaButton').and.callThrough();
-            spyOn(cta, 'upgradeComingSoonMemberCtaButton').and.callThrough();
             spyOn(cta, 'upgradeMemberCtaButton').and.callThrough();
             spyOn(cta, 'removeMemberCtaButton').and.callThrough();
 
@@ -143,7 +142,6 @@ define([
             it('loggedIn Friend - "' + COMING_SOON + '" button disabled and "' + BECOME_A_MEMBER + '" button NOT displayed' , function (done) {
                 ctaClassSetup(salesStartOneWeekInTheFuture, 'Friend', true)
                 expect(cta.disableBuyTicketsCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
                 expect(cta.upgradeMemberCtaButton).not.toHaveBeenCalled();
                 expect(cta.removeMemberCtaButton).toHaveBeenCalled();
                 done();
@@ -152,7 +150,6 @@ define([
             it('loggedIn Partner - "' + COMING_SOON + '" button disabled and "' + BECOME_A_MEMBER + '" button NOT displayed', function (done) {
                 ctaClassSetup(salesStartOneWeekInTheFuture, 'Partner', true)
                 expect(cta.disableBuyTicketsCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
                 expect(cta.upgradeMemberCtaButton).not.toHaveBeenCalled();
                 expect(cta.removeMemberCtaButton).toHaveBeenCalled();
                 done();
@@ -161,7 +158,6 @@ define([
             it('loggedIn Patron - "' + COMING_SOON + '" button disabled and "' + BECOME_A_MEMBER + '" button NOT displayed', function (done) {
                 ctaClassSetup(salesStartOneWeekInTheFuture, 'Patron', true)
                 expect(cta.disableBuyTicketsCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
                 expect(cta.upgradeMemberCtaButton).not.toHaveBeenCalled();
                 expect(cta.removeMemberCtaButton).toHaveBeenCalled();
                 done();
@@ -170,7 +166,6 @@ define([
             it('loggedIn NOT a member - "' + COMING_SOON + '" button disabled and "' + BECOME_A_MEMBER + '" button displayed', function (done) {
                 ctaClassSetup(salesStartOneWeekInTheFuture, null, true)
                 expect(cta.disableBuyTicketsCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
                 expect(cta.upgradeMemberCtaButton).not.toHaveBeenCalled();
                 expect(cta.removeMemberCtaButton).not.toHaveBeenCalled();
                 done();
@@ -179,7 +174,6 @@ define([
             it('loggedOut - "' + COMING_SOON + '" button disabled and "' + BECOME_A_MEMBER + '" button displayed', function (done) {
                 ctaClassSetup(salesStartOneWeekInTheFuture, null, true)
                 expect(cta.disableBuyTicketsCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
                 expect(cta.upgradeMemberCtaButton).not.toHaveBeenCalled();
                 expect(cta.removeMemberCtaButton).not.toHaveBeenCalled();
                 done();
@@ -199,7 +193,6 @@ define([
                 ctaClassSetup(saleStartedYesterday, 'Friend', true);
                 expect(cta.disableBuyTicketsCtaButton).toHaveBeenCalled();
                 expect(cta.upgradeMemberCtaButton).toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
                 expect(cta.removeMemberCtaButton).not.toHaveBeenCalled();
                 done();
             });
@@ -207,8 +200,7 @@ define([
             it('loggedIn Partner - "' + BUY_TICKETS + '" button disabled and "' + TICKETS_AVAILABLE_SOON + '" button displayed', function (done) {
                 ctaClassSetup(saleStartedYesterday, 'Partner', true);
                 expect(cta.disableBuyTicketsCtaButton).toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).toHaveBeenCalled();
-                expect(cta.upgradeMemberCtaButton).not.toHaveBeenCalled();
+                expect(cta.upgradeMemberCtaButton).toHaveBeenCalled();
                 expect(cta.removeMemberCtaButton).not.toHaveBeenCalled();
                 done();
             });
@@ -218,7 +210,6 @@ define([
                 ctaClassSetup(saleStartedYesterday, 'Patron', true);
 
                 expect(cta.disableBuyTicketsCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
                 expect(cta.upgradeMemberCtaButton).not.toHaveBeenCalled();
                 expect(cta.removeMemberCtaButton).toHaveBeenCalled();
 
@@ -230,7 +221,6 @@ define([
                 ctaClassSetup(saleStartedYesterday, null, true)
 
                 expect(cta.disableBuyTicketsCtaButton).toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
                 expect(cta.upgradeMemberCtaButton).not.toHaveBeenCalled();
                 expect(cta.removeMemberCtaButton).not.toHaveBeenCalled();
 
@@ -242,7 +232,6 @@ define([
                 ctaClassSetup(saleStartedYesterday, null, true)
 
                 expect(cta.disableBuyTicketsCtaButton).toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
                 expect(cta.upgradeMemberCtaButton).not.toHaveBeenCalled();
                 expect(cta.removeMemberCtaButton).not.toHaveBeenCalled();
 
@@ -262,7 +251,6 @@ define([
             it('loggedIn Friend - "' + BUY_TICKETS + '" disabled  and "' + UPGRADE_MEMBERSHIP + '" button displayed', function (done) {
                 ctaClassSetup(saleStarted8DaysAgo, 'Friend', true);
                 expect(cta.disableBuyTicketsCtaButton).toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
                 expect(cta.removeMemberCtaButton).not.toHaveBeenCalled();
                 expect(cta.upgradeMemberCtaButton).toHaveBeenCalled();
                 done();
@@ -271,7 +259,6 @@ define([
             it('loggedIn Partner - "' + BUY_TICKETS + '" enabled and memberCTA button removed', function (done) {
                 ctaClassSetup(saleStarted8DaysAgo, 'Partner', true);
                 expect(cta.disableBuyTicketsCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
                 expect(cta.upgradeMemberCtaButton).not.toHaveBeenCalled();
                 expect(cta.removeMemberCtaButton).toHaveBeenCalled();
                 done();
@@ -280,7 +267,6 @@ define([
             it('loggedIn Patron - "' + BUY_TICKETS + '" enabled and memberCTA button removed', function (done) {
                 ctaClassSetup(saleStarted8DaysAgo, 'Patron', true);
                 expect(cta.disableBuyTicketsCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
                 expect(cta.upgradeMemberCtaButton).not.toHaveBeenCalled();
                 expect(cta.removeMemberCtaButton).toHaveBeenCalled();
                 done();
@@ -289,7 +275,6 @@ define([
             it('loggedIn not a member - "' + BUY_TICKETS + '" disabled and "' + BECOME_A_MEMBER + '" button displayed', function (done) {
                 ctaClassSetup(saleStarted8DaysAgo, null, true)
                 expect(cta.disableBuyTicketsCtaButton).toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
                 expect(cta.upgradeMemberCtaButton).not.toHaveBeenCalled();
                 expect(cta.removeMemberCtaButton).not.toHaveBeenCalled();
                 done();
@@ -298,7 +283,6 @@ define([
             it('loggedOut - "' + BUY_TICKETS + '" disabled and "' + BECOME_A_MEMBER + '" button displayed', function (done) {
                 ctaClassSetup(saleStarted8DaysAgo, null, true)
                 expect(cta.disableBuyTicketsCtaButton).toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
                 expect(cta.upgradeMemberCtaButton).not.toHaveBeenCalled();
                 expect(cta.removeMemberCtaButton).not.toHaveBeenCalled();
                 done();
@@ -317,7 +301,6 @@ define([
             it('loggedIn Friend - "' + BUY_TICKETS + '" enabled and memberCTA button removed', function (done) {
                 ctaClassSetup(saleStarted15DaysAgo, 'Friend', true);
                 expect(cta.disableBuyTicketsCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
                 expect(cta.upgradeMemberCtaButton).not.toHaveBeenCalled();
                 expect(cta.removeMemberCtaButton).not.toHaveBeenCalled();
                 done();
@@ -326,7 +309,6 @@ define([
             it('loggedIn Partner - "' + BUY_TICKETS + '" enabled and memberCTA button removed', function (done) {
                 ctaClassSetup(saleStarted15DaysAgo, 'Partner', true);
                 expect(cta.disableBuyTicketsCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
                 expect(cta.upgradeMemberCtaButton).not.toHaveBeenCalled();
                 expect(cta.removeMemberCtaButton).not.toHaveBeenCalled();
                 done();
@@ -335,7 +317,6 @@ define([
             it('loggedIn Patron - "' + BUY_TICKETS + '" enabled and memberCTA button removed', function (done) {
                 ctaClassSetup(saleStarted15DaysAgo, 'Patron', true);
                 expect(cta.disableBuyTicketsCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
                 expect(cta.upgradeMemberCtaButton).not.toHaveBeenCalled();
                 expect(cta.removeMemberCtaButton).not.toHaveBeenCalled();
                 done();
@@ -344,7 +325,6 @@ define([
             it('loggedIn not a member - "' + BUY_TICKETS + '" enabled and memberCTA button removed', function (done) {
                 ctaClassSetup(saleStarted15DaysAgo, null, true)
                 expect(cta.disableBuyTicketsCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
                 expect(cta.upgradeMemberCtaButton).not.toHaveBeenCalled();
                 expect(cta.removeMemberCtaButton).not.toHaveBeenCalled();
                 done();
@@ -353,7 +333,6 @@ define([
             it('loggedOut - "' + BUY_TICKETS + '" enabled and memberCTA button removed', function (done) {
                 ctaClassSetup(saleStarted15DaysAgo, null, true)
                 expect(cta.disableBuyTicketsCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
                 expect(cta.upgradeMemberCtaButton).not.toHaveBeenCalled();
                 expect(cta.removeMemberCtaButton).not.toHaveBeenCalled();
                 done();


### PR DESCRIPTION
**Dependant on PR** https://github.com/guardian/membership-frontend/pull/181

- Removes code to stop partners from upgrading from events
- Fixes a bug where the become a member / upgrade button didn't show in the header (button was only available in the sidebar)

Screenshots are from a test event which is only available to Patrons

**Signed out**

![signed-out](https://cloud.githubusercontent.com/assets/123386/6168353/8e4339ea-b2bc-11e4-9514-181945b126b1.png)

**Signed in as partner**
![partner](https://cloud.githubusercontent.com/assets/123386/6168392/e7cdf2de-b2bc-11e4-9f6e-3271adc56830.png)

**Signed in as patron**
![patron](https://cloud.githubusercontent.com/assets/123386/6168396/ef5d2c90-b2bc-11e4-8e0e-da0a5678b88d.png)

Looking through this code, I think the approach in the JS could be simplified to only manipulate one button (rather than the two needed now) and to remove some of the coupling to specific tiers, possibly remove `component` too. It feels like there's a simpler way to reason about this.

This PR, however, makes the minimum changes to remove the upgrade restriction.