### PR TITLE
Variable cleanup, move all tones over to tone map

### DIFF
--- a/frontend/assets/stylesheets/_vars.scss
+++ b/frontend/assets/stylesheets/_vars.scss
@@ -149,15 +149,32 @@ $c-link: map-get($pasteup-palette, news-main-1);
 $c-error: map-get($pasteup-palette, error);
 $c-soldOut: #cc2b12;
 
-// Tone colours
-// DEPRECATED: prefer palette-tones / tone()
-$c-tone-live: map-get($pasteup-palette, live-main-1);
-$c-tone-live-accent: map-get($pasteup-palette, live-main-2);
-$c-tone-masterclass: #ffbb00;
-$c-tone-masterclass-accent: #fcdd03;
-$c-tone-friend: $c-neutral1;
-$c-tone-partner: map-get($pasteup-palette, news-main-2);
-$c-tone-patron: map-get($pasteup-palette, news-main-1);
+// Membership palette
+$mem-brandBlue: map-get($pasteup-palette, news-main-2);
+$mem-brandBlueDark: #197caa;
+
+// Buttons
+$c-button: $mem-brandBlueDark;
+$c-button-cancel: #b8b8b8;
+
+// Borders
+$c-border-brand: $mem-brandBlue;
+$c-border-neutral: $c-neutral3;
+
+// Messages
+$c-flash-error: #d61d00;
+$c-flash-error-border: #ff998a;
+$c-flash-error-background: #fdf4f3;
+$c-flash-success: #1c6326;
+$c-flash-success-border: #33a22b;
+$c-flash-success-background: #faffe5;
+
+// Thirdparty
+$c-thirdparty-twitter: #55acee;
+$c-thirdparty-facebook: #3b5998;
+
+// Tone Colours
+// =============================================================================
 
 // Usage: tone('live', 'accent')
 //        tone('live') => defaults to 'base' key
@@ -185,30 +202,3 @@ $palette-tones: (
         base: map-get($pasteup-palette, news-main-1)
     )
 );
-
-// Membership palette
-$mem-brandBlue: map-get($pasteup-palette, news-main-2);
-$mem-brandBlueDark: #197caa;
-// TODO: This is going to come out when brochure pages are revisited,
-// only used on /about page for Space.
-$mem-green: #aad802;
-
-// Buttons
-$c-button: $mem-brandBlueDark;
-$c-button-cancel: #b8b8b8;
-
-// Borders
-$c-border-brand: $mem-brandBlue;
-$c-border-neutral: $c-neutral3;
-
-// Messages
-$c-flash-error: #d61d00;
-$c-flash-error-border: #ff998a;
-$c-flash-error-background: #fdf4f3;
-$c-flash-success: #1c6326;
-$c-flash-success-border: #33a22b;
-$c-flash-success-background: #faffe5;
-
-// Thirdparty
-$c-thirdparty-twitter: #55acee;
-$c-thirdparty-facebook: #3b5998;

--- a/frontend/assets/stylesheets/components/_tier.scss
+++ b/frontend/assets/stylesheets/components/_tier.scss
@@ -68,10 +68,10 @@
 }
 .tier-header--partner {
     color: $black;
-    background-color: $c-tone-partner;
+    background-color: tone('partner');
 }
 .tier-header--patron {
-    background-color: $c-tone-patron;
+    background-color: tone('patron');
 }
 
 /**

--- a/frontend/assets/stylesheets/theme/_tones.scss
+++ b/frontend/assets/stylesheets/theme/_tones.scss
@@ -146,7 +146,7 @@
     border-color: tone('friend');
 }
 .tone-fill-friend {
-    fill: $c-tone-friend;
+    fill: tone('friend');
 }
 
 .tone-partner {
@@ -159,7 +159,7 @@
     border-color: tone('partner');
 }
 .tone-fill-partner {
-    fill: $c-tone-partner;
+    fill: tone('partner');
 }
 
 .tone-patron {
@@ -172,7 +172,7 @@
     border-color: tone('patron');
 }
 .tone-fill-patron {
-    fill: $c-tone-patron;
+    fill: tone('patron');
 }
 
 /* Neutral


### PR DESCRIPTION
Variable cleanup, move all tones over to tone map. We had a slight split with some tone colours being traditional variables and the majority using a sass-map. This PR moves the remaining tone colours into the map.

This feels like a more readable way of describing our colour palette so I'll probably move the main colours into a map soon.