### PR TITLE
Use dummy config for salt and pepper

### DIFF
--- a/frontend/conf/dev.conf
+++ b/frontend/conf/dev.conf
@@ -44,3 +44,6 @@ touchpoint.backend.default=DEV
 touchpoint.backend.test=UAT
 
 staff.authorised.emails.groups = "membership.dev@guardian.co.uk"
+
+activity.tracking.bcrypt.salt="$2a$10$oL3umggRoHlQuvgoYpWDx."
+activity.tracking.bcrypt.pepper="dummy-pepper"


### PR DESCRIPTION
We want to check the data we sent to activity tracking is in the correct format. Part of this uses bcrypt so I've created dummy config for dev environment. This should hopefully make Team city happy.