### PR TITLE
Change OAuth on event-overview page

### DIFF
--- a/frontend/app/controllers/Staff.scala
+++ b/frontend/app/controllers/Staff.scala
@@ -1,20 +1,12 @@
 package controllers
 
-import actions.Functions._
-import configuration.Config
 import play.api.mvc.Controller
 import services.GuardianLiveEventService
 
-import scala.concurrent.Future
-
 trait Staff extends Controller {
-  val permanentStaffGroups = Config.staffAuthorisedEmailGroups
   val guLiveEvents = GuardianLiveEventService
 
-  val AuthorisedStaff = GoogleAuthenticatedStaffAction andThen isInAuthorisedGroupGoogleAuthReq(
-    permanentStaffGroups, views.html.fragments.oauth.staffWrongGroup())
-
-  def eventOverview = AuthorisedStaff { implicit request =>
+  def eventOverview = GoogleAuthenticatedStaffAction { implicit request =>
      Ok(views.html.staff.eventOverview(guLiveEvents.events, guLiveEvents.eventsDraft))
   }
 }


### PR DESCRIPTION
Change the event overview page just to google oauth for GU staff no need for it to be permenant staff members only