### PR TITLE
Fix IE9 scrollbars on promos

### DIFF
--- a/frontend/assets/stylesheets/components/_promos.scss
+++ b/frontend/assets/stylesheets/components/_promos.scss
@@ -2,13 +2,17 @@
    Promos
    ========================================================================== */
 
+.promo-primary,
+.promo-secondary {
+    clear: both;
+    overflow: hidden;
+}
+
 /* ==========================================================================
    Promo Primary
    ========================================================================== */
 
 .promo-primary {
-    clear: both;
-    overflow: auto;
     background-color: $white;
 }
 .promo-primary,


### PR DESCRIPTION
Add overflow hidden to promos, fixes IE9 scrollbars on about and patrons page page.

**Before**

![screen shot 2015-02-18 at 16 55 50](https://cloud.githubusercontent.com/assets/123386/6251978/02dd6600-b78f-11e4-9bf6-9aedbea2dd08.png)

**After**

![screen shot 2015-02-18 at 16 54 23](https://cloud.githubusercontent.com/assets/123386/6251983/079a339e-b78f-11e4-852e-9d37e453b049.png)
