### PR TITLE
Tidy up ticket sales

### DIFF
--- a/frontend/app/model/RichEvent.scala
+++ b/frontend/app/model/RichEvent.scala
@@ -15,6 +15,7 @@ object RichEvent {
     eventListUrl: String,
     termsUrl: String,
     largeImg: Boolean,
+    preSale: Boolean,
     highlightsOpt: Option[HighlightsMetadata] = None,
     chooseTier: ChooseTierMetadata
   )
@@ -34,6 +35,7 @@ object RichEvent {
     eventListUrl=controllers.routes.Event.list.url,
     termsUrl=Config.guardianLiveEventsTermsUrl,
     largeImg=true,
+    preSale=true,
     chooseTier=ChooseTierMetadata(
       "Guardian Live events are exclusively for Guardian members",
       "Choose a membership tier to continue with your booking"
@@ -52,6 +54,7 @@ object RichEvent {
     eventListUrl=controllers.routes.Event.masterclasses.url,
     termsUrl=Config.guardianMasterclassesTermsUrl,
     largeImg=false,
+    preSale=false,
     chooseTier=ChooseTierMetadata(
       "Choose a membership tier to continue with your booking",
       "Become a Partner or Patron to save 20% on your masterclass"
@@ -67,6 +70,7 @@ object RichEvent {
     eventListUrl=controllers.routes.Event.list.url,
     termsUrl=Config.guardianLiveEventsTermsUrl,
     largeImg=true,
+    preSale=true,
     chooseTier=ChooseTierMetadata(
       "Guardian Discover events are exclusively for Guardian members",
       "Choose a membership tier to continue with your booking"

--- a/frontend/app/views/fragments/event/infoPanel.scala.html
+++ b/frontend/app/views/fragments/event/infoPanel.scala.html
@@ -23,11 +23,7 @@
         <h4 class="event-info__name" itemprop="name">@event.name.text</h4>
 
         <div class="stats-listing">
-            @fragments.event.stats(event)
-            @* TODO: Make part of event stats *@
-            @for(ticketing <- event.internalTicketing if event.isBookable) {
-                @fragments.event.ticketSales(event, ticketing)
-            }
+            @fragments.event.stats(event, showTicketSales=true)
         </div>
 
          @for(ticketing <- event.internalTicketing) {

--- a/frontend/app/views/fragments/event/stats.scala.html
+++ b/frontend/app/views/fragments/event/stats.scala.html
@@ -1,8 +1,9 @@
-@(event: model.RichEvent.RichEvent)
+@(event: model.RichEvent.RichEvent, showTicketSales: Boolean = false)
 
 @import views.support.Dates._
+@import model.RichEvent.{GuLiveEvent, MasterclassEvent}
 
-
+@* Event start time *@
 <div class="stat-item">
     <div class="stat-item__first">
         @fragments.inlineIcon("time", List("icon-inline--medium", "icon-inline--top", "icon-inline--neutral"))
@@ -11,6 +12,8 @@
         <span itemprop="startDate" content="@event.start">@prettyDateWithTimeAndDayName(event.start)</span>
     </div>
 </div>
+
+@* Event locations *@
 <div class="stat-item">
     <div class="stat-item__first">
         @fragments.inlineIcon("location", List("icon-inline--medium", "icon-inline--top", "icon-inline--neutral"))
@@ -30,3 +33,17 @@
         }
     </div>
 </div>
+
+@* Event ticket sale dates *@
+@if(showTicketSales && event.metadata.preSale) {
+    @for(ticketing <- event.internalTicketing if event.isBookable) {
+        <div class="stat-item">
+            <div class="stat-item__first">
+                @fragments.inlineIcon("tickets", List("icon-inline--medium", "icon-inline--top", "icon-inline--neutral"))
+            </div>
+            <div class="stat-item__second">
+                @fragments.event.ticketSales(event, ticketing)
+            </div>
+        </div>
+    }
+}

--- a/frontend/app/views/fragments/event/ticketSales.scala.html
+++ b/frontend/app/views/fragments/event/ticketSales.scala.html
@@ -1,11 +1,9 @@
 @(event: model.RichEvent.RichEvent, ticketing: model.Eventbrite.InternalTicketing)
 
 @import views.support.Dates._
-@import com.github.nscala_time.time.Imports._
 @import org.joda.time.Instant
 @import model.RichEvent._
 @import com.gu.membership.salesforce.Tier
-
 
 @ticketDateForTier(tier: Tier, salesDate: Instant, needToDisplayTimes: Boolean) = @{
     Html(s"<time class='js-ticket-sale-start-${tier.slug}' datetime='$salesDate' itemprop='availabilityStarts' content='$salesDate'>${salesDate.pretty(needToDisplayTimes)}</time>")
@@ -15,46 +13,36 @@
     Html(s"<time datetime='$endSalesDate'>${endSalesDate.pretty(needToDisplayTimes)}</time>")
 }
 
-@event match {
-    case _: GuLiveEvent => {
-        <div class="event-info__tickets sticky-hidden u-cf" itemprops="offers" itemscope itemtype="http://schema.org/AggregateOffer">
-            <div class="event-info__sale-dates u-cf">
-                <div class="event-info__first">
-                    @fragments.inlineIcon("tickets", List("icon-inline--medium", "icon-inline--top", "icon-inline--neutral"))
-                </div>
-                <div class="event-info__second">
-                    <div class="sale-dates__header">Ticket release dates</div>
-
-                    @if(ticketing.salesDates.anyoneCanBuyTicket) {
-                        <button class="js-toggle fake-link u-align-right sales-dates-toggle"
-                                data-toggle-label="Hide"
-                                data-toggle="js-event-ticket-dates-@event.id">
-                            Show
-                        </button>
-                    }
-
-                    <ul class="sale-dates__list u-unstyled u-cf"
-                        id="js-event-ticket-dates-@event.id"@if(ticketing.salesDates.anyoneCanBuyTicket) { data-toggle-hidden}>
-                        @for(tier <- Seq(Tier.Patron, Tier.Partner, Tier.Friend)) {
-                            <li class="sale-dates__item" itemscope itemtype="http://schema.org/Offer">
-                                <meta itemprop="eligibleCustomerType" content="@tier">
-                                <meta itemprop="availabilityEnds" content="@ticketing.salesDates.datesByTier(tier)">
-                                <span class="sale-dates__item--left">@(tier + "s")</span>
-                                @ticketDateForTier(tier, ticketing.salesDates.datesByTier(tier), ticketing.salesDates.needToDistinguishTimes)
-                            </li>
-                        }
-                    </ul>
-
-                    <ul class="sale-dates__list u-unstyled u-cf">
-                        <li class="sale-dates__item">
-                            <span class="sale-dates__item--left">Sale ends</span>
-
-                            @ticketEndSaleDate(ticketing.salesEnd, ticketing.salesDates.needToDistinguishTimes)
-                        </li>
-                    </ul>
-                </div>
-            </div>
-        </div>
+<div class="ticket-sales" itemprops="offers" itemscope itemtype="http://schema.org/AggregateOffer">
+    <span class="ticket-sales__header">Ticket release dates</span>
+    @if(ticketing.salesDates.anyoneCanBuyTicket) {
+        <button class="ticket-sales__toggle u-button-reset u-align-right js-toggle"
+                data-toggle-label="Hide"
+                data-toggle="js-event-ticket-dates-@event.id">
+            Show
+        </button>
     }
-    case _: MasterclassEvent => {}
-}
+    <ul class="ticket-sales__list u-unstyled"
+        id="js-event-ticket-dates-@event.id"
+        @if(ticketing.salesDates.anyoneCanBuyTicket) { data-toggle-hidden}
+    >
+        @for(tier <- Seq(Tier.Patron, Tier.Partner, Tier.Friend)) {
+            <li class="ticket-sales__item" itemscope itemtype="http://schema.org/Offer">
+                <meta itemprop="eligibleCustomerType" content="@tier">
+                <meta itemprop="availabilityEnds" content="@ticketing.salesDates.datesByTier(tier)">
+                <span class="ticket-sales__item__label">@(tier + "s")</span>
+                <span class="ticket-sales__item__date">
+                    @ticketDateForTier(tier, ticketing.salesDates.datesByTier(tier), ticketing.salesDates.needToDistinguishTimes)
+                </span>
+            </li>
+        }
+    </ul>
+    <ul class="ticket-sales__list u-unstyled">
+        <li class="ticket-sales__item">
+            <span class="ticket-sales__item_label">Sale ends</span>
+            <span class="ticket-sales__item__date">
+                @ticketEndSaleDate(ticketing.salesEnd, ticketing.salesDates.needToDistinguishTimes)
+            </span>
+        </li>
+    </ul>
+</div>

--- a/frontend/assets/stylesheets/base/_helpers.scss
+++ b/frontend/assets/stylesheets/base/_helpers.scss
@@ -69,6 +69,7 @@
 .u-button-reset {
     padding: 0;
     border: 0;
+    outline: none;
     background: transparent;
 }
 

--- a/frontend/assets/stylesheets/components/_event-detail.scss
+++ b/frontend/assets/stylesheets/components/_event-detail.scss
@@ -430,14 +430,6 @@
     }
 }
 
-.sales-dates-toggle {
-    padding: rem($gs-baseline/2) rem($gs-baseline);
-    margin-top: -#{rem($gs-baseline/2)};
-    margin-right: -#{rem($gs-baseline)};
-    right: 0;
-    position: absolute;
-}
-
 /* Event Info Panel
    ========================================================================== */
 
@@ -454,29 +446,6 @@
     .event-info__name {
         @include fs-header(2);
         padding-bottom: rem($gs-baseline * 2);
-    }
-    // TODO: Refactor out into stat-item
-    .event-info__tickets {
-        border-bottom: 1px dotted $c-neutral3;
-        padding-bottom: rem($gs-gutter / 4);
-        margin-bottom: rem($gs-baseline / 4);
-    }
-    .event-info__sale-dates {
-        .sale-dates__header {
-            @include fs-textSans(3);
-            font-weight: bold;
-            display: inline;
-        }
-        .sale-dates__list:last-child {
-            padding-bottom: rem(5px);
-        }
-        .sale-dates__item {
-            @include fs-textSans(3);
-            text-align: right;
-            .sale-dates__item--left {
-                float: left;
-            }
-        }
     }
     .event-info__first {
         float: left;
@@ -510,7 +479,6 @@
     }
 }
 
-
 /* Status Panel
    ========================================================================== */
 
@@ -524,4 +492,37 @@
 }
 .status-panel__content {
    margin-top: rem($gs-baseline / 2);
+}
+
+/* Ticket Sales
+   ========================================================================== */
+
+.ticket-sales {
+    margin-top: rem($gs-baseline / 4);
+    position: relative;
+}
+.ticket-sales__header {
+    font-weight: bold;
+}
+.ticket-sales__toggle {
+    right: 0;
+    top: 0;
+    position: absolute;
+}
+.ticket-sales__toggle:hover,
+.ticket-sales__toggle:active {
+    text-decoration: underline;
+}
+.ticket-sales__item {
+    @include clearfix();
+}
+.ticket-sales__item__label,
+.ticket-sales__item__date {
+    display: inline-block;
+}
+.ticket-sales__item__label {
+    float: left;
+}
+.ticket-sales__item__date {
+    float: right;
 }

--- a/frontend/test/model/EventbriteTestObjects.scala
+++ b/frontend/test/model/EventbriteTestObjects.scala
@@ -32,6 +32,7 @@ object EventbriteTestObjects {
       eventListUrl="",
       termsUrl="",
       largeImg=false,
+      preSale=true,
       highlightsOpt=None,
       chooseTier=ChooseTierMetadata("", "")
     )


### PR DESCRIPTION
This PR tidies up ticket sales to remove the `match` logic, and update the styles to use the same `stat-item` component for dates and location. Also fixes a design consitency issues on small screens.

![screen shot 2015-02-19 at 11 39 39](https://cloud.githubusercontent.com/assets/123386/6266014/35e8a7d8-b82c-11e4-98d2-a28555c1131a.png)

![screen shot 2015-02-19 at 11 40 14](https://cloud.githubusercontent.com/assets/123386/6266015/3693ac28-b82c-11e4-8542-7f624d1ad723.png)
