### PR TITLE
Only show series details for Guardian-only events

### DIFF
--- a/frontend/app/views/fragments/event/seriesDetails.scala.html
+++ b/frontend/app/views/fragments/event/seriesDetails.scala.html
@@ -2,16 +2,18 @@
 
 @import views.support.Asset
 
-@for(description <- event.metadata.description) {
-    <div class="series-detail l-constrained tone-@event.metadata.identifier">
-        <div class="series-detail__content">
-            <h3 class="series-detail__title">
-                About @event.metadata.title
-            </h3>
-            <div class="series-detail__description">
-                @description
+@if(event.providerOpt.isEmpty) {
+    @for(description <- event.metadata.description) {
+        <div class="series-detail l-constrained tone-@event.metadata.identifier">
+            <div class="series-detail__content">
+                <h3 class="series-detail__title">
+                    About @event.metadata.title
+                </h3>
+                <div class="series-detail__description">
+                    @description
+                </div>
             </div>
+            <img class="series-detail__logo" src="@Asset.at("images/providers/" + event.metadata.identifier + ".svg")">
         </div>
-        <img class="series-detail__logo" src="@Asset.at("images/providers/" + event.providerOpt.getOrElse(event.metadata.identifier) + ".svg")">
-    </div>
+    }
 }


### PR DESCRIPTION
Spotted an issue with partner events where we show the partner logo next to a description for guardian live.

![screen shot 2015-02-19 at 16 28 06](https://cloud.githubusercontent.com/assets/123386/6271881/c2107a90-b85b-11e4-8ecf-97cfde3f574e.png)

Long term we should come up with a way of showing a custom description for partners, but in the short term this PR removes the detail panel for partner events.

![screen shot 2015-02-19 at 17 20 17](https://cloud.githubusercontent.com/assets/123386/6271884/c4dac91a-b85b-11e4-8d38-d7313a110c09.png)

// @mattandrews 