### PR TITLE
Warn on bad discounts on the event overview

### DIFF
--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -165,6 +165,8 @@ object Config {
 
   val discountMultiplier = config.getDouble("event.discountMultiplier")
 
+  val roundedDiscountPercentage: Int = math.round((1-discountMultiplier.toFloat)*100)
+
   val stage = config.getString("stage")
 
   val ophanJsUrl = config.getString("ophan.js.url")

--- a/frontend/app/model/Eventbrite.scala
+++ b/frontend/app/model/Eventbrite.scala
@@ -154,6 +154,10 @@ object Eventbrite {
 
     val savingText = formatPrice(saving)
 
+    val roundedSavingPercentage: Int = math.round(100 * (saving.toFloat / generalRelease.priceInPence))
+
+    lazy val nonStandardSaving = roundedSavingPercentage != Config.roundedDiscountPercentage
+
     val isSoldOut = member.isSoldOut
 
     val fewerMembersTicketsThanGeneralTickets = member.quantity_total < generalRelease.quantity_total

--- a/frontend/app/model/RichEvent.scala
+++ b/frontend/app/model/RichEvent.scala
@@ -92,6 +92,8 @@ object RichEvent {
     val availableWidths: String
     val fallbackImage = views.support.Asset.at("images/event-placeholder.gif")
     val pastImageOpt: Option[Asset]
+
+    def deficientGuardianMembersTickets: Boolean
   }
 
   case class GuLiveEvent(event: EBEvent, image: Option[EventImage], contentOpt: Option[Content]) extends RichEvent {
@@ -128,6 +130,7 @@ object RichEvent {
       guLiveMetadata.copy(highlightsOpt = highlight)
     }
 
+    def deficientGuardianMembersTickets = event.internalTicketing.flatMap(_.memberDiscountOpt).exists(_.fewerMembersTicketsThanGeneralTickets)
   }
 
   case class MasterclassEvent(event: EBEvent, data: Option[MasterclassData]) extends RichEvent {
@@ -147,6 +150,8 @@ object RichEvent {
 
     val contentOpt = None
     val pastImageOpt = None
+
+    def deficientGuardianMembersTickets = false
   }
 
 

--- a/frontend/app/views/fragments/event/overviewSection.scala.html
+++ b/frontend/app/views/fragments/event/overviewSection.scala.html
@@ -66,6 +66,15 @@
                             @if(ticketing.isSoldOut) {
                                 @eventTrait("Sold out")
                             }
+
+                            @for(discountTicketing <- ticketing.memberDiscountOpt) {
+                                @if(discountTicketing.nonStandardSaving) {
+                                        @eventTrait(s"${discountTicketing.roundedSavingPercentage}% discount", "important")
+                                }
+                                @if(event.deficientGuardianMembersTickets) {
+                                        @eventTrait("Fewer discount tickets than general", "important")
+                                }
+                            }
                         }
                     }
                     </ul>

--- a/frontend/test/model/EventbriteTestObjects.scala
+++ b/frontend/test/model/EventbriteTestObjects.scala
@@ -36,6 +36,8 @@ object EventbriteTestObjects {
       highlightsOpt=None,
       chooseTier=ChooseTierMetadata("", "")
     )
+
+    def deficientGuardianMembersTickets: Boolean = false
   }
 
 }


### PR DESCRIPTION
This adds warnings for these mis-configurations:

* Discount for Guardian Member tickets not being 20%(eg '**36% Discount**')
* Fewer Guardian Member tickets than General Release tickets (not an error on Masterclasses, but wrong for Guardian Live events) - '**Fewer discount tickets than general**'

![image](https://cloud.githubusercontent.com/assets/52038/6284571/34b3e5c2-b8e9-11e4-8e70-ac435e47be92.png)

https://membership.theguardian.com/staff/event-overview
https://membership.theguardian.com/staff/masterclass-overview

cc @feedmypixel 