### PR TITLE
Revert "Disable Eventbrite healthcheck, in order to bring rest of site u...

### DIFF
--- a/frontend/app/controllers/Healthcheck.scala
+++ b/frontend/app/controllers/Healthcheck.scala
@@ -11,7 +11,7 @@ case class Test(name: String, result: () => Boolean)
 object Healthcheck extends Controller {
 
   val tests = Seq(
-    // Test("Events", GuardianLiveEventService.events.nonEmpty _),
+    Test("Events", GuardianLiveEventService.events.nonEmpty _),
     Test("CloudWatch", CloudWatchHealth.hasPushedMetricSuccessfully _),
     Test("Zuora", () => TouchpointBackend.Normal.zuoraService.pingTask.get() > DateTime.now - 2.minutes)
   )


### PR DESCRIPTION
Reverts guardian/membership-frontend#235 - otherwise deploys will lead to the site showing no events while the servers warm up. The healthcheck itself should pass now that we've cleared the bad data. 

Cc @jennysivapalan @JuliaBellis @davidrapson 