### PR TITLE
Move comment builder to separate page

### DIFF
--- a/frontend/app/controllers/Staff.scala
+++ b/frontend/app/controllers/Staff.scala
@@ -11,6 +11,10 @@ trait Staff extends Controller {
      Ok(views.html.staff.eventOverview.guLive(guLiveEvents.events, guLiveEvents.eventsDraft))
   }
 
+  def eventDetails = GoogleAuthenticatedStaffAction { implicit request =>
+     Ok(views.html.staff.event.details())
+  }
+
   def masterclassOverview = GoogleAuthenticatedStaffAction { implicit request =>
      Ok(views.html.staff.eventOverview.masterclass(masterclassEvents.events, masterclassEvents.eventsDraft))
   }

--- a/frontend/app/views/fragments/utilities/commentBuilder.scala.html
+++ b/frontend/app/views/fragments/utilities/commentBuilder.scala.html
@@ -11,10 +11,12 @@
 <section class="utils-page-section js-comment-builder">
 
     <h2 class="utils-page-section-header">Comment Builder</h2>
+
     <fieldset class="fieldset">
 
         <div class="fieldset__heading">
             <h2 class="fieldset__headline">Comments</h2>
+            <div class="fieldset__note">This tool will enable you to create the comments needed to specify certain event details.</div>
         </div>
 
         <div class="fieldset__fields">
@@ -42,15 +44,8 @@
             </div>
 
             <div class="form-field">
-                <input id="not-sold-through-eventbrite" class="js-not-sold-through-eventbrite" type="checkbox"/>
-                <label class="label label--inline" for="not-sold-through-eventbrite">No tickets sold through Eventbrite</label>
-
-                <div class="form-note"><strong>NOTE</strong> only select this option if tickets are available to purchase through third parties</div>
-            </div>
-
-            <div class="form-field">
                 <label>Event tags</label>
-                <div class="form-note">(Masterclass only)</div>
+                <div class="form-note">Create the tags you wish the event to be associated with (Masterclass only)</div>
                 @for((category, count) <- MasterclassEvent.tags.zipWithIndex) {
                     @tagInput(category.categoryName, "cat-" + count)
                     @if(category.subCategories) {
@@ -60,6 +55,14 @@
                     }
                 }
             </div>
+
+            <div class="form-field">
+                <input id="not-sold-through-eventbrite" class="js-not-sold-through-eventbrite" type="checkbox"/>
+                <label class="label label--inline" for="not-sold-through-eventbrite">No tickets sold through Eventbrite</label>
+
+                <div class="form-note"><strong>NOTE</strong> only select this option if tickets are available to purchase through third parties</div>
+            </div>
+
         </div>
 
     </fieldset>
@@ -74,8 +77,8 @@
         <div class="results">
             <div class="result-section js-result-provider"></div>
             <div class="result-section js-result-image"></div>
-            <div class="result-section js-result-not-sold-through-eventbrite"></div>
             <div class="result-section js-result-custom-tags"></div>
+            <div class="result-section js-result-not-sold-through-eventbrite"></div>
         </div>
 
     </fieldset>

--- a/frontend/app/views/staff/event/details.scala.html
+++ b/frontend/app/views/staff/event/details.scala.html
@@ -1,0 +1,9 @@
+@tools("Event Overview") {
+    <main role="main" class="page-content">
+        <section class="utils-page-section">
+            <h1 class="page-headline">Events Details</h1>
+            <p class="page-intro">A page to help with creating the details associated with Membership events</p>
+        </section>
+        @fragments.utilities.commentBuilder()
+    </main>
+}

--- a/frontend/app/views/staff/eventOverview/guLive.scala.html
+++ b/frontend/app/views/staff/eventOverview/guLive.scala.html
@@ -8,6 +8,5 @@
         </section>
         @fragments.event.overviewSection("Live Events", liveEvents)
         @fragments.event.overviewSection("Draft Events", draftEvents)
-        @fragments.utilities.commentBuilder()
     </main>
 }

--- a/frontend/app/views/staff/eventOverview/masterclass.scala.html
+++ b/frontend/app/views/staff/eventOverview/masterclass.scala.html
@@ -8,6 +8,5 @@
         </section>
         @fragments.event.overviewSection("Live Events", liveEvents)
         @fragments.event.overviewSection("Draft Events", draftEvents)
-        @fragments.utilities.commentBuilder()
     </main>
 }

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -42,6 +42,7 @@ GET            /oauth2callback                    controllers.OAuth.oauth2Callba
 # Staff event page to show discounted events
 GET            /staff/event-overview              controllers.Staff.eventOverview
 GET            /staff/masterclass-overview        controllers.Staff.masterclassOverview
+GET            /staff/event-details               controllers.Staff.eventDetails
 
 GET            /choose-tier                       controllers.Joining.tierChooser()
 


### PR DESCRIPTION
- removed the comment builder from the event overview pages
- placed on /staff/event-overview behind staff OAuth
- rejig of form filed to put less used fields at the bottom
- addition of description text

![event overview the guardian membership 5](https://cloud.githubusercontent.com/assets/2305016/6348873/fcad5ec0-bc1b-11e4-9629-73a0ee0175a4.png)
