### PR TITLE
Use for comprehension for event description

### DIFF
--- a/frontend/app/views/event/page.scala.html
+++ b/frontend/app/views/event/page.scala.html
@@ -101,7 +101,11 @@
         <div class="event-content__container u-cf">
 
             <div class="event-content__body">
-                <div class="event__description copy" itemprop="description">@Html(event.description.getOrElse(EBRichText("foobar", "foobarhtml")).cleanHtml)</div>
+                @for(description <- event.description) {
+                    <div class="event__description copy" itemprop="description">
+                        @Html(description.cleanHtml)
+                    </div>
+                }
                 <div class="event__social">
                     <div class="h-aside hidden-mobile">Share this</div>
                     @fragments.social(eventDetail(event))


### PR DESCRIPTION
Whilst looking into embedding videos in event descriptions I noticed that we fallback to a `foobarhtml` string if there is no event description. Let me know if I'm misreading this or if it's needed for something but falling back to nothing feels better than accidentally showing a dummy string.