### PR TITLE
Refactor Cta.js / pre-sale messaging

### DIFF
--- a/frontend/app/views/fragments/event/infoPanel.scala.html
+++ b/frontend/app/views/fragments/event/infoPanel.scala.html
@@ -31,9 +31,6 @@
             @if(event.isBookable) {
                 @fragments.event.ticketCta(event)
                 @fragments.event.terms(event, List("event-info__terms"))
-                @if(ticketing.isCurrentlyAvailableToPaidMembersOnly) {
-                    <a class="action js-member-cta" href="@routes.Joiner.tierList">Become a member</a>
-                }
             }
         }
     </div>

--- a/frontend/assets/javascripts/src/main.js
+++ b/frontend/assets/javascripts/src/main.js
@@ -1,7 +1,7 @@
 require([
     'ajax',
     'src/utils/analytics/setup',
-    'src/modules/events/Cta',
+    'src/modules/events/cta',
     'src/modules/events/filter',
     'src/modules/slideshow',
     'src/modules/images',
@@ -22,7 +22,7 @@ require([
 ], function(
     ajax,
     analytics,
-    Cta,
+    cta,
     filter,
     slideshow,
     images,
@@ -61,7 +61,7 @@ require([
     (new UserDetails()).init();
 
     // Events
-    (new Cta()).init();
+    cta.init();
     filter.init();
     eventPriceEnhance.init();
 

--- a/frontend/assets/javascripts/src/modules/events/Cta.js
+++ b/frontend/assets/javascripts/src/modules/events/Cta.js
@@ -1,159 +1,163 @@
 define([
     '$',
     'bean',
-    'src/utils/component',
     'src/utils/user'
-], function ($, bean, component, user) {
-    'use strict';
+], function($, bean, userUtil) {
 
-    var FRIEND = 'Friend';
-    var PARTNER = 'Partner';
-    var PATRON = 'Patron';
-    var TIER_CHANGE_URL = '/tier/change';
-    var UPGRADE = 'Upgrade membership';
-    var TICKETS_AVAILABLE_SOON = 'Tickets available soon';
+    var CTA_ELEM = '.js-ticket-cta';
 
-    var Cta = function (containerElem) {
-        this.elem = containerElem;
-    };
-
-    component.define(Cta);
-
-    Cta.prototype.ticketDates = {};
-
-    Cta.prototype.classes = {
-        MEMBER_CTA: 'js-member-cta',
-        EVENT: 'js-event',
-        SALE_START: 'js-ticket-sale-start',
-        SALE_START_FRIEND: 'js-ticket-sale-start-friend',
-        SALE_START_PARTNER: 'js-ticket-sale-start-partner',
-        SALE_START_PATRON: 'js-ticket-sale-start-patron',
-        BUY_TICKET_CTA: 'js-ticket-cta',
-        TOOLTIP: 'tooltip',
-        LEGAL: 'js-legal-terms'
-    };
-
-    Cta.prototype.buyTicketCta = function () {
-
-        var salesStart = this.ticketDates.saleStart.getTime();
-        var friendSaleStart = this.ticketDates.saleStartFriend.getTime();
-        var partnerSaleStart = this.ticketDates.saleStartPartner.getTime();
-        var patronSaleStart = this.ticketDates.saleStartPatron.getTime();
-        var memberTier = this.memberTier;
-        var now = Date.now();
-        var $buyTicketsCtaButton = $(this.getElem('BUY_TICKET_CTA'));
-
-        if ($buyTicketsCtaButton.length) {
-            if (this.userIsLoggedIn && salesStart < now) {
-
-                // tickets on sale < 7 days
-                if (patronSaleStart < now && partnerSaleStart > now) {
-                    if (memberTier === PARTNER || memberTier === FRIEND) {
-                        this.disableBuyTicketsCtaButton();
-                    }
-                }
-
-                // tickets on sale > 8 days < 14 days
-                if (partnerSaleStart < now && friendSaleStart > now) {
-                    if (memberTier === FRIEND) {
-                        this.disableBuyTicketsCtaButton();
-                    }
-                }
-
-                // if we don't have a member tier and the user is logged in and friend sale has not passed
-                if (!memberTier && friendSaleStart > now) {
-                    this.disableBuyTicketsCtaButton();
-                }
-            }
-
-            if (!this.userIsLoggedIn && friendSaleStart > now) {
-                this.disableBuyTicketsCtaButton();
-            }
+    /**
+     * CTA Actions
+     *
+     * Map properties to status
+     * If a property is set to false that attribute won't be updated
+     */
+    var CTA_ACTIONS = {
+        join: {
+            label: 'Become a member',
+            action: '/join',
+            disabled: false
+        },
+        upgrade: {
+            label: 'Upgrade membership',
+            action: '/tier/change',
+            disabled: false
+        },
+        unavailable: {
+            label: 'Tickets available soon',
+            action: false,
+            disabled: true
         }
     };
 
-    Cta.prototype.disableBuyTicketsCtaButton = function () {
-        $(this.getElem('BUY_TICKET_CTA')).remove();
-        $(this.getElem('LEGAL')).remove();
-    };
+    /**
+     * Get sales dates
+     *
+     * Determine the pre-sale start and end date
+     * and all available tier dates.
+     */
+    function getSalesDates() {
 
-    Cta.prototype.memberCta = function () {
-
-        var salesStart = this.ticketDates.saleStart.getTime();
-        var friendSaleStart = this.ticketDates.saleStartFriend.getTime();
-        var partnerSaleStart = this.ticketDates.saleStartPartner.getTime();
-        var memberTier = this.memberTier;
-        var now = Date.now();
-        var $memberCtaElement = $(this.getElem('MEMBER_CTA'));
-
-        if ($memberCtaElement.length) {
-            if (this.userIsLoggedIn) {
-                if (memberTier) {
-                    // tickets not yet on sale
-                    if (salesStart > now) {
-                        this.removeMemberCtaButton();
-                    }
-                    // tickets on sale < 7 days
-                    if (salesStart < now && partnerSaleStart > now) {
-                        if (memberTier === PARTNER) {
-                            this.upgradeComingSoonMemberCtaButton();
-                        } else if (memberTier === FRIEND) {
-                            this.upgradeMemberCtaButton();
-                        } else if (memberTier === PATRON) {
-                            this.removeMemberCtaButton();
-                        }
-                    }
-                    // tickets on sale > 8 days < 14 days
-                    if (partnerSaleStart < now && friendSaleStart > now) {
-                        if (memberTier === FRIEND) {
-                            this.upgradeMemberCtaButton();
-                        } else if (memberTier === PARTNER || memberTier === PATRON) {
-                            this.removeMemberCtaButton();
-                        }
-                    }
-                }
-            }
-        }
-    };
-
-    Cta.prototype.upgradeComingSoonMemberCtaButton = function () {
-        $(this.getElem('MEMBER_CTA')).text(TICKETS_AVAILABLE_SOON).addClass('is-disabled').removeAttr('href');
-    };
-
-    Cta.prototype.upgradeMemberCtaButton = function () {
-        $(this.getElem('MEMBER_CTA')).text(UPGRADE).attr('href', TIER_CHANGE_URL);
-    };
-
-    Cta.prototype.removeMemberCtaButton = function () {
-        $(this.getElem('MEMBER_CTA')).remove();
-    };
-
-    Cta.prototype.parseDates = function () {
-        this.ticketDates = {
-            saleStart: new Date($(this.getElem('SALE_START')).attr('datetime')),
-            saleStartFriend: new Date($(this.getElem('SALE_START_FRIEND')).attr('datetime')),
-            saleStartPartner: new Date($(this.getElem('SALE_START_PARTNER')).attr('datetime')),
-            saleStartPatron: new Date($(this.getElem('SALE_START_PATRON')).attr('datetime'))
+        var tierDates = {
+            friend: new Date($('.js-ticket-sale-start-friend').attr('datetime')),
+            // Supporter has same sale start date as Friend
+            supporter: new Date($('.js-ticket-sale-start-friend').attr('datetime')),
+            partner: new Date($('.js-ticket-sale-start-partner').attr('datetime')),
+            patron: new Date($('.js-ticket-sale-start-patron').attr('datetime'))
         };
-    };
 
-    Cta.prototype.init = function () {
-        var self = this;
-        this.elem = this.elem || this.getElem('EVENT');
+        return {
+            preSaleStart: tierDates.patron,
+            preSaleEnd: tierDates.friend,
+            tiers: tierDates
+        };
+    }
 
-        /* buttons are either both not here, both here, or only one is here */
-        if (this.getElem('MEMBER_CTA') || this.getElem('BUY_TICKET_CTA')) {
+    /**
+     * Get the sale date for the current tier
+     *
+     * Returns false if there is no tier,
+     * or the tier is not eligible for pre-sales
+     */
+    function getTierSaleDate(tierDates, memberTier) {
+        return (memberTier) ? tierDates[memberTier.toLowerCase()] || false : false;
+    }
 
-            this.userIsLoggedIn = user.isLoggedIn();
+    /**
+     * Get new status for CTA
+     *
+     * 1. If event is bookable return false (don't do anything)
+     * 2. If event if off-sale return 'unavailable'
+     * 3. If in pre-sale mode and not logged-in return 'join'
+     * 4. If in pre-sale, logged-in but tier can't book yet return 'upgrade'
+     * 5. If in pre-sale, logged-in and tier can book return false (don't do anything)
+     */
+    function newStatus(preSaleStart, preSaleEnd, tierDate) {
+        var status = false;
 
-            user.getMemberDetail(function (memberDetail) {
-                self.memberTier = memberDetail && memberDetail.tier;
-                self.parseDates();
-                self.buyTicketCta();
-                self.memberCta();
+        var now = Date.now();
+        var isOffSale = (now < preSaleStart.getTime());
+        var isPreSale = (now > preSaleStart.getTime() && now < preSaleEnd.getTime());
+
+        /**
+         * Event is not on-sale
+         */
+        if (isOffSale) {
+            status = 'unavailable';
+        }
+
+        /**
+         * Event is in pre-sale mode
+         */
+        if (isPreSale) {
+            status = 'join';
+            /**
+             * We have a sale date for the tier
+             * (false if we are signed-out or have no sale-date)
+             */
+            if (tierDate) {
+                /**
+                 * Current tier's sale date is in the future
+                 */
+                if (tierDate > now) {
+                    status = 'upgrade';
+                } else {
+                    /**
+                     * Current tier's sale date is in the present,
+                     * so is bookable. Leave the button alone
+                     */
+                    status = false;
+                }
+            }
+        }
+
+        return status;
+    }
+
+    /**
+     * Enhance CTA
+     *
+     * Updates label, action or disabled status depending on status.
+     */
+    function enhanceCta(elem, ctaStatus) {
+        var newLabel = CTA_ACTIONS[ctaStatus].label || false,
+            newAction = CTA_ACTIONS[ctaStatus].action || false,
+            shouldDisable = CTA_ACTIONS[ctaStatus].disabled || false;
+
+        if (newLabel) {
+            elem.text(newLabel);
+        }
+
+        if (newAction) {
+            elem.attr('href', newAction);
+        }
+
+        if (shouldDisable) {
+            elem.addClass('is-disabled').attr('disabled', true);
+        }
+    }
+
+    function init() {
+        var elem = $(CTA_ELEM);
+        if (elem.length) {
+            userUtil.getMemberDetail(function (memberDetail) {
+
+                var memberTier = memberDetail && memberDetail.tier,
+                    ticketSales = getSalesDates(),
+                    tierSaleDate = getTierSaleDate(ticketSales.tiers, memberTier),
+                    ctaStatus = newStatus(ticketSales.preSaleStart, ticketSales.preSaleEnd, tierSaleDate);
+
+                if (ctaStatus) {
+                    enhanceCta(elem, ctaStatus);
+                }
+
             });
         }
+    }
+
+    return {
+        newStatus: newStatus,
+        init: init
     };
 
-    return Cta;
 });

--- a/frontend/assets/javascripts/src/modules/events/cta.js
+++ b/frontend/assets/javascripts/src/modules/events/cta.js
@@ -1,8 +1,7 @@
 define([
     '$',
-    'bean',
     'src/utils/user'
-], function($, bean, userUtil) {
+], function($, userUtil) {
 
     var CTA_ELEM = '.js-ticket-cta';
 

--- a/frontend/assets/stylesheets/components/_action.scss
+++ b/frontend/assets/stylesheets/components/_action.scss
@@ -125,11 +125,10 @@
 .action--booking {
     color: $white;
     background-color: $black;
-    border-color: $black;
+    border: 0 none;
 
     &:hover {
         background-color: lighten($black, 15%);
-        border-color: lighten($black, 15%);
     }
 }
 
@@ -208,6 +207,19 @@
     background-color: $c-neutral5;
     border-color: $c-neutral5;
 }
+
+/**
+ * Disabled state for booking actions
+ */
+.action--booking.is-disabled,
+.action--booking[disabled],
+.action--booking[disabled]:hover {
+    opacity: 0.2;
+    color: $white;
+    background-color: $black;
+    border-color: $black;
+}
+
 
 /* Actions - Proceed
    ========================================================================== */

--- a/frontend/assets/stylesheets/components/_action.scss
+++ b/frontend/assets/stylesheets/components/_action.scss
@@ -125,7 +125,7 @@
 .action--booking {
     color: $white;
     background-color: $black;
-    border: 0 none;
+    border: none;
 
     &:hover {
         background-color: lighten($black, 15%);

--- a/frontend/test/js/spec/Cta.spec.js
+++ b/frontend/test/js/spec/Cta.spec.js
@@ -1,364 +1,47 @@
-define([
-    '$',
-    'ajax',
-    'src/utils/user',
-    'src/modules/events/Cta'
-], function ($, ajax, user, Cta) {
+define(['src/modules/events/cta'], function (cta) {
 
-    ajax.init({page: {ajaxUrl: ''}});
+    describe('newStatus', function () {
 
-    describe('Early bird tickets', function() {
+        it('be unavailable if off-sale to everyone' , function () {
+            var preSaleStart = new Date('1 Jan 2199');
+            var preSaleEnd = new Date('1 Jan 2199');
 
-        var BUY_TICKETS = 'Book Tickets';
-        var COMING_SOON = 'Coming Soon';
-        var BECOME_A_MEMBER = 'Become a member';
-        var UPGRADE_MEMBERSHIP = 'Upgrade membership';
-        var TICKETS_AVAILABLE_SOON = 'Tickets available soon';
-        var cta;
-
-        // PhantomJS doesn't support bind yet
-        Function.prototype.bind = Function.prototype.bind || function (context) {
-            var fn = this;
-            return function () {
-                return fn.apply(context, arguments);
-            };
-        };
-
-        /**
-         * set the dates up for use in the class. This is mimicking scala behaviour and gives us control over setting the dates
-         * per test
-         * @param date
-         * @returns {{salesStart: *, patronStart: *, partnerStart: Date, friendStart: Date}}
-         */
-        function setUpBookingDates(date) {
-            var datePlusOneWeek = new Date(date);
-            var datePlusTwoWeeks = new Date(date);
-
-            datePlusOneWeek.setDate(datePlusOneWeek.getDate() + 7);
-            datePlusTwoWeeks.setDate(datePlusTwoWeeks.getDate() + 14);
-
-            return {
-                salesStart: date,
-                patronStart: date,
-                partnerStart: datePlusOneWeek,
-                friendStart: datePlusTwoWeeks
-            }
-        }
-
-        /**
-         * spy for user.loggedIn method
-         * @param isLoggedIn
-         */
-        function setUserLoggedInStatus(isLoggedIn) {
-            spyOn(user, 'isLoggedIn').and.callFake(function () {
-                return isLoggedIn;
-            });
-        }
-
-        /**
-         * spy for user.getMemberDetail method
-         * @param tier
-         */
-        function setUserTier(tier) {
-            user.getMemberDetail.and.callFake(function (callback) {
-                callback({
-                    userId: '10000004',
-                    tier: tier,
-                    joinDate: '2014-07-29T15:43:42.000Z',
-                    optIn: false
-                });
-            });
-        }
-
-        /**
-         * setup the fixture
-         * init the cta class
-         * run standard validations
-         * @param salesStart
-         * @param tier
-         * @param isLoggedIn
-         */
-        function ctaClassSetup(salesStart, tier, isLoggedIn) {
-            var bookingDates = setUpBookingDates(salesStart);
-
-            setUserLoggedInStatus(isLoggedIn);
-            setUserTier(tier);
-
-            spyOn(cta, 'parseDates').and.callFake(function () {
-                cta.ticketDates = {
-                    saleStart: bookingDates.salesStart,
-                    saleStartFriend: bookingDates.friendStart,
-                    saleStartPartner: bookingDates.partnerStart,
-                    saleStartPatron: bookingDates.patronStart
-                };
-            });
-
-            spyOn(cta, 'disableBuyTicketsCtaButton').and.callThrough();
-            spyOn(cta, 'upgradeComingSoonMemberCtaButton').and.callThrough();
-            spyOn(cta, 'upgradeMemberCtaButton').and.callThrough();
-            spyOn(cta, 'removeMemberCtaButton').and.callThrough();
-
-            cta.init();
-
-            expect(user.isLoggedIn).toHaveBeenCalled();
-            expect(user.getMemberDetail).toHaveBeenCalled();
-            expect(cta.memberTier).toEqual(tier);
-            expect(cta.userIsLoggedIn).toBeTruthy();
-        }
-
-        function memBeforeEach(done) {
-            cta = new Cta($.create('<div class="event__tickets"><div class="js-ticket-cta"></div><div class="js-member-cta"></div></div>'));
-            cta.elems = []; //reset component.js internal element cache
-
-            spyOn(user, 'getMemberDetail');
-
-            done();
-        }
-
-        describe('Fixture and CTA class', function () {
-
-            beforeEach(function (done) {
-                memBeforeEach(done);
-            });
-
-
-            it(' is correctly initialised', function (done) {
-                var tier = 'Friend';
-                ctaClassSetup(new Date(), tier, true)
-                done();
-            });
-
+            expect(cta.newStatus(preSaleStart, preSaleEnd)).toEqual('unavailable');
+            expect(cta.newStatus(preSaleStart, preSaleEnd), new Date('1 Feb 2015')).toEqual('unavailable');
+            expect(cta.newStatus(preSaleStart, preSaleEnd), new Date('31 Dec 2198')).toEqual('unavailable');
+            expect(cta.newStatus(preSaleStart, preSaleEnd), false).toEqual('unavailable');
         });
 
-        describe('Tickets NOT on sale', function () {
+        describe('Event in pre-sale mode', function () {
+            it('should prompt to become a member if pre-sale but logged-out' , function () {
+                var preSaleStart = new Date('1 Jan 2015');
+                var preSaleEnd = new Date('1 Jan 2199');
 
-            beforeEach(function (done) {
-                memBeforeEach(done);
+                expect(cta.newStatus(preSaleStart, preSaleEnd)).toEqual('join');
             });
+            it('should prompt to upgrade if the users tier cannot buy tickets yet' , function () {
 
+                var preSaleStart = new Date('1 Jan 2015');
+                var preSaleEnd = new Date('1 Jan 2199');
+                var tierDate = new Date('31 Dec 2198');
 
-            var salesStartOneWeekInTheFuture = new Date();
-            salesStartOneWeekInTheFuture.setDate(salesStartOneWeekInTheFuture.getDate() + 7);
-
-            it('loggedIn Friend - "' + COMING_SOON + '" button disabled and "' + BECOME_A_MEMBER + '" button NOT displayed' , function (done) {
-                ctaClassSetup(salesStartOneWeekInTheFuture, 'Friend', true)
-                expect(cta.disableBuyTicketsCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.removeMemberCtaButton).toHaveBeenCalled();
-                done();
+                expect(cta.newStatus(preSaleStart, preSaleEnd, tierDate)).toEqual('upgrade');
             });
+            it('should be bookable if the users tier can buy tickets' , function () {
 
-            it('loggedIn Partner - "' + COMING_SOON + '" button disabled and "' + BECOME_A_MEMBER + '" button NOT displayed', function (done) {
-                ctaClassSetup(salesStartOneWeekInTheFuture, 'Partner', true)
-                expect(cta.disableBuyTicketsCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.removeMemberCtaButton).toHaveBeenCalled();
-                done();
-            });
+                var preSaleStart = new Date('1 Jan 2015');
+                var preSaleEnd = new Date('1 Jan 2199');
+                var tierDate = new Date('1 Feb 2015');
 
-            it('loggedIn Patron - "' + COMING_SOON + '" button disabled and "' + BECOME_A_MEMBER + '" button NOT displayed', function (done) {
-                ctaClassSetup(salesStartOneWeekInTheFuture, 'Patron', true)
-                expect(cta.disableBuyTicketsCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.removeMemberCtaButton).toHaveBeenCalled();
-                done();
-            });
-
-            it('loggedIn NOT a member - "' + COMING_SOON + '" button disabled and "' + BECOME_A_MEMBER + '" button displayed', function (done) {
-                ctaClassSetup(salesStartOneWeekInTheFuture, null, true)
-                expect(cta.disableBuyTicketsCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.removeMemberCtaButton).not.toHaveBeenCalled();
-                done();
-            });
-
-            it('loggedOut - "' + COMING_SOON + '" button disabled and "' + BECOME_A_MEMBER + '" button displayed', function (done) {
-                ctaClassSetup(salesStartOneWeekInTheFuture, null, true)
-                expect(cta.disableBuyTicketsCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.removeMemberCtaButton).not.toHaveBeenCalled();
-                done();
+                /**
+                 * Should return status as bookable is the default action,
+                 * so don't do anything.
+                 */
+                expect(cta.newStatus(preSaleStart, preSaleEnd, tierDate)).toEqual(false);
             });
         });
 
-        describe('Tickets on sale FIRST week', function () {
-
-            beforeEach(function (done) {
-                memBeforeEach(done);
-            });
-
-            var saleStartedYesterday = new Date();
-            saleStartedYesterday.setDate(saleStartedYesterday.getDate() - 1);
-
-            it('loggedIn Friend - "' + BUY_TICKETS + '" button disabled and "' + UPGRADE_MEMBERSHIP + '" button displayed', function (done) {
-                ctaClassSetup(saleStartedYesterday, 'Friend', true);
-                expect(cta.disableBuyTicketsCtaButton).toHaveBeenCalled();
-                expect(cta.upgradeMemberCtaButton).toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.removeMemberCtaButton).not.toHaveBeenCalled();
-                done();
-            });
-
-            it('loggedIn Partner - "' + BUY_TICKETS + '" button disabled and "' + TICKETS_AVAILABLE_SOON + '" button displayed', function (done) {
-                ctaClassSetup(saleStartedYesterday, 'Partner', true);
-                expect(cta.disableBuyTicketsCtaButton).toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).toHaveBeenCalled();
-                expect(cta.upgradeMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.removeMemberCtaButton).not.toHaveBeenCalled();
-                done();
-            });
-
-            it('loggedIn Patron - "' + BUY_TICKETS + '" enabled and memberCTA button removed', function (done) {
-
-                ctaClassSetup(saleStartedYesterday, 'Patron', true);
-
-                expect(cta.disableBuyTicketsCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.removeMemberCtaButton).toHaveBeenCalled();
-
-                done();
-            });
-
-            it('loggedIn not a member - "' + BUY_TICKETS + '" disabled and "' + BECOME_A_MEMBER + '" button displayed', function (done) {
-
-                ctaClassSetup(saleStartedYesterday, null, true)
-
-                expect(cta.disableBuyTicketsCtaButton).toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.removeMemberCtaButton).not.toHaveBeenCalled();
-
-                done();
-            });
-
-            it('loggedOut - "' + BUY_TICKETS + '" disabled and "' + BECOME_A_MEMBER + '" button displayed', function (done) {
-
-                ctaClassSetup(saleStartedYesterday, null, true)
-
-                expect(cta.disableBuyTicketsCtaButton).toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.removeMemberCtaButton).not.toHaveBeenCalled();
-
-                done();
-            });
-        });
-
-        describe('Tickets on sale SECOND week', function () {
-
-            beforeEach(function (done) {
-                memBeforeEach(done);
-            });
-
-            var saleStarted8DaysAgo = new Date();
-            saleStarted8DaysAgo.setDate(saleStarted8DaysAgo.getDate() - 8);
-
-            it('loggedIn Friend - "' + BUY_TICKETS + '" disabled  and "' + UPGRADE_MEMBERSHIP + '" button displayed', function (done) {
-                ctaClassSetup(saleStarted8DaysAgo, 'Friend', true);
-                expect(cta.disableBuyTicketsCtaButton).toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.removeMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeMemberCtaButton).toHaveBeenCalled();
-                done();
-            });
-
-            it('loggedIn Partner - "' + BUY_TICKETS + '" enabled and memberCTA button removed', function (done) {
-                ctaClassSetup(saleStarted8DaysAgo, 'Partner', true);
-                expect(cta.disableBuyTicketsCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.removeMemberCtaButton).toHaveBeenCalled();
-                done();
-            });
-
-            it('loggedIn Patron - "' + BUY_TICKETS + '" enabled and memberCTA button removed', function (done) {
-                ctaClassSetup(saleStarted8DaysAgo, 'Patron', true);
-                expect(cta.disableBuyTicketsCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.removeMemberCtaButton).toHaveBeenCalled();
-                done();
-            });
-
-            it('loggedIn not a member - "' + BUY_TICKETS + '" disabled and "' + BECOME_A_MEMBER + '" button displayed', function (done) {
-                ctaClassSetup(saleStarted8DaysAgo, null, true)
-                expect(cta.disableBuyTicketsCtaButton).toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.removeMemberCtaButton).not.toHaveBeenCalled();
-                done();
-            });
-
-            it('loggedOut - "' + BUY_TICKETS + '" disabled and "' + BECOME_A_MEMBER + '" button displayed', function (done) {
-                ctaClassSetup(saleStarted8DaysAgo, null, true)
-                expect(cta.disableBuyTicketsCtaButton).toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.removeMemberCtaButton).not.toHaveBeenCalled();
-                done();
-            });
-        });
-
-        describe('Tickets on sale FRIEND release', function () {
-
-            beforeEach(function (done) {
-                memBeforeEach(done);
-            });
-
-            var saleStarted15DaysAgo = new Date();
-            saleStarted15DaysAgo.setDate(saleStarted15DaysAgo.getDate() - 15);
-
-            it('loggedIn Friend - "' + BUY_TICKETS + '" enabled and memberCTA button removed', function (done) {
-                ctaClassSetup(saleStarted15DaysAgo, 'Friend', true);
-                expect(cta.disableBuyTicketsCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.removeMemberCtaButton).not.toHaveBeenCalled();
-                done();
-            });
-
-            it('loggedIn Partner - "' + BUY_TICKETS + '" enabled and memberCTA button removed', function (done) {
-                ctaClassSetup(saleStarted15DaysAgo, 'Partner', true);
-                expect(cta.disableBuyTicketsCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.removeMemberCtaButton).not.toHaveBeenCalled();
-                done();
-            });
-
-            it('loggedIn Patron - "' + BUY_TICKETS + '" enabled and memberCTA button removed', function (done) {
-                ctaClassSetup(saleStarted15DaysAgo, 'Patron', true);
-                expect(cta.disableBuyTicketsCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.removeMemberCtaButton).not.toHaveBeenCalled();
-                done();
-            });
-
-            it('loggedIn not a member - "' + BUY_TICKETS + '" enabled and memberCTA button removed', function (done) {
-                ctaClassSetup(saleStarted15DaysAgo, null, true)
-                expect(cta.disableBuyTicketsCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.removeMemberCtaButton).not.toHaveBeenCalled();
-                done();
-            });
-
-            it('loggedOut - "' + BUY_TICKETS + '" enabled and memberCTA button removed', function (done) {
-                ctaClassSetup(saleStarted15DaysAgo, null, true)
-                expect(cta.disableBuyTicketsCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeComingSoonMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.upgradeMemberCtaButton).not.toHaveBeenCalled();
-                expect(cta.removeMemberCtaButton).not.toHaveBeenCalled();
-                done();
-            });
-        });
     });
+
 });
 

--- a/frontend/test/js/spec/cta.spec.js
+++ b/frontend/test/js/spec/cta.spec.js
@@ -34,7 +34,7 @@ define(['src/modules/events/cta'], function (cta) {
                 var tierDate = new Date('1 Feb 2015');
 
                 /**
-                 * Should return status as bookable is the default action,
+                 * Should return false as bookable is the default action,
                  * so don't do anything.
                  */
                 expect(cta.newStatus(preSaleStart, preSaleEnd, tierDate)).toEqual(false);

--- a/frontend/test/js/spec/cta.spec.js
+++ b/frontend/test/js/spec/cta.spec.js
@@ -1,47 +1,68 @@
+/**
+ * Rules for the CTA
+ * - If event is not on sale to anyone return 'unavailable' status object
+ * - If event is within priority booking mode and user is not logged-in return 'join' status object
+ * - If event is within priority booking mode, and user is logged-in user with a tier sale start date in the future return 'upgrade' status object
+ * - If event is within priority booking mode, and user is logged-in user with a tier sale start date in the past return empty status object
+ * - If event is on sale to everyone, and user is logged-in with or without a tier return empty status object
+ */
 define(['src/modules/events/cta'], function (cta) {
 
-    describe('newStatus', function () {
+    describe('Cta tests', function () {
 
-        it('be unavailable if off-sale to everyone' , function () {
-            var preSaleStart = new Date('1 Jan 2199');
-            var preSaleEnd = new Date('1 Jan 2199');
+        describe('getCtaStatus', function () {
 
-            expect(cta.newStatus(preSaleStart, preSaleEnd)).toEqual('unavailable');
-            expect(cta.newStatus(preSaleStart, preSaleEnd), new Date('1 Feb 2015')).toEqual('unavailable');
-            expect(cta.newStatus(preSaleStart, preSaleEnd), new Date('31 Dec 2198')).toEqual('unavailable');
-            expect(cta.newStatus(preSaleStart, preSaleEnd), false).toEqual('unavailable');
+            it('Event is not on sale to anyone' , function () {
+                var startDate = new Date('1 Jan 2198');
+                var endDate = new Date('1 Jan 2199');
+                var patronSaleStart = new Date(startDate.getTime());
+
+                it('with no user', function () {
+                    expect(cta.getCtaStatus(startDate, endDate, null).id).toEqual('unavailable');
+                });
+
+                it('with patron tier', function () {
+                    expect(cta.getCtaStatus(startDate, endDate, patronSaleStart).id).toEqual('unavailable');
+                });
+            });
+
+            describe('Event is within priority booking mode', function () {
+                var startDate = new Date('1 Jan 2015');
+                var endDate = new Date('1 Jan 2199');
+                var friendSaleStart = new Date(endDate.getTime());
+                var patronSaleStart = new Date(startDate.getTime());
+
+                it('with no user', function () {
+                    expect(cta.getCtaStatus(startDate, endDate, null).id).toEqual('join');
+                });
+
+                it('with friend tier', function () {
+                    expect(cta.getCtaStatus(startDate, endDate, friendSaleStart).id).toEqual('upgrade');
+                });
+
+                it('with patron tier', function () {
+                    expect(cta.getCtaStatus(startDate, endDate, patronSaleStart).id).toBeUndefined();
+                });
+            });
+
+            describe('Event is on sale to everyone', function () {
+                var startDate = new Date('1 Jan 2015');
+                var endDate = new Date('1 Feb 2015');
+                var friendSaleStart = new Date(endDate.getTime());
+                var patronSaleStart = new Date(startDate.getTime());
+
+                it('with no user', function () {
+                    expect(cta.getCtaStatus(startDate, endDate, null).id).toBeUndefined();
+                });
+
+                it('with friend tier', function () {
+                    expect(cta.getCtaStatus(startDate, endDate, friendSaleStart).id).toBeUndefined();
+                });
+
+                it('with patron tier', function () {
+                    expect(cta.getCtaStatus(startDate, endDate, patronSaleStart).id).toBeUndefined();
+                });
+            });
         });
-
-        describe('Event in pre-sale mode', function () {
-            it('should prompt to become a member if pre-sale but logged-out' , function () {
-                var preSaleStart = new Date('1 Jan 2015');
-                var preSaleEnd = new Date('1 Jan 2199');
-
-                expect(cta.newStatus(preSaleStart, preSaleEnd)).toEqual('join');
-            });
-            it('should prompt to upgrade if the users tier cannot buy tickets yet' , function () {
-
-                var preSaleStart = new Date('1 Jan 2015');
-                var preSaleEnd = new Date('1 Jan 2199');
-                var tierDate = new Date('31 Dec 2198');
-
-                expect(cta.newStatus(preSaleStart, preSaleEnd, tierDate)).toEqual('upgrade');
-            });
-            it('should be bookable if the users tier can buy tickets' , function () {
-
-                var preSaleStart = new Date('1 Jan 2015');
-                var preSaleEnd = new Date('1 Jan 2199');
-                var tierDate = new Date('1 Feb 2015');
-
-                /**
-                 * Should return false as bookable is the default action,
-                 * so don't do anything.
-                 */
-                expect(cta.newStatus(preSaleStart, preSaleEnd, tierDate)).toEqual(false);
-            });
-        });
-
     });
-
 });
-


### PR DESCRIPTION
This PR refactors Cta.js to improve the following:

- Makes code more tier agnostic, so we can easily add additional tiers
- Improve testability by extracting button status out into a testable method
- Fixes bug with off-sale events

## Fixes immediate bug with off-sale events

### New
![screen shot 2015-02-24 at 17 16 35](https://cloud.githubusercontent.com/assets/123386/6354676/e4df1dba-bc48-11e4-95a6-f91dbddc55d0.png)

### Old
![screen shot 2015-02-24 at 17 15 09](https://cloud.githubusercontent.com/assets/123386/6354647/bab6210a-bc48-11e4-87d1-f0374e4fa441.png)

## Maintains existing behaviour

Screenshots from a test event which is only on-sale to Patrons

### Signed-out, pre-sale

![signed-out-presale](https://cloud.githubusercontent.com/assets/123386/6354693/fe6cd984-bc48-11e4-96f3-0993154d3e5d.png)

### Signed-in, pre-sale, but unavailable to current tier

![tier-upgrade](https://cloud.githubusercontent.com/assets/123386/6354698/0bfc56c4-bc49-11e4-8a7f-ae48bf9eba6a.png)

### Signed-in, pre-sale, available to current tier

![tier-available](https://cloud.githubusercontent.com/assets/123386/6354703/150bc3d0-bc49-11e4-925c-3d22b3eb0a8b.png)


I've tried to comment this as best as I can and it's definitely much more easily testable than before but I could do with some eyes on this to make sure that a) it makes sense to everyone else and b) all cases have been accounted for.
