### PR TITLE
JSON not being defined error being thrown by jshint - 

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -26,6 +26,7 @@
         "require"  : false,
         "define"   : false,
         "s"        : false,
-        "guardian" : false
+        "guardian" : false,
+        "JSON"     : false
     }
 }


### PR DESCRIPTION
this stops the error being thrown on grunt build.