### PR TITLE
Add primary promo images to The Grid

### DIFF
--- a/frontend/app/views/fragments/promos/promoPrimary.scala.html
+++ b/frontend/app/views/fragments/promos/promoPrimary.scala.html
@@ -1,6 +1,6 @@
 @(
     title: Html,
-    imageUrl: String,
+    imageBasePath: String,
     stampImageOpt: Option[String] = None,
     isLead: Boolean = false,
     toneClass: Option[String] = None
@@ -14,7 +14,7 @@
     </div>
     <div class="promo-primary__media@if(stampImageOpt){ stamped-image}">
         <div class="promo-primary__image">
-            <img src="@Asset.at(imageUrl)" alt="@title" class="responsive-img">
+            <div class="js-imager-loaded-image" data-src="@imageBasePath/{width}.jpg" data-available-widths="1000,500,140" data-alt="@title" data-class="responsive-img"></div>
         </div>
         @for(url <- stampImageOpt) {
             <div class="stamped-image__container">

--- a/frontend/app/views/info/about.scala.html
+++ b/frontend/app/views/info/about.scala.html
@@ -8,7 +8,7 @@
 
     @* ===== About Membership ===== *@
     <div class="page-slice l-constrained l-side-margins">
-        @fragments.promos.promoPrimary(title=Html("About<br>Membership"), imageUrl="images/about/about-intro-1140.jpg", isLead=true) {
+        @fragments.promos.promoPrimary(title=Html("About<br>Membership"), imageBasePath="https://media.guim.co.uk/0f30a12f5d00d2b0e445e81c171cd0168d3cf5a7/0_0_1140_684", isLead=true) {
             <div class="text-feature">
                 <p>Guardian Members are changing the idea of what a news organisation does today.</p>
                 <p>Join the influential community of journalists, readers and contributors that is the Guardian, and connect to the conversations that matter.</p>
@@ -26,7 +26,7 @@
 
     @* ===== Bring the Guardian to life ===== *@
     <div class="page-slice l-constrained l-side-margins">
-        @fragments.promos.promoPrimary(title=Html("Guardian Live: Experience the Guardian brought to life"), imageUrl="images/about/about-events-1140.jpg", stampImageOpt=Some("images/logos/guardian-live-reversed.svg"), toneClass=Some("tone-trans-guardian-live")) {
+        @fragments.promos.promoPrimary(title=Html("Guardian Live: Experience the Guardian brought to life"), imageBasePath="https://media.guim.co.uk/76ef58a05920591099012edb80e7415379392a4c/0_0_1140_684", stampImageOpt=Some("images/logos/guardian-live-reversed.svg"), toneClass=Some("tone-trans-guardian-live")) {
             <div class="text-feature">
                 <p>Book tickets for our programme of discussions, debates, interviews, keynote speeches and festivals.</p>
             </div>
@@ -46,8 +46,7 @@
 
     @* ===== Founding Members ===== *@
     <div class="page-slice l-constrained l-side-margins">
-        @fragments.promos.promoPrimary(title=Html("Founding members: join us at the start"), imageUrl="images/about/about-founding-members-1140.jpg") {
-
+        @fragments.promos.promoPrimary(title=Html("Founding members: join us at the start"), imageBasePath="https://media.guim.co.uk/bb922fe62efbe24af2df336dd2b621c5799246b4/0_0_1140_683") {
             <blockquote class="blockquote blockquote--feature">
                 If you read the Guardian, join the Guardian. Support fearless, open, independent journalism. And have a great time doing it.
                 <cite class="blockquote__citation">Polly Toynbee, Guardian columnist</cite>
@@ -78,7 +77,7 @@
 
     @* ===== Become a Patron ===== *@
     <div class="page-slice l-constrained l-side-margins">
-        @fragments.promos.promoPrimary(title=Html("Become a Patron and support the Guardian's future"), imageUrl="images/about/about-patron-1140.jpg", toneClass=Some("tone-trans-brand-dark")) {
+        @fragments.promos.promoPrimary(title=Html("Become a Patron and support the Guardian's future"), imageBasePath="https://media.guim.co.uk/175fba5c61d2b398973befa5d6b49c1257740d5c/0_0_1140_683", toneClass=Some("tone-trans-brand-dark")) {
             <blockquote class="blockquote blockquote--feature">
                 The only relationship our journalists have is with our readers. Membership gives the real possibility of deepening the intense bond between the producers and consumers of the Guardian.
                 <cite class="blockquote__citation">Alan Rusbridger, editor-in-chief of the Guardian</cite>

--- a/frontend/app/views/joiner/tier/patron.scala.html
+++ b/frontend/app/views/joiner/tier/patron.scala.html
@@ -9,7 +9,7 @@
 
     @* ===== About Patronage ===== *@
     <div class="page-slice l-constrained l-side-margins">
-        @fragments.promos.promoPrimary(title=Html("Patrons of<br>the Guardian"), imageUrl="images/patrons/patrons-intro-1140.jpg", isLead=true) {
+        @fragments.promos.promoPrimary(title=Html("Patrons of<br>the Guardian"), imageBasePath="https://media.guim.co.uk/8caacf301dd036a2bbb1b458cf68b637d3c55e48/0_0_1140_683", isLead=true) {
             <div class="text-feature">
                 <p>The Patron tier is for those who care deeply about the Guardian’s journalism and the impact it has on the world.</p>
                 <p>From campaigning on issues affecting the voices less heard to holding those in power to account, Patrons ensure the Guardian can continue to surface the information and ideas that shape the global conversation.</p>
@@ -20,7 +20,7 @@
 
     @* ===== Ensuring our independence ===== *@
     <div class="page-slice l-constrained l-side-margins">
-        @fragments.promos.promoPrimary(title=Html("Ensuring our<br>independence"), imageUrl="images/patrons/patrons-alan-1140.jpg", toneClass=Some("tone-trans-brand-dark")) {
+        @fragments.promos.promoPrimary(title=Html("Ensuring our<br>independence"), imageBasePath="https://media.guim.co.uk/e6459f638392c8176e277733f6f0802953100fa4/0_0_1140_683", toneClass=Some("tone-trans-brand-dark")) {
             <div class="text-feature">
                 <p>The Guardian has no proprietor. Our editor has total independence.</p>
                 <p>The support of Patrons helps to ensure that the Guardian can stand witness to the world, without interference.</p>
@@ -43,7 +43,7 @@
 
     @* ===== Get Involved ===== *@
     <div class="page-slice l-constrained l-side-margins">
-        @fragments.promos.promoPrimary(title=Html("Choose to get involved"), imageUrl="images/patrons/patrons-get-involved-1140.jpg", toneClass=Some("tone-trans-brand-dark")) {
+        @fragments.promos.promoPrimary(title=Html("Choose to get involved"), imageBasePath="https://media.guim.co.uk/d8f51bea15bf046df4d166cfd60771b9c24a631f/0_0_1140_683", toneClass=Some("tone-trans-brand-dark")) {
             <p class="text-feature">Patrons are crucial to the future development of Membership, and there will be opportunities to get involved.  From hosting your own events to connecting members to one another, you will shape the future of the community.</p>
             @fragments.tier.packagePromo(Tier.Patron, showDescription=false, modifierClass=Some("package-promo--spread"))
         }

--- a/frontend/app/views/patterns/patterns.scala.html
+++ b/frontend/app/views/patterns/patterns.scala.html
@@ -279,7 +279,7 @@
     }
 
     @pattern("Promo - Primary") {
-        @fragments.promos.promoPrimary(Html("Primary Promo"), imageUrl="images/about/about-events-1140.jpg", toneClass=Some("tone-trans-guardian-live")) {
+        @fragments.promos.promoPrimary(Html("Primary Promo"), imageBasePath="https://media.guim.co.uk/d8f51bea15bf046df4d166cfd60771b9c24a631f/0_0_1140_683", toneClass=Some("tone-trans-guardian-live")) {
             <p class="text-feature">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ullam, error hic temporibus. Aliquam nemo delectus possimus repudiandae ut, aut fugit. Pariatur dolorem, explicabo, ducimus deserunt perspiciatis voluptates commodi debitis exercitationem.</p>
         }
     }


### PR DESCRIPTION
This PR adds promo primary images to The Grid. Also need to add secondary promo images but waiting on larger source images from Ben so this will happen in a separate PR.

Gets content images out of the codebase and allows gives us performance benefits of using responsive images here.

![screen shot 2015-03-02 at 11 26 17](https://cloud.githubusercontent.com/assets/123386/6439848/f574f2f0-c0ce-11e4-9454-be43ef96d080.png)
