### PR TITLE
For dev-purposes, tolerate having no network connection at all

### DIFF
--- a/frontend/app/actions/Functions.scala
+++ b/frontend/app/actions/Functions.scala
@@ -28,7 +28,7 @@ case class AuthenticatedException(user: IdMinimalUser, ex: Throwable)
  */
 object Functions extends LazyLogging {
 
-  val googleGroupChecker = new GoogleGroupChecker(Config.googleGroupCheckerAuthConfig)
+  lazy val googleGroupChecker = new GoogleGroupChecker(Config.googleGroupCheckerAuthConfig)
 
   def resultModifier(f: Result => Result) = new ActionBuilder[Request] {
     def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]) = block(request).map(f)


### PR DESCRIPTION
Practically, this means lazy loading the GoogleGroupChecker so that the entire server doesn't die on class iniitalisation - this helps a little in on-the-train dev, obviously most of the site will /not/ work without a network connection!