### PR TITLE
Update to use the most recent Ubuntu base, to allow packing to succeed

### DIFF
--- a/provisioning.json
+++ b/provisioning.json
@@ -8,7 +8,7 @@
         "access_key": "{{user `aws_access_key`}}",
         "secret_key": "{{user `aws_secret_key`}}",
         "region": "eu-west-1",
-        "source_ami": "ami-2c90315b",
+        "source_ami": "ami-73f97204",
         "instance_type": "t2.micro",
         "ssh_username": "ubuntu",
         "ami_name": "gu-membership-{{isotime \"2006-01-02\"}}"


### PR DESCRIPTION
The old AMI had some kind of configuration conflict, which died very cryptically half way through.

Incidentally, here's a command-line way of finding the latest Ubuntu images:

```
$ aws ec2 describe-images  --owner 099720109477 --region eu-west-1 --filter "Name=architecture,Values=x86_64" --filter "Name=virtualization-type,Values=hvm" | jq '.Images[] | select(contains({RootDeviceType: "ebs"})) | .ImageId + " " + .Name' | grep hvm-ssd/ubuntu-trusty-14.04-amd64-server | sort -r --key 2 | head -6
"ami-73f97204 ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20150209.1"
"ami-234ecc54 ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20150123"
"ami-823686f5 ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20141125"
"ami-f0b11187 ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20140927"
"ami-2c90315b ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20140926"
"ami-08fb5a7f ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20140924"
```

The new AMI constructed by packer from this updated AMI is `gu-membership-2015-03-03 (ami-fba2328c)`, and it's now successfully deployed in Production.