### PR TITLE
Remove unused CSRF token which is definitely not wanted on cached pages

### DIFF
--- a/frontend/app/views/event/guardianLive.scala.html
+++ b/frontend/app/views/event/guardianLive.scala.html
@@ -1,4 +1,4 @@
-@(eventPortfolio: model.EventPortfolio, pageInfo: model.PageInfo)(implicit token: play.filters.csrf.CSRF.Token)
+@(eventPortfolio: model.EventPortfolio, pageInfo: model.PageInfo)
 
 @main("Events", pageInfo=pageInfo) {
     <main role="main" class="l-constrained">

--- a/frontend/app/views/event/list.scala.html
+++ b/frontend/app/views/event/list.scala.html
@@ -3,7 +3,7 @@
     noResultsMessage: String,
     isFilterable: Boolean = false,
     showPastEvents: Boolean = false
-)(implicit token: play.filters.csrf.CSRF.Token)
+)
 
 @import com.gu.membership.salesforce.Tier
 

--- a/frontend/app/views/event/masterclass.scala.html
+++ b/frontend/app/views/event/masterclass.scala.html
@@ -3,7 +3,7 @@
     pageInfo: model.PageInfo,
     selectedTag: String = "",
     selectedSubTag: String = ""
-)(implicit token: play.filters.csrf.CSRF.Token)
+)
 
 @import model.RichEvent.MasterclassEvent
 

--- a/frontend/app/views/fragments/tier/packagePromo.scala.html
+++ b/frontend/app/views/fragments/tier/packagePromo.scala.html
@@ -4,7 +4,7 @@
     descriptionAnchor: Option[String] = None,
     modifierClass: Option[String] = None,
     isReversed: Boolean = false
-)(implicit token: play.filters.csrf.CSRF.Token)
+)
 
 @import model.Benefits
 

--- a/frontend/app/views/fragments/tier/tierTrail.scala.html
+++ b/frontend/app/views/fragments/tier/tierTrail.scala.html
@@ -1,7 +1,7 @@
 @(
     tier: com.gu.membership.salesforce.Tier,
     showCaption: Boolean = true
-)(implicit token: play.filters.csrf.CSRF.Token)
+)
 
 @import com.gu.membership.salesforce.Tier
 @import model.Benefits

--- a/frontend/app/views/index.scala.html
+++ b/frontend/app/views/index.scala.html
@@ -1,5 +1,3 @@
-@()(implicit token: play.filters.csrf.CSRF.Token)
-
 @import configuration.Config
 
 @main("Home Page") {


### PR DESCRIPTION
CSRF tokens wouldn't be much use at all if we shared them to lots of different users over the CDN!

CSRF tokens are needed on authenticated pages (which we don't cache), to ensure that form submission passes the CSRF token-check - a check designed to stop people being hacked by carefully-crafted links constructed by attackers - if the attackers don't know the token, they can't send the user directly to the POST action - not without the user seeing the form first.

I wonder if some of these errors in Sentry come from us using CSRF where we shouldn't:

https://app.getsentry.com/the-guardian/membership/group/41899380/

@mattandrews @davidrapson 