### PR TITLE
Fix visual bug with booking buttons

### DIFF
--- a/frontend/assets/stylesheets/components/_action.scss
+++ b/frontend/assets/stylesheets/components/_action.scss
@@ -125,7 +125,7 @@
 .action--booking {
     color: $white;
     background-color: $black;
-    border-color: $black;
+    border: none;
 
     &:hover {
         background-color: lighten($black, 15%);


### PR DESCRIPTION
I had put this tiny fix into PR https://github.com/guardian/membership-frontend/pull/247 but as that is currently block I've pulled this out into a separate PR. Plus it's bugging Ben W and I.

**Before**
![screen shot 2015-03-03 at 16 07 49](https://cloud.githubusercontent.com/assets/123386/6466503/ed5b0f86-c1bf-11e4-80bc-0ebecd46a0f2.png)

**After**
![screen shot 2015-03-03 at 16 11 30](https://cloud.githubusercontent.com/assets/123386/6466511/f8fccf46-c1bf-11e4-9a41-704c66b7d0d1.png)

*You can barely see it in the screenshot but there is a 1px blue border at the bottom of the booking button*
