### PR TITLE
Staff-authed supporter landing page

### DIFF
--- a/frontend/app/actions/CommonActions.scala
+++ b/frontend/app/actions/CommonActions.scala
@@ -36,6 +36,9 @@ trait CommonActions {
     GoogleAuthenticatedStaffAction andThen
     isInAuthorisedGroupGoogleAuthReq(permanentStaffGroups, views.html.fragments.oauth.staffUnauthorisedError())
 
+  val AuthorisedStaff =
+    GoogleAuthenticatedStaffAction andThen
+    isInAuthorisedGroupGoogleAuthReq(permanentStaffGroups, views.html.fragments.oauth.staffWrongGroup())
 
   val AuthenticatedStaffNonMemberAction =
     AuthenticatedAction andThen

--- a/frontend/app/configuration/CopyConfig.scala
+++ b/frontend/app/configuration/CopyConfig.scala
@@ -14,6 +14,9 @@ object CopyConfig {
   val copyTitleChooseTier = config.getString("copy.choosetier.title")
   val copyDescriptionChooseTier = config.getString("copy.choosetier.description")
 
+  val copyTitleSupporters = config.getString("copy.supporters.title")
+  val copyDescriptionSupporters = config.getString("copy.supporters.description")
+
   val copyTitlePatrons = config.getString("copy.patrons.title")
   val copyDescriptionPatrons = config.getString("copy.patrons.description")
 

--- a/frontend/app/controllers/Info.scala
+++ b/frontend/app/controllers/Info.scala
@@ -12,10 +12,6 @@ import scala.concurrent.Future
 
 trait Info extends Controller {
 
-  val permanentStaffGroups = Config.staffAuthorisedEmailGroups
-  val AuthorisedStaff = GoogleAuthenticatedStaffAction andThen isInAuthorisedGroupGoogleAuthReq(
-    permanentStaffGroups, views.html.fragments.oauth.staffWrongGroup())
-
   def help = CachedAction { implicit request =>
     Ok(views.html.info.help())
   }

--- a/frontend/app/model/Benefits.scala
+++ b/frontend/app/model/Benefits.scala
@@ -1,7 +1,7 @@
 package model
 
 import com.gu.membership.salesforce.Tier
-import com.gu.membership.salesforce.Tier.{Partner, Patron}
+import com.gu.membership.salesforce.Tier.{Supporter, Partner, Patron}
 
 object Benefits {
 
@@ -44,6 +44,8 @@ object Benefits {
 
   val friendsWithBenefits = benefitsFilter("book_tickets", "digital_digest", "video_highlights")
 
+  val supporterWithBenefits = benefitsFilter("book_tickets", "live_stream", "digital_digest", "membership_card")
+
   val partnerWithBenefits = benefitsFilter("discount", "discount_masterclasses", "plus_1_guest", "early_booking",
     "membership_card", "live_stream", "digital_digest", "video_highlights")
 
@@ -59,8 +61,8 @@ object Benefits {
   val friendBenefits = Benefits("Benefits", friendsWithBenefits,
     None, "Become a Friend", "Stay up to date and book tickets to Guardian Live events")
 
-  val supporterBenefits = Benefits("Friend benefits, plus…", friendsWithBenefits,
-    Some(Pricing(60, 5)), "Become a Supporter", "Do some sort of copy for this")
+  val supporterBenefits = Benefits("Benefits", supporterWithBenefits,
+    Some(Pricing(60, 5)), "Become a Supporter", "Stay up to date and book tickets to Guardian Live events")
 
   val partnerBenefits = Benefits("Friend benefits, plus…", partnerWithBenefits,
     Some(Pricing(135, 15)), "Become a Partner", "Support the Guardian and experience it brought to life, with early booking and discounted tickets")
@@ -77,7 +79,7 @@ object Benefits {
 
   def detailsLimited(tier: Tier) = tier match {
     case Tier.Friend => friendsWithBenefits
-    case Tier.Supporter => friendsWithBenefits
+    case Tier.Supporter => supporterBenefits
     case Tier.Partner => partnerWithBenefitsLimited
     case Tier.Patron => patronWithBenefitsLimited
   }

--- a/frontend/app/model/Benefits.scala
+++ b/frontend/app/model/Benefits.scala
@@ -36,6 +36,7 @@ object Benefits {
     lazy val yearlyMonthlyCost = (12 * monthly)
     lazy val yearlySaving = yearlyMonthlyCost - yearly
     lazy val yearlyWith6MonthSaving = yearly / 2f
+    lazy val hasYearlySaving = yearlySaving > 0
   }
 
   def benefitsFilter(identifiers: String*) = identifiers.flatMap { id =>

--- a/frontend/app/model/Benefits.scala
+++ b/frontend/app/model/Benefits.scala
@@ -1,7 +1,7 @@
 package model
 
 import com.gu.membership.salesforce.Tier
-import com.gu.membership.salesforce.Tier.{Supporter, Partner, Patron}
+import com.gu.membership.salesforce.Tier.{Partner, Patron}
 
 object Benefits {
 
@@ -80,7 +80,7 @@ object Benefits {
 
   def detailsLimited(tier: Tier) = tier match {
     case Tier.Friend => friendsWithBenefits
-    case Tier.Supporter => supporterBenefits
+    case Tier.Supporter => supporterWithBenefits
     case Tier.Partner => partnerWithBenefitsLimited
     case Tier.Patron => patronWithBenefitsLimited
   }

--- a/frontend/app/views/fragments/benefits/item.scala.html
+++ b/frontend/app/views/fragments/benefits/item.scala.html
@@ -1,6 +1,6 @@
-@(benefit: model.Benefits.BenefitItem, iconClasses: Seq[String] = Nil)
+@(benefit: model.Benefits.BenefitItem, componentClasses: Seq[String] = Nil, iconClasses: Seq[String] = Nil)
 
-<div class="benefit">
+<div class="benefit @componentClasses.mkString(" ")">
     <div class="benefit__icon @iconClasses.mkString(" ")">
         @fragments.inlineIcon(benefit.icon, List("icon-inline--medium", "icon-inline--top"))
     </div>

--- a/frontend/app/views/fragments/pricing/priceInfo.scala.html
+++ b/frontend/app/views/fragments/pricing/priceInfo.scala.html
@@ -16,7 +16,9 @@
                 <strong class="price-info__value">£@pricing.yearly</strong>
                 <span class="price-info__date">/year</span>
             </div>
-            <div class="price-info__saving">Save £@pricing.yearlySaving/year</div>
+            @if(pricing.hasYearlySaving) {
+                <div class="price-info__saving">Save £@pricing.yearlySaving/year</div>
+            }
         </div>
         <div class="price-info__item price-info__item--split price-info__item--last">
             <div class="price-info__detail price-info__detail--right">

--- a/frontend/app/views/fragments/tier/packageFeature.scala.html
+++ b/frontend/app/views/fragments/tier/packageFeature.scala.html
@@ -1,7 +1,6 @@
 @(tier: com.gu.membership.salesforce.Tier, isReversed: Boolean = false)(implicit token: play.filters.csrf.CSRF.Token)
 
 @import model.Benefits
-@import com.gu.membership.salesforce.Tier
 
 <div class="package-feature">
     <div class="package-feature__promo">

--- a/frontend/app/views/info/patron.scala.html
+++ b/frontend/app/views/info/patron.scala.html
@@ -1,8 +1,5 @@
 @(pageInfo: model.PageInfo)(implicit token: play.filters.csrf.CSRF.Token)
 
-@import views.support.Asset
-@import helper._
-@import model.Benefits
 @import com.gu.membership.salesforce.Tier
 
 @main("Patrons", pageInfo=pageInfo) {

--- a/frontend/app/views/info/supporters.scala.html
+++ b/frontend/app/views/info/supporters.scala.html
@@ -17,7 +17,7 @@
 
     @* ===== Ensuring our independence ===== *@
     <div class="page-slice l-constrained l-side-margins">
-        @fragments.promos.promoPrimary(title=Html("Ensuring our independance"), imageBasePath="https://media.guim.co.uk/f39c1024643f4860588fbf0b127475b73efa539c/0_0_1140_684", toneClass=Some("tone-trans-brand-dark")) {
+        @fragments.promos.promoPrimary(title=Html("Ensuring our independence"), imageBasePath="https://media.guim.co.uk/f39c1024643f4860588fbf0b127475b73efa539c/0_0_1140_684", toneClass=Some("tone-trans-brand-dark")) {
             <div class="text-feature">
                 <p>The Guardian has no proprietor. Our editor answers to nobody. Supporters ensure that the Guardian remains an independent voice standing witness to issues that matter without interference.</p>
             </div>

--- a/frontend/app/views/info/supporters.scala.html
+++ b/frontend/app/views/info/supporters.scala.html
@@ -7,7 +7,7 @@
 
     @* ===== About Supporters ===== *@
     <div class="page-slice l-constrained l-side-margins">
-        @fragments.promos.promoPrimary(title=Html("Be part of the Guardian"), imageBasePath="https://media.guim.co.uk/d8f51bea15bf046df4d166cfd60771b9c24a631f/0_0_1140_683", isLead=true) {
+        @fragments.promos.promoPrimary(title=Html("Be part of the Guardian"), imageBasePath="https://media.guim.co.uk/a56fc5b2ded2ced952f5fdac62d49d7232128d73/0_0_1140_684", isLead=true) {
             <div class="text-feature">
                 <p>Supporters protect our editorial freedom and help us seek out those stories that people are determined to keep hidden.</p>
             </div>
@@ -17,7 +17,7 @@
 
     @* ===== Ensuring our independence ===== *@
     <div class="page-slice l-constrained l-side-margins">
-        @fragments.promos.promoPrimary(title=Html("Ensuring our independance"), imageBasePath="https://media.guim.co.uk/e6459f638392c8176e277733f6f0802953100fa4/0_0_1140_683", toneClass=Some("tone-trans-brand-dark")) {
+        @fragments.promos.promoPrimary(title=Html("Ensuring our independance"), imageBasePath="https://media.guim.co.uk/f39c1024643f4860588fbf0b127475b73efa539c/0_0_1140_684", toneClass=Some("tone-trans-brand-dark")) {
             <div class="text-feature">
                 <p>The Guardian has no proprietor. Our editor answers to nobody. Supporters ensure that the Guardian remains an independent voice standing witness to issues that matter without interference.</p>
             </div>

--- a/frontend/app/views/info/supporters.scala.html
+++ b/frontend/app/views/info/supporters.scala.html
@@ -11,13 +11,13 @@
             <div class="text-feature">
                 <p>Supporters protect our editorial freedom and help us seek out those stories that people are determined to keep hidden.</p>
             </div>
-            @fragments.tier.packagePromo(Tier.Partner, showDescription=false, modifierClass=Some("package-promo--spread"))
+            @fragments.tier.packagePromo(Tier.Supporter, showDescription=false, modifierClass=Some("package-promo--spread"))
         }
     </div>
 
     @* ===== Ensuring our independence ===== *@
     <div class="page-slice l-constrained l-side-margins">
-        @fragments.promos.promoSecondary(title=Html("Ensuring our independance"), imageBasePath="https://media.guim.co.uk/e6459f638392c8176e277733f6f0802953100fa4/0_0_1140_683", toneClass=Some("tone-trans-brand-dark")) {
+        @fragments.promos.promoPrimary(title=Html("Ensuring our independance"), imageBasePath="https://media.guim.co.uk/e6459f638392c8176e277733f6f0802953100fa4/0_0_1140_683", toneClass=Some("tone-trans-brand-dark")) {
             <div class="text-feature">
                 <p>The Guardian has no proprietor. Our editor answers to nobody. Supporters ensure that the Guardian remains an independent voice standing witness to issues that matter without interference.</p>
             </div>
@@ -42,17 +42,18 @@
         <div class="page-slice__inner">
             <h2 class="page-slice__headline">What's included</h2>
             <div class="page-slice__content">
-                <ul class="grid grid--3up">
-                    @for(benefit <- Benefits.details(Tier.Friend).list) {
+                <ul class="grid grid--2up">
+                    @for(benefit <- Benefits.details(Tier.Supporter).list) {
                         <li class="grid__item">
-                            @fragments.benefits.item(benefit=benefit)
+                        @fragments.benefits.item(
+                            benefit=benefit,
+                            iconClasses=Seq("tone-color-supporter"),
+                            componentClasses=Seq("u-divider-dotted")
+                        )
                         </li>
                     }
                 </ul>
-
-                <p class="text-feature">Support the Guardian’s mission of promoting the open exchange of ideas</p>
-
-                @fragments.tier.packagePromo(Tier.Partner, showDescription=false, isReversed=true, modifierClass=Some("package-promo--spread"))
+                @fragments.tier.packagePromo(Tier.Supporter, showDescription=false, isReversed=true, modifierClass=Some("package-promo--spread"))
             </div>
         </div>
     </div>

--- a/frontend/app/views/info/supporters.scala.html
+++ b/frontend/app/views/info/supporters.scala.html
@@ -1,0 +1,60 @@
+@(pageInfo: model.PageInfo)(implicit token: play.filters.csrf.CSRF.Token)
+
+@import com.gu.membership.salesforce.Tier
+@import model.Benefits
+
+@main("Supporters", pageInfo=pageInfo) {
+
+    @* ===== About Supporters ===== *@
+    <div class="page-slice l-constrained l-side-margins">
+        @fragments.promos.promoPrimary(title=Html("Be part of the Guardian"), imageBasePath="https://media.guim.co.uk/d8f51bea15bf046df4d166cfd60771b9c24a631f/0_0_1140_683", isLead=true) {
+            <div class="text-feature">
+                <p>Supporters protect our editorial freedom and help us seek out those stories that people are determined to keep hidden.</p>
+            </div>
+            @fragments.tier.packagePromo(Tier.Partner, showDescription=false, modifierClass=Some("package-promo--spread"))
+        }
+    </div>
+
+    @* ===== Ensuring our independence ===== *@
+    <div class="page-slice l-constrained l-side-margins">
+        @fragments.promos.promoSecondary(title=Html("Ensuring our independance"), imageBasePath="https://media.guim.co.uk/e6459f638392c8176e277733f6f0802953100fa4/0_0_1140_683", toneClass=Some("tone-trans-brand-dark")) {
+            <div class="text-feature">
+                <p>The Guardian has no proprietor. Our editor answers to nobody. Supporters ensure that the Guardian remains an independent voice standing witness to issues that matter without interference.</p>
+            </div>
+        }
+    </div>
+
+    @* ===== Fuel our journalism ===== *@
+    <div class="page-slice l-constrained l-side-margins">
+        @fragments.promos.promoPrimary(title=Html("Fuel our journalism"), imageBasePath="https://media.guim.co.uk/8caacf301dd036a2bbb1b458cf68b637d3c55e48/0_0_1140_683", toneClass=Some("tone-trans-brand")) {
+            <blockquote class="blockquote blockquote--feature">
+                The only relationship our journalists have is with our readers. Membership gives the real possibility of deepening the intense bond between the producers and consumers of the Guardian.
+                <cite class="blockquote__citation">Alan Rusbridger, editor-in-chief of the Guardian</cite>
+            </blockquote>
+            <div class="action-group">
+                <a class="action u-no-top-margin" href="@routes.Joiner.enterDetails(Tier.Partner)">Become a Supporter</a>
+            </div>
+        }
+    </div>
+
+    @* ===== Join Today ===== *@
+    <div class="page-slice page-slice--split tone-tint l-constrained">
+        <div class="page-slice__inner">
+            <h2 class="page-slice__headline">What's included</h2>
+            <div class="page-slice__content">
+                <ul class="grid grid--3up">
+                    @for(benefit <- Benefits.details(Tier.Friend).list) {
+                        <li class="grid__item">
+                            @fragments.benefits.item(benefit=benefit)
+                        </li>
+                    }
+                </ul>
+
+                <p class="text-feature">Support the Guardian’s mission of promoting the open exchange of ideas</p>
+
+                @fragments.tier.packagePromo(Tier.Partner, showDescription=false, isReversed=true, modifierClass=Some("package-promo--spread"))
+            </div>
+        </div>
+    </div>
+
+}

--- a/frontend/assets/stylesheets/_vars.scss
+++ b/frontend/assets/stylesheets/_vars.scss
@@ -196,6 +196,9 @@ $palette-tones: (
     friend: (
         base: $c-neutral1
     ),
+    supporter: (
+        base: $black
+    ),
     partner: (
         base: map-get($pasteup-palette, news-main-2)
     ),

--- a/frontend/assets/stylesheets/theme/_tones.scss
+++ b/frontend/assets/stylesheets/theme/_tones.scss
@@ -175,6 +175,19 @@
     fill: tone('patron');
 }
 
+.tone-supporter {
+    background-color: tone('supporter');
+}
+.tone-color-supporter {
+    color: tone('supporter');
+}
+.tone-border-supporter {
+    border-color: tone('supporter');
+}
+.tone-fill-supporter {
+    fill: tone('supporter');
+}
+
 /* Neutral
    ========================================================================== */
 

--- a/frontend/conf/copy.conf
+++ b/frontend/conf/copy.conf
@@ -7,6 +7,9 @@ copy.join.description="Guardian Membership is launching in beta. We have ambitio
 copy.choosetier.title="Join Guardian Membership: choose your tier"
 copy.choosetier.description="Guardian Membership brings together diverse, progressive minds, journalistic skills and the best of what others create to give you a richer understanding of the world and the opportunity to shape it. Join now as a Founding Partner or Patron and guarantee that the price you pay today will not rise."
 
+copy.supporters.title="Supporters of the Guardian"
+copy.supporters.description="Supporters protect our editorial freedom and help us seek out those stories that people are determined to keep hidden."
+
 copy.patrons.title="Patrons of the Guardian"
 copy.patrons.description="The Patron tier is for those who care deeply about the Guardian’s journalism and the impact it has on the world. From campaigning on issues affecting the voices less heard to holding those in power to account, Patrons ensure the Guardian can continue to surface the information and ideas that shape the global conversation."
 

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -88,7 +88,9 @@ GET            /help                              controllers.Info.help
 GET            /feedback                          controllers.Info.feedback
 POST           /feedback                          controllers.Info.submitFeedback
 GET            /about                             controllers.Info.about
+GET            /about/supporters                  controllers.Info.supporters
 GET            /patrons                           controllers.Info.patron
+
 
 # Offer
 GET            /offer/subscriber                  controllers.Offer.subscriber


### PR DESCRIPTION
This PR adds a version of the supporter landing page which is behind staff-authentication . To provide some context and necessary qualifications:

- This uses dummy copy and images based on the wireframes
- The design is based solely on the building blocks we have available now. It probably needs some refinement.
- Pricing uses the Partner tier as the config for the new tier has not been merged in yet.

That said this is hopefully a start as it provides something tangibile to work from:

![supporters the guardian membership](https://cloud.githubusercontent.com/assets/123386/6468400/a6d1c0f2-c1cc-11e4-8a51-77f1d4adc3aa.png)

**Note**: This PR also moves the location of the Patrons template as it was in the Info controller but the template was off in its own special directory, made sense to merge it in.