### PR TITLE
Add method of modelling responsive images in scala

### DIFF
--- a/frontend/app/controllers/FrontPage.scala
+++ b/frontend/app/controllers/FrontPage.scala
@@ -1,11 +1,112 @@
 package controllers
 
+import model.{ResponsiveImage, ResponsiveImageGroup}
 import play.api.mvc.Controller
 
 trait FrontPage extends Controller {
 
   def index = CachedAction { implicit request =>
-    Ok(views.html.index())
+
+    val slideShowImages = Seq(
+      ResponsiveImageGroup(altText="Guardian Live event: Pussy Riot - art, sex and disobedience",
+        availableImages = Seq(
+          ResponsiveImage(
+            path="https://media.guim.co.uk/eab86e9c81414932e0d50a1cd609dccfc20ca5d2/0_0_2279_1368/2000.jpg",
+            width=2000
+          ),
+          ResponsiveImage(
+            path="https://media.guim.co.uk/eab86e9c81414932e0d50a1cd609dccfc20ca5d2/0_0_2279_1368/1000.jpg",
+            width=1000
+          ),
+          ResponsiveImage(
+            path="https://media.guim.co.uk/eab86e9c81414932e0d50a1cd609dccfc20ca5d2/0_0_2279_1368/500.jpg",
+            width=500
+          )
+        )
+      ),
+      ResponsiveImageGroup(altText="Guardian Live with Russell Brand",
+        availableImages = Seq(
+          ResponsiveImage(
+            path="https://media.guim.co.uk/da867c363957d748bd04cfd9d4890033203a58c6/0_0_2279_1368/2000.jpg",
+            width=2000
+          ),
+          ResponsiveImage(
+            path="https://media.guim.co.uk/da867c363957d748bd04cfd9d4890033203a58c6/0_0_2279_1368/1000.jpg",
+            width=1000
+          ),
+          ResponsiveImage(
+            path="https://media.guim.co.uk/da867c363957d748bd04cfd9d4890033203a58c6/0_0_2279_1368/500.jpg",
+            width=500
+          )
+        )
+      ),
+      ResponsiveImageGroup(altText="A life in music: Jimmy Page",
+        availableImages = Seq(
+          ResponsiveImage(
+            path="https://media.guim.co.uk/733834b0b9f84e4367cf676919008bfd88007f25/0_0_2279_1368/2000.jpg",
+            width=2000
+          ),
+          ResponsiveImage(
+            path="https://media.guim.co.uk/733834b0b9f84e4367cf676919008bfd88007f25/0_0_2279_1368/1000.jpg",
+            width=1000
+          ),
+          ResponsiveImage(
+            path="https://media.guim.co.uk/733834b0b9f84e4367cf676919008bfd88007f25/0_0_2279_1368/500.jpg",
+            width=500
+          )
+        )
+      ),
+      ResponsiveImageGroup(altText="Guardian Live with Russell Brand",
+        availableImages = Seq(
+          ResponsiveImage(
+            path="https://media.guim.co.uk/e736acb945406974844bea77ca49b2c1e450013e/0_0_2279_1368/2000.jpg",
+            width=2000
+          ),
+          ResponsiveImage(
+            path="https://media.guim.co.uk/e736acb945406974844bea77ca49b2c1e450013e/0_0_2279_1368/1000.jpg",
+            width=1000
+          ),
+          ResponsiveImage(
+            path="https://media.guim.co.uk/e736acb945406974844bea77ca49b2c1e450013e/0_0_2279_1368/500.jpg",
+            width=500
+          )
+        )
+      ),
+      ResponsiveImageGroup(altText="Observer Ideas - Stories that inspire: Tinie Tempah",
+        availableImages = Seq(
+          ResponsiveImage(
+            path="https://media.guim.co.uk/1e687530a52ef14cd9c1eacb1e8757600c382f86/0_0_2279_1368/2000.jpg",
+            width=2000
+          ),
+          ResponsiveImage(
+            path="https://media.guim.co.uk/1e687530a52ef14cd9c1eacb1e8757600c382f86/0_0_2279_1368/1000.jpg",
+            width=1000
+          ),
+          ResponsiveImage(
+            path="https://media.guim.co.uk/1e687530a52ef14cd9c1eacb1e8757600c382f86/0_0_2279_1368/500.jpg",
+            width=500
+          )
+        )
+      ),
+      ResponsiveImageGroup(altText="Guardian Live event: Vivienne Westwood",
+        availableImages = Seq(
+          ResponsiveImage(
+            path="https://media.guim.co.uk/85d46476d07fb744327c60a4c5117a7ddc2796d0/0_0_2279_1368/2000.jpg",
+            width=2000
+          ),
+          ResponsiveImage(
+            path="https://media.guim.co.uk/85d46476d07fb744327c60a4c5117a7ddc2796d0/0_0_2279_1368/1000.jpg",
+            width=1000
+          ),
+          ResponsiveImage(
+            path="https://media.guim.co.uk/85d46476d07fb744327c60a4c5117a7ddc2796d0/0_0_2279_1368/500.jpg",
+            width=500
+          )
+        )
+      )
+    )
+
+    Ok(views.html.index(slideShowImages))
   }
 }
 

--- a/frontend/app/model/ResponsiveImage.scala
+++ b/frontend/app/model/ResponsiveImage.scala
@@ -1,0 +1,14 @@
+package model
+
+case class ResponsiveImage(path: String, width: Int)
+
+case class ResponsiveImageGroup(
+  name: Option[String] = None,
+  altText: String,
+  availableImages: Seq[ResponsiveImage]
+) {
+  val defaultImage = availableImages.head.path
+  val srcset = availableImages.map { img =>
+    img.path + " " + img.width.toString() + "w"
+  }.mkString(", ")
+}

--- a/frontend/app/views/fragments/media/slideshowItem.scala.html
+++ b/frontend/app/views/fragments/media/slideshowItem.scala.html
@@ -1,6 +1,5 @@
-@(imgSrc: String, description: String)
+@(imgGroup: model.ResponsiveImageGroup, description: String)
 
-@import views.support.Asset
 
 <figure class="slideshow__element js-slideshow-item">
     <figcaption class="slideshow__detail">
@@ -11,5 +10,10 @@
         </div>
         <div class="slideshow__description">@description</div>
     </figcaption>
-    <div data-src="@imgSrc" data-alt="@description" data-class="responsive-img slideshow__image" class="js-image-slideshow"></div>
+    <img
+        alt="@imgGroup.altText"
+        data-srcset="@imgGroup.srcset"
+        sizes="100vw"
+        class="responsive-img slideshow__image js-lazyload"
+    />
 </figure>

--- a/frontend/app/views/index.scala.html
+++ b/frontend/app/views/index.scala.html
@@ -1,3 +1,5 @@
+@(pageImages: Seq[model.ResponsiveImageGroup])
+
 @import configuration.Config
 
 @main("Home Page") {
@@ -5,13 +7,10 @@
 <main role="main" class="l-constrained">
 
     @* ===== Slideshow ===== *@
-    <section class="slideshow js-slideshow" data-slideshow-duration="5000">
-        @fragments.media.slideshowItem("https://media.guim.co.uk/eab86e9c81414932e0d50a1cd609dccfc20ca5d2/0_0_2279_1368/{width}.jpg", "Guardian Live event: Pussy Riot - art, sex and disobedience")
-        @fragments.media.slideshowItem("https://media.guim.co.uk/da867c363957d748bd04cfd9d4890033203a58c6/0_0_2279_1368/{width}.jpg", "Guardian Live with Russell Brand")
-        @fragments.media.slideshowItem("https://media.guim.co.uk/733834b0b9f84e4367cf676919008bfd88007f25/0_0_2279_1368/{width}.jpg", "A life in music: Jimmy Page")
-        @fragments.media.slideshowItem("https://media.guim.co.uk/e736acb945406974844bea77ca49b2c1e450013e/0_0_2279_1368/{width}.jpg", "Guardian Live with Russell Brand")
-        @fragments.media.slideshowItem("https://media.guim.co.uk/1e687530a52ef14cd9c1eacb1e8757600c382f86/0_0_2279_1368/{width}.jpg", "Observer Ideas - Stories that inspire: Tinie Tempah")
-        @fragments.media.slideshowItem("https://media.guim.co.uk/85d46476d07fb744327c60a4c5117a7ddc2796d0/0_0_2279_1368/{width}.jpg", "Guardian Live event: Vivienne Westwood")
+    <section class="slideshow js-slideshow" data-slideshow-duration="6000">
+        @for(imgGroup <- pageImages) {
+            @fragments.media.slideshowItem(imgGroup, imgGroup.altText)
+        }
     </section>
 
     @* ===== Introduction ===== *@

--- a/frontend/assets/javascripts/src/modules/images.js
+++ b/frontend/assets/javascripts/src/modules/images.js
@@ -7,7 +7,6 @@ define([
 
     var LAZYLOAD_CLASS = 'js-lazyload';
     var IMAGE_LOADED_IMAGE = '.js-imager-loaded-image';
-    var IMAGES_SLIDESHOW = '.js-image-slideshow';
 
     function init() {
 
@@ -27,15 +26,6 @@ define([
                     lazyload: true,
                     lazyloadOffset: 100
                 });
-            });
-        }
-
-        if (document.querySelectorAll(IMAGES_SLIDESHOW).length) {
-            new Imager(IMAGES_SLIDESHOW, {
-                availableWidths: guardian.membership.homeImages.widths,
-                availablePixelRatios: guardian.membership.homeImages.ratios,
-                lazyload: true,
-                lazyloadOffset: 100
             });
         }
 

--- a/frontend/test/model/ResponsiveImageTest.scala
+++ b/frontend/test/model/ResponsiveImageTest.scala
@@ -1,0 +1,26 @@
+package model
+
+import play.api.test.PlaySpecification
+
+class ResponsiveImageTest extends PlaySpecification {
+
+  "ResponsiveImageGroup" should {
+    "generate a srcset string for a sequence of images" in {
+      val imageGroup = ResponsiveImageGroup(altText="Guardian Live event: Pussy Riot - art, sex and disobedience",
+        availableImages = Seq(
+          ResponsiveImage(
+            path="https://media.guim.co.uk/eab86e9c81414932e0d50a1cd609dccfc20ca5d2/0_0_2279_1368/1000.jpg",
+            width=1000
+          ),
+          ResponsiveImage(
+            path="https://media.guim.co.uk/eab86e9c81414932e0d50a1cd609dccfc20ca5d2/0_0_2279_1368/500.jpg",
+            width=500
+          )
+        )
+      )
+
+      imageGroup.srcset mustEqual "https://media.guim.co.uk/eab86e9c81414932e0d50a1cd609dccfc20ca5d2/0_0_2279_1368/1000.jpg 1000w, https://media.guim.co.uk/eab86e9c81414932e0d50a1cd609dccfc20ca5d2/0_0_2279_1368/500.jpg 500w"
+    }
+  }
+
+}


### PR DESCRIPTION
This PR adds a couple of new case classes to help model images. The main goal is to use these to reduce the duplication of image logic in `RichEvent` but as an initial test I have updated the homepage slideshow to use the new case class.

- Add `ResponsiveImageGroup` case class
- Add tests for `srcset` string generation
- Update homepage slideshow to use new `ResponsiveImageGroup` as a test case
- Bonus (basic) lazy-loading of images in the slideshow

Thanks to @jennysivapalan for the assistance on this one.