### PR TITLE
Increase test-user validity period to 2 days

### DIFF
--- a/frontend/app/utils/TestUsers.scala
+++ b/frontend/app/utils/TestUsers.scala
@@ -4,10 +4,16 @@ import com.gu.identity.testing.usernames.TestUsernames
 
 import configuration.Config
 import model.IdMinimalUser
+import com.github.nscala_time.time.Imports._
 
 object TestUsers {
 
-  lazy val testUsers = TestUsernames(com.gu.identity.testing.usernames.Encoder.withSecret(Config.config.getString("identity.test.users.secret")))
+  val ValidityPeriod = 2.days
+
+  lazy val testUsers = TestUsernames(
+    com.gu.identity.testing.usernames.Encoder.withSecret(Config.config.getString("identity.test.users.secret")),
+    recency = ValidityPeriod.standardDuration
+  )
 
   def isTestUser(userPrivateFields: model.PrivateFields): Boolean =
     userPrivateFields.firstName.exists(testUsers.isValid)

--- a/frontend/app/views/support/Dates.scala
+++ b/frontend/app/views/support/Dates.scala
@@ -2,9 +2,16 @@ package views.support
 
 import com.github.nscala_time.time.Imports._
 import org.joda.time.Instant
+import org.joda.time.format.PeriodFormat
 import play.twirl.api.Html
 
 object Dates {
+
+  val humanPeriodFormat = PeriodFormat.getDefault()
+
+  implicit class RichPeriod(period: Period) {
+    lazy val pretty = period.withMillis(0).toString(humanPeriodFormat)
+  }
 
   implicit class RichDateTime(dt: DateTime) {
     lazy val pretty = prettyDate(dt)

--- a/frontend/app/views/testing/testUsers.scala.html
+++ b/frontend/app/views/testing/testUsers.scala.html
@@ -1,5 +1,7 @@
 @(userString: String)
 
+@import views.support.Dates._
+@import utils.TestUsers.ValidityPeriod
 @import configuration.Config
 
 @main("Test Users") {
@@ -12,7 +14,7 @@
             <div class="page-section__content copy">
                 <h2 class="section-body-headline">New Test User key: <strong>@userString</strong></h2>
                 <div class="text-intro">
-                    <p>Your user will be valid for the next half hour. When registering please populate the following fields with your new test user key.</p>
+                    <p>Your user will be valid for the next @ValidityPeriod.pretty. When registering please populate the following fields with your new test user key.</p>
                 </div>
                 <div class="aside aside--panel">
                     <ul class="u-unstyled">


### PR DESCRIPTION
...to help with Jason Burr's testing upgrades, cancellation/ refunds etc.

Includes a bit of [a tweak to the text](https://github.com/guardian/membership-frontend/commit/03ad1332e#diff-42fa2c35148cb59287132cf607ecef67) to make it reflect the configured value:

![image](https://cloud.githubusercontent.com/assets/52038/6504052/e50c44b4-c32a-11e4-813c-c175fbcff5e5.png)


cc @jamesoram 