### PR TITLE
Add password authentication on paid to paid upgrades

### DIFF
--- a/frontend/app/controllers/TierController.scala
+++ b/frontend/app/controllers/TierController.scala
@@ -88,7 +88,7 @@ trait UpgradeTier {
       val reauthFailedMessage: Future[Result] = Future {
         Redirect(routes.TierController.upgrade(tier))
           .flashing("error" ->
-          s"Email and password do not match, please check and re-enter details.") //todo confirm error message
+          s"That password does not match our records. Please try again.")
       }
 
       def doUpgrade: Future[Result] = {

--- a/frontend/app/forms/MemberForm.scala
+++ b/frontend/app/forms/MemberForm.scala
@@ -46,7 +46,7 @@ object MemberForm {
     val billingAddress: Option[Address]
   }
 
-  case class PaidMemberChangeForm(deliveryAddress: Address, billingAddress: Option[Address]) extends MemberChangeForm
+  case class PaidMemberChangeForm(password: String)
   case class FreeMemberChangeForm(payment: PaymentForm, deliveryAddress: Address, billingAddress: Option[Address]) extends MemberChangeForm
 
   case class FeedbackForm(category: String, page: String, feedback: String, name: String, email: String)
@@ -135,8 +135,7 @@ object MemberForm {
 
   val paidMemberChangeForm: Form[PaidMemberChangeForm] = Form(
     mapping(
-      "deliveryAddress" -> paidAddressMapping,
-      "billingAddress" -> optional(paidAddressMapping)
+      "password" -> nonEmptyText
     )(PaidMemberChangeForm.apply)(PaidMemberChangeForm.unapply)
   )
 

--- a/frontend/app/services/IdentityService.scala
+++ b/frontend/app/services/IdentityService.scala
@@ -129,8 +129,8 @@ trait IdentityApi {
   def post(endpoint: String, data: Option[JsObject], headers: List[(String, String)], parameters: List[(String, String)], metricName: String): Future[Int] = {
     Timing.record(IdentityApiMetrics, metricName) {
       val requestHolder = WS.url(s"${Config.idApiUrl}/$endpoint").withHeaders(headers: _*).withQueryString(parameters: _*).withRequestTimeout(5000)
-      val response = data.map(requestHolder.post(_)).getOrElse(requestHolder.post(Results.EmptyContent()))
-      response.map (r => recordAndLogResponse(r.status, s"POST $metricName", endpoint ))
+      val response = requestHolder.post(data.getOrElse(JsNull))
+      response.foreach(r => recordAndLogResponse(r.status, s"POST $metricName", endpoint ))
       response.map(_.status)
     }
   }

--- a/frontend/app/views/tier/upgrade/paidToPaid.scala.html
+++ b/frontend/app/views/tier/upgrade/paidToPaid.scala.html
@@ -133,36 +133,46 @@
                         Payments will taken on or shortly after the @dayInMonthWithSuffixAndMonth(preview.futureSubscriptionInvoice.renewalDate)
                         each @currentSubscription.paymentPeriodLabel.
                     </p>
+                }
+            </div>
+        </section>
+        <section class="page-section page-section--bordered">
+            <div class="page-section__lead-in">
+                <h2 class="page-section__headline">
+                    Re-enter password
+                </h2>
+            </div>
+            <div class="page-section__content">
+                <form action="@routes.TierController.upgrade(targetTier)" method="POST" class="js-form" id="payment-form">
+                    @CSRF.formField
+                    <div class="fieldset__fields js-password-container">
 
-                    <form action="@routes.TierController.upgrade(targetTier)" method="POST" class="js-form" id="payment-form">
-                        @CSRF.formField
-                        Please re-enter your Guardian Identity password:
-                        <div class="fieldset__fields js-password-container">
+                        <div class="form-field form-field--no-margin">
+                            <label class="label label--inline" for="user-password">WHAT SHALL WE PUT HERE?</label>
 
-                            <div class="form-field form-field--no-margin">
-                                <label class="label label--inline" for="user-password">Password</label>
-
-                                <input class="input-text"
-                                       type="password"
-                                       id="user-password"
-                                       name="password"
-                                       value=""
-                                       autocomplete="off"
-                                       autocapitalize="off"
-                                       autocorrect="off"
-                                       spellcheck="false"
-                                       required/>
-                                @fragments.form.errorMessage("Please enter a password")
-                            </div>
-
+                            <input class="input-text"
+                                   type="password"
+                                   id="user-password"
+                                   name="password"
+                                   value=""
+                                   autocomplete="off"
+                                   autocapitalize="off"
+                                   autocorrect="off"
+                                   spellcheck="false"
+                                   required/>
+                            @fragments.form.errorMessage("Please enter a password")
                         </div>
+
+                    </div>
+
+                    @paidPreviewOpt.map { preview =>
 
                         <div class="actions js-waiting-container">
                             <button type="submit" class="action js-submit-input" id="qa-upgrade-submit">Pay @preview.totalPrice.pretty Now</button>
                             <div class="loader js-loader"></div>
                         </div>
-                    </form>
-                }
+                    }
+                </form>
             </div>
         </section>
 

--- a/frontend/app/views/tier/upgrade/paidToPaid.scala.html
+++ b/frontend/app/views/tier/upgrade/paidToPaid.scala.html
@@ -17,11 +17,14 @@
 @main("Upgrade to " + targetTier, pageInfo=pageInfo) {
 
     <main role="main" class="page-content l-constrained">
-        @for(flashMsg <- flashMessage) {
-            @fragments.notifications.flashMessage(flashMsg)
-        }
 
         @fragments.page.pageHeader("Great, glad to see you've decided to become a " + targetTier)
+
+        @for(flashMsg <- flashMessage) {
+            <div class="page-section">
+                @fragments.notifications.flashMessage(flashMsg)
+            </div>
+        }
 
         <div class="page-section page-section--bordered">
             <div class="page-section__lead-in">

--- a/frontend/app/views/tier/upgrade/paidToPaid.scala.html
+++ b/frontend/app/views/tier/upgrade/paidToPaid.scala.html
@@ -4,7 +4,8 @@
     userFields: model.PrivateFields,
     pageInfo: model.PageInfo,
     paidPreviewOpt: Option[model.Zuora.PaidPreview],
-    currentSubscription: model.Zuora.SubscriptionDetails
+    currentSubscription: model.Zuora.SubscriptionDetails,
+    flashMessage: Option[model.FlashMessage]
 )(implicit token: play.filters.csrf.CSRF.Token)
 
 @import helper._
@@ -16,6 +17,9 @@
 @main("Upgrade to " + targetTier, pageInfo=pageInfo) {
 
     <main role="main" class="page-content l-constrained">
+        @for(flashMsg <- flashMessage) {
+            @fragments.notifications.flashMessage(flashMsg)
+        }
 
         @fragments.page.pageHeader("Great, glad to see you've decided to become a " + targetTier)
 
@@ -132,6 +136,27 @@
 
                     <form action="@routes.TierController.upgrade(targetTier)" method="POST" class="js-form" id="payment-form">
                         @CSRF.formField
+                        Please re-enter your Guardian Identity password:
+                        <div class="fieldset__fields js-password-container">
+
+                            <div class="form-field form-field--no-margin">
+                                <label class="label label--inline" for="user-password">Password</label>
+
+                                <input class="input-text"
+                                       type="password"
+                                       id="user-password"
+                                       name="password"
+                                       value=""
+                                       autocomplete="off"
+                                       autocapitalize="off"
+                                       autocorrect="off"
+                                       spellcheck="false"
+                                       required/>
+                                @fragments.form.errorMessage("Please enter a password")
+                            </div>
+
+                        </div>
+
                         <div class="actions js-waiting-container">
                             <button type="submit" class="action js-submit-input" id="qa-upgrade-submit">Pay @preview.totalPrice.pretty Now</button>
                             <div class="loader js-loader"></div>

--- a/frontend/app/views/tier/upgrade/paidToPaid.scala.html
+++ b/frontend/app/views/tier/upgrade/paidToPaid.scala.html
@@ -13,6 +13,7 @@
 @import views.support.Prices._
 @import views.support.Dates._
 @import views.support.Asset
+@import configuration.Config
 
 @main("Upgrade to " + targetTier, pageInfo=pageInfo) {
 
@@ -137,21 +138,13 @@
                         each @currentSubscription.paymentPeriodLabel.
                     </p>
                 }
-            </div>
-        </section>
-        <section class="page-section page-section--bordered">
-            <div class="page-section__lead-in">
-                <h2 class="page-section__headline">
-                    Re-enter password
-                </h2>
-            </div>
-            <div class="page-section__content">
+
                 <form action="@routes.TierController.upgrade(targetTier)" method="POST" class="js-form" id="payment-form">
                     @CSRF.formField
                     <div class="fieldset__fields js-password-container">
 
                         <div class="form-field form-field--no-margin">
-                            <label class="label label--inline" for="user-password">WHAT SHALL WE PUT HERE?</label>
+                            <label class="label label--inline" for="user-password">Re-enter your password</label>
 
                             <input class="input-text"
                                    type="password"
@@ -165,6 +158,7 @@
                                    required/>
                             @fragments.form.errorMessage("Please enter a password")
                         </div>
+                        <a href="@Config.idWebAppUrl/reset">Forgotten your password?</a>
 
                     </div>
 

--- a/frontend/test/services/IdentityServiceTest.scala
+++ b/frontend/test/services/IdentityServiceTest.scala
@@ -25,7 +25,7 @@ class IdentityServiceTest extends Specification with Mockito {
       identityService.updateEmail(user, "joe.bloggs@awesome-email.com", identityRequest)
 
       val expectedJson = Json.parse("{\"primaryEmailAddress\": \"joe.bloggs@awesome-email.com\"}").as[JsObject]
-      there was one(identityAPI).post("user/4444", expectedJson , headers, trackingParameters, "update-user")
+      there was one(identityAPI).post("user/4444", Some(expectedJson) , headers, trackingParameters, "update-user")
     }
 
     "post json for updating users details on joining friend" in {
@@ -43,7 +43,7 @@ class IdentityServiceTest extends Specification with Mockito {
       identityService.updateUserFieldsBasedOnJoining(user, friendForm, identityRequest)
 
       val expectedJson = Resource.getJson(s"model/identity/update-friend.json").as[JsObject]
-      there was one(identityAPI).post("user/4444", expectedJson, headers, trackingParameters, "update-user")
+      there was one(identityAPI).post("user/4444", Some(expectedJson), headers, trackingParameters, "update-user")
     }
 
     "post json for updating users details on joining paid tier" in {
@@ -64,7 +64,7 @@ class IdentityServiceTest extends Specification with Mockito {
       identityService.updateUserFieldsBasedOnJoining(user, paidForm, identityRequest)
 
       val expectedJson = Resource.getJson(s"model/identity/update-paid.json").as[JsObject]
-      there was one(identityAPI).post("user/4444", expectedJson, headers, trackingParameters, "update-user")
+      there was one(identityAPI).post("user/4444", Some(expectedJson), headers, trackingParameters, "update-user")
     }
   }
 
@@ -81,7 +81,7 @@ class IdentityServiceTest extends Specification with Mockito {
     identityService.updateUserFieldsBasedOnUpgrade(user, paidMemberChangeForm, identityRequest)
 
     val expectedJson = Resource.getJson(s"model/identity/update-upgrade.json").as[JsObject]
-    there was one(identityAPI).post("user/4444", expectedJson, headers, trackingParameters, "update-user")
+    there was one(identityAPI).post("user/4444", Some(expectedJson), headers, trackingParameters, "update-user")
 
   }
 }


### PR DESCRIPTION
On paid to paid upgrades we need the user to re-enter their password.

I'm just waiting on copy from @davidmcdowell but otherwise this is good to be reviewed.

@jamesoram Let me know if you want to run through testing this? Locally I've been testing this by signing up as a partner and then upgrade to patron.