### PR TITLE
Add isPaidTier flag to user/me

### DIFF
--- a/frontend/app/controllers/User.scala
+++ b/frontend/app/controllers/User.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import com.gu.membership.salesforce.{FreeMember, Member, PaidMember}
+import model.PaidTiers
 import org.joda.time.Instant
 import org.joda.time.format.ISODateTimeFormat
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
@@ -56,6 +57,7 @@ trait User extends Controller {
     "regNumber" -> member.regNumber.mkString,
     "firstName" -> member.firstName,
     "tier" -> member.tier.name,
+    "isPaidTier" -> PaidTiers.isPaid(member.tier),
     "joinDate" -> member.joinDate
   )
 }

--- a/frontend/app/model/TierPlan.scala
+++ b/frontend/app/model/TierPlan.scala
@@ -1,6 +1,12 @@
 package model
 
 import com.gu.membership.salesforce.Tier
+import model.PaidTiers.isPaid
+
+
+object PaidTiers {
+  def isPaid(tier: Tier) = tier >= Tier.Supporter
+}
 
 trait ProductRatePlan {
   def salesforceTier: String
@@ -18,7 +24,7 @@ object FriendTierPlan extends TierPlan {
 }
 
 case class PaidTierPlan(tier: Tier, annual: Boolean) extends TierPlan {
-  assert(tier >= Tier.Partner)
+  assert(isPaid(tier))
 }
 
 object StaffPlan extends ProductRatePlan {


### PR DESCRIPTION
Adds an `isPaidTier` flag to `user/me` to help with checking members area content. Thanks to @rtyley 

``` json
{
    "userId": "123456789",
    "regNumber": "123456",
    "firstName": "Bobby",
    "tier": "Partner",
    "isPaidTier": true,
    "joinDate": 123456789
}
```