### PR TITLE
Fix alignment flash message

### DIFF
--- a/frontend/app/views/fragments/notifications/flashMessage.scala.html
+++ b/frontend/app/views/fragments/notifications/flashMessage.scala.html
@@ -1,10 +1,5 @@
 @(flashMessage: model.FlashMessage)
 
-<section class="page-section page-section--no-padding">
-    <div class="page-section__content">
-        <div class="flash-message flash-message--@flashMessage.level">
-            @flashMessage.message
-        </div>
-    </div>
-</section>
-
+<div class="flash-message flash-message--@flashMessage.level">
+    @flashMessage.message
+</div>

--- a/frontend/app/views/info/feedback.scala.html
+++ b/frontend/app/views/info/feedback.scala.html
@@ -7,7 +7,11 @@
     <main role="main" class="page-content l-constrained">
 
         @for(flashMsg <- flashMsgOpt) {
-            @fragments.notifications.flashMessage(flashMsg)
+            <section class="form-section form-section--no-padding">
+                <div class="form-section__content">
+                @fragments.notifications.flashMessage(flashMsg)
+                </div>
+            </section>
         }
 
         <section class="form-header">

--- a/frontend/app/views/joiner/staff.scala.html
+++ b/frontend/app/views/joiner/staff.scala.html
@@ -29,7 +29,11 @@
     <main class="page-content l-constrained" role="main">
 
         @for(flashMsg <- flashMessage) {
-            @fragments.notifications.flashMessage(flashMsg)
+            <section class="page-section page-section--no-padding">
+                <div class="page-section__content">
+                @fragments.notifications.flashMessage(flashMsg)
+                </div>
+            </section>
         }
 
         @fragments.page.pageHeader("Guardian Staff Membership",

--- a/frontend/app/views/tier/upgrade/paidToPaid.scala.html
+++ b/frontend/app/views/tier/upgrade/paidToPaid.scala.html
@@ -22,9 +22,11 @@
         @fragments.page.pageHeader("Great, glad to see you've decided to become a " + targetTier)
 
         @for(flashMsg <- flashMessage) {
-            <div class="page-section">
+            <section class="page-section page-section--no-padding">
+                <div class="page-section__content">
                 @fragments.notifications.flashMessage(flashMsg)
-            </div>
+                </div>
+            </section>
         }
 
         <div class="page-section page-section--bordered">


### PR DESCRIPTION
@marchibbins spotted the alignment of the feedback flash message was out of alignment when you were between the tablet and desktop breakpoints.
The flash message is displayed on pages with different layouts, functional and form layout pages.
- moved the layout out of the flash message fragment
- placed layout around the flash message fragment

## old (miss aligned)
![old](https://cloud.githubusercontent.com/assets/2305016/6508260/aea669ca-c34f-11e4-8204-68177a0f3e33.jpg)

## aligned correctly 
![fixed](https://cloud.githubusercontent.com/assets/2305016/6508265/b5ca598c-c34f-11e4-9dd0-e6310288b688.jpg)

