### PR TITLE
Correctly use .js- class for password strength initalisation

### DIFF
--- a/frontend/assets/javascripts/src/modules/form/helper/password.js
+++ b/frontend/assets/javascripts/src/modules/form/helper/password.js
@@ -3,7 +3,6 @@ define(['bean'], function (bean) {
     'use strict';
 
     var STRENGTH_INDICATOR_ELEM = document.querySelector('.js-password-strength-indicator');
-    var USER_PASSWORD_ELEM = document.getElementById('user-password');
     var PASSWORD_STRENGTH_INPUT_ELEM = document.querySelector('.js-password-strength');
     var STRENGTH_LABEL_ELEM = document.querySelector('.js-password-strength-label');
     var config = {
@@ -22,7 +21,7 @@ define(['bean'], function (bean) {
     };
 
     var init = function() {
-        if (USER_PASSWORD_ELEM) {
+        if (PASSWORD_STRENGTH_INPUT_ELEM) {
             addListeners();
         }
     };


### PR DESCRIPTION
Use the class ```.js-password-strength``` to init the password strength work not the id of the input

An error popped up on [sentry](https://app.getsentry.com/the-guardian/membership/group/56892196/) because the password strength work was initialising on a none .js- class which meant the password for paid To paid was incorrectly trying to init the password strength JavaScript. 
Not the paid to paid's html's fault. FYI @jennysivapalan 

