### PR TITLE
Update CORS config to allow requests to /user/me from theguardian.com

### DIFF
--- a/frontend/app/actions/CommonActions.scala
+++ b/frontend/app/actions/CommonActions.scala
@@ -2,15 +2,18 @@ package actions
 
 import actions.Fallbacks._
 import actions.Functions._
-import play.api.libs.json.Json
 import com.gu.googleauth
 import configuration.Config
 import controllers._
 import play.api.http.HeaderNames._
-import play.api.mvc.{RequestHeader, Cookie, DiscardingCookie, ActionBuilder}
+import play.api.libs.json.Json
 import play.api.mvc.Results._
+import play.api.mvc._
 import services.AuthenticationService
 import utils.GuMemCookie
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 trait CommonActions {
 
@@ -18,9 +21,17 @@ trait CommonActions {
 
   val CachedAction = resultModifier(Cached(_))
 
-  val Cors = resultModifier(_.withHeaders(
-    ACCESS_CONTROL_ALLOW_ORIGIN -> Config.corsAllowOrigin,
-    ACCESS_CONTROL_ALLOW_CREDENTIALS -> "true"))
+  val Cors = new ActionBuilder[Request] {
+    def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]) = {
+      block(request).map { result =>
+        (for (originHeader <- request.headers.get(ORIGIN) if Config.corsAllowOrigin.contains(originHeader)) yield {
+          result.withHeaders(
+            ACCESS_CONTROL_ALLOW_ORIGIN -> originHeader,
+            ACCESS_CONTROL_ALLOW_CREDENTIALS -> "true")
+        }).getOrElse(result)
+      }
+    }
+  }
 
   val AuthenticatedAction = NoCacheAction andThen authenticated()
 

--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -159,7 +159,7 @@ object Config {
   val googleAdwordsJoinerConversionLabel =
     Tier.allPublic.map { tier => tier -> config.getString(s"google.adwords.joiner.conversion.${tier.slug}") }.toMap
 
-  val corsAllowOrigin = config.getString("cors.allow.origin")
+  val corsAllowOrigin: Set[String] = config.getString("cors.allow.origin").split(",").toSet
 
   val discountMultiplier = config.getDouble("event.discountMultiplier")
 

--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -16,7 +16,7 @@ event.discountMultiplier=0.8
 
 content.api.key=""
 
-cors.allow.origin="https://profile.theguardian.com"
+cors.allow.origin="https://profile.theguardian.com,http://www.theguardian.com"
 
 eventbrite.url="http://www.eventbrite.co.uk"
 

--- a/frontend/conf/dev.conf
+++ b/frontend/conf/dev.conf
@@ -25,7 +25,7 @@ ws.acceptAnyCertificate=true
 membership.url="https://mem.thegulocal.com"
 membership.feedback="membership.dev@theguardian.com"
 
-cors.allow.origin="https://profile.thegulocal.com"
+cors.allow.origin="https://profile.thegulocal.com,http://www.thegulocal.com"
 
 # This is the current exception to putting credentials into this file, for now.
 aws.access.key=${?AWS_ACCESS_KEY}


### PR DESCRIPTION
Update CORS config to allow requests to `/user/me` from theguardian.com. Thanks to @rtyley for helping me sort this out.