### PR TITLE
Make Sale end date show *time* if it's happening today-ish

### DIFF
--- a/frontend/app/views/fragments/event/ticketSales.scala.html
+++ b/frontend/app/views/fragments/event/ticketSales.scala.html
@@ -2,6 +2,7 @@
 
 @import views.support.Dates._
 @import org.joda.time.Instant
+@import com.github.nscala_time.time.Imports._
 @import model.RichEvent._
 @import com.gu.membership.salesforce.Tier
 
@@ -10,7 +11,7 @@
 }
 
 @ticketEndSaleDate(endSalesDate: Instant, needToDisplayTimes: Boolean) = @{
-    Html(s"<time datetime='$endSalesDate'>${endSalesDate.pretty(needToDisplayTimes)}</time>")
+    Html(s"<time datetime='$endSalesDate'>${endSalesDate.pretty(needToDisplayTimes || endSalesDate.isContemporary())}</time>")
 }
 
 <div class="ticket-sales" itemprops="offers" itemscope itemtype="http://schema.org/AggregateOffer">

--- a/frontend/app/views/support/Dates.scala
+++ b/frontend/app/views/support/Dates.scala
@@ -22,6 +22,7 @@ object Dates {
     lazy val pretty = prettyDate(new DateTime(dt))
     lazy val prettyWithTime = prettyDateWithTime(new DateTime(dt))
     def pretty(includeTime: Boolean): String = if (includeTime) prettyWithTime else pretty
+    def isContemporary(threshold: Duration = 24.hours) = new Interval(dt - threshold, dt + threshold).contains(DateTime.now)
   }
 
   def prettyDate(dt: DateTime): String = dt.toString("d MMMMM YYYY")


### PR DESCRIPTION
Actually a 24 hour window either side at the moment

Madeleine Williams requested:

- Would it be possible to state on the final day of ticket sales the end time for sales? The end time is the start time of the event as people can buy online right up until then.

cc @davidrapson 