### PR TITLE
Clean up how event images are modeled in RichEvent

### DIFF
--- a/frontend/app/model/RichEvent.scala
+++ b/frontend/app/model/RichEvent.scala
@@ -81,46 +81,34 @@ object RichEvent {
 
   trait RichEvent {
     val event: EBEvent
-    val imgUrl: String
+    val imgOpt: Option[model.ResponsiveImageGroup]
     val socialImgUrl: String
     val tags: Seq[String]
     val metadata: Metadata
     val imageMetadata: Option[Grid.Metadata]
     val contentOpt: Option[Content]
-    val srcsetOpt: Option[Seq[String]]
-    val availableWidths: String
-    val fallbackImage = views.support.Asset.at("images/event-placeholder.gif")
     val pastImageOpt: Option[Asset]
-
     def deficientGuardianMembersTickets: Boolean
   }
 
   abstract class LiveEvent(image: Option[EventImage], contentOpt: Option[Content]) extends RichEvent {
 
-    private val widths = image.fold(List.empty[Int])(_.assets.map(_.dimensions.width))
-
     val imageMetadata = image.map(_.metadata)
 
-    val imgUrl = image.flatMap(_.assets.headOption).fold(fallbackImage){ asset =>
-      asset.secureUrl.getOrElse(asset.file)
-    }
+    val imgOpt = image.map { imgData =>
+      Some(ResponsiveImageGroup(
+        altText=event.name.toString(),
+        availableImages=imgData.assets.map { asset =>
+          ResponsiveImage(
+            path=asset.secureUrl.getOrElse(asset.file),
+            width=asset.dimensions.width
+          )
+        }
+      ))
+    }.getOrElse(None)
 
-    val availableWidths = widths.mkString(",")
-
-    val srcsetOpt = image.map(_.assets.map { asset =>
-        asset.secureUrl.getOrElse(asset.file) + " " + asset.dimensions.width.toString() + "w"
-    })
-
-    val pastImageOpt = for {
-      content <- contentOpt
-      elements <- content.elements
-      element <- elements.find(_.relation == "main")
-      assetOpt <- element.assets.find(_.typeData.get("width") == Some("460"))
-    } yield assetOpt
-
-    val socialImgUrl = image.flatMap(_.assets.find(_.dimensions.width == widths.max)).fold(fallbackImage){ asset =>
-      asset.secureUrl.getOrElse(asset.file)
-    }
+    //TODO: Should be Option[String]
+    val socialImgUrl = imgOpt.map(_.defaultImage).getOrElse("")
 
     val tags = Nil
 
@@ -129,6 +117,13 @@ object RichEvent {
 
     val highlight = contentOpt.map(c => HighlightsMetadata("Read more about this event", c.webUrl))
       .orElse(Some(fallbackHighlightsMetadata))
+
+    val pastImageOpt = for {
+      content <- contentOpt
+      elements <- content.elements
+      element <- elements.find(_.relation == "main")
+      assetOpt <- element.assets.find(_.typeData.get("width") == Some("460"))
+    } yield assetOpt
 
     def deficientGuardianMembersTickets = event.internalTicketing.flatMap(_.memberDiscountOpt).exists(_.fewerMembersTicketsThanGeneralTickets)
   }
@@ -148,17 +143,23 @@ object RichEvent {
   }
 
   case class MasterclassEvent(event: EBEvent, data: Option[MasterclassData]) extends RichEvent {
-    val imgUrl = data.flatMap(_.images.headOption).flatMap(_.file)
-      .getOrElse(fallbackImage)
-      .replace("http://static", "https://static-secure")
+
+    val imgOpt = data.flatMap(_.images.headOption).flatMap { asset =>
+      asset.file.map { imgUrl =>
+        ResponsiveImageGroup(
+          altText = event.name.toString(),
+          availableImages = Seq(ResponsiveImage(
+            path = imgUrl.replace("http://static", "https://static-secure"),
+            width = asset.typeData.get("width").map(_.toInt).getOrElse(460)
+          ))
+        )
+      }
+    }
 
     val imageMetadata = None
 
-    val availableWidths = ""
-
-    val srcsetOpt = None
-
-    val socialImgUrl = imgUrl
+    //TODO: Should be Option[String]
+    val socialImgUrl = imgOpt.map(_.defaultImage).getOrElse("")
 
     val tags = event.description.map(_.html).flatMap(MasterclassEvent.extractTags).getOrElse(Nil)
 

--- a/frontend/app/model/RichEvent.scala
+++ b/frontend/app/model/RichEvent.scala
@@ -97,7 +97,7 @@ object RichEvent {
 
     val imgOpt = image.flatMap { imgData =>
       Some(ResponsiveImageGroup(
-        altText=event.name.toString(),
+        altText=event.name.text,
         availableImages=imgData.assets.map { asset =>
           ResponsiveImage(
             path=asset.secureUrl.getOrElse(asset.file),
@@ -147,7 +147,7 @@ object RichEvent {
     val imgOpt = data.flatMap(_.images.headOption).flatMap { asset =>
       asset.file.map { imgUrl =>
         ResponsiveImageGroup(
-          altText = event.name.toString(),
+          altText = event.name.text,
           availableImages = Seq(ResponsiveImage(
             path = imgUrl.replace("http://static", "https://static-secure"),
             width = asset.typeData.get("width").map(_.toInt).getOrElse(460)

--- a/frontend/app/model/RichEvent.scala
+++ b/frontend/app/model/RichEvent.scala
@@ -95,7 +95,7 @@ object RichEvent {
 
     val imageMetadata = image.map(_.metadata)
 
-    val imgOpt = image.map { imgData =>
+    val imgOpt = image.flatMap { imgData =>
       Some(ResponsiveImageGroup(
         altText=event.name.toString(),
         availableImages=imgData.assets.map { asset =>
@@ -105,7 +105,7 @@ object RichEvent {
           )
         }
       ))
-    }.getOrElse(None)
+    }
 
     //TODO: Should be Option[String]
     val socialImgUrl = imgOpt.map(_.defaultImage).getOrElse("")

--- a/frontend/app/views/event/page.scala.html
+++ b/frontend/app/views/event/page.scala.html
@@ -85,17 +85,18 @@
     <div class="event-content" itemscope itemtype="http://schema.org/Event">
 
         @if(event.metadata.largeImg) {
-            <div class="event-content__image" itemprop="image" content="@event.socialImgUrl">
-                @fragments.event.image(event, lazyLoad=false)
-            </div>
-
-            <div class="event-image-credit u-event-content-width">
-                <div class="event-image-credit__detail">
-                    @fragments.inlineIcon("caption-camera")
-                    <span class="u-align-middle">@event.imageMetadata.flatMap(_.description)</span>
-                    <span class="u-align-middle">Photograph: @event.imageMetadata.map(_.photographer)</span>
+            @for(img <- event.imgOpt) {
+                <div class="event-content__image" itemprop="image" content="@event.socialImgUrl">
+                    @fragments.event.image(event, lazyLoad=false)
                 </div>
-            </div>
+                <div class="event-image-credit u-event-content-width">
+                    <div class="event-image-credit__detail">
+                        @fragments.inlineIcon("caption-camera")
+                        <span class="u-align-middle">@event.imageMetadata.flatMap(_.description)</span>
+                        <span class="u-align-middle">Photograph: @event.imageMetadata.map(_.photographer)</span>
+                    </div>
+                </div>
+            }
         }
 
         <div class="event-content__container u-cf">
@@ -119,7 +120,9 @@
                 }
 
                 @if(!event.metadata.largeImg) {
-                    <img class="responsive-img hidden-mobile" src="@event.imgUrl" />
+                    @for(img <- event.imgOpt) {
+                        <img class="responsive-img hidden-mobile" src="@img.defaultImage" />
+                    }
                 }
 
                 @if(!event.isPastEvent){

--- a/frontend/app/views/fragments/event/image.scala.html
+++ b/frontend/app/views/fragments/event/image.scala.html
@@ -1,18 +1,10 @@
 @(event: model.RichEvent.RichEvent, sizes: Option[String] = None, lazyLoad: Boolean = true)
 
-@srcVal = @{ if (lazyLoad) event.fallbackImage else event.imgUrl }
-
-@event.srcsetOpt.fold {
-    <img src="@srcVal"
-         @if(lazyLoad){data-src="@event.imgUrl"}
-         alt="@event.name.text"
-         class="responsive-img@if(lazyLoad){ js-lazyload}"
-    />
-} { srcset =>
-    <img src="@srcVal"
-         @if(lazyLoad){data-}srcset="@srcset.mkString(", ")"
-         sizes="@sizes.getOrElse("100vw")"
-         alt="@event.name.text"
-         class="responsive-img@if(lazyLoad){ js-lazyload}"
+@for(img <- event.imgOpt) {
+    <img src="@img.defaultImage"
+    @if(lazyLoad){data-srcset="@img.srcset"} else {srcset="@img.srcset"}
+    sizes="@sizes.getOrElse("100vw")"
+    alt="@img.altText"
+    class="responsive-img @if(lazyLoad) { js-lazyload} "
     />
 }

--- a/frontend/test/model/EventbriteTestObjects.scala
+++ b/frontend/test/model/EventbriteTestObjects.scala
@@ -15,14 +15,12 @@ object EventbriteTestObjects {
   def eventTicketClass = EBTicketClass("", "", false, 0, 0, None, eventTime.toInstant, None, None)
 
   case class TestRichEvent(event: EBEvent) extends RichEvent {
-    val imgUrl = ""
-    val availableWidths = ""
+    val imgOpt = None
     val socialImgUrl = ""
     val imageMetadata = None
     val tags = Nil
     val contentOpt = None
     val pastImageOpt = None
-    val srcsetOpt= None
 
     val metadata = Metadata(
       identifier="",

--- a/frontend/test/model/GuLiveEventTest.scala
+++ b/frontend/test/model/GuLiveEventTest.scala
@@ -1,6 +1,6 @@
 package model
 
-import model.Eventbrite._
+import model.EventbriteTestObjects._
 import model.Grid.{GridResult, Metadata}
 import model.GridDeserializer._
 import model.RichEvent.{GuLiveEvent, EventImage}
@@ -10,7 +10,7 @@ import utils.Resource
 
 class GuLiveEventTest extends PlaySpecification with Mockito {
 
-  val event = mock[EBEvent]
+  val event = eventWithName()
   val grid = Resource.getJson("model/grid/api-image.json")
   val gridResponse = grid.as[GridResult]
 
@@ -19,51 +19,20 @@ class GuLiveEventTest extends PlaySpecification with Mockito {
       val image = EventImage(gridResponse.data.exports.get(0).assets, gridResponse.data.metadata)
       val guEvent = GuLiveEvent(event, Some(image), None)
 
-      guEvent.imgUrl mustEqual "https://some-media-thing/aede0da05506d0d8cb993558b7eb9ad1d2d3e675/294_26_1584_950/1000.jpg"
       guEvent.imageMetadata.flatMap(_.description) mustEqual Some("It's Chris!")
       guEvent.imageMetadata.map(_.photographer) mustEqual Some("Joe Bloggs/Guardian Images")
-      guEvent.availableWidths mustEqual "1000,500"
       guEvent.socialImgUrl mustEqual "https://some-media-thing/aede0da05506d0d8cb993558b7eb9ad1d2d3e675/294_26_1584_950/1000.jpg"
-    }
-
-    "generate srcset string for an image" in {
-      val image = EventImage(gridResponse.data.exports.get(0).assets, gridResponse.data.metadata)
-      val guEvent = GuLiveEvent(event, Some(image), None)
-
-      guEvent.srcsetOpt mustEqual Some(List("https://some-media-thing/aede0da05506d0d8cb993558b7eb9ad1d2d3e675/294_26_1584_950/1000.jpg 1000w", "http://some-media-thing/aede0da05506d0d8cb993558b7eb9ad1d2d3e675/294_26_1584_950/500.jpg 500w"))
     }
 
     "use file url, metadata, socialUrl for image when no secure url is present" in {
       val image = EventImage(gridResponse.data.exports.get(1).assets, gridResponse.data.metadata)
       val guEvent = GuLiveEvent(event, Some(image), None)
 
-      guEvent.imgUrl mustEqual "http://some-media-thing/aede0da05506d0d8cb993558b7eb9ad1d2d3e675/0_130_1703_1022/1000.jpg"
       guEvent.imageMetadata.flatMap(_.description) mustEqual Some("It's Chris!")
       guEvent.imageMetadata.map(_.photographer) mustEqual Some("Joe Bloggs/Guardian Images")
 
-      guEvent.availableWidths mustEqual "1000,500,140"
       guEvent.socialImgUrl mustEqual "http://some-media-thing/aede0da05506d0d8cb993558b7eb9ad1d2d3e675/0_130_1703_1022/1000.jpg"
     }
 
-    "use fallback image when no image is found from the Grid" in {
-      val guEvent = GuLiveEvent(event, None, None)
-
-      guEvent.socialImgUrl must contain("event-placeholder.gif")
-      guEvent.imageMetadata.flatMap(_.description) mustEqual None
-      guEvent.imageMetadata.map(_.photographer) mustEqual None
-      guEvent.availableWidths mustEqual ""
-      guEvent.socialImgUrl must contain("event-placeholder.gif")
-    }
-
-    "use fallback image when assets in export is an empty list from the Grid" in {
-      val image = EventImage(Nil, Metadata(None, None, None))
-      val guEvent = GuLiveEvent(event, Some(image), None)
-
-      guEvent.socialImgUrl must contain("event-placeholder.gif")
-      guEvent.imageMetadata.flatMap(_.description) mustEqual None
-      guEvent.imageMetadata.map(_.photographer).get mustEqual ""
-      guEvent.availableWidths mustEqual ""
-      guEvent.socialImgUrl must contain("event-placeholder.gif")
-    }
   }
 }


### PR DESCRIPTION
Update RichEvent to model images as ResponsiveImageGroups

- Switch event images to be an `Option` so we can handle the case where there is no image
- Remove need for `fallbackImage`
- Remove need for `availableWidths` and `srcset` to be calculated in `RichEvent`

The generation of the `imgOpt` in each case is the only slightly complex bit of Scala so I'd appreciate feedback on that in case there's a simpler way of building these up (maybe move the generation to `Asset` or `Grid` at least for live events)

// @jennysivapalan 
