### PR TITLE
Disable source maps in production

### DIFF
--- a/frontend/Gruntfile.js
+++ b/frontend/Gruntfile.js
@@ -55,7 +55,7 @@ module.exports = function (grunt) {
                 }],
                 options: {
                     style: 'compressed',
-                    sourcemap: isDev ? 'auto' : 'none',
+                    sourcemap: isDev ? true : false,
                     noCache: true,
                     quiet: isDev ? false : true,
                     loadPath: [

--- a/frontend/Gruntfile.js
+++ b/frontend/Gruntfile.js
@@ -55,7 +55,7 @@ module.exports = function (grunt) {
                 }],
                 options: {
                     style: 'compressed',
-                    sourcemap: isDev ? true : false,
+                    sourcemap: isDev ? 'auto' : 'none',
                     noCache: true,
                     quiet: isDev ? false : true,
                     loadPath: [
@@ -67,7 +67,7 @@ module.exports = function (grunt) {
 
         postcss: {
             options: {
-                map: true,
+                map: isDev ? true : false,
                 processors: [
                     require('autoprefixer-core')({browsers: ['> 5%', 'last 2 versions', 'IE 9', 'Safari 6']}).postcss
                 ]


### PR DESCRIPTION
**TL;DR Production CSS is now 3x smaller**

We have a couple of different grunt tasks which generate source maps, so there's a few different places so we end up with this situation:

![screen shot 2015-03-09 at 10 05 42](https://cloud.githubusercontent.com/assets/123386/6553034/33b7d8dc-c644-11e4-9da4-1116f3d9d402.png)

This PR ensures that source maps are fully disabled in production.

**Before**
![css-size-before](https://cloud.githubusercontent.com/assets/123386/6553036/39ee97ae-c644-11e4-810c-a53743c5f3f6.png)

**After**
![css-size-after](https://cloud.githubusercontent.com/assets/123386/6553039/3fe25a2e-c644-11e4-8166-e36a0deca501.png)

I did start some work to monitor asset sizes in Cloud Watch but never actually finished it, this might prompt me to pick that back up again.