### PR TITLE
Only display discount messaging where available

### DIFF
--- a/frontend/app/views/fragments/form/billingAddress.scala.html
+++ b/frontend/app/views/fragments/form/billingAddress.scala.html
@@ -1,8 +1,8 @@
 @(heading: String)
 
 @pseudoRadio(title: String) = {
-    <div class="psuedo-radio">
-        <span class="billing-address-choice">@title</span>
+    <div class="pseudo-radio">
+        <span class="pseudo-radio__label">@title</span>
     </div>
 }
 

--- a/frontend/app/views/fragments/form/paymentOptions.scala.html
+++ b/frontend/app/views/fragments/form/paymentOptions.scala.html
@@ -2,14 +2,6 @@
 
 @import model.Benefits
 
-@pseudoRadio(title: String, detail: String, note: String) = {
-    <div class="psuedo-radio">
-        <div class="payment-title">@title</div>
-        <div>@detail</div>
-        <div>@note</div>
-    </div>
-}
-
 <fieldset class="fieldset">
 
     <div class="fieldset__heading">
@@ -31,11 +23,14 @@
                            value="annual"
                            checked="checked"
                            data-pricing-option-amount="@pricing.yearly"/>
-                    @pseudoRadio(
-                        s"Pay £${pricing.yearly}/year",
-                        s"£${pricing.yearly} one off annual payment (save £${pricing.yearlySaving} a year)",
-                        "1 year membership, 3 months free"
-                    )
+
+                    <div class="pseudo-radio">
+                        <div class="pseudo-radio__header">Pay £@pricing.yearly/year</div>
+                        @if(pricing.hasYearlySaving) {
+                            <p class="pseudo-radio__note">£@pricing.yearly one off annual payment (save £@pricing.yearlySaving a year)</p>
+                            <p class="pseudo-radio__note">1 year membership, 3 months free</p>
+                        }
+                    </div>
                 }
             </label>
 
@@ -48,11 +43,14 @@
                            id="monthly"
                            value="month"
                            data-pricing-option-amount="@pricing.monthly"/>
-                    @pseudoRadio(
-                        s"Pay £${pricing.monthly}/month",
-                        s"£${pricing.monthly} per month (£${pricing.yearlyMonthlyCost} per year)",
-                        "1 year membership, pay in instalments over a year"
-                    )
+
+                    <div class="pseudo-radio">
+                        <div class="pseudo-radio__header">Pay £@pricing.monthly/month</div>
+                        @if(pricing.hasYearlySaving) {
+                            <p class="pseudo-radio__note">£@pricing.monthly per month (£@pricing.yearlyMonthlyCost per year)</p>
+                            <p class="pseudo-radio__note">1 year membership, pay in instalments over a year</p>
+                        }
+                    </div>
                 }
             </label>
         </div>

--- a/frontend/app/views/fragments/form/paymentOptions.scala.html
+++ b/frontend/app/views/fragments/form/paymentOptions.scala.html
@@ -27,7 +27,7 @@
                     <div class="pseudo-radio">
                         <div class="pseudo-radio__header">Pay £@pricing.yearly/year</div>
                         @if(pricing.hasYearlySaving) {
-                            <p class="pseudo-radio__note">£@pricing.yearly one off annual payment (save £@pricing.yearlySaving a year)</p>
+                            <p class="pseudo-radio__note">£@pricing.yearly one off annual payment (save £@pricing.yearlySaving per year)</p>
                             <p class="pseudo-radio__note">1 year membership, 3 months free</p>
                         } else {
                             <p class="pseudo-radio__note">One-off annual payment</p>

--- a/frontend/app/views/fragments/form/paymentOptions.scala.html
+++ b/frontend/app/views/fragments/form/paymentOptions.scala.html
@@ -29,6 +29,8 @@
                         @if(pricing.hasYearlySaving) {
                             <p class="pseudo-radio__note">£@pricing.yearly one off annual payment (save £@pricing.yearlySaving a year)</p>
                             <p class="pseudo-radio__note">1 year membership, 3 months free</p>
+                        } else {
+                            <p class="pseudo-radio__note">One-off annual payment</p>
                         }
                     </div>
                 }
@@ -48,8 +50,8 @@
                         <div class="pseudo-radio__header">Pay £@pricing.monthly/month</div>
                         @if(pricing.hasYearlySaving) {
                             <p class="pseudo-radio__note">£@pricing.monthly per month (£@pricing.yearlyMonthlyCost per year)</p>
-                            <p class="pseudo-radio__note">1 year membership, pay in instalments over a year</p>
                         }
+                        <p class="pseudo-radio__note">1 year membership, pay in instalments over a year</p>
                     </div>
                 }
             </label>

--- a/frontend/assets/stylesheets/base/_form.scss
+++ b/frontend/assets/stylesheets/base/_form.scss
@@ -208,8 +208,8 @@ form {
 /* ==========================================================================
    Psuedo radio form inputs
    ========================================================================== */
-.psuedo-radio {
-    @include fs-textSans(3);
+
+.pseudo-radio {
     width: 100%;
     border: 1px solid transparent;
     padding: rem($gs-gutter) rem($gs-gutter) rem($gs-gutter) rem(36px);
@@ -223,33 +223,30 @@ form {
         @include radio-circle($c-neutral5);
     }
 }
-
-input[type=radio]:checked + .psuedo-radio {
+input[type=radio]:checked + .pseudo-radio {
     border-color: $c-border-brand;
-
     &:before {
-        @include radio-circle();
+        background-color: $mem-brandBlue;
     }
 }
-
-/* ==========================================================================
-   Payment titles
-   ========================================================================== */
-.payment-title {
-    @include fs-bodyHeading(2);
-}
-
-/* ==========================================================================
-   Billing address titles
-   ========================================================================== */
-
-.billing-address-choice {
+.pseudo-radio__label {
     @include fs-bodyCopy(2);
+    line-height: 1.2;
+}
+.pseudo-radio__header {
+    @include fs-bodyHeading(2);
+    line-height: 1.2;
+    margin-bottom: rem($gs-baseline / 2);
+}
+.pseudo-radio__note {
+    @include fs-textSans(3);
+    margin-bottom: 0;
 }
 
 /* ==========================================================================
    Payment credit card types
    ========================================================================== */
+
 $small-card: 32px;
 $large-card: 35px;
 $card-icon-offset: 1px;
@@ -273,6 +270,7 @@ $card-icon-offset: 1px;
 /* ==========================================================================
    Credit card notes
    ========================================================================== */
+
 .credit-card-note {
     color: $c-neutral2;
 }


### PR DESCRIPTION
Only display discount messaging where available on payment page:

![screen shot 2015-03-09 at 17 34 53](https://cloud.githubusercontent.com/assets/123386/6560530/bd0b30e6-c682-11e4-9817-af13b1396da1.png)

![screen shot 2015-03-09 at 17 34 44](https://cloud.githubusercontent.com/assets/123386/6560534/befd0514-c682-11e4-81b9-83104b3ec91b.png)

We might want to display a different message for this case, but will pick this up with @davidmcdowell in the morning.