### PR TITLE
Event page class-name and specifictiy fixes

### DIFF
--- a/frontend/app/views/event/page.scala.html
+++ b/frontend/app/views/event/page.scala.html
@@ -35,7 +35,7 @@
                 </div>
             </div>
             @for(internalTicketing <- event.internalTicketing) {
-                <div class="event-ticket@if(internalTicketing.isFree) { event-ticket--free }u-cf">
+                <div class="event-ticket@if(internalTicketing.isFree) { event-ticket--free} u-cf">
                     <div class="event-ticket__details">
                         @fragments.pricing.priceInfoEvent(event, isPrimary=true) <!-- internalTicketing -->
                     </div>

--- a/frontend/app/views/fragments/event/item.scala.html
+++ b/frontend/app/views/fragments/event/item.scala.html
@@ -13,7 +13,7 @@
         <div class="event-item__meta">
             @fragments.event.itemMetaTitle(event)
             <div class="event-item__time" itemprop="startDate" content="@event.start">@event.start.pretty</div>
-            <div itemprop="location" itemscope itemtype="http://schema.org/Place">
+            <div class="event-item__location" itemprop="location" itemscope itemtype="http://schema.org/Place">
                 @fragments.event.addressSummary(event)
             </div>
             <div class="event-item__footer">

--- a/frontend/app/views/fragments/event/itemHero.scala.html
+++ b/frontend/app/views/fragments/event/itemHero.scala.html
@@ -10,7 +10,7 @@
         <div class="event-item__meta">
             @fragments.event.itemMetaTitle(event)
             <div class="event-item__time" itemprop="startDate" content="@event.start">@event.start.pretty</div>
-            <div itemprop="location" itemscope itemtype="http://schema.org/Place">
+            <div class="event-item__location" itemprop="location" itemscope itemtype="http://schema.org/Place">
                 @fragments.event.addressSummary(event)
             </div>
             @for(desc <- event.description) {

--- a/frontend/assets/stylesheets/components/_event-detail.scss
+++ b/frontend/assets/stylesheets/components/_event-detail.scss
@@ -104,47 +104,34 @@
 }
 
 .event-details {
-
     margin-bottom: rem($gs-baseline / 2);
 
     @include mq(tablet) {
-        margin-bottom: rem($gs-gutter);
-    }
-
-    .event-details__time {
-        max-width: rem(gs-span(8));
-        @include fs-headline(2);
-
-        @include mq(tablet) {
-            @include fs-headline(4);
-        }
-    }
-
-    .event-details__time__part {
-        white-space: nowrap;
-    }
-
-    .event-details__location {
-        @include fs-data(4);
-
-        .event-location {
-            color: inherit;
-        }
+        margin-bottom: rem($gs-baseline);
     }
 }
+.event-details__time {
+    @include fs-headline(2);
 
+    @include mq(tablet) {
+        @include fs-headline(4, true);
+    }
+}
+.event-details__time__part {
+    white-space: nowrap;
+}
+.event-details__location {
+    @include fs-data(4);
+    color: inherit;
+}
 
 /* ==========================================================================
    Event Location Summary
    ========================================================================== */
+
 .event-location {
-    // Remove space between inline block elements
-    font-size: 0;
+    font-size: 0; // Remove space between inline block elements
     line-height: 1;
-    color: $c-neutral2;
-}
-.event-location--reversed {
-    color: $white;
 }
 .event-location__detail {
     @include fs-data(4);
@@ -177,7 +164,6 @@
    ========================================================================== */
 
 .event-ticket {
-    padding-top: rem($gs-gutter);
     @include mq(tablet) {
         display: table;
     }

--- a/frontend/assets/stylesheets/components/_event-items.scss
+++ b/frontend/assets/stylesheets/components/_event-items.scss
@@ -55,6 +55,9 @@
     .event-item__time {
         @include fs-data(4);
     }
+    .event-item__location {
+        color: $c-neutral2;
+    }
     .event-item__description {
         @include fs-bodyCopy(1);
         padding: rem($gs-baseline) 0 0;


### PR DESCRIPTION
This PR fixes a rogue `u-cf` that was being appended to the `event-details` container. And cleans up a few layout and specificity details that fixing this classname highlighted.