### PR TITLE
Paid-to-paid updates

### DIFF
--- a/frontend/app/views/fragments/form/forgottenPassword.scala.html
+++ b/frontend/app/views/fragments/form/forgottenPassword.scala.html
@@ -1,5 +1,0 @@
-@(text: String)
-
-@import configuration.Config
-
-<a href="@Config.idWebAppUrl/reset">@text</a>

--- a/frontend/app/views/tier/upgrade/paidToPaid.scala.html
+++ b/frontend/app/views/tier/upgrade/paidToPaid.scala.html
@@ -29,13 +29,20 @@
             </section>
         }
 
-        <div class="page-section page-section--bordered">
+        <div class="page-section">
             <div class="page-section__lead-in">
-                <h2 class="page-section__headline">What happens now</h2>
+                <a href="@routes.TierController.change" class="action action--secondary u-no-top-margin">
+                    @fragments.actionIcon("arrow-left", leftIcon=true)
+                    <span class="action__label">Change Tier</span>
+                </a>
             </div>
             <div class="page-section__content">
+                <h2 class="h-section">What happens now</h2>
                 <p>When you upgrade we want to make sure you are charged the right amount. We will charge for your <strong>@currentTier</strong> membership up until today and the amount remaining will be deducted from your first payment as a <strong>@targetTier</strong>.</p>
                 <p><strong>@targetTier</strong> payments start today and will recur @{currentSubscription.paymentPeriodLabel}ly.</p>
+            </div>
+            <div class="page-section__supplementary">
+
             </div>
         </div>
 
@@ -51,14 +58,14 @@
                         <td id="qa-upgrade-current-tier">@currentSubscription.planName</td>
                     </tr>
                     <tr role="row">
+                        <th role="rowheader">Start Date</th>
+                        <td id="qa-upgrade-current-start-date">@prettyDate(currentSubscription.startDate)</td>
+                    </tr>
+                    <tr role="row">
                         <th role="rowheader">@{currentSubscription.paymentPeriodLabel.capitalize}ly Payment</th>
                         <td id="qa-upgrade-current-payment">@currentSubscription.planAmount.pretty</td>
                     </tr>
-                    <tr role="row">
-                        <th role="rowheader">Last payment</th>
-                        <td id="qa-upgrade-current-last-date">@prettyDate(currentSubscription.startDate)</td>
-                    </tr>
-                    <tr role="row">
+                       <tr role="row">
                         <th role="rowheader">End date</th>
                         <td id="qa-upgrade-current-end-date">@prettyDate(new DateTime())</td>
                     </tr>
@@ -79,12 +86,16 @@
                             <td id="qa-upgrade-new-tier">@targetTier</td>
                         </tr>
                         <tr role="row">
-                            <th role="rowheader">New @{currentSubscription.paymentPeriodLabel}ly payment</th>
-                            <td id="qa-upgrade-new-recurring-payment">@preview.futureSubscriptionInvoice.price.pretty</td>
+                            <th role="rowheader">Start date</th>
+                            <td id="qa-upgrade-new-start-date">@prettyDate(new DateTime())</td>
                         </tr>
                         <tr role="row">
                             <th role="rowheader">First payment</th>
                             <td id="qa-upgrade-new-first-payment">@preview.totalPrice.pretty</td>
+                        </tr>
+                        <tr role="row">
+                            <th role="rowheader">@{currentSubscription.paymentPeriodLabel.capitalize}ly payment</th>
+                            <td id="qa-upgrade-new-recurring-payment">@preview.futureSubscriptionInvoice.price.pretty</td>
                         </tr>
                         <tr role="row">
                             <th role="rowheader">Next payment due</th>
@@ -102,6 +113,7 @@
             </div>
             <div class="page-section__content">
                 <address>@fragments.user.deliveryAddress(userFields)</address>
+                <p class="text-note">We’ll send you a new welcome pack in the post.</p>
             </div>
         </section>
 
@@ -146,7 +158,9 @@
                     <fieldset class="fieldset fieldset--simple">
                         <div class="fieldset__fields js-password-container">
                             @fragments.form.enterPassword("Re-enter your password")
-                            @fragments.form.forgottenPassword("Forgotten your password?")
+                            <p class="copy l-pad-top">
+                                <a href="@Config.idWebAppUrl/reset" class="text-note">Forgotten your password?</a>
+                            </p>
                         </div>
                     </fieldset>
 

--- a/frontend/app/views/tier/upgrade/paidToPaid.scala.html
+++ b/frontend/app/views/tier/upgrade/paidToPaid.scala.html
@@ -58,11 +58,11 @@
                         <td id="qa-upgrade-current-tier">@currentSubscription.planName</td>
                     </tr>
                     <tr role="row">
-                        <th role="rowheader">Start Date</th>
+                        <th role="rowheader">Start date</th>
                         <td id="qa-upgrade-current-start-date">@prettyDate(currentSubscription.startDate)</td>
                     </tr>
                     <tr role="row">
-                        <th role="rowheader">@{currentSubscription.paymentPeriodLabel.capitalize}ly Payment</th>
+                        <th role="rowheader">@{currentSubscription.paymentPeriodLabel.capitalize}ly payment</th>
                         <td id="qa-upgrade-current-payment">@currentSubscription.planAmount.pretty</td>
                     </tr>
                        <tr role="row">
@@ -110,10 +110,10 @@
         <section class="page-section page-section--bordered">
             <div class="page-section__lead-in">
                 <h2 class="page-section__headline">Delivery address</h2>
+                <p class="text-note">We’ll send you a new welcome pack in the post.</p>
             </div>
             <div class="page-section__content">
                 <address>@fragments.user.deliveryAddress(userFields)</address>
-                <p class="text-note">We’ll send you a new welcome pack in the post.</p>
             </div>
         </section>
 

--- a/frontend/assets/stylesheets/base/_base.scss
+++ b/frontend/assets/stylesheets/base/_base.scss
@@ -93,4 +93,5 @@ blockquote,
 
 address {
     font-style: normal;
+    margin-bottom: rem($gs-baseline / 2);
 }

--- a/frontend/assets/stylesheets/components/_page.scss
+++ b/frontend/assets/stylesheets/components/_page.scss
@@ -116,9 +116,10 @@ $_page-offset: rem(gs-span(2) + $gs-gutter);
 .page-intro {
     color: $c-neutral2;
     @include fs-headline(2);
+    margin-bottom: 0;
 
     @include mq(tablet) {
-        @include fs-headline(3);
+        @include fs-headline(3, true);
     }
 }
 
@@ -140,20 +141,21 @@ $_page-offset: rem(gs-span(2) + $gs-gutter);
  */
 .page-section {
     @include clearfix;
-    padding-bottom: rem($gs-baseline * 2);
+    padding-bottom: rem($gs-baseline);
 
     @include mq(desktop) {
         width: auto;
     }
     @include mq(mem-full) {
         position: relative;
+        min-height: rem(gs-height(3));
     }
 }
 .page-section--no-padding {
     padding-bottom: 0;
 }
 .page-section__header {
-    padding-bottom: rem($gs-baseline*3);
+    padding-bottom: rem($gs-baseline * 3);
 
     @include mq(mem-full) {
         padding-left: $_page-offset;
@@ -168,7 +170,7 @@ $_page-offset: rem(gs-span(2) + $gs-gutter);
 }
 .page-section__headline {
     @include fs-header(3);
-    padding-bottom: rem($gs-gutter * 1.6);
+    margin-bottom: rem($gs-baseline / 4);
 }
 .page-section__content {
     @include mq(tablet) {


### PR DESCRIPTION
Some updates to paid-to-paid upgrade page from David M.

- Back to change tier button added
- Current tier fields re-ordered. The last payment date is wrong, and should be the start date (we currently don't get last payment date from Zuora)
- New tier fields re-ordered, and start date added
- Address explanation added ("We’ll send you a new welcome pack in the post.")

![upgrade to patron the guardian membership](https://cloud.githubusercontent.com/assets/123386/6579522/a15baa5e-c742-11e4-82ef-af42207ed4c1.png)

Additional context here: https://jira.gutools.co.uk/browse/MEM-677

Some requests I've not made as we would have to make extra calls to zuora to get that information.

// @jennysivapalan 