### PR TITLE
Update unauthorised staff message

### DIFF
--- a/frontend/app/views/fragments/oauth/staffUnauthorisedError.scala.html
+++ b/frontend/app/views/fragments/oauth/staffUnauthorisedError.scala.html
@@ -8,6 +8,6 @@
 
 <p>We use a Google group to authenticate email addresses. The group is managed by HR and updated once a month.</p>
 <p>If you've recently joined the Guardian as a permanent employee or fixed term contractor then please try and register again at the beginning of next month.</p>
-<p>If you have an urgent requirement please email <a href="mailto:hr.admin@@theguardian.com">hr.admin@@theguardian.com</a> and ask to be added to the staff google group - Once this is done you will be able to join.</p>
+<p>If you have been a permanent employee or fixed term contractor for more than six weeks please email <a href="mailto:hr.admin@@theguardian.com">hr.admin@@theguardian.com</a> and ask to be added to the staff google group - Once this is done you will be able to join.</p>
 
-<p><strong>If you have been a permanent employee or fixed term contractor for more than a month and are still having problems please email <a href="mailto:@Config.membershipSupportStaffEmail">@Config.membershipSupportStaffEmail</a>.</strong></p>
+<p><strong>If you have been added to the staff google group and are still having problems please email <a href="mailto:@Config.membershipSupportStaffEmail">@Config.membershipSupportStaffEmail</a>.</strong></p>


### PR DESCRIPTION
Request from David M:

> The majority of emails queries sent to staff.membership@theguardian.com are regarding staff not added to approved list. I'd like to re-phrase the last two sentences of the message to clarify how to resolve this issue.

[https://jira.gutools.co.uk/browse/MEM-668]()