### PR TITLE
Refactor social images

### DIFF
--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -61,7 +61,7 @@ trait Event extends Controller with ActivityTracking {
       event.name.text,
       path,
       event.description.map(_.blurb),
-      Some(event.socialImgUrl)
+      event.socialImgUrl
     )
     Ok(views.html.event.page(event, pageInfo))
   }

--- a/frontend/app/model/RichEvent.scala
+++ b/frontend/app/model/RichEvent.scala
@@ -82,7 +82,7 @@ object RichEvent {
   trait RichEvent {
     val event: EBEvent
     val imgOpt: Option[model.ResponsiveImageGroup]
-    val socialImgUrl: String
+    val socialImgUrl: Option[String]
     val tags: Seq[String]
     val metadata: Metadata
     val imageMetadata: Option[Grid.Metadata]
@@ -107,8 +107,7 @@ object RichEvent {
       ))
     }
 
-    //TODO: Should be Option[String]
-    val socialImgUrl = imgOpt.map(_.defaultImage).getOrElse("")
+    val socialImgUrl = imgOpt.map(_.defaultImage)
 
     val tags = Nil
 
@@ -158,8 +157,7 @@ object RichEvent {
 
     val imageMetadata = None
 
-    //TODO: Should be Option[String]
-    val socialImgUrl = imgOpt.map(_.defaultImage).getOrElse("")
+    val socialImgUrl = imgOpt.map(_.defaultImage)
 
     val tags = event.description.map(_.html).flatMap(MasterclassEvent.extractTags).getOrElse(Nil)
 

--- a/frontend/app/views/event/page.scala.html
+++ b/frontend/app/views/event/page.scala.html
@@ -86,7 +86,7 @@
 
         @if(event.metadata.largeImg) {
             @for(img <- event.imgOpt) {
-                <div class="event-content__image" itemprop="image" content="@event.socialImgUrl">
+                <div class="event-content__image">
                     @fragments.event.image(event, lazyLoad=false)
                 </div>
                 <div class="event-image-credit u-event-content-width">

--- a/frontend/app/views/fragments/event/image.scala.html
+++ b/frontend/app/views/fragments/event/image.scala.html
@@ -2,9 +2,10 @@
 
 @for(img <- event.imgOpt) {
     <img src="@img.defaultImage"
-    @if(lazyLoad){data-srcset="@img.srcset"} else {srcset="@img.srcset"}
-    sizes="@sizes.getOrElse("100vw")"
-    alt="@img.altText"
-    class="responsive-img @if(lazyLoad) { js-lazyload} "
+        @if(lazyLoad){data-srcset="@img.srcset"} else {srcset="@img.srcset"}
+        sizes="@sizes.getOrElse("100vw")"
+        alt="@img.altText"
+        class="responsive-img @if(lazyLoad) { js-lazyload} "
+        itemprop="image"
     />
 }

--- a/frontend/app/views/fragments/event/item.scala.html
+++ b/frontend/app/views/fragments/event/item.scala.html
@@ -6,7 +6,7 @@
 
 <a href="@routes.Event.details(event.slug)" class="event-item" itemscope itemtype="http://schema.org/Event">
     <meta itemprop="url" content="@event.memUrl">
-    <div class="event-item__media" itemprop="image" content="@event.socialImgUrl">
+    <div class="event-item__media">
         @fragments.event.image(event, sizes=Some("(min-width: 739px) 33.3vw, (min-width: 479px) 50vw, 100vw"))
     </div>
     <div class="event-item__content">

--- a/frontend/app/views/fragments/event/itemHero.scala.html
+++ b/frontend/app/views/fragments/event/itemHero.scala.html
@@ -24,7 +24,7 @@
             </div>
         </div>
     </div>
-    <div class="event-item__media" itemprop="image" content="@event.socialImgUrl">
+    <div class="event-item__media">
         @fragments.event.image(event, lazyLoad=false)
     </div>
 </a>

--- a/frontend/app/views/fragments/event/itemMinimal.scala.html
+++ b/frontend/app/views/fragments/event/itemMinimal.scala.html
@@ -4,7 +4,7 @@
 
 <a href="@routes.Event.details(event.slug)" class="event-item @if(isCard){ event-item--card} else { event-item--minimal}" itemscope itemtype="http://schema.org/Event">
     <meta itemprop="url" content="@event.memUrl">
-    <div class="event-item__media" itemprop="image" content="@event.socialImgUrl">
+    <div class="event-item__media">
         @fragments.event.image(event, sizes=Some(sizesVal))
     </div>
     <div class="event-item__content">

--- a/frontend/app/views/fragments/event/itemSnapshot.scala.html
+++ b/frontend/app/views/fragments/event/itemSnapshot.scala.html
@@ -1,7 +1,7 @@
 @(event: model.RichEvent.RichEvent, isStacked: Boolean = false)
 
 <div class="event-snapshot@if(isStacked){ event-snapshot--stack}" itemscope itemtype="http://schema.org/Event">
-    <div class="event-snapshot__media" itemprop="image" content="@event.socialImgUrl">
+    <div class="event-snapshot__media">
         @fragments.event.image(event)
     </div>
     <div class="event-snapshot__content">

--- a/frontend/app/views/fragments/event/itemSnapshotOrder.scala.html
+++ b/frontend/app/views/fragments/event/itemSnapshotOrder.scala.html
@@ -5,7 +5,7 @@
 @import views.support.Prices._
 
 <div class="event-snapshot event-snapshot--wide" itemscope itemtype="http://schema.org/Event">
-    <div class="event-snapshot__media" itemprop="image" content="@event.socialImgUrl">
+    <div class="event-snapshot__media">
         @fragments.event.image(event)
     </div>
     <div class="event-snapshot__content">

--- a/frontend/app/views/fragments/event/overviewSection.scala.html
+++ b/frontend/app/views/fragments/event/overviewSection.scala.html
@@ -37,7 +37,14 @@
                         <div>
                             <div class="event-detail_image">
                                 <a href="/event/@event.id" target="_blank">
-                                    <img src="@event.socialImgUrl" alt="Event Image" class="responsive-img"/>
+                                    @event.imgOpt.fold {
+                                        <img
+                                            src="data:image/gif;base64,R0lGODdhQAHAAIAAAMzMzJaWliwAAAAAQAHAAAAC/oSPqcvtD6OctNqLs968+w+G4kiW5omm6sq27gvH8kzX9o3n+s73/g8MCofEovGITCqXzKbzCY1Kp9Sq9YrNarfcrvcLDovH5LL5jE6r1+y2+w2Py+f0uv2Oz+v3/L7/DxgoOEhYaHiImKi4yNjo+AgZKTlJWWl5iZmpucnZ6fkJGio6SlpqeoqaqrrK2ur6ChsrO0tba3uLm6u7y9vr+wscLDxMXGx8jJysvMzc7PwMHS09TV1tfY2drb3N3e39DR4uPk5ebn6Onq6+zt7u/g4fLz9PX29/j5+vv8/f7/8PMKDAgQQLGjyIMKHChQwbOnwIMaLEiRQrWryIMaPGVI0cO3r8CDKkyJEkS5o8iTKlypUsW7p8CTOmzJk0a9q8iTOnzp08e/r8CTSo0KFEixo9ijSp0qVMmzp9CjWq1KlUq1q9ijWr1q1cu3r9Cjas2AkFAAA7"
+                                            alt="@event.name.text" class="responsive-img"
+                                        />
+                                    } { img =>
+                                        <img src="@img.defaultImage"" alt="@event.name.text" class="responsive-img"/>
+                                    }
                                     <span class="pseudo-link event-detail-title">@event.name.text</span>
                                 </a>
                             </div>

--- a/frontend/app/views/main.scala.html
+++ b/frontend/app/views/main.scala.html
@@ -20,7 +20,9 @@
 
         <meta property="og:title" content="@pageInfo.title | @Config.siteTitle"/>
         <meta property="og:description" content="@pageInfo.description"/>
-        <meta property="og:image" content="@pageInfo.image"/>
+        @for(pageImage <- pageInfo.image) {
+            <meta property="og:image" content="@pageImage"/>
+        }
         <meta property="og:url" content="@(Config.membershipUrl + pageInfo.url)"/>
 
         <meta property="og:type" content="website"/>

--- a/frontend/assets/stylesheets/tools/components/_event-overview.scss
+++ b/frontend/assets/stylesheets/tools/components/_event-overview.scss
@@ -80,6 +80,8 @@
 }
 
 .event-detail-title {
+    @include fs-data(3);
+
     @include mq(tablet) {
         position: absolute;
         bottom: 0;

--- a/frontend/test/model/EventbriteTestObjects.scala
+++ b/frontend/test/model/EventbriteTestObjects.scala
@@ -16,7 +16,7 @@ object EventbriteTestObjects {
 
   case class TestRichEvent(event: EBEvent) extends RichEvent {
     val imgOpt = None
-    val socialImgUrl = ""
+    val socialImgUrl = None
     val imageMetadata = None
     val tags = Nil
     val contentOpt = None

--- a/frontend/test/model/GuLiveEventTest.scala
+++ b/frontend/test/model/GuLiveEventTest.scala
@@ -21,7 +21,7 @@ class GuLiveEventTest extends PlaySpecification with Mockito {
 
       guEvent.imageMetadata.flatMap(_.description) mustEqual Some("It's Chris!")
       guEvent.imageMetadata.map(_.photographer) mustEqual Some("Joe Bloggs/Guardian Images")
-      guEvent.socialImgUrl mustEqual "https://some-media-thing/aede0da05506d0d8cb993558b7eb9ad1d2d3e675/294_26_1584_950/1000.jpg"
+      guEvent.socialImgUrl.get mustEqual "https://some-media-thing/aede0da05506d0d8cb993558b7eb9ad1d2d3e675/294_26_1584_950/1000.jpg"
     }
 
     "use file url, metadata, socialUrl for image when no secure url is present" in {
@@ -31,7 +31,7 @@ class GuLiveEventTest extends PlaySpecification with Mockito {
       guEvent.imageMetadata.flatMap(_.description) mustEqual Some("It's Chris!")
       guEvent.imageMetadata.map(_.photographer) mustEqual Some("Joe Bloggs/Guardian Images")
 
-      guEvent.socialImgUrl mustEqual "http://some-media-thing/aede0da05506d0d8cb993558b7eb9ad1d2d3e675/0_130_1703_1022/1000.jpg"
+      guEvent.socialImgUrl.get mustEqual "http://some-media-thing/aede0da05506d0d8cb993558b7eb9ad1d2d3e675/0_130_1703_1022/1000.jpg"
     }
 
   }


### PR DESCRIPTION
- Update socialImgUrl to be an `Option`, now that event images are considered optional
- Remove need to use `socialImgUrl` on event items (not required for Schema markup)
- Tweak event overview page to not use social image URL

// @jennysivapalan 