### PR TITLE
Improve ResponsiveImage default sizes

### DIFF
--- a/frontend/app/model/ResponsiveImage.scala
+++ b/frontend/app/model/ResponsiveImage.scala
@@ -7,8 +7,14 @@ case class ResponsiveImageGroup(
   altText: String,
   availableImages: Seq[ResponsiveImage]
 ) {
-  val defaultImage = availableImages.head.path
-  val srcset = availableImages.map { img =>
+
+  private val sortedImages = availableImages.sortBy(_.width)
+
+  val smallestImage = sortedImages.head.path
+  val defaultImage = sortedImages.find(_.width > 300).map(_.path).getOrElse(smallestImage)
+
+  val srcset = sortedImages.map { img =>
     img.path + " " + img.width.toString() + "w"
   }.mkString(", ")
+
 }

--- a/frontend/app/model/RichEvent.scala
+++ b/frontend/app/model/RichEvent.scala
@@ -97,12 +97,11 @@ object RichEvent {
 
     val imgOpt = image.flatMap { imgData =>
       Some(ResponsiveImageGroup(
-        altText=event.name.text,
-        availableImages=imgData.assets.map { asset =>
-          ResponsiveImage(
-            path=asset.secureUrl.getOrElse(asset.file),
-            width=asset.dimensions.width
-          )
+        altText = event.name.text,
+        availableImages = imgData.assets.map { asset =>
+          val path = asset.secureUrl.getOrElse(asset.file)
+          val width = asset.dimensions.width
+          ResponsiveImage(path, width)
         }
       ))
     }

--- a/frontend/app/views/event/list.scala.html
+++ b/frontend/app/views/event/list.scala.html
@@ -95,11 +95,11 @@
                             </li>
                         }
                     </ul>
+                    <button class="action action--secondary u-no-margin js-toggle" data-toggle="js-toggle-past-events" data-toggle-label="Less" data-toggle-icon="minus">
+                        @fragments.actionIcon("plus", leftIcon=true)
+                        <span class="action__label js-toggle-label">More past events</span>
+                    </button>
                 }
-                <button class="action action--secondary u-no-margin js-toggle" data-toggle="js-toggle-past-events" data-toggle-label="Less" data-toggle-icon="minus">
-                    @fragments.actionIcon("plus", leftIcon=true)
-                    <span class="action__label js-toggle-label">More past events</span>
-                </button>
             </div>
         </section>
     }

--- a/frontend/app/views/fragments/event/image.scala.html
+++ b/frontend/app/views/fragments/event/image.scala.html
@@ -1,7 +1,8 @@
 @(event: model.RichEvent.RichEvent, sizes: Option[String] = None, lazyLoad: Boolean = true)
 
 @for(img <- event.imgOpt) {
-    <img src="@img.defaultImage"
+    <img
+        @if(!lazyLoad){src="@img.defaultImage"}
         @if(lazyLoad){data-srcset="@img.srcset"} else {srcset="@img.srcset"}
         sizes="@sizes.getOrElse("100vw")"
         alt="@img.altText"

--- a/frontend/test/model/GuLiveEventTest.scala
+++ b/frontend/test/model/GuLiveEventTest.scala
@@ -15,24 +15,16 @@ class GuLiveEventTest extends PlaySpecification with Mockito {
   val gridResponse = grid.as[GridResult]
 
   "GuLiveEventTest" should {
-    "contain secure url, metadata and socialUrl for image" in {
-      val image = EventImage(gridResponse.data.exports.get(0).assets, gridResponse.data.metadata)
-      val guEvent = GuLiveEvent(event, Some(image), None)
 
-      guEvent.imageMetadata.flatMap(_.description) mustEqual Some("It's Chris!")
-      guEvent.imageMetadata.map(_.photographer) mustEqual Some("Joe Bloggs/Guardian Images")
-      guEvent.socialImgUrl.get mustEqual "https://some-media-thing/aede0da05506d0d8cb993558b7eb9ad1d2d3e675/294_26_1584_950/1000.jpg"
-    }
+    "contain metadata and socialUrl for an event image" in {
 
-    "use file url, metadata, socialUrl for image when no secure url is present" in {
       val image = EventImage(gridResponse.data.exports.get(1).assets, gridResponse.data.metadata)
       val guEvent = GuLiveEvent(event, Some(image), None)
 
       guEvent.imageMetadata.flatMap(_.description) mustEqual Some("It's Chris!")
       guEvent.imageMetadata.map(_.photographer) mustEqual Some("Joe Bloggs/Guardian Images")
 
-      guEvent.socialImgUrl.get mustEqual "http://some-media-thing/aede0da05506d0d8cb993558b7eb9ad1d2d3e675/0_130_1703_1022/1000.jpg"
+      guEvent.socialImgUrl.get mustEqual "http://some-media-thing/aede0da05506d0d8cb993558b7eb9ad1d2d3e675/0_130_1703_1022/500.jpg"
     }
-
   }
 }

--- a/frontend/test/model/ResponsiveImageTest.scala
+++ b/frontend/test/model/ResponsiveImageTest.scala
@@ -5,7 +5,9 @@ import play.api.test.PlaySpecification
 class ResponsiveImageTest extends PlaySpecification {
 
   "ResponsiveImageGroup" should {
-    "generate a srcset string for a sequence of images" in {
+
+    "generate a src and srcset information for a sequence of images" in {
+
       val imageGroup = ResponsiveImageGroup(altText="Guardian Live event: Pussy Riot - art, sex and disobedience",
         availableImages = Seq(
           ResponsiveImage(
@@ -15,12 +17,22 @@ class ResponsiveImageTest extends PlaySpecification {
           ResponsiveImage(
             path="https://media.guim.co.uk/eab86e9c81414932e0d50a1cd609dccfc20ca5d2/0_0_2279_1368/500.jpg",
             width=500
+          ),
+          ResponsiveImage(
+            path="https://media.guim.co.uk/eab86e9c81414932e0d50a1cd609dccfc20ca5d2/0_0_2279_1368/140.jpg",
+            width=140
           )
         )
       )
 
-      imageGroup.srcset mustEqual "https://media.guim.co.uk/eab86e9c81414932e0d50a1cd609dccfc20ca5d2/0_0_2279_1368/1000.jpg 1000w, https://media.guim.co.uk/eab86e9c81414932e0d50a1cd609dccfc20ca5d2/0_0_2279_1368/500.jpg 500w"
+      imageGroup.smallestImage mustEqual "https://media.guim.co.uk/eab86e9c81414932e0d50a1cd609dccfc20ca5d2/0_0_2279_1368/140.jpg"
+
+      imageGroup.defaultImage mustEqual "https://media.guim.co.uk/eab86e9c81414932e0d50a1cd609dccfc20ca5d2/0_0_2279_1368/500.jpg"
+
+      imageGroup.srcset mustEqual "https://media.guim.co.uk/eab86e9c81414932e0d50a1cd609dccfc20ca5d2/0_0_2279_1368/140.jpg 140w, https://media.guim.co.uk/eab86e9c81414932e0d50a1cd609dccfc20ca5d2/0_0_2279_1368/500.jpg 500w, https://media.guim.co.uk/eab86e9c81414932e0d50a1cd609dccfc20ca5d2/0_0_2279_1368/1000.jpg 1000w"
+
     }
+
   }
 
 }

--- a/frontend/test/resources/model/grid/api-image.json
+++ b/frontend/test/resources/model/grid/api-image.json
@@ -63,6 +63,7 @@
                         }
                     },
                     {
+                        "secureUrl": "https://some-media-thing/aede0da05506d0d8cb993558b7eb9ad1d2d3e675/294_26_1584_950/500.jpg",
                         "file": "http://some-media-thing/aede0da05506d0d8cb993558b7eb9ad1d2d3e675/294_26_1584_950/500.jpg",
                         "dimensions": {
                             "width": 500,


### PR DESCRIPTION
This PR makes a couple of adjustments to `ResponsiveImage`

- Tries to use a medium sized image for `defaultImage` otherwise uses the smallest (rather than defaulting to largest which can be ~2000px)
- Removes `src` for lazy-loaded event images

// @feedmypixel 