### PR TITLE
Update EventsListPage QA tests to only select available events

### DIFF
--- a/frontend/app/views/fragments/event/item.scala.html
+++ b/frontend/app/views/fragments/event/item.scala.html
@@ -4,7 +4,7 @@
 @import configuration.Config
 @import model.Eventbrite._
 
-<a href="@routes.Event.details(event.slug)" class="event-item" itemscope itemtype="http://schema.org/Event">
+<a href="@routes.Event.details(event.slug)" class="event-item@if(event.isBookable){ qa-available-event-item}" itemscope itemtype="http://schema.org/Event">
     <meta itemprop="url" content="@event.memUrl">
     <div class="event-item__media" itemprop="image" content="@event.socialImgUrl">
         @fragments.event.image(event, sizes=Some("(min-width: 739px) 33.3vw, (min-width: 479px) 50vw, 100vw"))

--- a/frontend/app/views/fragments/event/itemHero.scala.html
+++ b/frontend/app/views/fragments/event/itemHero.scala.html
@@ -4,7 +4,7 @@
 @import configuration.Config
 @import model.Eventbrite._
 
-<a href="@routes.Event.details(event.slug)" class="event-item event-item--hero" itemscope itemtype="http://schema.org/Event">
+<a href="@routes.Event.details(event.slug)" class="event-item event-item--hero@if(event.isBookable){ qa-available-event-item}" itemscope itemtype="http://schema.org/Event">
     <meta itemprop="url" content="@event.memUrl">
     <div class="event-item__content">
         <div class="event-item__meta">

--- a/frontend/app/views/fragments/event/itemMetaTitle.scala.html
+++ b/frontend/app/views/fragments/event/itemMetaTitle.scala.html
@@ -4,5 +4,5 @@
     @if(event.isSoldOut){
         <span class="event-status event-status--sold-out" data-filter-key="status">Sold out</span>
     }
-    <span itemprop="name" data-filter-key="title">@event.name.text</span>
+    <span itemprop="name" data-filter-key="title" class="qa-event-item-title">@event.name.text</span>
 </h4>

--- a/functional-tests/src/main/scala/com/gu/membership/pages/EventsListPage.scala
+++ b/functional-tests/src/main/scala/com/gu/membership/pages/EventsListPage.scala
@@ -6,21 +6,13 @@ import org.openqa.selenium.{JavascriptExecutor, By, WebDriver, WebElement}
 
 class EventsListPage(driver: WebDriver) extends BaseMembershipPage(driver) {
 
-  private def eventLinkList: util.List[WebElement] = driver.findElements(By.cssSelector(".event-item"))
+  private def eventLinkList: util.List[WebElement] = driver.findElements(By.cssSelector(".qa-available-event-item"))
 
-  private def eventsTitleList: util.List[WebElement] = driver.findElements(By.cssSelector(".event-item__title>span"))
-
-  private def eventsLocationList: util.List[WebElement] = driver.findElements(By.cssSelector(".event-item__location"))
-
-  private def eventsTimeList: util.List[WebElement] = driver.findElements(By.cssSelector(".event-item__time"))
+  private def eventsTitleList: util.List[WebElement] = driver.findElements(By.cssSelector(".qa-event-item-title"))
 
   def getEventTitleByIndex(index: Int): String = eventsTitleList.get(index).getText
 
   def getEventsListSize: Int = eventLinkList.size()
-
-  def getEventLocationByIndex(index: Int): String = eventsLocationList.get(index).getText
-
-  def getEventTimeByIndex(index: Int): String = eventsTimeList.get(index).getText
 
   def clickEventByIndex(index: Int): EventPage = {
     val event = eventLinkList.get(index)
@@ -31,6 +23,6 @@ class EventsListPage(driver: WebDriver) extends BaseMembershipPage(driver) {
   }
 
   def clickAnEvent(): EventPage = {
-    clickEventByIndex(10)
+    clickEventByIndex(3)
   }
 }


### PR DESCRIPTION
Prompted by PR https://github.com/guardian/membership-frontend/pull/310 this PR adds extra `qa-` selectors to available events to avoid James having to constantly change which item is clicked to avoid sold out events.

// @jamesoram 