### PR TITLE
Remove l-side-margins classes

### DIFF
--- a/frontend/app/views/info/about.scala.html
+++ b/frontend/app/views/info/about.scala.html
@@ -7,7 +7,7 @@
 @main("About", pageInfo=pageInfo) {
 
     @* ===== About Membership ===== *@
-    <div class="page-slice l-constrained l-side-margins">
+    <div class="page-slice l-constrained">
         @fragments.promos.promoPrimary(title=Html("About<br>Membership"), imageBasePath="https://media.guim.co.uk/0f30a12f5d00d2b0e445e81c171cd0168d3cf5a7/0_0_1140_684", isLead=true) {
             <div class="text-feature">
                 <p>Guardian Members are changing the idea of what a news organisation does today.</p>
@@ -37,7 +37,7 @@
     </div>
 
     @* ===== Bring the Guardian to life ===== *@
-    <div class="page-slice l-constrained l-side-margins">
+    <div class="page-slice l-constrained">
         @fragments.promos.promoPrimary(title=Html("Guardian Live: Experience the Guardian brought to life"), imageBasePath="https://media.guim.co.uk/76ef58a05920591099012edb80e7415379392a4c/0_0_1140_684", stampImageOpt=Some("images/logos/guardian-live-reversed.svg"), toneClass=Some("tone-trans-guardian-live")) {
             <div class="text-feature">
                 <p>Book tickets for our programme of discussions, debates, interviews, keynote speeches and festivals.</p>
@@ -57,16 +57,14 @@
     </div>
 
     @* ===== Founding Members ===== *@
-    <div class="page-slice l-constrained l-side-margins">
+    <div class="page-slice l-constrained">
         @fragments.promos.promoPrimary(title=Html("Founding members: join us at the start"), imageBasePath="https://media.guim.co.uk/bb922fe62efbe24af2df336dd2b621c5799246b4/0_0_1140_683") {
             <blockquote class="blockquote blockquote--feature">
                 If you read the Guardian, join the Guardian. Support fearless, open, independent journalism.
                 <cite class="blockquote__citation">Polly Toynbee, Guardian columnist</cite>
             </blockquote>
             <p class="text-feature">Join before March 31st to become a Founding Member and the price you pay will not rise.</p>
-            <div class="action-group">
-                <a class="action u-no-top-margin" href="@routes.Joiner.tierList" id="qa-join">Join today</a>
-            </div>
+            <a class="action u-no-top-margin" href="@routes.Joiner.tierList" id="qa-join">Join today</a>
         }
     </div>
 
@@ -89,20 +87,18 @@
     </div>
 
     @* ===== Become a Patron ===== *@
-    <div class="page-slice l-constrained l-side-margins">
+    <div class="page-slice l-constrained">
         @fragments.promos.promoPrimary(title=Html("Become a Patron and support the Guardian's future"), imageBasePath="https://media.guim.co.uk/175fba5c61d2b398973befa5d6b49c1257740d5c/0_0_1140_683", toneClass=Some("tone-trans-brand-dark")) {
             <blockquote class="blockquote blockquote--feature">
                 The only relationship our journalists have is with our readers. Membership gives the real possibility of deepening the intense bond between the producers and consumers of the Guardian.
                 <cite class="blockquote__citation">Alan Rusbridger, editor-in-chief of the Guardian</cite>
             </blockquote>
-            <div class="action-group">
-                <a class="action u-no-top-margin" href="@routes.Info.patron">Become a Patron</a>
-            </div>
+            <a class="action u-no-top-margin" href="@routes.Info.patron">Become a Patron</a>
         }
     </div>
 
     @* ===== What's Included ===== *@
-    <div class="page-slice tone-tint l-side-margins l-constrained" id="whats-included">
+    <div class="page-slice tone-tint l-constrained" id="whats-included">
         <h2 class="page-slice__headline">What's included in Membership</h2>
         <div class="page-slice__content">
             @fragments.tier.packageFeature(Tier.Friend, isReversed=true)

--- a/frontend/app/views/info/patron.scala.html
+++ b/frontend/app/views/info/patron.scala.html
@@ -5,7 +5,7 @@
 @main("Patrons", pageInfo=pageInfo) {
 
     @* ===== About Patronage ===== *@
-    <div class="page-slice l-constrained l-side-margins">
+    <div class="page-slice l-constrained">
         @fragments.promos.promoPrimary(title=Html("Patrons of<br>the Guardian"), imageBasePath="https://media.guim.co.uk/8caacf301dd036a2bbb1b458cf68b637d3c55e48/0_0_1140_683", isLead=true) {
             <div class="text-feature">
                 <p>The Patron tier is for those who care deeply about the Guardian’s journalism and the impact it has on the world.</p>
@@ -16,7 +16,7 @@
     </div>
 
     @* ===== Ensuring our independence ===== *@
-    <div class="page-slice l-constrained l-side-margins">
+    <div class="page-slice l-constrained">
         @fragments.promos.promoPrimary(title=Html("Ensuring our<br>independence"), imageBasePath="https://media.guim.co.uk/e6459f638392c8176e277733f6f0802953100fa4/0_0_1140_683", toneClass=Some("tone-trans-brand-dark")) {
             <div class="text-feature">
                 <p>The Guardian has no proprietor. Our editor has total independence.</p>
@@ -39,7 +39,7 @@
     </div>
 
     @* ===== Get Involved ===== *@
-    <div class="page-slice l-constrained l-side-margins">
+    <div class="page-slice l-constrained">
         @fragments.promos.promoPrimary(title=Html("Choose to get involved"), imageBasePath="https://media.guim.co.uk/d8f51bea15bf046df4d166cfd60771b9c24a631f/0_0_1140_683", toneClass=Some("tone-trans-brand-dark")) {
             <p class="text-feature">Patrons are crucial to the future development of Membership, and there will be opportunities to get involved.  From hosting your own events to connecting members to one another, you will shape the future of the community.</p>
             @fragments.tier.packagePromo(Tier.Patron, showDescription=false, modifierClass=Some("package-promo--spread"))

--- a/frontend/app/views/info/supporters.scala.html
+++ b/frontend/app/views/info/supporters.scala.html
@@ -6,7 +6,7 @@
 @main("Supporters", pageInfo=pageInfo) {
 
     @* ===== About Supporters ===== *@
-    <div class="page-slice l-constrained l-side-margins">
+    <div class="page-slice l-constrained">
         @fragments.promos.promoPrimary(title=Html("Be part of the Guardian"), imageBasePath="https://media.guim.co.uk/a56fc5b2ded2ced952f5fdac62d49d7232128d73/0_0_1140_684", isLead=true) {
             <div class="text-feature">
                 <p>Supporters protect our editorial freedom and help us seek out those stories that people are determined to keep hidden.</p>
@@ -16,7 +16,7 @@
     </div>
 
     @* ===== Ensuring our independence ===== *@
-    <div class="page-slice l-constrained l-side-margins">
+    <div class="page-slice l-constrained">
         @fragments.promos.promoPrimary(title=Html("Ensuring our independence"), imageBasePath="https://media.guim.co.uk/f39c1024643f4860588fbf0b127475b73efa539c/0_0_1140_684", toneClass=Some("tone-trans-brand-dark")) {
             <div class="text-feature">
                 <p>The Guardian has no proprietor. Our editor answers to nobody. Supporters ensure that the Guardian remains an independent voice standing witness to issues that matter without interference.</p>
@@ -25,7 +25,7 @@
     </div>
 
     @* ===== Fuel our journalism ===== *@
-    <div class="page-slice l-constrained l-side-margins">
+    <div class="page-slice l-constrained">
         @fragments.promos.promoPrimary(title=Html("Fuel our journalism"), imageBasePath="https://media.guim.co.uk/8caacf301dd036a2bbb1b458cf68b637d3c55e48/0_0_1140_683", toneClass=Some("tone-trans-brand")) {
             <blockquote class="blockquote blockquote--feature">
                 The only relationship our journalists have is with our readers. Membership gives the real possibility of deepening the intense bond between the producers and consumers of the Guardian.

--- a/frontend/app/views/offer/subscriber.scala.html
+++ b/frontend/app/views/offer/subscriber.scala.html
@@ -7,7 +7,7 @@
     @defining(Benefits.details(Tier.Partner)) { benefits =>
         <main role="main">
 
-            <div class="page-slice page-slice--slim l-constrained l-side-margins">
+            <div class="page-slice page-slice--slim l-constrained">
             @fragments.promos.letterbox(
                 "images/offer/subscriptions/audience-1140.jpg",
                 "Guardian Live Audience",
@@ -88,7 +88,7 @@
                 </div>
             </section>
 
-            <div class="page-slice page-slice--slim l-constrained l-side-margins">
+            <div class="page-slice page-slice--slim l-constrained">
             @fragments.promos.letterbox(
                 "images/offer/subscriptions/guardian-window-1140.jpg",
                 "Guardian logo in window"


### PR DESCRIPTION
We actually don't need the `l-side-margin` classes on individual components yet as we have this class globally on the wrapper container. For now we can remove them.

The double side margins sometimes cause the following issue so this resolves a layout issue too:

![screen shot 2015-03-13 at 11 33 45](https://cloud.githubusercontent.com/assets/123386/6637671/35afdb74-c975-11e4-830a-96a016e2c6b6.png)
