### PR TITLE
Add new fields for Zuora (ready to make a setting update)

### DIFF
--- a/frontend/app/services/zuora/ZuoraActions.scala
+++ b/frontend/app/services/zuora/ZuoraActions.scala
@@ -139,6 +139,7 @@ case class Subscribe(memberId: MemberId, customerOpt: Option[Stripe.Customer], r
           <ns1:Subscription xsi:type="ns2:Subscription">
             <ns2:AutoRenew>true</ns2:AutoRenew>
             <ns2:ContractEffectiveDate>{now}</ns2:ContractEffectiveDate>
+            <ns2:ContractAcceptanceDate>{now}</ns2:ContractAcceptanceDate>
             <ns2:InitialTerm>12</ns2:InitialTerm>
             <ns2:RenewalTerm>12</ns2:RenewalTerm>
             <ns2:TermStartDate>{now}</ns2:TermStartDate>
@@ -166,6 +167,7 @@ case class CancelPlan(subscriptionId: String, subscriptionRatePlanId: String, da
         <ns1:Amendments>
           <ns2:EffectiveDate>{dateStr}</ns2:EffectiveDate>
           <ns2:ContractEffectiveDate>{dateStr}</ns2:ContractEffectiveDate>
+          <ns2:ContractAcceptanceDate>{dateStr}</ns2:ContractAcceptanceDate>
           <ns2:Name>Cancellation</ns2:Name>
           <ns2:RatePlanData>
             <ns1:RatePlan>
@@ -194,6 +196,7 @@ case class DowngradePlan(subscriptionId: String, subscriptionRatePlanId: String,
       <ns1:requests>
         <ns1:Amendments>
           <ns2:ContractEffectiveDate>{dateStr}</ns2:ContractEffectiveDate>
+          <ns2:ContractAcceptanceDate>{dateStr}</ns2:ContractAcceptanceDate>
           <ns2:Name>Downgrade</ns2:Name>
           <ns2:RatePlanData>
             <ns1:RatePlan>
@@ -207,6 +210,7 @@ case class DowngradePlan(subscriptionId: String, subscriptionRatePlanId: String,
         </ns1:Amendments>
         <ns1:Amendments>
           <ns2:ContractEffectiveDate>{dateStr}</ns2:ContractEffectiveDate>
+          <ns2:ContractAcceptanceDate>{dateStr}</ns2:ContractAcceptanceDate>
           <ns2:Name>Downgrade</ns2:Name>
           <ns2:RatePlanData>
             <ns1:RatePlan>
@@ -242,6 +246,7 @@ case class UpgradePlan(subscriptionId: String, subscriptionRatePlanId: String, n
       <ns1:requests>
         <ns1:Amendments>
           <ns2:ContractEffectiveDate>{dateStr}</ns2:ContractEffectiveDate>
+          <ns2:ContractAcceptanceDate>{dateStr}</ns2:ContractAcceptanceDate>
           <ns2:Name>Upgrade</ns2:Name>
           <ns2:RatePlanData>
             <ns1:RatePlan>
@@ -255,6 +260,7 @@ case class UpgradePlan(subscriptionId: String, subscriptionRatePlanId: String, n
         </ns1:Amendments>
         <ns1:Amendments>
           <ns2:ContractEffectiveDate>{dateStr}</ns2:ContractEffectiveDate>
+          <ns2:ContractAcceptanceDate>{dateStr}</ns2:ContractAcceptanceDate>
           <ns2:EffectiveDate>{dateStr}</ns2:EffectiveDate>
           <ns2:Name>Upgrade</ns2:Name>
           <ns2:Status>Completed</ns2:Status>
@@ -264,6 +270,7 @@ case class UpgradePlan(subscriptionId: String, subscriptionRatePlanId: String, n
         </ns1:Amendments>
         <ns1:Amendments>
           <ns2:ContractEffectiveDate>{dateStr}</ns2:ContractEffectiveDate>
+          <ns2:ContractAcceptanceDate>{dateStr}</ns2:ContractAcceptanceDate>
           <ns2:Name>Upgrade</ns2:Name>
           <ns2:RatePlanData>
             <ns1:RatePlan>

--- a/frontend/app/services/zuora/ZuoraActions.scala
+++ b/frontend/app/services/zuora/ZuoraActions.scala
@@ -167,7 +167,7 @@ case class CancelPlan(subscriptionId: String, subscriptionRatePlanId: String, da
         <ns1:Amendments>
           <ns2:EffectiveDate>{dateStr}</ns2:EffectiveDate>
           <ns2:ContractEffectiveDate>{dateStr}</ns2:ContractEffectiveDate>
-          <ns2:ContractAcceptanceDate>{dateStr}</ns2:ContractAcceptanceDate>
+          <ns2:CustomerAcceptanceDate>{dateStr}</ns2:CustomerAcceptanceDate>
           <ns2:Name>Cancellation</ns2:Name>
           <ns2:RatePlanData>
             <ns1:RatePlan>
@@ -196,7 +196,7 @@ case class DowngradePlan(subscriptionId: String, subscriptionRatePlanId: String,
       <ns1:requests>
         <ns1:Amendments>
           <ns2:ContractEffectiveDate>{dateStr}</ns2:ContractEffectiveDate>
-          <ns2:ContractAcceptanceDate>{dateStr}</ns2:ContractAcceptanceDate>
+          <ns2:CustomerAcceptanceDate>{dateStr}</ns2:CustomerAcceptanceDate>
           <ns2:Name>Downgrade</ns2:Name>
           <ns2:RatePlanData>
             <ns1:RatePlan>
@@ -210,7 +210,7 @@ case class DowngradePlan(subscriptionId: String, subscriptionRatePlanId: String,
         </ns1:Amendments>
         <ns1:Amendments>
           <ns2:ContractEffectiveDate>{dateStr}</ns2:ContractEffectiveDate>
-          <ns2:ContractAcceptanceDate>{dateStr}</ns2:ContractAcceptanceDate>
+          <ns2:CustomerAcceptanceDate>{dateStr}</ns2:CustomerAcceptanceDate>
           <ns2:Name>Downgrade</ns2:Name>
           <ns2:RatePlanData>
             <ns1:RatePlan>
@@ -246,7 +246,7 @@ case class UpgradePlan(subscriptionId: String, subscriptionRatePlanId: String, n
       <ns1:requests>
         <ns1:Amendments>
           <ns2:ContractEffectiveDate>{dateStr}</ns2:ContractEffectiveDate>
-          <ns2:ContractAcceptanceDate>{dateStr}</ns2:ContractAcceptanceDate>
+          <ns2:CustomerAcceptanceDate>{dateStr}</ns2:CustomerAcceptanceDate>
           <ns2:Name>Upgrade</ns2:Name>
           <ns2:RatePlanData>
             <ns1:RatePlan>
@@ -260,7 +260,7 @@ case class UpgradePlan(subscriptionId: String, subscriptionRatePlanId: String, n
         </ns1:Amendments>
         <ns1:Amendments>
           <ns2:ContractEffectiveDate>{dateStr}</ns2:ContractEffectiveDate>
-          <ns2:ContractAcceptanceDate>{dateStr}</ns2:ContractAcceptanceDate>
+          <ns2:CustomerAcceptanceDate>{dateStr}</ns2:CustomerAcceptanceDate>
           <ns2:EffectiveDate>{dateStr}</ns2:EffectiveDate>
           <ns2:Name>Upgrade</ns2:Name>
           <ns2:Status>Completed</ns2:Status>
@@ -270,7 +270,7 @@ case class UpgradePlan(subscriptionId: String, subscriptionRatePlanId: String, n
         </ns1:Amendments>
         <ns1:Amendments>
           <ns2:ContractEffectiveDate>{dateStr}</ns2:ContractEffectiveDate>
-          <ns2:ContractAcceptanceDate>{dateStr}</ns2:ContractAcceptanceDate>
+          <ns2:CustomerAcceptanceDate>{dateStr}</ns2:CustomerAcceptanceDate>
           <ns2:Name>Upgrade</ns2:Name>
           <ns2:RatePlanData>
             <ns1:RatePlan>


### PR DESCRIPTION
In order for subscribers to get a specific rate plan we need to enable a setting change in the Zuora console. This setting change will requires us to pass new fields for all subscriptions. Existing subscriptions will be unaffected but new subscriptions and amendments to all subscriptions will be affected by this setting change. We can start passing the required fields before we make the setting change. They will be ignored until the setting change comes into affect. 

For Subscribe calls to Zuora the new field is called `ContractAcceptanceDate`. For Amend (upgrades, downgrades and cancellations) the new field is called `CustomerAcceptanceDate`. Sadly this has taken me the best part of a week to figure out, I need :cake:.

@jamesoram I've tested this with dev environment with both the setting change off and on and things seem to work fine. I've spoken to Jason Burr about the compabitility testing for this and we're meeting on Monday. In the meantime if you are able to test this, we just need to check all flows work as expected with the setting change off.

@rtyley does the above explanation make sense in terms of how we want to manage the change?