### PR TITLE
Respect Guardian Style for displaying times

### DIFF
--- a/frontend/app/views/support/Dates.scala
+++ b/frontend/app/views/support/Dates.scala
@@ -26,7 +26,7 @@ object Dates {
   }
 
   def prettyDate(dt: DateTime): String = dt.toString("d MMMMM YYYY")
-  def prettyTime(dt: DateTime): String = dt.toString("h:mm") + dt.toString("a").toLowerCase
+  def prettyTime(dt: DateTime): String = dt.toString(if (dt.getMinuteOfHour==0) "h" else "h.mm") + dt.toString("a").toLowerCase
 
   def prettyDateWithTime(dt: DateTime): String = prettyDate(dt) + ", " + prettyTime(dt)
 

--- a/frontend/test/views/support/DatesTest.scala
+++ b/frontend/test/views/support/DatesTest.scala
@@ -5,10 +5,21 @@ import org.specs2.mutable.Specification
 
 class DatesTest extends Specification {
   "dateRange" should {
+    "respect Guardian style: 1am, 6.30pm, etc" in {
+      Dates.prettyTime(new DateTime(2015, 3, 22,  1,  0)) mustEqual "1am"
+      Dates.prettyTime(new DateTime(2015, 3, 22, 18, 30)) mustEqual "6.30pm"
+    }
+
+    "respect Guardian style on date ranges" in {
+      val dt1 = new DateTime(2015, 3, 22, 14, 45)
+      val dt2 = new DateTime(2015, 3, 22, 17,  0)
+      Dates.dateRange(dt1, dt2) mustEqual Dates.Range("Sunday 22 March 2015, 2.45pm", "5pm")
+    }
+
     "merge date if both dates are on the same day" in {
       val dt1 = new DateTime(2014, 11, 6, 10, 20)
       val dt2 = new DateTime(2014, 11, 6, 12, 30)
-      Dates.dateRange(dt1, dt2) mustEqual Dates.Range("Thursday 6 November 2014, 10:20am", "12:30pm")
+      Dates.dateRange(dt1, dt2) mustEqual Dates.Range("Thursday 6 November 2014, 10.20am", "12.30pm")
     }
 
     "merge month and year if both are the same" in {


### PR DESCRIPTION
http://www.theguardian.com/guardian-observer-style-guide-t

    times: 1am, 6.30pm, etc

So we display times like this:

![image](https://cloud.githubusercontent.com/assets/52038/6640125/44422990-c98d-11e4-83fb-f5634866bf5b.png)

...and this...

![image](https://cloud.githubusercontent.com/assets/52038/6640100/157dc452-c98d-11e4-8e44-18edd869a142.png)

Note the `.`, not `:` between the hour and the minute - that's _Guardian_ style :-)