### PR TITLE
Take out quizzes form offers and comps

### DIFF
--- a/frontend/app/services/GuardianContentService.scala
+++ b/frontend/app/services/GuardianContentService.scala
@@ -115,7 +115,7 @@ trait GuardianContent {
       .showTags("all")
       .pageSize(100)
       .page(page)
-      .tag("type/quiz | tone/extraoffers")
+      .tag("tone/extraoffers")
     //todo: filter response for member access flag
     client.getResponse(itemQuery).andThen {
       case Failure(GuardianContentApiError(status, message)) =>

--- a/frontend/app/views/offer/offersandcomps.scala.html
+++ b/frontend/app/views/offer/offersandcomps.scala.html
@@ -5,9 +5,9 @@
         <section class="listing-header">
             <h1 class="listing-headline">Offers and competitions</h1>
         </section>
-        <section class="listing listing--lead listing--padded">
+        <section class="listing listing--padded">
             <div class="listing__lead-in">
-                <h3 class="listing__title h-intro">most recent</h3>
+                <h3 class="h-intro">most recent</h3>
             </div>
             <div class="listing__content">
             @if(membersOnlyContent.isEmpty) {


### PR DESCRIPTION
- remove quizzes from CAPI query
- make blue line go across the page

![offers competitions the guardian membership](https://cloud.githubusercontent.com/assets/2305016/6669685/1faa1df6-cbf2-11e4-8b7e-40157e5b7c7c.png)
