### PR TITLE
Skip change tier for existing members

### DIFF
--- a/frontend/app/actions/CommonActions.scala
+++ b/frontend/app/actions/CommonActions.scala
@@ -3,6 +3,7 @@ package actions
 import actions.Fallbacks._
 import actions.Functions._
 import com.gu.googleauth
+import com.gu.membership.salesforce.Tier
 import configuration.Config
 import controllers._
 import play.api.http.HeaderNames._
@@ -36,6 +37,8 @@ trait CommonActions {
   val AuthenticatedAction = NoCacheAction andThen authenticated()
 
   val AuthenticatedNonMemberAction = AuthenticatedAction andThen onlyNonMemberFilter()
+
+  def AuthenticatedNonMemberWithKnownTierChangeAction(tier: Tier) = AuthenticatedAction andThen onlyNonMemberFilter(onPaidMember = result => tierChangeEnterDetails(tier)(result))
 
   val GoogleAuthAction: ActionBuilder[GoogleAuthRequest] = OAuthActions.AuthAction
 

--- a/frontend/app/actions/Fallbacks.scala
+++ b/frontend/app/actions/Fallbacks.scala
@@ -1,5 +1,6 @@
 package actions
 
+import com.gu.membership.salesforce.Tier
 import play.api.mvc.Results._
 import play.api.mvc.{Call, RequestHeader}
 import play.twirl.api.Html
@@ -8,6 +9,9 @@ import play.twirl.api.Html
 object Fallbacks {
 
   def changeTier(implicit req: RequestHeader) = redirectTo(controllers.routes.TierController.change())
+
+  def tierChangeEnterDetails(tier: Tier)(implicit req: RequestHeader) =
+    redirectTo(controllers.routes.TierController.upgrade(tier))
 
   def notYetAMemberOn(implicit request: RequestHeader) =
     redirectTo(controllers.routes.Joiner.tierChooser()).addingToSession("preJoinReturnUrl" -> request.uri)

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -63,7 +63,7 @@ trait Joiner extends Controller with ActivityTracking {
     }
   }
 
-  def enterDetails(tier: Tier) = (secureHiddenTiers(tier) andThen AuthenticatedNonMemberAction).async { implicit request =>
+  def enterDetails(tier: Tier) = (secureHiddenTiers(tier) andThen AuthenticatedNonMemberWithKnownTierChangeAction(tier)).async { implicit request =>
     for {
       (privateFields, marketingChoices, passwordExists) <- identityDetails(request.user, request)
     } yield {


### PR DESCRIPTION
For members who click buttons to enter details page for a tier, skip the change/tier page and redirect them to the upgrade route with tier (`tier/change/:tier`). 

This is required for the supporter page where the benefits are not included on the `change/tier` page but we supply a link to the `join/supporter/enter-details`. 

This is also useful on the existing about/patrons which contains `/join/patron/enter-details` and on the `join` page.

@rtyley Please could you sanity check the action (including the naming!)