### PR TITLE
Add asset size monitoring script

### DIFF
--- a/frontend/asset-size.sh
+++ b/frontend/asset-size.sh
@@ -7,8 +7,8 @@ for stylesheet in ${STYLESHEETS[@]}; do
     size=`cat $stylesheet | wc -c`
     gzip_size=`gzip -c $stylesheet | wc -c`
 
-    aws cloudwatch put-metric-data --namespace TestGlob --metric-name $name --dimensions "Compression=None" --value $size
-    aws cloudwatch put-metric-data --namespace TestGlob --metric-name $name --dimensions "Compression=Gzip" --value $gzip_size
+    aws cloudwatch put-metric-data --namespace Assets --metric-name $name --dimensions "Compression=None" --value $size
+    aws cloudwatch put-metric-data --namespace Assets --metric-name $name --dimensions "Compression=Gzip" --value $gzip_size
 done
 
 JAVASCRIPTS=("public/dist/javascripts/*/*.js")
@@ -18,6 +18,6 @@ for javascript in ${JAVASCRIPTS[@]}; do
     size=`cat $javascript | wc -c`
     gzip_size=`gzip -c $javascript | wc -c`
 
-    aws cloudwatch put-metric-data --namespace TestGlob --metric-name $name --dimensions "Compression=None" --value $size
-    aws cloudwatch put-metric-data --namespace TestGlob --metric-name $name --dimensions "Compression=Gzip" --value $gzip_size
+    aws cloudwatch put-metric-data --namespace Assets --metric-name $name --dimensions "Compression=None" --value $size
+    aws cloudwatch put-metric-data --namespace Assets --metric-name $name --dimensions "Compression=Gzip" --value $gzip_size
 done

--- a/frontend/asset-size.sh
+++ b/frontend/asset-size.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+STYLESHEETS=("public/dist/stylesheets/**/*.css")
+
+for stylesheet in ${STYLESHEETS[@]}; do
+    name=`basename $stylesheet`
+    size=`cat $stylesheet | wc -c`
+    gzip_size=`gzip -c $stylesheet | wc -c`
+
+    aws cloudwatch put-metric-data --namespace TestGlob --metric-name $name --dimensions "Compression=None" --value $size
+    aws cloudwatch put-metric-data --namespace TestGlob --metric-name $name --dimensions "Compression=Gzip" --value $gzip_size
+done
+
+JAVASCRIPTS=("public/dist/javascripts/*/*.js")
+
+for javascript in ${JAVASCRIPTS[@]}; do
+    name=`basename $javascript`
+    size=`cat $javascript | wc -c`
+    gzip_size=`gzip -c $javascript | wc -c`
+
+    aws cloudwatch put-metric-data --namespace TestGlob --metric-name $name --dimensions "Compression=None" --value $size
+    aws cloudwatch put-metric-data --namespace TestGlob --metric-name $name --dimensions "Compression=Gzip" --value $gzip_size
+done

--- a/project/PlayArtifact.scala
+++ b/project/PlayArtifact.scala
@@ -14,7 +14,8 @@ object PlayArtifact extends Plugin {
 
     playArtifactResources := Seq(
       dist.value -> s"packages/${magentaPackageName.value}/app.zip",
-      baseDirectory.value / "conf" / "deploy.json" -> "deploy.json"
+      baseDirectory.value / "conf" / "deploy.json" -> "deploy.json",
+      baseDirectory.value / "asset-size.sh" -> "asset-size.sh"
     ),
 
     playArtifactFile := "artifacts.zip",

--- a/project/PlayArtifact.scala
+++ b/project/PlayArtifact.scala
@@ -14,8 +14,7 @@ object PlayArtifact extends Plugin {
 
     playArtifactResources := Seq(
       dist.value -> s"packages/${magentaPackageName.value}/app.zip",
-      baseDirectory.value / "conf" / "deploy.json" -> "deploy.json",
-      baseDirectory.value / "asset-size.sh" -> "asset-size.sh"
+      baseDirectory.value / "conf" / "deploy.json" -> "deploy.json"
     ),
 
     playArtifactFile := "artifacts.zip",


### PR DESCRIPTION
This PR is an attempt to track the size of our CSS and JS so we can monitor if they get too large. The current approach was something @wpf500 help me put together several weeks ago, thought I'd actually try and finish it off.

I think the general approach was to run a shell script when new boxes start up as we only want to log asset sizes a) for PROD and b) when assets actually change. The one thing I'm not clear on is how to actually run the script as part of the deploy process.

@rtyley I'd appreciate your :eyes: on this, there's probably a number of different ways to log the asset size so if you think there is a better way I'm all :ear:s