### PR TITLE
add membership.team@guardian.co.uk to test users OAuth

### DIFF
--- a/frontend/app/controllers/Testing.scala
+++ b/frontend/app/controllers/Testing.scala
@@ -11,7 +11,7 @@ object Testing extends Controller with LazyLogging {
   val analyticsOffCookie = Cookie("ANALYTICS_OFF_KEY", "true", httpOnly = false)
 
   val AuthorisedTester = GoogleAuthenticatedStaffAction andThen isInAuthorisedGroupGoogleAuthReq(
-    Set("membership.dev@guardian.co.uk", "touchpoint@guardian.co.uk"),
+    Set("membership.dev@guardian.co.uk", "touchpoint@guardian.co.uk", "membership.team@guardian.co.uk"),
       views.html.fragments.oauth.staffWrongGroup())
 
   def testUser = AuthorisedTester { implicit request =>


### PR DESCRIPTION
This is to enable eden access to ```https://membership.theguardian.com/test-users```


cc @rtyley 