### PR TITLE
Abstract images/metadata out into ResponsiveImageGroup object

### DIFF
--- a/frontend/app/controllers/FrontPage.scala
+++ b/frontend/app/controllers/FrontPage.scala
@@ -8,7 +8,7 @@ trait FrontPage extends Controller {
   def index = CachedAction { implicit request =>
 
     val slideShowImages = Seq(
-      ResponsiveImageGroup(altText="Guardian Live event: Pussy Riot - art, sex and disobedience",
+      ResponsiveImageGroup(altText=Some("Guardian Live event: Pussy Riot - art, sex and disobedience"),
         availableImages = Seq(
           ResponsiveImage(
             path="https://media.guim.co.uk/eab86e9c81414932e0d50a1cd609dccfc20ca5d2/0_0_2279_1368/2000.jpg",
@@ -24,7 +24,7 @@ trait FrontPage extends Controller {
           )
         )
       ),
-      ResponsiveImageGroup(altText="Guardian Live with Russell Brand",
+      ResponsiveImageGroup(altText=Some("Guardian Live with Russell Brand"),
         availableImages = Seq(
           ResponsiveImage(
             path="https://media.guim.co.uk/da867c363957d748bd04cfd9d4890033203a58c6/0_0_2279_1368/2000.jpg",
@@ -40,7 +40,7 @@ trait FrontPage extends Controller {
           )
         )
       ),
-      ResponsiveImageGroup(altText="A life in music: Jimmy Page",
+      ResponsiveImageGroup(altText=Some("A life in music: Jimmy Page"),
         availableImages = Seq(
           ResponsiveImage(
             path="https://media.guim.co.uk/733834b0b9f84e4367cf676919008bfd88007f25/0_0_2279_1368/2000.jpg",
@@ -56,7 +56,7 @@ trait FrontPage extends Controller {
           )
         )
       ),
-      ResponsiveImageGroup(altText="Guardian Live with Russell Brand",
+      ResponsiveImageGroup(altText=Some("Guardian Live with Russell Brand"),
         availableImages = Seq(
           ResponsiveImage(
             path="https://media.guim.co.uk/e736acb945406974844bea77ca49b2c1e450013e/0_0_2279_1368/2000.jpg",
@@ -72,7 +72,7 @@ trait FrontPage extends Controller {
           )
         )
       ),
-      ResponsiveImageGroup(altText="Observer Ideas - Stories that inspire: Tinie Tempah",
+      ResponsiveImageGroup(altText=Some("Observer Ideas - Stories that inspire: Tinie Tempah"),
         availableImages = Seq(
           ResponsiveImage(
             path="https://media.guim.co.uk/1e687530a52ef14cd9c1eacb1e8757600c382f86/0_0_2279_1368/2000.jpg",
@@ -88,7 +88,7 @@ trait FrontPage extends Controller {
           )
         )
       ),
-      ResponsiveImageGroup(altText="Guardian Live event: Vivienne Westwood",
+      ResponsiveImageGroup(altText=Some("Guardian Live event: Vivienne Westwood"),
         availableImages = Seq(
           ResponsiveImage(
             path="https://media.guim.co.uk/85d46476d07fb744327c60a4c5117a7ddc2796d0/0_0_2279_1368/2000.jpg",

--- a/frontend/app/model/MembersOnlyContent.scala
+++ b/frontend/app/model/MembersOnlyContent.scala
@@ -1,21 +1,9 @@
 package model
 
-import com.gu.contentapi.client.model.{Asset, Content}
+import com.gu.contentapi.client.model.Content
 
 case class MembersOnlyContent(content: Content) {
-  val elementOpt = content.elements.flatMap(_.find(_.relation == "main"))
-  val imgOpt = elementOpt.flatMap { element =>
-    Some(ResponsiveImageGroup(
-      None,
-      element.assets.headOption.flatMap(_.typeData.get("altText")).fold("")(a => a),
-      element.assets.flatMap { asset =>
-        for {
-         secureFile <- asset.file.map(_.replace("http://static", "https://static-secure"))
-         width <- asset.typeData.get("width")
-        } yield ResponsiveImage(secureFile, width.toInt)
-      }
-    ))
-  }
+  val imgOpt = ResponsiveImageGroup(content)
   val tagTitle = content.tags.map { tag =>
     tag.id.toLowerCase match {
       case "type/quiz" | "tone/extraoffers" => tag.webTitle

--- a/frontend/app/services/GridService.scala
+++ b/frontend/app/services/GridService.scala
@@ -9,7 +9,7 @@ import com.typesafe.scalalogging.slf4j.LazyLogging
 import configuration.Config
 import model.Grid._
 import model.GridDeserializer._
-import model.RichEvent.EventImage
+import model.RichEvent.GridImage
 import monitoring.GridApiMetrics
 import play.api.libs.ws.WSRequestHolder
 
@@ -18,7 +18,7 @@ import scala.concurrent.Future
 
 case class GridService(gridUrl: String) extends WebServiceHelper[GridObject, Error] with LazyLogging{
 
-  lazy val agent = Agent[Map[Uri, EventImage]](Map.empty)
+  lazy val agent = Agent[Map[Uri, GridImage]](Map.empty)
 
   def isUrlCorrectFormat(url: Uri) = url.toString.startsWith(gridUrl)
 
@@ -26,7 +26,7 @@ case class GridService(gridUrl: String) extends WebServiceHelper[GridObject, Err
 
   def cropParam(url: Uri) = url.query.param("crop")
 
-  def getRequestedCrop(url: Uri) : Future[Option[EventImage]] = {
+  def getRequestedCrop(url: Uri) : Future[Option[GridImage]] = {
     val currentImageData = agent.get()
     if(currentImageData.contains(url)) Future.successful(currentImageData.get(url))
     else {
@@ -35,7 +35,7 @@ case class GridService(gridUrl: String) extends WebServiceHelper[GridObject, Err
           grid <- gridOpt
           exports <- grid.data.exports
         } yield {
-          val image = EventImage(findAssets(exports, cropParam(url)), grid.data.metadata)
+          val image = GridImage(findAssets(exports, cropParam(url)), grid.data.metadata)
           agent send {
             oldImageData =>
               val newImageData = oldImageData + (url -> image)

--- a/frontend/app/services/MasterclassDataExtractor.scala
+++ b/frontend/app/services/MasterclassDataExtractor.scala
@@ -1,11 +1,12 @@
 package services
 
 import com.gu.contentapi.client.model.{Asset, Content}
+import model.ResponsiveImageGroup
 
 import scala.util.matching.Regex
 
 //todo refactor this to use Content and not webUrl and images
-case class MasterclassData(eventId: String, webUrl: String, images: List[Asset])
+case class MasterclassData(eventId: String, webUrl: String, images: Option[ResponsiveImageGroup])
 
 object MasterclassDataExtractor {
 
@@ -13,16 +14,13 @@ object MasterclassDataExtractor {
   val regex = new Regex(eventbriteUrl)
 
   def extractEventbriteInformation(content: Content): Seq[MasterclassData] = {
-    val elementOpt = content.elements.flatMap(_.find(_.relation == "main"))
-    val assets = elementOpt.map(_.assets).getOrElse(List.empty)
-
     val eventbriteIdsFromRefs =
       content.references.filter(_.`type` == "eventbrite").map(_.id.stripPrefix("eventbrite/"))
 
     val eventbriteIds =
       if (eventbriteIdsFromRefs.nonEmpty) eventbriteIdsFromRefs else scrapeEventbriteIdsFrom(content)
 
-    eventbriteIds.map(eventId => MasterclassData(eventId, content.webUrl, assets))
+    eventbriteIds.map(eventId => MasterclassData(eventId, content.webUrl, ResponsiveImageGroup(content)))
   }
 
   def scrapeEventbriteIdsFrom(content: Content): Seq[String] = for {

--- a/frontend/app/views/event/page.scala.html
+++ b/frontend/app/views/event/page.scala.html
@@ -87,15 +87,19 @@
         @if(event.metadata.largeImg) {
             @for(img <- event.imgOpt) {
                 <div class="event-content__image">
-                    @fragments.event.image(event, lazyLoad=false)
+                    <img src="@img.defaultImage" srcset="@img.srcset" sizes="100vw" alt="@img.altText" class="responsive-img" itemprop="image" />
                 </div>
-                <div class="event-image-credit u-event-content-width">
-                    <div class="event-image-credit__detail">
-                        @fragments.inlineIcon("caption-camera")
-                        <span class="u-align-middle">@event.imageMetadata.flatMap(_.description)</span>
-                        <span class="u-align-middle">Photograph: @event.imageMetadata.map(_.photographer)</span>
+                @for(imgMetadata <- img.metadata) {
+                    <div class="event-image-credit u-event-content-width">
+                        <div class="event-image-credit__detail">
+                            @fragments.inlineIcon("caption-camera")
+                            @for(imgDescription <- imgMetadata.description) {
+                                <span class="u-align-middle">@imgDescription</span>
+                            }
+                            <span class="u-align-middle">Photograph: @imgMetadata.photographer</span>
+                        </div>
                     </div>
-                </div>
+                }
             }
         }
 
@@ -118,6 +122,7 @@
                 @if(event.isPastEvent) {
                     @fragments.event.relatedEntry(event)
                 }
+
 
                 @if(!event.metadata.largeImg) {
                     @for(img <- event.imgOpt) {

--- a/frontend/app/views/fragments/media/slideshowItem.scala.html
+++ b/frontend/app/views/fragments/media/slideshowItem.scala.html
@@ -1,5 +1,4 @@
-@(imgGroup: model.ResponsiveImageGroup, description: String)
-
+@(imgGroup: model.ResponsiveImageGroup, descriptionOpt: Option[String])
 
 <figure class="slideshow__element js-slideshow-item">
     <figcaption class="slideshow__detail">
@@ -8,7 +7,9 @@
             <span class="progress-indicator__separator">/ </span>
             <span class="progress-indicator__count js-slideshow-total"></span>
         </div>
-        <div class="slideshow__description">@description</div>
+        @for(description <- descriptionOpt) {
+            <div class="slideshow__description">@description</div>
+        }
     </figcaption>
     <img
         alt="@imgGroup.altText"

--- a/frontend/test/model/GuLiveEventTest.scala
+++ b/frontend/test/model/GuLiveEventTest.scala
@@ -3,7 +3,7 @@ package model
 import model.EventbriteTestObjects._
 import model.Grid.{GridResult, Metadata}
 import model.GridDeserializer._
-import model.RichEvent.{GuLiveEvent, EventImage}
+import model.RichEvent.{GuLiveEvent, GridImage}
 import org.specs2.mock.Mockito
 import play.api.test.PlaySpecification
 import utils.Resource
@@ -18,7 +18,7 @@ class GuLiveEventTest extends PlaySpecification with Mockito {
 
     "contain metadata and socialUrl for an event image" in {
 
-      val image = EventImage(gridResponse.data.exports.get(1).assets, gridResponse.data.metadata)
+      val image = GridImage(gridResponse.data.exports.get(1).assets, gridResponse.data.metadata)
       val guEvent = GuLiveEvent(event, Some(image), None)
 
       guEvent.imageMetadata.flatMap(_.description) mustEqual Some("It's Chris!")

--- a/frontend/test/model/GuLiveEventTest.scala
+++ b/frontend/test/model/GuLiveEventTest.scala
@@ -21,8 +21,8 @@ class GuLiveEventTest extends PlaySpecification with Mockito {
       val image = GridImage(gridResponse.data.exports.get(1).assets, gridResponse.data.metadata)
       val guEvent = GuLiveEvent(event, Some(image), None)
 
-      guEvent.imageMetadata.flatMap(_.description) mustEqual Some("It's Chris!")
-      guEvent.imageMetadata.map(_.photographer) mustEqual Some("Joe Bloggs/Guardian Images")
+      guEvent.imgOpt.flatMap(_.metadata.flatMap(_.description)) mustEqual Some("It's Chris!")
+      guEvent.imgOpt.flatMap(_.metadata.map(_.photographer)) mustEqual Some("Joe Bloggs/Guardian Images")
 
       guEvent.socialImgUrl.get mustEqual "http://some-media-thing/aede0da05506d0d8cb993558b7eb9ad1d2d3e675/0_130_1703_1022/500.jpg"
     }

--- a/frontend/test/model/ResponsiveImageTest.scala
+++ b/frontend/test/model/ResponsiveImageTest.scala
@@ -8,7 +8,7 @@ class ResponsiveImageTest extends PlaySpecification {
 
     "generate a src and srcset information for a sequence of images" in {
 
-      val imageGroup = ResponsiveImageGroup(altText="Guardian Live event: Pussy Riot - art, sex and disobedience",
+      val imageGroup = ResponsiveImageGroup(altText=Some("Guardian Live event: Pussy Riot - art, sex and disobedience"),
         availableImages = Seq(
           ResponsiveImage(
             path="https://media.guim.co.uk/eab86e9c81414932e0d50a1cd609dccfc20ca5d2/0_0_2279_1368/1000.jpg",

--- a/frontend/test/services/MasterclassDataExtractorTest.scala
+++ b/frontend/test/services/MasterclassDataExtractorTest.scala
@@ -38,8 +38,6 @@ class MasterclassDataExtractorTest extends Specification {
       val masterclassContent = masterclassesContent(0)
       masterclassContent.eventId mustEqual("13906168725")
       masterclassContent.webUrl mustEqual("writing-gu-url")
-      masterclassContent.images.size mustEqual(2)
-      masterclassContent.images.flatMap(_.file) must contain(exactly("main-image-file-location-1", "main-image-file-location-2"))
     }
 
     "create multiple masterclass content for multiple eventbrite urls" in {
@@ -51,7 +49,6 @@ class MasterclassDataExtractorTest extends Specification {
       masterclassesContent.size mustEqual(2)
       masterclassesContent.map(_.eventId) must contain(exactly("13906168725", "1234"))
       masterclassesContent.map(_.webUrl) must contain(exactly("writing-gu-url", "writing-gu-url"))
-      masterclassesContent.flatMap(_.images.flatMap(_.file)) must contain(exactly("main-image-file-location-1", "main-image-file-location-2", "main-image-file-location-1", "main-image-file-location-2"))
 
     }
 
@@ -78,11 +75,5 @@ class MasterclassDataExtractorTest extends Specification {
       masterclassesContent.size mustEqual(0)
     }
 
-    "create a masterclass with empty asset list if no main element is found" in {
-      val itemWithNoMainElement = item.copy(elements = Some(List(thumbnailElement)))
-      val masterclassesContent = extractEventbriteInformation(itemWithNoMainElement)
-
-      masterclassesContent(0).images must be(List())
-    }
   }
 }


### PR DESCRIPTION
Removes duplication from `RichEvent` and `MembersOnlyContent` so that the generation of `ResponsiveImageGroups` is centralised for Grid and CAPI images.

![screen shot 2015-03-18 at 15 28 35](https://cloud.githubusercontent.com/assets/123386/6712415/504224d4-cd84-11e4-8a47-1deda1e6369e.png)

![screen shot 2015-03-18 at 15 28 44](https://cloud.githubusercontent.com/assets/123386/6712421/536b4dde-cd84-11e4-8714-a470814fd9a3.png)

@feedmypixel This now leaves `MembersOnlyContent` being pretty light so might be worth having a quick chat about how we use it.

/cc @rtyley 