### PR TITLE
Youtube verification meta tag

### DIFF
--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -151,6 +151,8 @@ object Config {
 
   val googleAnalyticsTrackingId = config.getString("google.analytics.tracking.id")
 
+  val youtubeMembershipVerificationId = config.getString("youtube.membership.verification.id")
+
   val facebookJoinerConversionTrackingId =
     Tier.allPublic.map { tier => tier -> config.getString(s"facebook.joiner.conversion.${tier.slug}") }.toMap
 

--- a/frontend/app/views/main.scala.html
+++ b/frontend/app/views/main.scala.html
@@ -29,6 +29,7 @@
         <meta property="fb:app_id" content="@Config.facebookAppId"/>
         <meta name="twitter:site" content="@@@Config.twitterUsername"/>
         <meta name="twitter:card" content="summary"/>
+        <meta name="google-site-verification" content="@Config.youtubeMembershipVerificationId"/>
 
         <title>@(title + " | " + Config.siteTitle )</title>
         @fragments.javaScriptFirstSteps(pageInfo)

--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -57,6 +57,8 @@ membership.home.images.ratios=[1]
 
 twitter.username="gdnmembership"
 
+youtube.membership.verification.id="On5TdND1ogf_N5wl1yln5CQ2G78A_mYrwWFl4W64HY0"
+
 stripe.api.url="https://api.stripe.com/v1"
 
 # Touchpoint-backend environment-specific information


### PR DESCRIPTION
We have had a request from the Guardian Membership YouTube team to allow us to google verify their account against our site. They are keen to show slides/extra video on their YouTube channel before live streams.

- add Guardian Membership YouTube google verification code to config
- add meta tag in main