### PR TITLE
add in tier name for omniture hooks

### DIFF
--- a/frontend/app/views/joiner/thankyou.scala.html
+++ b/frontend/app/views/joiner/thankyou.scala.html
@@ -19,7 +19,13 @@
     event.ticket_classes.length * ticketHeight + iframeChrome
 }
 
-@title = @{ if (upgrade) "Thank you for upgrading" else "Thank you | " + member.tier.name }
+@title = @{
+    if(upgrade) {
+        s"Thank you for upgrading | ${member.tier.name}"
+    } else {
+        s"Thank you | ${member.tier.name}"
+    }
+}
 
 @pageHeader = @{
     if(upgrade) {


### PR DESCRIPTION
This changes the page title on ```/tier/change/<tier>/summary``` to include the Tier. This is to enable Omniture tracking.

The page title will now be

```Thank you for upgrading | <tier> | The Guardian Membership```