### PR TITLE
Do not send test user stats to tracking tool

### DIFF
--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -147,7 +147,7 @@ trait Joiner extends Controller with ActivityTracking {
         } {
           event.service.wsMetrics.put(s"join-$tier-event", 1)
           val memberData = MemberData(member.salesforceContactId, request.user.id, tier.name)
-          track(EventActivity("membershipRegistrationViaEvent", Some(memberData), EventData(event)))
+          track(EventActivity("membershipRegistrationViaEvent", Some(memberData), EventData(event)))(request.user)
         }
         result
       }.recover {

--- a/frontend/app/controllers/Testing.scala
+++ b/frontend/app/controllers/Testing.scala
@@ -8,7 +8,9 @@ import actions.Functions._
 
 object Testing extends Controller with LazyLogging {
 
-  val analyticsOffCookie = Cookie("ANALYTICS_OFF_KEY", "true", httpOnly = false)
+  val AnalyticsCookieName = "ANALYTICS_OFF_KEY"
+
+  val analyticsOffCookie = Cookie(AnalyticsCookieName, "true", httpOnly = false)
 
   val AuthorisedTester = GoogleAuthenticatedStaffAction andThen isInAuthorisedGroupGoogleAuthReq(
     Set("membership.dev@guardian.co.uk", "touchpoint@guardian.co.uk", "crm@guardian.co.uk"),

--- a/frontend/app/controllers/TierController.scala
+++ b/frontend/app/controllers/TierController.scala
@@ -23,7 +23,7 @@ trait DowngradeTier {
 
   def downgradeToFriendConfirm() = PaidMemberAction.async { implicit request => // POST
     for {
-      cancelledSubscription <- request.touchpointBackend.downgradeSubscription(request.member)
+      cancelledSubscription <- request.touchpointBackend.downgradeSubscription(request.member, request.user)
     } yield Redirect("/tier/change/friend/summary")
   }
 
@@ -131,7 +131,7 @@ trait CancelTier {
 
   def cancelTierConfirm() = MemberAction.async { implicit request =>
     for {
-      _ <- request.touchpointBackend.cancelSubscription(request.member)
+      _ <- request.touchpointBackend.cancelSubscription(request.member, request.user)
     } yield {
       Redirect("/tier/cancel/summary")
     }

--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -180,8 +180,7 @@ trait MemberService extends LazyLogging with ActivityTracking {
             subscriptionPaymentAnnual = Some(annual),
             marketingChoices = None
           )
-        )
-      )
+        ))(user)
       memberId
     }
   }
@@ -208,7 +207,7 @@ trait MemberService extends LazyLogging with ActivityTracking {
         Some(formData.marketingChoices)
     )
 
-    track(MemberActivity("membershipRegistration", trackingInfo))
+    track(MemberActivity("membershipRegistration", trackingInfo))(user)
   }
 }
 


### PR DESCRIPTION
It's not the best implementation but this should stop test users in production being tracked in our tool. It doesn't catch two tracking activities which are view event details and buy action invoked but I don't think it matters.

@rtyley is there a better way to do this?

cc @mattandrews @dominickendrick 