### PR TITLE
Add social profiles

### DIFF
--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -152,6 +152,9 @@ object Config {
   val googleAnalyticsTrackingId = config.getString("google.analytics.tracking.id")
 
   val youtubeMembershipVerificationId = config.getString("youtube.membership.verification.id")
+  val youtubeUrl = config.getString("youtube.url")
+
+  val googleplusUrl = config.getString("googleplus.url")
 
   val facebookJoinerConversionTrackingId =
     Tier.allPublic.map { tier => tier -> config.getString(s"facebook.joiner.conversion.${tier.slug}") }.toMap

--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -85,7 +85,6 @@ object Config {
 
   val facebookAppId = config.getString("facebook.app.id")
 
-
   val touchpointDefaultBackend = touchpointBackendConfigFor("default")
   val touchpointTestBackend = touchpointBackendConfigFor("test")
 
@@ -152,9 +151,6 @@ object Config {
   val googleAnalyticsTrackingId = config.getString("google.analytics.tracking.id")
 
   val youtubeMembershipVerificationId = config.getString("youtube.membership.verification.id")
-  val youtubeUrl = config.getString("youtube.url")
-
-  val googleplusUrl = config.getString("googleplus.url")
 
   val facebookJoinerConversionTrackingId =
     Tier.allPublic.map { tier => tier -> config.getString(s"facebook.joiner.conversion.${tier.slug}") }.toMap

--- a/frontend/app/configuration/Social.scala
+++ b/frontend/app/configuration/Social.scala
@@ -1,0 +1,8 @@
+package configuration
+import configuration.Config
+
+object Social {
+  val youtube = "https://www.youtube.com/user/guardianmembership"
+  val googleplus = "https://plus.google.com/+guardianmembership/"
+  val twitter = s"http://www.twitter.com/${Config.twitterUsername}"
+}

--- a/frontend/app/views/main.scala.html
+++ b/frontend/app/views/main.scala.html
@@ -25,6 +25,21 @@
         }
         <meta property="og:url" content="@(Config.membershipUrl + pageInfo.url)"/>
 
+        <script type="application/ld+json">
+            {
+                "@@context": "http://schema.org",
+                "@@type": "Organization",
+                "name": "Guardian Membership",
+                "url": "@(Config.membershipUrl)",
+                "logo": "@(Config.membershipUrl)@Asset.at("images/favicons/152x152.png")",
+                "sameAs" : [
+                    "http://www.twitter.com/@(Config.twitterUsername)",
+                    "@(Config.youtubeUrl)",
+                    "@(Config.googleplusUrl)"
+                ]
+            }
+        </script>
+
         <meta property="og:type" content="website"/>
         <meta property="fb:app_id" content="@Config.facebookAppId"/>
         <meta name="twitter:site" content="@@@Config.twitterUsername"/>

--- a/frontend/app/views/main.scala.html
+++ b/frontend/app/views/main.scala.html
@@ -4,7 +4,7 @@
     pageInfo: model.PageInfo = model.PageInfo.default
 )(content: Html)
 
-@import configuration.Config
+@import configuration.{Config, Social}
 @import views.support.Asset
 
 <!DOCTYPE html lang="en-GB">
@@ -25,6 +25,12 @@
         }
         <meta property="og:url" content="@(Config.membershipUrl + pageInfo.url)"/>
 
+        <meta property="og:type" content="website"/>
+        <meta property="fb:app_id" content="@Config.facebookAppId"/>
+        <meta name="twitter:site" content="@@@Config.twitterUsername"/>
+        <meta name="twitter:card" content="summary"/>
+        <meta name="google-site-verification" content="@Config.youtubeMembershipVerificationId"/>
+
         <script type="application/ld+json">
             {
                 "@@context": "http://schema.org",
@@ -33,18 +39,12 @@
                 "url": "@(Config.membershipUrl)",
                 "logo": "@(Config.membershipUrl)@Asset.at("images/favicons/152x152.png")",
                 "sameAs" : [
-                    "http://www.twitter.com/@(Config.twitterUsername)",
-                    "@(Config.youtubeUrl)",
-                    "@(Config.googleplusUrl)"
+                    "@(Social.youtube)",
+                    "@(Social.googleplus)",
+                    "@(Social.twitter)"
                 ]
             }
         </script>
-
-        <meta property="og:type" content="website"/>
-        <meta property="fb:app_id" content="@Config.facebookAppId"/>
-        <meta name="twitter:site" content="@@@Config.twitterUsername"/>
-        <meta name="twitter:card" content="summary"/>
-        <meta name="google-site-verification" content="@Config.youtubeMembershipVerificationId"/>
 
         <title>@(title + " | " + Config.siteTitle )</title>
         @fragments.javaScriptFirstSteps(pageInfo)

--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -58,11 +58,8 @@ membership.home.images.ratios=[1]
 twitter.username="gdnmembership"
 
 youtube.membership.verification.id="On5TdND1ogf_N5wl1yln5CQ2G78A_mYrwWFl4W64HY0"
-youtube.url="https://www.youtube.com/user/guardianmembership"
 
 stripe.api.url="https://api.stripe.com/v1"
-
-googleplus.url="https://plus.google.com/+guardianmembership/"
 
 # Touchpoint-backend environment-specific information
 touchpoint.backend {

--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -58,8 +58,11 @@ membership.home.images.ratios=[1]
 twitter.username="gdnmembership"
 
 youtube.membership.verification.id="On5TdND1ogf_N5wl1yln5CQ2G78A_mYrwWFl4W64HY0"
+youtube.url="https://www.youtube.com/user/guardianmembership"
 
 stripe.api.url="https://api.stripe.com/v1"
+
+googleplus.url="https://plus.google.com/+guardianmembership/"
 
 # Touchpoint-backend environment-specific information
 touchpoint.backend {


### PR DESCRIPTION
This, eventually, should give us something like this: 

![screen shot 2015-03-19 at 12 23 29](https://cloud.githubusercontent.com/assets/394376/6730268/c66ce988-ce32-11e4-9a4f-7da9fc1f866b.png)

I don't think we'll get the description text as that's drawn from Wikipedia, but it should link to the social media profiles.

More info: https://developers.google.com/structured-data/customize/social-profiles

Test the output script tag here: https://developers.google.com/structured-data/testing-tool/ (I've confirmed it passes locally)

cc @rtyley / @feedmypixel 