### PR TITLE
Use updated google-site-verification token created by @rtyley

### DIFF
--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -150,8 +150,6 @@ object Config {
 
   val googleAnalyticsTrackingId = config.getString("google.analytics.tracking.id")
 
-  val youtubeMembershipVerificationId = config.getString("youtube.membership.verification.id")
-
   val facebookJoinerConversionTrackingId =
     Tier.allPublic.map { tier => tier -> config.getString(s"facebook.joiner.conversion.${tier.slug}") }.toMap
 

--- a/frontend/app/views/main.scala.html
+++ b/frontend/app/views/main.scala.html
@@ -29,7 +29,7 @@
         <meta property="fb:app_id" content="@Config.facebookAppId"/>
         <meta name="twitter:site" content="@@@Config.twitterUsername"/>
         <meta name="twitter:card" content="summary"/>
-        <meta name="google-site-verification" content="@Config.youtubeMembershipVerificationId"/>
+        <meta name="google-site-verification" content="qf7V0ceP_mY_0jTl7R7C1wZSKn2gK7TlharWVLr8Ea0" />
 
         <script type="application/ld+json">
             {

--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -57,8 +57,6 @@ membership.home.images.ratios=[1]
 
 twitter.username="gdnmembership"
 
-youtube.membership.verification.id="On5TdND1ogf_N5wl1yln5CQ2G78A_mYrwWFl4W64HY0"
-
 stripe.api.url="https://api.stripe.com/v1"
 
 # Touchpoint-backend environment-specific information


### PR DESCRIPTION
...not @feedmypixel, who is leaving soon :-( He wasn't able to remove himself as an owner from the site because he was the one who validated it!

This token was created using Google Webmaster tools, using my Guardian G+ account:

https://www.google.com/webmasters/verification/verification?hl=en&siteUrl=https://membership.theguardian.com/&priorities=vfile,vmeta,vdns,vanalytics,vtagmanager&tid=alternate&authuser=1
