### PR TITLE
Update promoSecondary to use ResponsiveImageGroup

### DIFF
--- a/frontend/app/controllers/FrontPage.scala
+++ b/frontend/app/controllers/FrontPage.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import model.{ResponsiveImage, ResponsiveImageGroup}
+import model.{ResponsiveImageGenerator, ResponsiveImage, ResponsiveImageGroup}
 import play.api.mvc.Controller
 
 trait FrontPage extends Controller {
@@ -8,101 +8,29 @@ trait FrontPage extends Controller {
   def index = CachedAction { implicit request =>
 
     val slideShowImages = Seq(
-      ResponsiveImageGroup(altText=Some("Guardian Live event: Pussy Riot - art, sex and disobedience"),
-        availableImages = Seq(
-          ResponsiveImage(
-            path="https://media.guim.co.uk/eab86e9c81414932e0d50a1cd609dccfc20ca5d2/0_0_2279_1368/2000.jpg",
-            width=2000
-          ),
-          ResponsiveImage(
-            path="https://media.guim.co.uk/eab86e9c81414932e0d50a1cd609dccfc20ca5d2/0_0_2279_1368/1000.jpg",
-            width=1000
-          ),
-          ResponsiveImage(
-            path="https://media.guim.co.uk/eab86e9c81414932e0d50a1cd609dccfc20ca5d2/0_0_2279_1368/500.jpg",
-            width=500
-          )
-        )
+      ResponsiveImageGroup(
+        altText=Some("Guardian Live event: Pussy Riot - art, sex and disobedience"),
+        availableImages=ResponsiveImageGenerator("eab86e9c81414932e0d50a1cd609dccfc20ca5d2/0_0_2279_1368", List(2000, 1000, 500))
       ),
-      ResponsiveImageGroup(altText=Some("Guardian Live with Russell Brand"),
-        availableImages = Seq(
-          ResponsiveImage(
-            path="https://media.guim.co.uk/da867c363957d748bd04cfd9d4890033203a58c6/0_0_2279_1368/2000.jpg",
-            width=2000
-          ),
-          ResponsiveImage(
-            path="https://media.guim.co.uk/da867c363957d748bd04cfd9d4890033203a58c6/0_0_2279_1368/1000.jpg",
-            width=1000
-          ),
-          ResponsiveImage(
-            path="https://media.guim.co.uk/da867c363957d748bd04cfd9d4890033203a58c6/0_0_2279_1368/500.jpg",
-            width=500
-          )
-        )
+      ResponsiveImageGroup(
+        altText=Some("Guardian Live with Russell Brand"),
+        availableImages=ResponsiveImageGenerator("da867c363957d748bd04cfd9d4890033203a58c6/0_0_2279_1368", List(2000, 1000, 500))
       ),
-      ResponsiveImageGroup(altText=Some("A life in music: Jimmy Page"),
-        availableImages = Seq(
-          ResponsiveImage(
-            path="https://media.guim.co.uk/733834b0b9f84e4367cf676919008bfd88007f25/0_0_2279_1368/2000.jpg",
-            width=2000
-          ),
-          ResponsiveImage(
-            path="https://media.guim.co.uk/733834b0b9f84e4367cf676919008bfd88007f25/0_0_2279_1368/1000.jpg",
-            width=1000
-          ),
-          ResponsiveImage(
-            path="https://media.guim.co.uk/733834b0b9f84e4367cf676919008bfd88007f25/0_0_2279_1368/500.jpg",
-            width=500
-          )
-        )
+      ResponsiveImageGroup(
+        altText=Some("A life in music: Jimmy Page"),
+        availableImages=ResponsiveImageGenerator("733834b0b9f84e4367cf676919008bfd88007f25/0_0_2279_1368", List(2000, 1000, 500))
       ),
-      ResponsiveImageGroup(altText=Some("Guardian Live with Russell Brand"),
-        availableImages = Seq(
-          ResponsiveImage(
-            path="https://media.guim.co.uk/e736acb945406974844bea77ca49b2c1e450013e/0_0_2279_1368/2000.jpg",
-            width=2000
-          ),
-          ResponsiveImage(
-            path="https://media.guim.co.uk/e736acb945406974844bea77ca49b2c1e450013e/0_0_2279_1368/1000.jpg",
-            width=1000
-          ),
-          ResponsiveImage(
-            path="https://media.guim.co.uk/e736acb945406974844bea77ca49b2c1e450013e/0_0_2279_1368/500.jpg",
-            width=500
-          )
-        )
+      ResponsiveImageGroup(
+        altText=Some("Guardian Live with Russell Brand"),
+        availableImages=ResponsiveImageGenerator("e736acb945406974844bea77ca49b2c1e450013e/0_0_2279_1368", List(2000, 1000, 500))
       ),
-      ResponsiveImageGroup(altText=Some("Observer Ideas - Stories that inspire: Tinie Tempah"),
-        availableImages = Seq(
-          ResponsiveImage(
-            path="https://media.guim.co.uk/1e687530a52ef14cd9c1eacb1e8757600c382f86/0_0_2279_1368/2000.jpg",
-            width=2000
-          ),
-          ResponsiveImage(
-            path="https://media.guim.co.uk/1e687530a52ef14cd9c1eacb1e8757600c382f86/0_0_2279_1368/1000.jpg",
-            width=1000
-          ),
-          ResponsiveImage(
-            path="https://media.guim.co.uk/1e687530a52ef14cd9c1eacb1e8757600c382f86/0_0_2279_1368/500.jpg",
-            width=500
-          )
-        )
+      ResponsiveImageGroup(
+        altText=Some("Observer Ideas - Stories that inspire: Tinie Tempah"),
+        availableImages=ResponsiveImageGenerator("1e687530a52ef14cd9c1eacb1e8757600c382f86/0_0_2279_1368", List(2000, 1000, 500))
       ),
-      ResponsiveImageGroup(altText=Some("Guardian Live event: Vivienne Westwood"),
-        availableImages = Seq(
-          ResponsiveImage(
-            path="https://media.guim.co.uk/85d46476d07fb744327c60a4c5117a7ddc2796d0/0_0_2279_1368/2000.jpg",
-            width=2000
-          ),
-          ResponsiveImage(
-            path="https://media.guim.co.uk/85d46476d07fb744327c60a4c5117a7ddc2796d0/0_0_2279_1368/1000.jpg",
-            width=1000
-          ),
-          ResponsiveImage(
-            path="https://media.guim.co.uk/85d46476d07fb744327c60a4c5117a7ddc2796d0/0_0_2279_1368/500.jpg",
-            width=500
-          )
-        )
+      ResponsiveImageGroup(
+        altText=Some("Guardian Live event: Vivienne Westwood"),
+        availableImages=ResponsiveImageGenerator("85d46476d07fb744327c60a4c5117a7ddc2796d0/0_0_2279_1368", List(2000, 1000, 500))
       )
     )
 

--- a/frontend/app/controllers/Info.scala
+++ b/frontend/app/controllers/Info.scala
@@ -1,13 +1,10 @@
 package controllers
 
-import configuration.Config
 import configuration.CopyConfig
 import forms.MemberForm._
-import model.{FlashMessage, PageInfo}
+import model.{ResponsiveImageGenerator, ResponsiveImageGroup, FlashMessage, PageInfo}
 import play.api.mvc.Controller
 import services.EmailService
-import actions.Functions._
-
 import scala.concurrent.Future
 
 trait Info extends Controller {
@@ -17,12 +14,26 @@ trait Info extends Controller {
   }
 
   def about = CachedAction { implicit request =>
+
     val pageInfo = PageInfo(
       CopyConfig.copyTitleAbout,
       request.path,
       Some(CopyConfig.copyDescriptionAbout)
     )
-    Ok(views.html.info.about(pageInfo))
+
+    val pageImages = Seq(
+      ResponsiveImageGroup(
+        name=Some("masterclasses"),
+        altText=Some("Guardian Live event: Pussy Riot - art, sex and disobedience"),
+        availableImages=ResponsiveImageGenerator("ae3ad30b485e9651a772e85dd82bae610f57a034/0_0_1140_684", List(1000, 500))
+      ),
+      ResponsiveImageGroup(
+        name=Some("midland-goods-shed"),
+        altText=Some("A home for big ideas"),
+        availableImages=ResponsiveImageGenerator("ed9347da5fc1e55721b243a958d42fca1983d012/0_0_1140_684", List(1000, 500))
+      )
+    )
+    Ok(views.html.info.about(pageInfo, pageImages))
   }
 
   def feedback = NoCacheAction { implicit request =>
@@ -33,14 +44,21 @@ trait Info extends Controller {
   def giftingPlaceholder = NoCacheAction { implicit request =>
     Ok(views.html.info.giftingPlaceholder())
   }
-  
+
   def supporter = CachedAction { implicit request =>
     val pageInfo = PageInfo(
       CopyConfig.copyTitleSupporters,
       request.path,
       Some(CopyConfig.copyDescriptionSupporters)
     )
-    Ok(views.html.info.supporter(pageInfo))
+    val pageImages = Seq(
+      ResponsiveImageGroup(
+        name=Some("polly-toynbee"),
+        altText=Some("If you read the Guardian, join the Guardian"),
+        availableImages=ResponsiveImageGenerator("17a31ff294d3c77274091c5e078713fc06ef5cd2/0_0_1999_1200", List(1000, 500))
+      )
+    )
+    Ok(views.html.info.supporter(pageInfo, pageImages))
   }
 
   def patron() = CachedAction { implicit request =>
@@ -49,7 +67,14 @@ trait Info extends Controller {
       request.path,
       Some(CopyConfig.copyDescriptionPatrons)
     )
-    Ok(views.html.info.patron(pageInfo))
+    val pageImages = Seq(
+      ResponsiveImageGroup(
+        name=Some("backstage-pass"),
+        altText=Some("Backstage pass to the Guardian"),
+        availableImages=ResponsiveImageGenerator("83afa3867ef76d82c86291f4387b5799c26e07f8/0_0_1140_684", List(1000, 500))
+      )
+    )
+    Ok(views.html.info.patron(pageInfo, pageImages))
   }
 
   def submitFeedback = NoCacheAction.async { implicit request =>

--- a/frontend/app/model/ResponsiveImage.scala
+++ b/frontend/app/model/ResponsiveImage.scala
@@ -41,6 +41,7 @@ object ResponsiveImageGroup {
 case class ResponsiveImage(path: String, width: Int)
 
 case class ResponsiveImageGroup(
+  name: Option[String] = None,
   altText: Option[String],
   metadata: Option[Grid.Metadata] = None,
   availableImages: Seq[ResponsiveImage]

--- a/frontend/app/model/ResponsiveImage.scala
+++ b/frontend/app/model/ResponsiveImage.scala
@@ -3,6 +3,14 @@ package model
 import com.gu.contentapi.client.model.Content
 import model.RichEvent.GridImage
 
+object ResponsiveImageGenerator {
+  def apply(id: String, sizes: Seq[Int]): Seq[ResponsiveImage] = {
+    sizes.map { size =>
+      ResponsiveImage(s"https://media.guim.co.uk/$id/$size.jpg", size)
+    }
+  }
+}
+
 object ResponsiveImageGroup {
   def apply(content: Content): Option[ResponsiveImageGroup] = {
     val elementOpt = content.elements.flatMap(_.find(_.relation == "main"))

--- a/frontend/app/views/fragments/promos/promoSecondary.scala.html
+++ b/frontend/app/views/fragments/promos/promoSecondary.scala.html
@@ -1,6 +1,6 @@
 @(
     title: Html,
-    imageBasePath: String,
+    img: model.ResponsiveImageGroup,
     stampImageOpt: Option[String] = None,
     toneClass: Option[String] = None
 )(content: Html)
@@ -13,7 +13,7 @@
             <h2 class="promo-secondary__title h-promo">@title</h2>
         </div>
         <div class="promo-secondary__image@if(stampImageOpt){ stamped-image}">
-            <div class="js-imager-loaded-image" data-src="@imageBasePath/{width}.jpg" data-available-widths="1000,500,140" data-alt="@title" data-class="responsive-img"></div>
+            <img src="@img.defaultImage" srcset="@img.srcset" sizes="100vw" alt="@img.altText" class="responsive-img" />
             @for(url <- stampImageOpt) {
                 <div class="stamped-image__container">
                     <img src="@Asset.at(url)" alt="" class="stamped-image__stamp">

--- a/frontend/app/views/info/about.scala.html
+++ b/frontend/app/views/info/about.scala.html
@@ -1,4 +1,4 @@
-@(pageInfo: model.PageInfo)(implicit token: play.filters.csrf.CSRF.Token)
+@(pageInfo: model.PageInfo, pageImages: Seq[model.ResponsiveImageGroup])(implicit token: play.filters.csrf.CSRF.Token)
 
 @import com.gu.membership.salesforce.Tier
 @import configuration.Config
@@ -45,15 +45,17 @@
         }
     </div>
 
-    @* ===== Guardian Masterclasses ===== *@
-    <div class="page-slice page-slice--slim l-constrained">
-        @fragments.promos.promoSecondary(Html("Guardian Masterclasses: Learn with the Guardian"), imageBasePath="https://media.guim.co.uk/ae3ad30b485e9651a772e85dd82bae610f57a034/0_0_1140_684", stampImageOpt=Some("images/logos/guardian-masterclasses-reversed.svg"), toneClass=Some("tone-masterclasses")) {
+    @for(img <- pageImages.find(_.name.contains("masterclasses"))) {
+        @* ===== Guardian Masterclasses ===== *@
+        <div class="page-slice page-slice--slim l-constrained">
+        @fragments.promos.promoSecondary(Html("Guardian Masterclasses: Learn with the Guardian"), img=img, stampImageOpt = Some("images/logos/guardian-masterclasses-reversed.svg"), toneClass = Some("tone-masterclasses")) {
             <p class="text-feature">
                 Guardian Masterclasses offer a broad range of short and long courses across a variety of disciplines with a 20% discount for Partners and Patrons.
             </p>
             <a class="action" href="@routes.Event.masterclasses">View all courses</a>
         }
-    </div>
+        </div>
+    }
 
     @* ===== Founding Members ===== *@
     <div class="page-slice l-constrained">
@@ -67,23 +69,26 @@
         }
     </div>
 
-    @* ===== Big ideas ===== *@
-    <div class="page-slice page-slice--slim l-constrained">
-        @fragments.promos.promoSecondary(Html("A home for big ideas"), imageBasePath="https://media.guim.co.uk/ed9347da5fc1e55721b243a958d42fca1983d012/0_0_1140_684", toneClass=Some("tone-guardian-live")) {
+    @for(img <- pageImages.find(_.name.contains("midland-goods-shed"))) {
+        @* ===== Big ideas ===== *@
+        <div class="page-slice page-slice--slim l-constrained">
+        @fragments.promos.promoSecondary(Html("A home for big ideas"), img=img, toneClass = Some("tone-guardian-live")) {
             <div class="text-feature">
                 <p>In 2016, the Guardian will reopen the Midland Goods Shed at London’s King’s Cross to create a new kind of civic space.</p>
                 <p>The building will be a hub for big ideas and stimulating conversations. It will host events,
-                activities and courses from Guardian Live and institutions we admire, as well as being the home of Guardian Membership.</p>
+                    activities and courses from Guardian Live and institutions we admire, as well as being the home of Guardian Membership.</p>
             </div>
             <div class="action-group">
-                <a class="action" target="_blank" href="@Config.guardianMembershipBuildingSpaceUrl">More about the building</a>
+                <a class="action" target="_blank" href="@Config.guardianMembershipBuildingSpaceUrl">
+                    More about the building</a>
                 <a class="action action--secondary" target="_blank" href="@Config.guardianMembershipBuildingBlogUrl">
                     Building progress blog
                     @fragments.actionIcon("arrow-right")
                 </a>
             </div>
         }
-    </div>
+        </div>
+    }
 
     @* ===== Become a Patron ===== *@
     <div class="page-slice l-constrained">

--- a/frontend/app/views/info/patron.scala.html
+++ b/frontend/app/views/info/patron.scala.html
@@ -1,4 +1,4 @@
-@(pageInfo: model.PageInfo)(implicit token: play.filters.csrf.CSRF.Token)
+@(pageInfo: model.PageInfo, pageImages: Seq[model.ResponsiveImageGroup])(implicit token: play.filters.csrf.CSRF.Token)
 
 @import com.gu.membership.salesforce.Tier
 
@@ -25,18 +25,21 @@
         }
     </div>
 
-    @* ===== Backstage Pass ===== *@
-    <div class="page-slice page-slice--slim l-constrained">
-        @fragments.promos.promoSecondary(Html("Backstage pass to<br>the Guardian"), imageBasePath="https://media.guim.co.uk/83afa3867ef76d82c86291f4387b5799c26e07f8/0_0_1140_684", toneClass=Some("tone-brand")) {
-            <p class="text-feature">In return for your support, Patrons are given a behind-the-scenes view of how the Guardian operates.  For example, tour our newsroom, visit our printing presses or attend a campaign lecture.</p>
+    @for(img <- pageImages.find(_.name.contains("backstage-pass"))) {
+        @* ===== Backstage Pass ===== *@
+        <div class="page-slice page-slice--slim l-constrained">
+        @fragments.promos.promoSecondary(Html("Backstage pass to<br>the Guardian"), img=img, toneClass = Some("tone-brand")) {
+            <p class="text-feature">
+                In return for your support, Patrons are given a behind-the-scenes view of how the Guardian operates.  For example, tour our newsroom, visit our printing presses or attend a campaign lecture.</p>
             <a class="action"
-               href="@routes.Joiner.enterDetails(Tier.Patron)"
-               data-metric-trigger="click"
-               data-metric-category="join"
-               data-metric-action="patron"
+            href="@routes.Joiner.enterDetails(Tier.Patron)"
+            data-metric-trigger="click"
+            data-metric-category="join"
+            data-metric-action="patron"
             >Become a Patron today</a>
         }
-    </div>
+        </div>
+    }
 
     @* ===== Get Involved ===== *@
     <div class="page-slice l-constrained">

--- a/frontend/app/views/info/supporter.scala.html
+++ b/frontend/app/views/info/supporter.scala.html
@@ -1,4 +1,4 @@
-@(pageInfo: model.PageInfo)(implicit token: play.filters.csrf.CSRF.Token)
+@(pageInfo: model.PageInfo, pageImages: Seq[model.ResponsiveImageGroup])(implicit token: play.filters.csrf.CSRF.Token)
 
 @import com.gu.membership.salesforce.Tier
 @import model.Benefits
@@ -41,15 +41,17 @@
         }
     </div>
 
-    @* =====  Join The Guardian and support The Guardian ===== *@
-    <div class="page-slice page-slice--slim l-constrained">
-    @fragments.promos.promoSecondary(Html("If you read the Guardian, join the Guardian"), imageBasePath="//media.guim.co.uk/17a31ff294d3c77274091c5e078713fc06ef5cd2/0_0_1999_1200", toneClass=Some("tone-trans-brand-dark")) {
-        <blockquote class="blockquote blockquote--feature">
-            You matter to us not just for your support, but because we gain from your insight too. Through the conversations we are having with members, we can challenge conventional wisdoms together.
-            <cite class="blockquote__citation">Polly Toynbee, Guardian columnist</cite>
-        </blockquote>
+    @for(img <- pageImages.find(_.name.contains("polly-toynbee"))) {
+        @* ===== Join The Guardian and support The Guardian ===== *@
+        <div class="page-slice page-slice--slim l-constrained">
+        @fragments.promos.promoSecondary(Html("If you read the Guardian, join the Guardian"), img=img, toneClass = Some("tone-trans-brand-dark")) {
+            <blockquote class="blockquote blockquote--feature">
+                You matter to us not just for your support, but because we gain from your insight too. Through the conversations we are having with members, we can challenge conventional wisdoms together.
+                <cite class="blockquote__citation">Polly Toynbee, Guardian columnist</cite>
+            </blockquote>
+        }
+        </div>
     }
-    </div>
 
     @* ===== Join Today ===== *@
     <div class="page-slice page-slice--split tone-tint l-constrained">

--- a/frontend/app/views/patterns/patterns.scala.html
+++ b/frontend/app/views/patterns/patterns.scala.html
@@ -283,13 +283,6 @@
         }
     }
 
-    @pattern("Promo - Secondary") {
-        @fragments.promos.promoSecondary(Html("Secondary Promo"), imageBasePath="https://media.guim.co.uk/83afa3867ef76d82c86291f4387b5799c26e07f8/0_0_1140_684", toneClass=Some("tone-guardian-live")) {
-            <p class="text-feature">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ullam, error hic temporibus. Aliquam nemo delectus possimus repudiandae ut, aut fugit. Pariatur dolorem, explicabo, ducimus deserunt perspiciatis voluptates commodi debitis exercitationem.</p>
-        }
-    }
-
-
     @pattern("Promo Video - Secondary") {
         <div class="page-slice page-slice--slim l-constrained">
         @fragments.promos.promoVideoSecondary(


### PR DESCRIPTION
This PR adds a new `ResponsiveImageGenerator` object to reduce the amount of boilerplate needed to generate a sequence of `ResponsiveImage`s for a hardcoded Grid image (e.g., those use on homepage carousel, about page etc.)

It also updates the `promoSecondary` component to use this new config as an example.

The only component left using `Imager.js` is `promoPrimary` (omitted converting that here to keep the size of the PR down), once this goes in I'll raise another PR to update `promoPrimary` and remove `Imager.js` as a dependancy.