### PR TITLE
Update deps

### DIFF
--- a/frontend/app/actions/Functions.scala
+++ b/frontend/app/actions/Functions.scala
@@ -5,7 +5,7 @@ import com.gu.googleauth.{GoogleGroupChecker, UserIdentity}
 import com.gu.membership.salesforce.PaidMember
 import com.gu.membership.util.Timing
 import com.gu.monitoring.CloudWatch
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import configuration.Config
 import controllers.IdentityRequest
 import model.IdMinimalUser

--- a/frontend/app/controllers/Testing.scala
+++ b/frontend/app/controllers/Testing.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import play.api.mvc.{Controller, Cookie}
 import play.twirl.api.Html
 import utils.TestUsers.testUsers

--- a/frontend/app/services/GridService.scala
+++ b/frontend/app/services/GridService.scala
@@ -5,7 +5,7 @@ import com.gu.membership.util.WebServiceHelper
 import com.gu.monitoring.StatusMetrics
 import com.netaporter.uri.Uri
 import com.netaporter.uri.Uri.parse
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import configuration.Config
 import model.Grid._
 import model.GridDeserializer._

--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -5,7 +5,7 @@ import com.gu.membership.salesforce._
 import com.gu.membership.stripe.Stripe
 import com.gu.membership.stripe.Stripe.Customer
 import com.gu.membership.util.Timing
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import configuration.Config
 import controllers.IdentityRequest
 import forms.MemberForm._

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   //libraries
   val sentryRavenLogback = "net.kencochrane.raven" % "raven-logback" % "6.0.0"
   val identityCookie = "com.gu.identity" %% "identity-cookie" % "3.44"
-  val identityTestUsers = "com.gu" %% "identity-test-users" % "0.4"
+  val identityTestUsers = "com.gu" %% "identity-test-users" % "0.5"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
   val membershipCommon = "com.gu" %% "membership-common" % "0.59"
   val playGoogleAuth = "com.gu" %% "play-googleauth" % "0.1.10"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,14 +7,14 @@ object Dependencies {
   val sentryRavenLogback = "net.kencochrane.raven" % "raven-logback" % "6.0.0"
   val identityCookie = "com.gu.identity" %% "identity-cookie" % "3.44"
   val identityTestUsers = "com.gu" %% "identity-test-users" % "0.4"
-  val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.4"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.58"
+  val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.59"
   val playGoogleAuth = "com.gu" %% "play-googleauth" % "0.1.10"
-  val contentAPI = "com.gu" %% "content-api-client" % "5.1"
+  val contentAPI = "com.gu" %% "content-api-client" % "5.2"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache
   val playFilters = PlayImport.filters
-  val awsSimpleEmail = "com.amazonaws" % "aws-java-sdk-ses" % "1.9.16"
+  val awsSimpleEmail = "com.amazonaws" % "aws-java-sdk-ses" % "1.9.24"
   val snowPlow = "com.snowplowanalytics" % "snowplow-java-tracker" % "0.5.2-SNAPSHOT"
   val bCrypt = "com.github.t3hnar" %% "scala-bcrypt" % "2.4"
 

--- a/project/Membership.scala
+++ b/project/Membership.scala
@@ -29,7 +29,7 @@ trait Membership {
   val commonSettings = Seq(
     organization := "com.gu",
     version := appVersion,
-    scalaVersion := "2.11.5",
+    scalaVersion := "2.11.6",
     resolvers ++= Seq(
       "Guardian Github Releases" at "https://guardian.github.io/maven/repo-releases",
       "Guardian Github Snapshots" at "http://guardian.github.com/maven/repo-snapshots",


### PR DESCRIPTION
This is a repeat attempt of #363 - `identity-test-users` had a superfluous dependency on this:

"com.typesafe.scala-logging" %% "scala-logging-slf4j"

...which conflicted with the update to the new version in common:

"com.typesafe.scala-logging" %% "scala-logging"

I'll get my coat.

guardian/identity-test-users@ad296db

cc @jennysivapalan 