### PR TITLE
Remove hard breaks from promo blocks

### DIFF
--- a/frontend/app/views/fragments/promos/promoPrimary.scala.html
+++ b/frontend/app/views/fragments/promos/promoPrimary.scala.html
@@ -1,5 +1,5 @@
 @(
-    title: Html,
+    title: String,
     imageBasePath: String,
     stampImageOpt: Option[String] = None,
     isLead: Boolean = false,

--- a/frontend/app/views/info/about.scala.html
+++ b/frontend/app/views/info/about.scala.html
@@ -7,7 +7,7 @@
 
     @* ===== About Membership ===== *@
     <div class="page-slice l-constrained">
-        @fragments.promos.promoPrimary(title=Html("About<br>Membership"), imageBasePath="https://media.guim.co.uk/0f30a12f5d00d2b0e445e81c171cd0168d3cf5a7/0_0_1140_684", isLead=true) {
+        @fragments.promos.promoPrimary(title="About Membership", imageBasePath="https://media.guim.co.uk/0f30a12f5d00d2b0e445e81c171cd0168d3cf5a7/0_0_1140_684", isLead=true) {
             <div class="text-feature">
                 <p>Guardian Members are changing the idea of what a news organisation does today.</p>
                 <p>Join the influential community of journalists, readers and contributors that is the Guardian, and connect to the conversations that matter.</p>
@@ -37,7 +37,7 @@
 
     @* ===== Bring the Guardian to life ===== *@
     <div class="page-slice l-constrained">
-        @fragments.promos.promoPrimary(title=Html("Guardian Live: Experience the Guardian brought to life"), imageBasePath="https://media.guim.co.uk/76ef58a05920591099012edb80e7415379392a4c/0_0_1140_684", stampImageOpt=Some("images/logos/guardian-live-reversed.svg"), toneClass=Some("tone-trans-guardian-live")) {
+        @fragments.promos.promoPrimary(title="Guardian Live: Experience the Guardian brought to life", imageBasePath="https://media.guim.co.uk/76ef58a05920591099012edb80e7415379392a4c/0_0_1140_684", stampImageOpt=Some("images/logos/guardian-live-reversed.svg"), toneClass=Some("tone-trans-guardian-live")) {
             <div class="text-feature">
                 <p>Book tickets for our programme of discussions, debates, interviews, keynote speeches and festivals.</p>
             </div>
@@ -59,7 +59,7 @@
 
     @* ===== Founding Members ===== *@
     <div class="page-slice l-constrained">
-        @fragments.promos.promoPrimary(title=Html("Founding members: join us at the start"), imageBasePath="https://media.guim.co.uk/bb922fe62efbe24af2df336dd2b621c5799246b4/0_0_1140_683") {
+        @fragments.promos.promoPrimary(title="Founding members: join us at the start", imageBasePath="https://media.guim.co.uk/bb922fe62efbe24af2df336dd2b621c5799246b4/0_0_1140_683") {
             <blockquote class="blockquote blockquote--feature">
                 If you read the Guardian, join the Guardian. Support fearless, open, independent journalism.
                 <cite class="blockquote__citation">Polly Toynbee, Guardian columnist</cite>
@@ -92,7 +92,7 @@
 
     @* ===== Become a Patron ===== *@
     <div class="page-slice l-constrained">
-        @fragments.promos.promoPrimary(title=Html("Become a Patron and support the Guardian's future"), imageBasePath="https://media.guim.co.uk/175fba5c61d2b398973befa5d6b49c1257740d5c/0_0_1140_683", toneClass=Some("tone-trans-brand-dark")) {
+        @fragments.promos.promoPrimary(title="Become a Patron and support the Guardian's future", imageBasePath="https://media.guim.co.uk/175fba5c61d2b398973befa5d6b49c1257740d5c/0_0_1140_683", toneClass=Some("tone-trans-brand-dark")) {
             <blockquote class="blockquote blockquote--feature">
                 The only relationship our journalists have is with our readers. Membership gives the real possibility of deepening the intense bond between the producers and consumers of the Guardian.
                 <cite class="blockquote__citation">Alan Rusbridger, editor-in-chief of the Guardian</cite>

--- a/frontend/app/views/info/patron.scala.html
+++ b/frontend/app/views/info/patron.scala.html
@@ -6,7 +6,7 @@
 
     @* ===== About Patronage ===== *@
     <div class="page-slice l-constrained">
-        @fragments.promos.promoPrimary(title=Html("Patrons of<br>the Guardian"), imageBasePath="https://media.guim.co.uk/8caacf301dd036a2bbb1b458cf68b637d3c55e48/0_0_1140_683", isLead=true) {
+        @fragments.promos.promoPrimary(title="Patrons of the Guardian", imageBasePath="https://media.guim.co.uk/8caacf301dd036a2bbb1b458cf68b637d3c55e48/0_0_1140_683", isLead=true) {
             <div class="text-feature">
                 <p>The Patron tier is for those who care deeply about the Guardian’s journalism and the impact it has on the world.</p>
                 <p>From campaigning on issues affecting the voices less heard to holding those in power to account, Patrons ensure the Guardian can continue to surface the information and ideas that shape the global conversation.</p>
@@ -17,7 +17,7 @@
 
     @* ===== Ensuring our independence ===== *@
     <div class="page-slice l-constrained">
-        @fragments.promos.promoPrimary(title=Html("Ensuring our<br>independence"), imageBasePath="https://media.guim.co.uk/e6459f638392c8176e277733f6f0802953100fa4/0_0_1140_683", toneClass=Some("tone-trans-brand-dark")) {
+        @fragments.promos.promoPrimary(title="Ensuring our independence", imageBasePath="https://media.guim.co.uk/e6459f638392c8176e277733f6f0802953100fa4/0_0_1140_683", toneClass=Some("tone-trans-brand-dark")) {
             <div class="text-feature">
                 <p>The Guardian has no proprietor. Our editor has total independence.</p>
                 <p>The support of Patrons helps to ensure that the Guardian can stand witness to the world, without interference.</p>
@@ -29,13 +29,12 @@
         @* ===== Backstage Pass ===== *@
         <div class="page-slice page-slice--slim l-constrained">
         @fragments.promos.promoSecondary(Html("Backstage pass to<br>the Guardian"), img=img, toneClass = Some("tone-brand")) {
-            <p class="text-feature">
-                In return for your support, Patrons are given a behind-the-scenes view of how the Guardian operates.  For example, tour our newsroom, visit our printing presses or attend a campaign lecture.</p>
+            <p class="text-feature">In return for your support, Patrons are given a behind-the-scenes view of how the Guardian operates.  For example, tour our newsroom, visit our printing presses or attend a campaign lecture.</p>
             <a class="action"
-            href="@routes.Joiner.enterDetails(Tier.Patron)"
-            data-metric-trigger="click"
-            data-metric-category="join"
-            data-metric-action="patron"
+                href="@routes.Joiner.enterDetails(Tier.Patron)"
+                data-metric-trigger="click"
+                data-metric-category="join"
+                data-metric-action="patron"
             >Become a Patron today</a>
         }
         </div>
@@ -43,7 +42,7 @@
 
     @* ===== Get Involved ===== *@
     <div class="page-slice l-constrained">
-        @fragments.promos.promoPrimary(title=Html("Choose to get involved"), imageBasePath="https://media.guim.co.uk/d8f51bea15bf046df4d166cfd60771b9c24a631f/0_0_1140_683", toneClass=Some("tone-trans-brand-dark")) {
+        @fragments.promos.promoPrimary(title="Choose to get involved", imageBasePath="https://media.guim.co.uk/d8f51bea15bf046df4d166cfd60771b9c24a631f/0_0_1140_683", toneClass=Some("tone-trans-brand-dark")) {
             <p class="text-feature">Patrons are crucial to the future development of Membership, and there will be opportunities to get involved.  From hosting your own events to connecting members to one another, you will shape the future of the community.</p>
             @fragments.tier.packagePromo(Tier.Patron, showDescription=false, modifierClass=Some("package-promo--spread"))
         }

--- a/frontend/app/views/info/supporter.scala.html
+++ b/frontend/app/views/info/supporter.scala.html
@@ -7,7 +7,7 @@
 
     @* ===== About Supporters ===== *@
     <div class="page-slice l-constrained">
-        @fragments.promos.promoPrimary(title=Html("Introducing Supporter Membership"), imageBasePath="//media.guim.co.uk/a0e123f3289d26e0cf30153e64b89f4655a7e0d2/0_0_1999_1200", isLead=true) {
+        @fragments.promos.promoPrimary(title="Introducing Supporter Membership", imageBasePath="//media.guim.co.uk/a0e123f3289d26e0cf30153e64b89f4655a7e0d2/0_0_1999_1200", isLead=true) {
             <div class="text-feature">
                 <p>Supporters keep our journalism fearless, open and free from interference. For £5 a month.</p>
             </div>
@@ -29,7 +29,7 @@
 
     @* ===== Ensuring our independence ===== *@
     <div class="page-slice l-constrained">
-        @fragments.promos.promoPrimary(title=Html("Fearless, progressive and free from interference"), imageBasePath="//media.guim.co.uk/8cc033c84791f1583fc52f337d3c6c3ffb368f8e/0_0_1999_1200") {
+        @fragments.promos.promoPrimary(title="Fearless, progressive and free from interference", imageBasePath="//media.guim.co.uk/8cc033c84791f1583fc52f337d3c6c3ffb368f8e/0_0_1999_1200") {
             <div class="text-feature">
                 <p>The Guardian publishes the stories that others keep hidden.</p>
                 <p>We have become the most read, serious English-language newspaper in the world, visited by 120 million unique browsers each month. Our journalism is for everyone. The Guardian is open, without a paywall, and we remain true to our 200-year old progressive values.</p>

--- a/frontend/app/views/patterns/patterns.scala.html
+++ b/frontend/app/views/patterns/patterns.scala.html
@@ -278,7 +278,7 @@
     }
 
     @pattern("Promo - Primary") {
-        @fragments.promos.promoPrimary(Html("Primary Promo"), imageBasePath="https://media.guim.co.uk/d8f51bea15bf046df4d166cfd60771b9c24a631f/0_0_1140_683", toneClass=Some("tone-trans-guardian-live")) {
+        @fragments.promos.promoPrimary("Primary Promo", imageBasePath="https://media.guim.co.uk/d8f51bea15bf046df4d166cfd60771b9c24a631f/0_0_1140_683", toneClass=Some("tone-trans-guardian-live")) {
             <p class="text-feature">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ullam, error hic temporibus. Aliquam nemo delectus possimus repudiandae ut, aut fugit. Pariatur dolorem, explicabo, ducimus deserunt perspiciatis voluptates commodi debitis exercitationem.</p>
         }
     }


### PR DESCRIPTION
it seems Google is not a fan of hard breaks, particularly in the first header. This PR removes all hard `<br>`s from `promoPrimary` blocks.

![screen shot 2015-03-20 at 15 58 46](https://cloud.githubusercontent.com/assets/123386/6755488/68eceada-cf1b-11e4-9de0-72c9dfaee199.png)

It does change the wrapping of the text compared to PROD, but it's a bit naff for us to do this anyway it's better for us to just respect the natural flow of the text.

**About - New**
![about - new](https://cloud.githubusercontent.com/assets/123386/6755529/c0d76a72-cf1b-11e4-9878-fcc9d3ae094b.png)

**About - PROD**
![about - live](https://cloud.githubusercontent.com/assets/123386/6755534/c5a7de42-cf1b-11e4-8be4-13571a09add5.png)

**Patrons - New**
![patrons - new](https://cloud.githubusercontent.com/assets/123386/6755541/caea22ca-cf1b-11e4-8043-908f1e40a5f8.png)

**Patrons - PROD**
![patrons - live](https://cloud.githubusercontent.com/assets/123386/6755545/cfd8fb08-cf1b-11e4-95d0-2a77013e5d19.png)

// @rtyley 