### PR TITLE
Track clicks on show release dates

### DIFF
--- a/frontend/app/views/fragments/event/ticketSales.scala.html
+++ b/frontend/app/views/fragments/event/ticketSales.scala.html
@@ -18,7 +18,10 @@
     @if(ticketing.salesDates.anyoneCanBuyTicket) {
         <button class="ticket-sales__toggle u-button-reset u-align-right js-toggle"
                 data-toggle-label="Hide"
-                data-toggle="js-event-ticket-dates-@event.id">
+                data-toggle="js-event-ticket-dates-@event.id"
+                data-metric-trigger="click"
+                data-metric-category="events"
+                data-metric-action="toggle-release-dates">
             Show
         </button>
     }


### PR DESCRIPTION
At some point we seem to have lost click tracking on the 'Show' link for ticket release dates…or maybe we never had it.

![screen shot 2015-03-20 at 17 01 52](https://cloud.githubusercontent.com/assets/123386/6756673/4f3c5ad2-cf23-11e4-947f-4f66714fae47.png)

We'll now get an event like this when someone clicks on it

![screen shot 2015-03-20 at 17 01 14](https://cloud.githubusercontent.com/assets/123386/6756682/5f873cc2-cf23-11e4-8556-2b66b8b179ca.png)

// @mattandrews @davidmcdowell 