### PR TITLE
Don't show mixed-content warning on past-event pages with related articles

### DIFF
--- a/frontend/app/model/RichEvent.scala
+++ b/frontend/app/model/RichEvent.scala
@@ -86,7 +86,7 @@ object RichEvent {
     val tags: Seq[String]
     val metadata: Metadata
     val contentOpt: Option[Content]
-    val pastImageOpt: Option[Asset]
+    val pastImageOpt: Option[ResponsiveImageGroup]
     def deficientGuardianMembersTickets: Boolean
   }
 
@@ -104,12 +104,7 @@ object RichEvent {
     val highlight = contentOpt.map(c => HighlightsMetadata("Read more about this event", c.webUrl))
       .orElse(Some(fallbackHighlightsMetadata))
 
-    val pastImageOpt = for {
-      content <- contentOpt
-      elements <- content.elements
-      element <- elements.find(_.relation == "main")
-      assetOpt <- element.assets.find(_.typeData.get("width") == Some("460"))
-    } yield assetOpt
+    val pastImageOpt = contentOpt.flatMap(ResponsiveImageGroup(_))
 
     def deficientGuardianMembersTickets = event.internalTicketing.flatMap(_.memberDiscountOpt).exists(_.fewerMembersTicketsThanGeneralTickets)
   }

--- a/frontend/app/views/fragments/event/relatedEntry.scala.html
+++ b/frontend/app/views/fragments/event/relatedEntry.scala.html
@@ -5,8 +5,8 @@
     <div class="related-entry block-hover">
         <a href="@content.webUrl" class="minimal-link no-underline">
             <div class="related-entry__media block-hover__media">
-                @for(image <- event.pastImageOpt) {
-                    <img src="@image.file" alt="" class="responsive-img" />
+                @for(img <- event.pastImageOpt) {
+                    <img src="@img.defaultImage" srcset="@img.srcset" sizes="100vw" alt="@img.altText" class="responsive-img" />
                 }
             </div>
             <div class="related-entry__content">


### PR DESCRIPTION
"this page includes other resources which are not secure" - the side box image which was using old code to pull an image off the related article.

https://membership.theguardian.com/event/dior-and-i-preview-screening-and-director-qa-15946684964

![screenshot](https://cloud.githubusercontent.com/assets/52038/6764621/3cd3adee-cfb1-11e4-8902-02d06b433c50.png)

We've already got [fixed code](https://github.com/guardian/membership-frontend/blob/6f2e9561/frontend/app/model/ResponsiveImage.scala#L15) for this in `ResponsiveImageGroup`, which converts the image url to the secure version, so using that fixes the problem and lets us delete some code too.

cc @davidrapson 