### PR TITLE
Set Cache-Control to serve *stale* cached-content on server errors

### DIFF
--- a/frontend/app/controllers/Cached.scala
+++ b/frontend/app/controllers/Cached.scala
@@ -1,12 +1,16 @@
 package controllers
 
+import com.github.nscala_time.time.Imports._
 import org.joda.time.DateTime
 import play.api.mvc.Result
-import com.github.nscala_time.time.Imports._
+
+import scala.math.max
 
 object Cached {
 
   private val cacheableStatusCodes = Seq(200, 301, 404)
+
+  private val tenDaysInSeconds = 10.days.standardDuration.seconds
 
   def apply(result: Result): Result = apply(60)(result)
 
@@ -18,8 +22,9 @@ object Cached {
 
   private def cacheHeaders(maxAge: Int, result: Result) = {
     val now = DateTime.now
+    val staleWhileRevalidateSeconds = max(maxAge / 10, 1)
     result.withHeaders(
-      "Cache-Control" -> s"max-age=$maxAge",
+      "Cache-Control" -> s"max-age=$maxAge, stale-while-revalidate=$staleWhileRevalidateSeconds, stale-if-error=$tenDaysInSeconds",
       "Expires" -> toHttpDateTimeString(now + maxAge.seconds),
       "Date" -> toHttpDateTimeString(now)
     )

--- a/frontend/test/controllers/common/CachedTest.scala
+++ b/frontend/test/controllers/common/CachedTest.scala
@@ -1,18 +1,21 @@
 package controllers.common
 
 import org.specs2.mutable.Specification
-import play.api.mvc.Results
+import play.api.mvc.{Result, Results}
 import controllers.Cached
 import org.joda.time.DateTime
 
 class CachedTest extends Specification with Results {
 
   "Cached" should {
+    def cacheControlSectionsOn(result: Result): Seq[String] =
+      result.header.headers("Cache-Control").split(",").toSeq.map(_.trim)
 
-    "cache live content for 30 seconds" in {
-      val result = Cached(2)(Ok("foo"))
-      val headers = result.header.headers
-      headers("Cache-Control") mustEqual "max-age=2"
+    "cache live content for the specified number of seconds" in {
+      cacheControlSectionsOn(Cached(2)(Ok)) must contain("max-age=2")
+    }
+    "serve stale content on error for 10 days if necessary" in {
+      cacheControlSectionsOn(Cached(Ok)) must contain("stale-if-error=864000")
     }
   }
 


### PR DESCRIPTION
For our cached pages (the front of the site, the events pages) this allows Fastly to serve cached copies of the pages even when the server is down. This would have been helpful for the outage on Friday 20th February, for instance.

https://docs.fastly.com/guides/caching/does-fastly-allow-serving-old-content-while-fetching-new-content

With the static parts of the site working even with no operating servers, we've got to be aware that the uncached parts - generating an eventbrite discount for ticket purchase, or joining/upgrading as a member, would still be inoperable and require fixing ASAP!

See also: https://github.com/guardian/frontend/blob/9205d67/common/app/model/Cached.scala#L39

cc @jennysivapalan @davidrapson @mattandrews 