### PR TITLE
Make discount-codes clearer to users so they don't delete them

### DIFF
--- a/frontend/app/services/DiscountCode.scala
+++ b/frontend/app/services/DiscountCode.scala
@@ -6,6 +6,7 @@ object DiscountCode {
   def generate(text: String): String = {
     val md = java.security.MessageDigest.getInstance("SHA-1")
     val digest = md.digest(text.getBytes)
-    new BigInteger(digest).abs.toString(36).toUpperCase.substring(0, 8)
+    val uniqueUserEventCode = new BigInteger(digest).abs.toString(36).toUpperCase.substring(0, 8)
+    s"MEMBER-CODE-$uniqueUserEventCode"
   }
 }


### PR DESCRIPTION
Madeleine on the Events team told me that users sometimes delete the promotional code when on the Eventbrite ticket page - because they think "I didn't mean to type that there!" and they assume it's something they accidentally typed. Of course, once they delete the code, their discount is gone, and they can't get their ticket.

This change means that the code looks like "MEMBER-CODE-59JUK82L" rather than just "59JUK82L", and hopefully this means users will be less likely to delete it.

*Before*
![image](https://cloud.githubusercontent.com/assets/52038/6777147/91b5fbe4-d13e-11e4-8786-090000a69c08.png)

*After*
![image](https://cloud.githubusercontent.com/assets/52038/6777129/7ad470a4-d13e-11e4-9877-2ca72ca5a7e3.png)

cc @davidmcdowell @davidrapson @jennysivapalan 