### PR TITLE
Tweaks to ticket show hide toggle

### DIFF
--- a/frontend/app/views/fragments/event/ticketSales.scala.html
+++ b/frontend/app/views/fragments/event/ticketSales.scala.html
@@ -14,15 +14,15 @@
 }
 
 <div class="ticket-sales" itemprops="offers" itemscope itemtype="http://schema.org/AggregateOffer">
-    <span class="ticket-sales__header">Ticket release dates</span>
+    <span class="ticket-sales__header">@if(ticketing.salesDates.anyoneCanBuyTicket) {Tickets on sale now} else {Ticket release dates}</span>
     @if(ticketing.salesDates.anyoneCanBuyTicket) {
-        <button class="ticket-sales__toggle u-button-reset u-align-right js-toggle"
+        <button class="ticket-sales__toggle show-hide-indicator u-button-reset js-toggle"
                 data-toggle-label="Hide"
                 data-toggle="js-event-ticket-dates-@event.id"
                 data-metric-trigger="click"
                 data-metric-category="events"
                 data-metric-action="toggle-release-dates">
-            Show
+            Release dates
         </button>
     }
     <ul class="ticket-sales__list u-unstyled"

--- a/frontend/app/views/fragments/event/ticketSales.scala.html
+++ b/frontend/app/views/fragments/event/ticketSales.scala.html
@@ -16,12 +16,14 @@
 <div class="ticket-sales" itemprops="offers" itemscope itemtype="http://schema.org/AggregateOffer">
     <span class="ticket-sales__header">@if(ticketing.salesDates.anyoneCanBuyTicket) {Tickets on sale now} else {Ticket release dates}</span>
     @if(ticketing.salesDates.anyoneCanBuyTicket) {
-        <button class="ticket-sales__toggle show-hide-indicator u-button-reset js-toggle"
+        <button class="ticket-sales__toggle u-button-reset js-toggle"
                 data-toggle-label="Hide"
                 data-toggle="js-event-ticket-dates-@event.id"
                 data-metric-trigger="click"
                 data-metric-category="events"
-                data-metric-action="toggle-release-dates">
+                data-metric-action="toggle-release-dates"
+                data-toggle-icon="triangle-up">
+            @fragments.inlineIcon("triangle-down", Seq("u-align-right"))
             Release dates
         </button>
     }

--- a/frontend/assets/images/inline-svgs/raw/triangle-down.svg
+++ b/frontend/assets/images/inline-svgs/raw/triangle-down.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20"><path d="M5 6h10l-5 9-5-9z" fill="#444"/></svg>

--- a/frontend/assets/images/inline-svgs/raw/triangle-up.svg
+++ b/frontend/assets/images/inline-svgs/raw/triangle-up.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20"><path d="M15 14h-10l5-9 5 9z" fill="#444"/></svg>

--- a/frontend/assets/stylesheets/components/_event-detail.scss
+++ b/frontend/assets/stylesheets/components/_event-detail.scss
@@ -492,9 +492,9 @@
     font-weight: bold;
 }
 .ticket-sales__toggle {
-    right: 0;
-    top: 0;
-    position: absolute;
+    @include fs-data(2);
+    color: $c-neutral2;
+    display: block;
 }
 .ticket-sales__toggle:hover,
 .ticket-sales__toggle:active {


### PR DESCRIPTION
- ability to add an open close indicator to toggle element
- changed toggle text for show/hide ticket dates
- dropped toggle cta under header
- change header to `Tickets on sale now` when all tickets are on sale

### Tickets before general release
![screen shot 2015-03-23 at 12 46 57](https://cloud.githubusercontent.com/assets/2305016/6782106/0281c45e-d16a-11e4-9b4c-1f0d9ed3c40d.png)

### Tickets after general release
![screen shot 2015-03-23 at 12 47 20](https://cloud.githubusercontent.com/assets/2305016/6782133/1150ed52-d16a-11e4-8b58-244e8b36e566.png)


### Tickets after general release (opened)

![screen shot 2015-03-23 at 12 47 25](https://cloud.githubusercontent.com/assets/2305016/6782145/1b7ef3aa-d16a-11e4-9fed-10f784b8dbbb.png)
