### PR TITLE
Remove Imager.js

### DIFF
--- a/frontend/app/controllers/Info.scala
+++ b/frontend/app/controllers/Info.scala
@@ -14,23 +14,59 @@ trait Info extends Controller {
   }
 
   def about = CachedAction { implicit request =>
-
     val pageInfo = PageInfo(
       CopyConfig.copyTitleAbout,
       request.path,
       Some(CopyConfig.copyDescriptionAbout)
     )
-
     val pageImages = Seq(
+      ResponsiveImageGroup(
+        name=Some("intro"),
+        altText=Some("About Membership"),
+        availableImages=ResponsiveImageGenerator(
+          id="0f30a12f5d00d2b0e445e81c171cd0168d3cf5a7/0_0_1140_684",
+          sizes=List(1000,500)
+        )
+      ),
+      ResponsiveImageGroup(
+        name=Some("guardian-live"),
+        altText=Some("Guardian Live: Experience the Guardian brought to life"),
+        availableImages=ResponsiveImageGenerator(
+          id="76ef58a05920591099012edb80e7415379392a4c/0_0_1140_684",
+          sizes=List(1000,500)
+        )
+      ),
+      ResponsiveImageGroup(
+        name=Some("founding-members"),
+        altText=Some("Founding members: join us at the start"),
+        availableImages=ResponsiveImageGenerator(
+          id="bb922fe62efbe24af2df336dd2b621c5799246b4/0_0_1140_683",
+          sizes=List(1000,500)
+        )
+      ),
+      ResponsiveImageGroup(
+        name=Some("patrons"),
+        altText=Some("Become a Patron and support the Guardian's future"),
+        availableImages=ResponsiveImageGenerator(
+          id="175fba5c61d2b398973befa5d6b49c1257740d5c/0_0_1140_683",
+          sizes=List(1000,500)
+        )
+      ),
       ResponsiveImageGroup(
         name=Some("masterclasses"),
         altText=Some("Guardian Live event: Pussy Riot - art, sex and disobedience"),
-        availableImages=ResponsiveImageGenerator("ae3ad30b485e9651a772e85dd82bae610f57a034/0_0_1140_684", List(1000, 500))
+        availableImages=ResponsiveImageGenerator(
+          id="ae3ad30b485e9651a772e85dd82bae610f57a034/0_0_1140_684",
+          sizes=List(1000, 500)
+        )
       ),
       ResponsiveImageGroup(
         name=Some("midland-goods-shed"),
         altText=Some("A home for big ideas"),
-        availableImages=ResponsiveImageGenerator("ed9347da5fc1e55721b243a958d42fca1983d012/0_0_1140_684", List(1000, 500))
+        availableImages=ResponsiveImageGenerator(
+          id="ed9347da5fc1e55721b243a958d42fca1983d012/0_0_1140_684",
+          sizes=List(1000, 500)
+        )
       )
     )
     Ok(views.html.info.about(pageInfo, pageImages))
@@ -53,9 +89,28 @@ trait Info extends Controller {
     )
     val pageImages = Seq(
       ResponsiveImageGroup(
+        name=Some("intro"),
+        altText=Some("Introducing Supporter Membership"),
+        availableImages=ResponsiveImageGenerator(
+          id="a0e123f3289d26e0cf30153e64b89f4655a7e0d2/0_0_1999_1200",
+          sizes=List(1000,500)
+        )
+      ),
+      ResponsiveImageGroup(
+        name=Some("fearless"),
+        altText=Some("Fearless, progressive and free from interference"),
+        availableImages=ResponsiveImageGenerator(
+          id="8cc033c84791f1583fc52f337d3c6c3ffb368f8e/0_0_1999_1200",
+          sizes=List(1000,500)
+        )
+      ),
+      ResponsiveImageGroup(
         name=Some("polly-toynbee"),
         altText=Some("If you read the Guardian, join the Guardian"),
-        availableImages=ResponsiveImageGenerator("17a31ff294d3c77274091c5e078713fc06ef5cd2/0_0_1999_1200", List(1000, 500))
+        availableImages=ResponsiveImageGenerator(
+          id="17a31ff294d3c77274091c5e078713fc06ef5cd2/0_0_1999_1200",
+          sizes=List(1000, 500)
+        )
       )
     )
     Ok(views.html.info.supporter(pageInfo, pageImages))
@@ -69,9 +124,36 @@ trait Info extends Controller {
     )
     val pageImages = Seq(
       ResponsiveImageGroup(
+        name=Some("intro"),
+        altText=Some("Patrons of the Guardian"),
+        availableImages=ResponsiveImageGenerator(
+          id="8caacf301dd036a2bbb1b458cf68b637d3c55e48/0_0_1140_683",
+          sizes=List(1000,500)
+        )
+      ),
+      ResponsiveImageGroup(
+        name=Some("independence"),
+        altText=Some("Ensuring our independence"),
+        availableImages=ResponsiveImageGenerator(
+          id="e6459f638392c8176e277733f6f0802953100fa4/0_0_1140_683",
+          sizes=List(1000,500)
+        )
+      ),
+      ResponsiveImageGroup(
+        name=Some("get-involved"),
+        altText=Some("Choose to get involved"),
+        availableImages=ResponsiveImageGenerator(
+          id="d8f51bea15bf046df4d166cfd60771b9c24a631f/0_0_1140_683",
+          sizes=List(1000,500)
+        )
+      ),
+      ResponsiveImageGroup(
         name=Some("backstage-pass"),
         altText=Some("Backstage pass to the Guardian"),
-        availableImages=ResponsiveImageGenerator("83afa3867ef76d82c86291f4387b5799c26e07f8/0_0_1140_684", List(1000, 500))
+        availableImages=ResponsiveImageGenerator(
+          id="83afa3867ef76d82c86291f4387b5799c26e07f8/0_0_1140_684",
+          sizes=List(1000, 500)
+        )
       )
     )
     Ok(views.html.info.patron(pageInfo, pageImages))

--- a/frontend/app/controllers/PatternLibrary.scala
+++ b/frontend/app/controllers/PatternLibrary.scala
@@ -1,11 +1,30 @@
 package controllers
 
-import model.EventPortfolio
+import model.{ResponsiveImageGenerator, ResponsiveImageGroup, EventPortfolio}
 import play.api.mvc.Controller
 import services.{GuardianLiveEventService, EventbriteService}
 
 trait PatternLibrary extends Controller {
   val guLiveEvents: EventbriteService
+
+  val pageImages = Seq(
+    ResponsiveImageGroup(
+      name=Some("sample-1"),
+      altText=Some("Patrons of the Guardian"),
+      availableImages=ResponsiveImageGenerator(
+        id="8caacf301dd036a2bbb1b458cf68b637d3c55e48/0_0_1140_683",
+        sizes=List(1000,500)
+      )
+    ),
+    ResponsiveImageGroup(
+      name=Some("sample-2"),
+      altText=Some("Ensuring our independence"),
+      availableImages=ResponsiveImageGenerator(
+        id="e6459f638392c8176e277733f6f0802953100fa4/0_0_1140_683",
+        sizes=List(1000,500)
+      )
+    )
+  )
 
   def patterns = NoCacheAction { implicit request =>
     Ok(views.html.patterns.patterns(
@@ -14,7 +33,9 @@ trait PatternLibrary extends Controller {
         guLiveEvents.getEvents,
         guLiveEvents.getEventsArchive,
         guLiveEvents.getPartnerEvents
-      )))
+      ),
+      pageImages
+    ))
   }
 
 }

--- a/frontend/app/views/fragments/promos/promoPrimary.scala.html
+++ b/frontend/app/views/fragments/promos/promoPrimary.scala.html
@@ -1,6 +1,6 @@
 @(
     title: String,
-    imageBasePath: String,
+    img: model.ResponsiveImageGroup,
     stampImageOpt: Option[String] = None,
     isLead: Boolean = false,
     toneClass: Option[String] = None
@@ -14,7 +14,7 @@
     </div>
     <div class="promo-primary__media@if(stampImageOpt){ stamped-image}">
         <div class="promo-primary__image">
-            <div class="js-imager-loaded-image" data-src="@imageBasePath/{width}.jpg" data-available-widths="1000,500,140" data-alt="@title" data-class="responsive-img"></div>
+            <img src="@img.defaultImage" srcset="@img.srcset" sizes="100vw" alt="@img.altText" class="responsive-img" />
         </div>
         @for(url <- stampImageOpt) {
             <div class="stamped-image__container">

--- a/frontend/app/views/info/about.scala.html
+++ b/frontend/app/views/info/about.scala.html
@@ -6,44 +6,48 @@
 @main("About", pageInfo=pageInfo) {
 
     @* ===== About Membership ===== *@
-    <div class="page-slice l-constrained">
-        @fragments.promos.promoPrimary(title="About Membership", imageBasePath="https://media.guim.co.uk/0f30a12f5d00d2b0e445e81c171cd0168d3cf5a7/0_0_1140_684", isLead=true) {
-            <div class="text-feature">
-                <p>Guardian Members are changing the idea of what a news organisation does today.</p>
-                <p>Join the influential community of journalists, readers and contributors that is the Guardian, and connect to the conversations that matter.</p>
-                <p>Join before March 31st to become a Founding Member and the price you pay will not rise.</p>
-            </div>
-            <div class="action-group">
-                <a class="action" href="@routes.Joiner.tierList">Join today</a>
-                <a class="action action--secondary js-scroll-to" href="#whats-included">
-                    What's included
-                    @fragments.actionIcon("arrow-right")
-                </a>
-            </div>
-        }
-    </div>
+    @for(img <- pageImages.find(_.name.contains("intro"))) {
+        <div class="page-slice l-constrained">
+            @fragments.promos.promoPrimary(title="About Membership", img=img, isLead=true) {
+                <div class="text-feature">
+                    <p>Guardian Members are changing the idea of what a news organisation does today.</p>
+                    <p>Join the influential community of journalists, readers and contributors that is the Guardian, and connect to the conversations that matter.</p>
+                    <p>Join before March 31st to become a Founding Member and the price you pay will not rise.</p>
+                </div>
+                <div class="action-group">
+                    <a class="action" href="@routes.Joiner.tierList">Join today</a>
+                    <a class="action action--secondary js-scroll-to" href="#whats-included">
+                        What's included
+                        @fragments.actionIcon("arrow-right")
+                    </a>
+                </div>
+            }
+        </div>
+    }
 
     @* ===== What is Membership Video ===== *@
     <div id="what-is-guardian-membership" class="page-slice page-slice--slim l-constrained">
-    @fragments.promos.promoVideoSecondary(
-        Html("If you believe in Guardian journalism, become a Guardian Member"),
-        videoUrl=Config.videoWhatIsGuardianMembership,
-        toneClass=Some("tone-trans-brand-dark")){
-        <div class="text-feature">
-            <p>Alan Rusbridger, Polly Toynbee, Jonathan Freedland, Owen Jones and Zoe Williams introduce Guardian Membership.</p>
-        </div>
-    }
+        @fragments.promos.promoVideoSecondary(
+            Html("If you believe in Guardian journalism, become a Guardian Member"),
+            videoUrl=Config.videoWhatIsGuardianMembership,
+            toneClass=Some("tone-trans-brand-dark")){
+            <div class="text-feature">
+                <p>Alan Rusbridger, Polly Toynbee, Jonathan Freedland, Owen Jones and Zoe Williams introduce Guardian Membership.</p>
+            </div>
+        }
     </div>
 
     @* ===== Bring the Guardian to life ===== *@
-    <div class="page-slice l-constrained">
-        @fragments.promos.promoPrimary(title="Guardian Live: Experience the Guardian brought to life", imageBasePath="https://media.guim.co.uk/76ef58a05920591099012edb80e7415379392a4c/0_0_1140_684", stampImageOpt=Some("images/logos/guardian-live-reversed.svg"), toneClass=Some("tone-trans-guardian-live")) {
-            <div class="text-feature">
-                <p>Book tickets for our programme of discussions, debates, interviews, keynote speeches and festivals.</p>
-            </div>
-            <a class="action" href="@routes.Event.list">See our live events</a>
-        }
-    </div>
+    @for(img <- pageImages.find(_.name.contains("guardian-live"))) {
+        <div class="page-slice l-constrained">
+            @fragments.promos.promoPrimary(title="Guardian Live: Experience the Guardian brought to life", img=img, stampImageOpt=Some("images/logos/guardian-live-reversed.svg"), toneClass=Some("tone-trans-guardian-live")) {
+                <div class="text-feature">
+                    <p>Book tickets for our programme of discussions, debates, interviews, keynote speeches and festivals.</p>
+                </div>
+                <a class="action" href="@routes.Event.list">See our live events</a>
+            }
+        </div>
+    }
 
     @for(img <- pageImages.find(_.name.contains("masterclasses"))) {
         @* ===== Guardian Masterclasses ===== *@
@@ -58,16 +62,19 @@
     }
 
     @* ===== Founding Members ===== *@
-    <div class="page-slice l-constrained">
-        @fragments.promos.promoPrimary(title="Founding members: join us at the start", imageBasePath="https://media.guim.co.uk/bb922fe62efbe24af2df336dd2b621c5799246b4/0_0_1140_683") {
-            <blockquote class="blockquote blockquote--feature">
-                If you read the Guardian, join the Guardian. Support fearless, open, independent journalism.
-                <cite class="blockquote__citation">Polly Toynbee, Guardian columnist</cite>
-            </blockquote>
-            <p class="text-feature">Join before March 31st to become a Founding Member and the price you pay will not rise.</p>
-            <a class="action" href="@routes.Joiner.tierList" id="qa-join">Join today</a>
-        }
-    </div>
+    @for(img <- pageImages.find(_.name.contains("founding-members"))) {
+        <div class="page-slice l-constrained">
+            @fragments.promos.promoPrimary(title="Founding members: join us at the start", img=img) {
+                <blockquote class="blockquote blockquote--feature">
+                    If you read the Guardian, join the Guardian. Support fearless, open, independent journalism.
+                    <cite class="blockquote__citation">Polly Toynbee, Guardian columnist</cite>
+                </blockquote>
+                <p class="text-feature">
+                    Join before March 31st to become a Founding Member and the price you pay will not rise.</p>
+                <a class="action" href="@routes.Joiner.tierList" id="qa-join">Join today</a>
+            }
+        </div>
+    }
 
     @for(img <- pageImages.find(_.name.contains("midland-goods-shed"))) {
         @* ===== Big ideas ===== *@
@@ -91,15 +98,17 @@
     }
 
     @* ===== Become a Patron ===== *@
-    <div class="page-slice l-constrained">
-        @fragments.promos.promoPrimary(title="Become a Patron and support the Guardian's future", imageBasePath="https://media.guim.co.uk/175fba5c61d2b398973befa5d6b49c1257740d5c/0_0_1140_683", toneClass=Some("tone-trans-brand-dark")) {
-            <blockquote class="blockquote blockquote--feature">
-                The only relationship our journalists have is with our readers. Membership gives the real possibility of deepening the intense bond between the producers and consumers of the Guardian.
-                <cite class="blockquote__citation">Alan Rusbridger, editor-in-chief of the Guardian</cite>
-            </blockquote>
-            <a class="action" href="@routes.Info.patron">Become a Patron</a>
-        }
-    </div>
+    @for(img <- pageImages.find(_.name.contains("patrons"))) {
+        <div class="page-slice l-constrained">
+            @fragments.promos.promoPrimary(title="Become a Patron and support the Guardian's future", img=img, toneClass=Some("tone-trans-brand-dark")) {
+                <blockquote class="blockquote blockquote--feature">
+                    The only relationship our journalists have is with our readers. Membership gives the real possibility of deepening the intense bond between the producers and consumers of the Guardian.
+                    <cite class="blockquote__citation">Alan Rusbridger, editor-in-chief of the Guardian</cite>
+                </blockquote>
+                <a class="action" href="@routes.Info.patron">Become a Patron</a>
+            }
+        </div>
+    }
 
     @* ===== What's Included ===== *@
     <div class="page-slice tone-tint l-constrained" id="whats-included">

--- a/frontend/app/views/info/patron.scala.html
+++ b/frontend/app/views/info/patron.scala.html
@@ -5,48 +5,55 @@
 @main("Patrons", pageInfo=pageInfo) {
 
     @* ===== About Patronage ===== *@
-    <div class="page-slice l-constrained">
-        @fragments.promos.promoPrimary(title="Patrons of the Guardian", imageBasePath="https://media.guim.co.uk/8caacf301dd036a2bbb1b458cf68b637d3c55e48/0_0_1140_683", isLead=true) {
-            <div class="text-feature">
-                <p>The Patron tier is for those who care deeply about the Guardian’s journalism and the impact it has on the world.</p>
-                <p>From campaigning on issues affecting the voices less heard to holding those in power to account, Patrons ensure the Guardian can continue to surface the information and ideas that shape the global conversation.</p>
-            </div>
-            @fragments.tier.packagePromo(Tier.Patron, showDescription=false, modifierClass=Some("package-promo--spread"))
-        }
-    </div>
+    @for(img <- pageImages.find(_.name.contains("intro"))) {
+        <div class="page-slice l-constrained">
+            @fragments.promos.promoPrimary(title="Patrons of the Guardian", img=img, isLead=true) {
+                <div class="text-feature">
+                    <p>The Patron tier is for those who care deeply about the Guardian’s journalism and the impact it has on the world.</p>
+                    <p>From campaigning on issues affecting the voices less heard to holding those in power to account, Patrons ensure the Guardian can continue to surface the information and ideas that shape the global conversation.</p>
+                </div>
+                @fragments.tier.packagePromo(Tier.Patron, showDescription = false, modifierClass = Some("package-promo--spread"))
+            }
+        </div>
+    }
 
     @* ===== Ensuring our independence ===== *@
-    <div class="page-slice l-constrained">
-        @fragments.promos.promoPrimary(title="Ensuring our independence", imageBasePath="https://media.guim.co.uk/e6459f638392c8176e277733f6f0802953100fa4/0_0_1140_683", toneClass=Some("tone-trans-brand-dark")) {
-            <div class="text-feature">
-                <p>The Guardian has no proprietor. Our editor has total independence.</p>
-                <p>The support of Patrons helps to ensure that the Guardian can stand witness to the world, without interference.</p>
-            </div>
-        }
-    </div>
+    @for(img <- pageImages.find(_.name.contains("independence"))) {
+        <div class="page-slice l-constrained">
+            @fragments.promos.promoPrimary(title="Ensuring our independence", img=img, toneClass=Some("tone-trans-brand-dark")) {
+                <div class="text-feature">
+                    <p>The Guardian has no proprietor. Our editor has total independence.</p>
+                    <p>The support of Patrons helps to ensure that the Guardian can stand witness to the world, without interference.</p>
+                </div>
+            }
+        </div>
+    }
 
+    @* ===== Backstage Pass ===== *@
     @for(img <- pageImages.find(_.name.contains("backstage-pass"))) {
-        @* ===== Backstage Pass ===== *@
         <div class="page-slice page-slice--slim l-constrained">
-        @fragments.promos.promoSecondary(Html("Backstage pass to<br>the Guardian"), img=img, toneClass = Some("tone-brand")) {
-            <p class="text-feature">In return for your support, Patrons are given a behind-the-scenes view of how the Guardian operates.  For example, tour our newsroom, visit our printing presses or attend a campaign lecture.</p>
-            <a class="action"
-                href="@routes.Joiner.enterDetails(Tier.Patron)"
-                data-metric-trigger="click"
-                data-metric-category="join"
-                data-metric-action="patron"
-            >Become a Patron today</a>
-        }
+            @fragments.promos.promoSecondary(Html("Backstage pass to the Guardian"), img=img) {
+                <p class="text-feature">In return for your support, Patrons are given a behind-the-scenes view of how the Guardian operates.  For example, tour our newsroom, visit our printing presses or attend a campaign lecture.</p>
+                <a class="action"
+                    href="@routes.Joiner.enterDetails(Tier.Patron)"
+                    data-metric-trigger="click"
+                    data-metric-category="join"
+                    data-metric-action="patron"
+                >Become a Patron today</a>
+            }
         </div>
     }
 
     @* ===== Get Involved ===== *@
-    <div class="page-slice l-constrained">
-        @fragments.promos.promoPrimary(title="Choose to get involved", imageBasePath="https://media.guim.co.uk/d8f51bea15bf046df4d166cfd60771b9c24a631f/0_0_1140_683", toneClass=Some("tone-trans-brand-dark")) {
-            <p class="text-feature">Patrons are crucial to the future development of Membership, and there will be opportunities to get involved.  From hosting your own events to connecting members to one another, you will shape the future of the community.</p>
-            @fragments.tier.packagePromo(Tier.Patron, showDescription=false, modifierClass=Some("package-promo--spread"))
-        }
-    </div>
+    @for(img <- pageImages.find(_.name.contains("get-involved"))) {
+        <div class="page-slice l-constrained">
+            @fragments.promos.promoPrimary(title="Choose to get involved", img=img, toneClass=Some("tone-trans-brand-dark")) {
+                <p class="text-feature">
+                    Patrons are crucial to the future development of Membership, and there will be opportunities to get involved.  From hosting your own events to connecting members to one another, you will shape the future of the community.</p>
+                @fragments.tier.packagePromo(Tier.Patron, showDescription = false, modifierClass = Some("package-promo--spread"))
+            }
+        </div>
+    }
 
     @* ===== Join Today ===== *@
     <div class="page-slice page-slice--split tone-tint l-constrained">

--- a/frontend/app/views/info/supporter.scala.html
+++ b/frontend/app/views/info/supporter.scala.html
@@ -6,14 +6,16 @@
 @main("Supporters", pageInfo=pageInfo) {
 
     @* ===== About Supporters ===== *@
-    <div class="page-slice l-constrained">
-        @fragments.promos.promoPrimary(title="Introducing Supporter Membership", imageBasePath="//media.guim.co.uk/a0e123f3289d26e0cf30153e64b89f4655a7e0d2/0_0_1999_1200", isLead=true) {
-            <div class="text-feature">
-                <p>Supporters keep our journalism fearless, open and free from interference. For £5 a month.</p>
-            </div>
-            @fragments.tier.packagePromo(Tier.Supporter, showDescription=false, modifierClass=Some("package-promo--spread"))
-        }
-    </div>
+    @for(img <- pageImages.find(_.name.contains("intro"))) {
+        <div class="page-slice l-constrained">
+            @fragments.promos.promoPrimary(title="Introducing Supporter Membership", img=img, isLead=true) {
+                <div class="text-feature">
+                    <p>Supporters keep our journalism fearless, open and free from interference. For £5 a month.</p>
+                </div>
+                @fragments.tier.packagePromo(Tier.Supporter, showDescription=false, modifierClass=Some("package-promo--spread"))
+            }
+        </div>
+    }
 
     @* ===== Support open, independent journalism ===== *@
     <div id="supporter-video" class="page-slice page-slice--slim l-constrained">
@@ -28,23 +30,25 @@
     </div>
 
     @* ===== Ensuring our independence ===== *@
-    <div class="page-slice l-constrained">
-        @fragments.promos.promoPrimary(title="Fearless, progressive and free from interference", imageBasePath="//media.guim.co.uk/8cc033c84791f1583fc52f337d3c6c3ffb368f8e/0_0_1999_1200") {
-            <div class="text-feature">
-                <p>The Guardian publishes the stories that others keep hidden.</p>
-                <p>We have become the most read, serious English-language newspaper in the world, visited by 120 million unique browsers each month. Our journalism is for everyone. The Guardian is open, without a paywall, and we remain true to our 200-year old progressive values.</p>
-                <p>Become a Supporter to ensure the whole picture is available to everyone.</p>
-            </div>
-            <div class="action-group">
-                <a class="action" href="@routes.Joiner.enterDetails(Tier.Supporter)">Become a Supporter</a>
-            </div>
-        }
-    </div>
+    @for(img <- pageImages.find(_.name.contains("fearless"))) {
+        <div class="page-slice l-constrained">
+            @fragments.promos.promoPrimary(title="Fearless, progressive and free from interference", img=img) {
+                <div class="text-feature">
+                    <p>The Guardian publishes the stories that others keep hidden.</p>
+                    <p>We have become the most read, serious English-language newspaper in the world, visited by 120 million unique browsers each month. Our journalism is for everyone. The Guardian is open, without a paywall, and we remain true to our 200-year old progressive values.</p>
+                    <p>Become a Supporter to ensure the whole picture is available to everyone.</p>
+                </div>
+                <div class="action-group">
+                    <a class="action" href="@routes.Joiner.enterDetails(Tier.Supporter)">Become a Supporter</a>
+                </div>
+            }
+        </div>
+    }
 
+    @* ===== Join The Guardian and support The Guardian ===== *@
     @for(img <- pageImages.find(_.name.contains("polly-toynbee"))) {
-        @* ===== Join The Guardian and support The Guardian ===== *@
         <div class="page-slice page-slice--slim l-constrained">
-        @fragments.promos.promoSecondary(Html("If you read the Guardian, join the Guardian"), img=img, toneClass = Some("tone-trans-brand-dark")) {
+        @fragments.promos.promoSecondary(Html("If you read the Guardian, join the Guardian"), img=img, toneClass=Some("tone-trans-brand-dark")) {
             <blockquote class="blockquote blockquote--feature">
                 You matter to us not just for your support, but because we gain from your insight too. Through the conversations we are having with members, we can challenge conventional wisdoms together.
                 <cite class="blockquote__citation">Polly Toynbee, Guardian columnist</cite>

--- a/frontend/app/views/patterns/patterns.scala.html
+++ b/frontend/app/views/patterns/patterns.scala.html
@@ -1,4 +1,5 @@
-@(eventPortfolio: model.EventPortfolio)(implicit token: play.filters.csrf.CSRF.Token)
+@(eventPortfolio: model.EventPortfolio, pageImages: Seq[model.ResponsiveImageGroup])(implicit token: play.filters.csrf.CSRF.Token)
+
 @import com.gu.membership.salesforce.Tier
 @import configuration.Config
 @import model.{Benefits, FlashMessage}
@@ -277,24 +278,34 @@
         @fragments.event.seriesDetails(eventPortfolio.orderedEvents.head)
     }
 
-    @pattern("Promo - Primary") {
-        @fragments.promos.promoPrimary("Primary Promo", imageBasePath="https://media.guim.co.uk/d8f51bea15bf046df4d166cfd60771b9c24a631f/0_0_1140_683", toneClass=Some("tone-trans-guardian-live")) {
-            <p class="text-feature">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ullam, error hic temporibus. Aliquam nemo delectus possimus repudiandae ut, aut fugit. Pariatur dolorem, explicabo, ducimus deserunt perspiciatis voluptates commodi debitis exercitationem.</p>
+    @for(img <- pageImages.find(_.name.contains("sample-1"))) {
+        @pattern("Promo - Primary") {
+            @fragments.promos.promoPrimary("Primary Promo", img=img, toneClass=Some("tone-trans-guardian-live")) {
+                <p class="text-feature">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ullam, error hic temporibus. Aliquam nemo delectus possimus repudiandae ut, aut fugit. Pariatur dolorem, explicabo, ducimus deserunt perspiciatis voluptates commodi debitis exercitationem.</p>
+            }
         }
     }
 
-    @pattern("Promo Video - Secondary") {
-        <div class="page-slice page-slice--slim l-constrained">
-        @fragments.promos.promoVideoSecondary(
-            Html("If you believe in Guardian journalism, become a Guardian Member"),
-            videoUrl = Config.videoWhatIsGuardianMembership,
-            toneClass = Some("tone-trans-brand-dark")) {
-            <div class="text-feature">
-                <p> Alan Rusbridger, Polly Toynbee, Jonathan Freedland, Owen Jones and Zoe Williams talk about why readers play such an important part of the Guardian.</p>
-                <p>Sign up as a member, you’ll be supporting free, independent journalism and helping us create original, compelling stories.</p>
-            </div>
-            <a class="action u-no-top-margin" href="@routes.Joiner.tierList">Join today</a>
+    @for(img <- pageImages.find(_.name.contains("sample-2"))) {
+        @pattern("Promo - Secondary") {
+            @fragments.promos.promoSecondary(Html("Secondary Promo"), img=img, toneClass=Some("tone-brand-dark")) {
+                <p class="text-feature">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ullam, error hic temporibus. Aliquam nemo delectus possimus repudiandae ut, aut fugit. Pariatur dolorem, explicabo, ducimus deserunt perspiciatis voluptates commodi debitis exercitationem.</p>
+            }
         }
+    }
+
+    @pattern("Promo - Video") {
+        <div class="page-slice page-slice--slim l-constrained">
+            @fragments.promos.promoVideoSecondary(
+                Html("If you believe in Guardian journalism, become a Guardian Member"),
+                videoUrl = Config.videoWhatIsGuardianMembership,
+                toneClass = Some("tone-trans-brand-dark")) {
+                <div class="text-feature">
+                    <p> Alan Rusbridger, Polly Toynbee, Jonathan Freedland, Owen Jones and Zoe Williams talk about why readers play such an important part of the Guardian.</p>
+                    <p>Sign up as a member, you’ll be supporting free, independent journalism and helping us create original, compelling stories.</p>
+                </div>
+                <a class="action u-no-top-margin" href="@routes.Joiner.tierList">Join today</a>
+            }
         </div>
     }
 

--- a/frontend/assets/javascripts/bower.json
+++ b/frontend/assets/javascripts/bower.json
@@ -9,7 +9,6 @@
     "reqwest": "~1.1.0",
     "zxcvbn": "*",
     "curl": "~0.8.10",
-    "imager.js": "~0.3.0",
     "raven-js": "~1.1.16",
     "lodash-amd": "~3.1.0",
     "respimage": "~1.3.0",

--- a/frontend/assets/javascripts/src/modules/images.js
+++ b/frontend/assets/javascripts/src/modules/images.js
@@ -1,34 +1,13 @@
-define([
-    'respimage',
-    'lazySizes',
-    'lib/bower-components/imager.js/Imager',
-    'src/utils/helper'
-], function(respimage, lazySizes, Imager, utilsHelper) {
+define(['respimage', 'lazySizes'], function(respimage, lazySizes) {
 
     var LAZYLOAD_CLASS = 'js-lazyload';
-    var IMAGE_LOADED_IMAGE = '.js-imager-loaded-image';
 
     function init() {
-
         window.lazySizesConfig.lazyClass = LAZYLOAD_CLASS;
         var lazyImgs = document.querySelectorAll('.' + LAZYLOAD_CLASS);
         if(lazyImgs.length) {
             lazySizes.init();
         }
-
-        var imagerImages = utilsHelper.toArray(document.querySelectorAll(IMAGE_LOADED_IMAGE));
-
-        if (imagerImages.length) {
-            imagerImages.map(function(image) {
-                var imageAvailableWidths = image.getAttribute('data-available-widths');
-                new Imager([image], {
-                    availableWidths: imageAvailableWidths ? imageAvailableWidths.split(',') : [],
-                    lazyload: true,
-                    lazyloadOffset: 100
-                });
-            });
-        }
-
     }
 
     return {


### PR DESCRIPTION
This PR removes Imager.js as a dependency by updating remaining images to use native responsive images (only `promoPrimary`).

- Remove Imager.js :no_entry_sign: 
- All promo images now using `ResponsiveImage` and modelled in controller
