### PR TITLE
Add Australia and USA staff groups

### DIFF
--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -124,7 +124,7 @@ google.groups {
   client.password=""
 }
 
-staff.authorised.emails.groups = "permanent.ftc.staff@guardian.co.uk,permanent.ftc.staff.global@guardian.co.uk,freestaff.membership@guardian.co.uk"
+staff.authorised.emails.groups = "permanent.ftc.staff@guardian.co.uk,all.staff.usa@theguardian.com,all.staff.australia@theguardian.com,freestaff.membership@guardian.co.uk"
 
 grid.images {
   media.url=""


### PR DESCRIPTION
The permanent.ftc.staff.global@guardian.co.uk group has been removed, this PR adds the following groups for Australia and USA staff members:

- all.staff.australia@theguardian.com
- all.staff.usa@theguardian.com

// @rtyley 