### PR TITLE
Fix omniture pageName

### DIFF
--- a/frontend/app/views/main.scala.html
+++ b/frontend/app/views/main.scala.html
@@ -11,6 +11,8 @@
 <html class="js-off id--signed-out @htmlClass">
     <head>
         <meta charset="utf-8">
+        <title>@(title + " | " + Config.siteTitle )</title>
+
         @fragments.meta.mobile()
         <meta name="description"                    content="@pageInfo.description"/>
         <meta name="rating"                         content="general"/>
@@ -46,7 +48,6 @@
             }
         </script>
 
-        <title>@(title + " | " + Config.siteTitle )</title>
         @fragments.javaScriptFirstSteps(pageInfo)
 
         <!--[if (gt IE 9) | (IEMobile)]><!-->

--- a/frontend/assets/javascripts/src/modules/analytics/omniture.js
+++ b/frontend/assets/javascripts/src/modules/analytics/omniture.js
@@ -10,7 +10,6 @@ define([
 
         require(['js!omniture'], function () {
 
-            var pageTitle = document.getElementsByTagName('title')[0].textContent;
             /*global s_gi: true */
             var s = s_gi('guardiangu-network');
             var s_code;
@@ -26,7 +25,7 @@ define([
                 }
             }
 
-            s.pageName = pageTitle;
+            s.pageName = document.title;
             s.channel = MEMBERSHIP_STRING;
             s.eVar5 = NONE_STRING;
 


### PR DESCRIPTION
This PR fixes the value for `pageName` sent to Omniture.

Rather than looking for `document.title` we were looking for the first `<title>` element. The addition of a new `script` tag for social links *above* the page `<title`> element mean that the Omniture setup got the title of the first icon of the SVG sprite…

That was a weird one to track down.

This PR updates the Omniture script to use the standard `document.title`;


// @feedmypixel 