### PR TITLE
Fix yearly payment period string ongoing payments

### DIFF
--- a/frontend/app/views/fragments/form/cardDetail.scala.html
+++ b/frontend/app/views/fragments/form/cardDetail.scala.html
@@ -17,10 +17,9 @@
                 <h3 class="credit-card-note__header">Ongoing payments</h3>
                 @Benefits.details(tier).pricing.fold{
                 }{ pricing =>
-                    <p>Your card will be charged £
-                        <span class="js-card-note-pricing-charge"
-                              data-annual="@pricing.yearly"
-                              data-month="@pricing.monthly">@pricing.yearly</span>
+                    <p>Your card will be charged £<span class="js-card-note-pricing-charge"
+                                                         data-annual="@pricing.yearly"
+                                                         data-month="@pricing.monthly">@pricing.yearly</span>
                         every
                         <span class="js-card-note-pricing-period"
                               data-annual="year"

--- a/frontend/assets/javascripts/src/modules/form/payment/options.js
+++ b/frontend/assets/javascripts/src/modules/form/payment/options.js
@@ -1,11 +1,11 @@
-define(['bean'], function (bean) {
+define(['$', 'bean'], function ($, bean) {
     'use strict';
 
     var PAYMENT_OPTIONS_CONTAINER_ELEM = document.querySelector('.js-payment-options-container');
     var FORM_SUBMIT_PRICE_OPTION_ELEM = document.querySelector('.js-submit-price-option');
     var CARD_DETAILS_NOTE_ELEM = document.querySelector('.js-card-details-note');
     var CARD_NOTE_CHARGE_ELEM = CARD_DETAILS_NOTE_ELEM.querySelector('.js-card-note-pricing-charge');
-    var CARD_NOTE_PERIOD_ELEM = CARD_DETAILS_NOTE_ELEM.querySelector('.js-card-note-pricing-period');
+    var $CARD_NOTE_PERIOD_ELEMS = $('.js-card-note-pricing-period');
     var CARD_NOTE_PAYMENT_TAKEN_ELEM = CARD_DETAILS_NOTE_ELEM.querySelector('.js-card-note-payment-taken');
 
     var init = function () {
@@ -34,10 +34,9 @@ define(['bean'], function (bean) {
      */
     var populateCardNote = function(period) {
         var attr = 'data-' + period;
-
         CARD_NOTE_CHARGE_ELEM.textContent = CARD_NOTE_CHARGE_ELEM.getAttribute(attr);
-        CARD_NOTE_PERIOD_ELEM.textContent = CARD_NOTE_PERIOD_ELEM.getAttribute(attr);
         CARD_NOTE_PAYMENT_TAKEN_ELEM.innerHTML = CARD_NOTE_PAYMENT_TAKEN_ELEM.getAttribute(attr);
+        $CARD_NOTE_PERIOD_ELEMS.text($CARD_NOTE_PERIOD_ELEMS.attr(attr));
     };
 
     return {


### PR DESCRIPTION
- There was a bug where the second period string was not being updated. It now reads "taken on or shortly after the 24th every `month`" rather than "taken on or shortly after the 24th every `year`"
- Removed the white space between the £ and amount.

![period-string](https://cloud.githubusercontent.com/assets/2305016/6801258/0ada303c-d21e-11e4-9110-2909b399ce66.gif)


