### PR TITLE
[Do not merge] Updates to choose tier for members area

### DIFF
--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -43,6 +43,11 @@ object Config {
   def eventImageUrlPath(id: String): String =
     config.getString("membership.event.images.url") + id
 
+  val eventImageWidths = config.getList("membership.event.images.widths").unwrapped
+  val eventImageRatios = config.getList("membership.event.images.ratios").unwrapped
+  val homeImageWidths = config.getList("membership.home.images.widths").unwrapped
+  val homeImageRatios = config.getList("membership.home.images.ratios").unwrapped
+
   val idKeys = if (config.getBoolean("identity.production.keys")) new ProductionKeys else new PreProductionKeys
 
   val idApiUrl = config.getString("identity.api.url")

--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -43,11 +43,6 @@ object Config {
   def eventImageUrlPath(id: String): String =
     config.getString("membership.event.images.url") + id
 
-  val eventImageWidths = config.getList("membership.event.images.widths").unwrapped
-  val eventImageRatios = config.getList("membership.event.images.ratios").unwrapped
-  val homeImageWidths = config.getList("membership.home.images.widths").unwrapped
-  val homeImageRatios = config.getList("membership.home.images.ratios").unwrapped
-
   val idKeys = if (config.getBoolean("identity.production.keys")) new ProductionKeys else new PreProductionKeys
 
   val idApiUrl = config.getString("identity.api.url")
@@ -125,10 +120,10 @@ object Config {
       username = backendConf.getString("zuora.api.username"),
       password = backendConf.getString("zuora.api.password"),
       productRatePlans = Map(
-          FriendTierPlan -> backendConf.getString(s"zuora.api.friend"),
-          StaffPlan -> backendConf.getString(s"zuora.api.staff")
-        ) ++ Seq(Tier.Supporter, Tier.Partner, Tier.Patron).map(plansForTier).reduce(_ ++ _)
-      )
+        FriendTierPlan -> backendConf.getString(s"zuora.api.friend"),
+        StaffPlan -> backendConf.getString(s"zuora.api.staff")
+      ) ++ Seq(Tier.Supporter, Tier.Partner, Tier.Patron).map(plansForTier).reduce(_ ++ _)
+    )
 
     TouchpointBackendConfig(salesforceConfig, stripeApiConfig, zuoraApiConfig)
   }

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -1,5 +1,3 @@
-
-
 package controllers
 
 import actions.Functions._

--- a/frontend/app/model/MembershipAccess.scala
+++ b/frontend/app/model/MembershipAccess.scala
@@ -1,0 +1,6 @@
+package model
+
+case class MembershipAccess(accessType: String) {
+  val isMembersOnly = accessType.equals("members-only")
+  val isPaidMembersOnly = accessType.equals("paid-members-only")
+}

--- a/frontend/app/views/joiner/tierChooser.scala.html
+++ b/frontend/app/views/joiner/tierChooser.scala.html
@@ -9,8 +9,8 @@
 
 @sectionTitle = @{
     contentAccessOpt.map {
-        case i if i.isMembersOnly => "You need to be a Guardian member to gain access"
-        case i if i.isPaidMembersOnly => "You need to be a Partner or a Patron to gain access"
+        case i if i.isMembersOnly => "You need to be a Guardian member to view this page"
+        case i if i.isPaidMembersOnly => "You need to be a Partner or a Patron to view this page"
     }.getOrElse(eventOpt.fold("Choose a membership tier to continue")(_.metadata.chooseTier.sectionTitle))
 }
 

--- a/frontend/app/views/joiner/tierChooser.scala.html
+++ b/frontend/app/views/joiner/tierChooser.scala.html
@@ -1,11 +1,18 @@
 @(
     pageInfo: model.PageInfo,
-    sectionTitle: String,
     eventOpt: Option[model.RichEvent.RichEvent],
-    contentAccessOpt: Option[model.MembershipAccess]
+    contentAccessOpt: Option[model.MembershipAccess],
+    returnUri: String
 )(implicit token: play.filters.csrf.CSRF.Token)
 
 @import com.gu.membership.salesforce.Tier
+
+@sectionTitle = @{
+    contentAccessOpt.map {
+        case i if i.isMembersOnly => "You need to be a Guardian member to gain access"
+        case i if i.isPaidMembersOnly => "You need to be a Partner or a Patron to gain access"
+    }.getOrElse(eventOpt.fold("Choose a membership tier to continue")(_.metadata.chooseTier.sectionTitle))
+}
 
 @main("Join Choose Tier", pageInfo=pageInfo) {
 
@@ -16,9 +23,12 @@
         <section class="page-section page-section--no-padding">
             <div class="page-section__lead-in">
                 @fragments.joiner.joinStepCounter(1, 3)
+                <p class="text-note copy tier-hidden">Already a member? <a href="@returnUri">Please sign in</a></p>
             </div>
             <div class="page-section__content">
-                <h2 class="h-section h-section--lead">@sectionTitle</h2>
+                <h2 class="h-section h-section--lead">
+                    @sectionTitle
+                </h2>
                 @if(contentAccessOpt.filter(_.isPaidMembersOnly)) {
                     <ul class="grid grid--bordered grid--2up-stacked">
                         <li class="grid__item">

--- a/frontend/app/views/joiner/tierChooser.scala.html
+++ b/frontend/app/views/joiner/tierChooser.scala.html
@@ -1,4 +1,9 @@
-@(eventOpt: Option[model.RichEvent.RichEvent], pageInfo: model.PageInfo)(implicit token: play.filters.csrf.CSRF.Token)
+@(
+    pageInfo: model.PageInfo,
+    sectionTitle: String,
+    eventOpt: Option[model.RichEvent.RichEvent],
+    contentAccessOpt: Option[model.MembershipAccess]
+)(implicit token: play.filters.csrf.CSRF.Token)
 
 @import com.gu.membership.salesforce.Tier
 
@@ -13,18 +18,29 @@
                 @fragments.joiner.joinStepCounter(1, 3)
             </div>
             <div class="page-section__content">
-                <h2 class="h-section h-section--lead">@eventOpt.fold("Choose a membership tier to continue with your booking")(_.metadata.chooseTier.sectionTitle)</h2>
-                <ul class="grid grid--single-row grid--bordered grid--3up-stacked">
-                    <li class="grid__item">
-                        @fragments.tier.packagePromo(Tier.Friend, Some("#package-benefits-friend"))
-                    </li>
-                    <li class="grid__item">
-                        @fragments.tier.packagePromo(Tier.Partner, Some("#package-benefits-partner"))
-                    </li>
-                    <li class="grid__item">
-                        @fragments.tier.packagePromo(Tier.Patron, Some("#package-benefits-patron"))
-                    </li>
-                </ul>
+                <h2 class="h-section h-section--lead">@sectionTitle</h2>
+                @if(contentAccessOpt.filter(_.isPaidMembersOnly)) {
+                    <ul class="grid grid--bordered grid--2up-stacked">
+                        <li class="grid__item">
+                            @fragments.tier.packagePromo(Tier.Partner, Some("#package-benefits-partner"))
+                        </li>
+                        <li class="grid__item">
+                            @fragments.tier.packagePromo(Tier.Patron, Some("#package-benefits-patron"))
+                        </li>
+                    </ul>
+                } else {
+                    <ul class="grid grid--bordered grid--3up-stacked">
+                        <li class="grid__item">
+                            @fragments.tier.packagePromo(Tier.Friend, Some("#package-benefits-friend"))
+                        </li>
+                        <li class="grid__item">
+                            @fragments.tier.packagePromo(Tier.Partner, Some("#package-benefits-partner"))
+                        </li>
+                        <li class="grid__item">
+                            @fragments.tier.packagePromo(Tier.Patron, Some("#package-benefits-patron"))
+                        </li>
+                    </ul>
+                }
             </div>
             @for(event <- eventOpt) {
                 <div class="page-section__supplementary">

--- a/frontend/assets/stylesheets/components/_pricing.scss
+++ b/frontend/assets/stylesheets/components/_pricing.scss
@@ -82,9 +82,6 @@
 
     }
     .price-info__item--single {
-        text-align: right;
-    }
-    .price-info__item--single {
         padding-right: 0;
     }
     .price-info__item--last {

--- a/frontend/assets/stylesheets/components/_related.scss
+++ b/frontend/assets/stylesheets/components/_related.scss
@@ -48,3 +48,26 @@
         @include fs-headline(3, true);
     }
 }
+
+.entry {
+    display: table;
+    width: 100%;
+    border-top: 1px solid $c-neutral3;
+    background-color: $c-neutral7;
+    margin-bottom: rem($gs-gutter / 2);
+    padding: rem($gs-gutter / 4);
+}
+.entry__media,
+.entry__content {
+    display: table-cell;
+    vertical-align: top;
+}
+.entry__media  {
+    width: rem(gs-span(2));
+    padding-right: rem($gs-gutter/2);
+}
+.entry__title {
+    color: $black;
+    @include fs-headline(2);
+    font-weight: 500;
+}

--- a/frontend/assets/stylesheets/components/_related.scss
+++ b/frontend/assets/stylesheets/components/_related.scss
@@ -48,26 +48,3 @@
         @include fs-headline(3, true);
     }
 }
-
-.entry {
-    display: table;
-    width: 100%;
-    border-top: 1px solid $c-neutral3;
-    background-color: $c-neutral7;
-    margin-bottom: rem($gs-gutter / 2);
-    padding: rem($gs-gutter / 4);
-}
-.entry__media,
-.entry__content {
-    display: table-cell;
-    vertical-align: top;
-}
-.entry__media  {
-    width: rem(gs-span(2));
-    padding-right: rem($gs-gutter/2);
-}
-.entry__title {
-    color: $black;
-    @include fs-headline(2);
-    font-weight: 500;
-}

--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -6,6 +6,8 @@ session.secure=true
 site.title="The Guardian Membership"
 index.title="Home Page"
 
+guardian.url = "http://www.theguardian.com"
+
 membership.url="https://membership.theguardian.com"
 membership.feedback="membershipfeedback@theguardian.com"
 


### PR DESCRIPTION
**WIP** Updates to choose tier for members area content

- Refactor logic to not require query string, use similar referer logic from https://github.com/guardian/membership-frontend/pull/366
- Pass correct return URL to profile depending on source for existing members link.

PR opened to give visibility to @rtyley 

![screen shot 2015-03-24 at 16 51 20](https://cloud.githubusercontent.com/assets/123386/6807397/2aa723ca-d246-11e4-9e37-fe22b7adff8f.png)

![screen shot 2015-03-24 at 16 51 40](https://cloud.githubusercontent.com/assets/123386/6807398/2ab8d11a-d246-11e4-8667-def41133f4f6.png)