### PR TITLE
Refactor FAQ styling

### DIFF
--- a/frontend/app/views/fragments/faq/answers.scala.html
+++ b/frontend/app/views/fragments/faq/answers.scala.html
@@ -1,10 +1,10 @@
 @(faqs: List[model.Faq.Item])
 
 @for(faq <- faqs){
-    <section class="help-faqs" id="@faq.id">
-        <h3 class="help-faqs__headline">@faq.question</h3>
-        <div class="help-faqs__answer copy">
+    <div class="faq-answer" id="@faq.id">
+        <h3 class="faq-answer__headline">@faq.question</h3>
+        <div class="faq-answer__answer copy">
             <p>@faq.answer</p>
         </div>
-    </section>
+    </div>
 }

--- a/frontend/app/views/fragments/faq/questions.scala.html
+++ b/frontend/app/views/fragments/faq/questions.scala.html
@@ -1,14 +1,18 @@
 @(faqs: List[model.Faq.Item])
 
-<ul class="help-list u-unstyled">
-@for(faq <- faqs){
-    <li class="help-item">
-        <a class="help-question" href="#@faq.id">
-            <span class="icon-holder">
-                @fragments.inlineIcon("arrow-down")
-            </span>
-            <span class="help-question__text">@faq.question</span>
-        </a>
-    </li>
-}
+<ul class="faq-list u-unstyled">
+    @for(faq <- faqs){
+        <li class="faq-list__item">
+            <a class="faq-question" href="#@faq.id">
+                <div class="faq-question__icon">
+                    <span class="icon-holder">
+                        @fragments.inlineIcon("arrow-down")
+                    </span>
+                </div>
+                <span class="faq-question__text">
+                    @faq.question
+                </span>
+            </a>
+        </li>
+    }
 </ul>

--- a/frontend/app/views/info/help.scala.html
+++ b/frontend/app/views/info/help.scala.html
@@ -7,9 +7,9 @@
         <section class="page-section">
             <div class="page-section__content">
                 @fragments.faq.questions(Faq.help)
-                <div class="section-faq-anwsers l-pad-right">
+                <section class="section-faq-anwsers l-pad-right">
                     @fragments.faq.answers(Faq.help)
-                </div>
+                </section>
             </div>
             <div class="page-section__supplementary">
                 <aside class="aside copy" role="complementary">

--- a/frontend/assets/stylesheets/components/_faqs.scss
+++ b/frontend/assets/stylesheets/components/_faqs.scss
@@ -1,35 +1,37 @@
 /* ==========================================================================
-   Help page
+   FAQs
    ========================================================================== */
 
-.help-intro {
-    padding-bottom: rem($gs-gutter * 2);
-}
-
-.help-list {
+.faq-list {
     border-top: 1px solid $mem-brandBlue;
     margin-bottom: rem($gs-baseline);
 }
-
-.help-item {
+.faq-list__item {
     background-color: $c-neutral8;
     padding: rem($gs-baseline);
     border-bottom: 1px dotted $c-neutral3;
 }
 
-.help-question {
-    display: block;
+.faq-question {
+    display: table;
+    width: 100%;
 }
-.help-question__text {
+.faq-question__icon,
+.faq-question__text {
+    display: table-cell;
+    vertical-align: top;
+}
+.faq-question__icon {
+    width: rem($gs-gutter * 2);
+}
+.faq-question__text {
     color: $c-body;
-    display: inline-block;
-    padding-left: rem($gs-baseline / 2);
 }
 
-.help-faqs {
+.faq-answer {
     padding-bottom: rem($gs-gutter);
 }
-.help-faqs__headline {
+.faq-answer__headline {
     @include fs-headline(3);
     margin-bottom: 0;
     font-weight: bold;

--- a/frontend/assets/stylesheets/style.scss
+++ b/frontend/assets/stylesheets/style.scss
@@ -92,7 +92,7 @@
 @import 'components/stats';
 @import 'components/tier';
 @import 'components/user';
-@import 'components/help';
+@import 'components/faqs';
 @import 'components/modal';
 @import 'components/loader';
 @import 'components/social';


### PR DESCRIPTION
This PR refactors FAQ styling, to improve the following:

- Fixes some layout issues on small screens (also causes some pages to have scroll overflow)
- Renames from `help-` to `faqs-` to make the component names more readable (not only used on help page)
- Fixes a couple of minor BEM conventions

**New**

![screen shot 2015-03-24 at 17 43 15](https://cloud.githubusercontent.com/assets/123386/6808724/8dbb435e-d24d-11e4-926b-6200f802ea6c.png)

**Old**

![screen shot 2015-03-24 at 17 42 43](https://cloud.githubusercontent.com/assets/123386/6808733/9242debe-d24d-11e4-90fc-41d489359f5f.png)
