### PR TITLE
Cleaunp event extra bar, fix regression

### DIFF
--- a/frontend/app/views/event/page.scala.html
+++ b/frontend/app/views/event/page.scala.html
@@ -56,38 +56,34 @@
 
     @* Limited availability messaging *@
     @if(event.isBookable && event.isLimitedAvailability) {
-        <div class="event-header event-header--extra">
-            <div class="event-header__container event-header__container--details">
-                <span class="event-header__message">@event.limitedAvailabilityText</span>
+        <div class="event-extra">
+            <div class="event-extra__container l-constrained">
+                <div class="event-extra__item event-extra__message">@event.limitedAvailabilityText</div>
             </div>
         </div>
     }
 
     @* Sold out & past events *@
     @if(!event.isBookable) {
-        <div class="event-header event-header--extra">
-            <div class="event-header__container event-header__container--details">
-                <div class="event-ticket event-ticket--aligned">
-                    <div class="event-ticket__details">
-                        <div class="event-ticket__details__status">
-                            @event.statusText
-                        </div>
-                    </div>
-                    <div class="event-ticket__action">
-                        @if(event.isPastEvent) {
-                            @for(highlight <- event.metadata.highlightsOpt) {
-                                <a class="action action--external"
-                                   href="@highlight.url"
-                                   data-metric-trigger="click"
-                                   data-metric-category="events"
-                                   data-metric-action="highlights">@highlight.title</a>
-                            }
-                        } else {
-                            @if(event.isSoldOut) {
-                                @fragments.event.waitlist(event)
-                            }
+        <div class="event-extra">
+            <div class="event-extra__container l-constrained">
+                <div class="event-extra__item event-extra__status">
+                    @event.statusText
+                </div>
+                <div class="event-extra__item event-extra__action">
+                    @if(event.isPastEvent) {
+                        @for(highlight <- event.metadata.highlightsOpt) {
+                            <a class="action action--external"
+                               href="@highlight.url"
+                               data-metric-trigger="click"
+                               data-metric-category="events"
+                               data-metric-action="highlights">@highlight.title</a>
                         }
-                    </div>
+                    } else {
+                        @if(event.isSoldOut) {
+                            @fragments.event.waitlist(event)
+                        }
+                    }
                 </div>
             </div>
         </div>

--- a/frontend/assets/stylesheets/components/_action.scss
+++ b/frontend/assets/stylesheets/components/_action.scss
@@ -152,11 +152,6 @@
        background-color: transparent;
    }
 
-   @include mq($until: tablet) {
-       margin-top: rem($gs-baseline);
-       margin-bottom: 0;
-   }
-
    @include mq(tablet) {
        width: auto;
    }

--- a/frontend/assets/stylesheets/components/_event-detail.scss
+++ b/frontend/assets/stylesheets/components/_event-detail.scss
@@ -52,24 +52,6 @@
         max-height: none;
     }
 }
-.event-header__message {
-    @include fs-data(4);
-}
-
-/**
- * Extra event header details
- */
-.event-header--extra {
-    color: $white;
-    background-color: $c-neutral1;
-
-    .event-header__container {
-        min-height: 0;
-        overflow: auto;
-        padding-top: rem($gs-baseline);
-        padding-bottom: rem($gs-baseline);
-    }
-}
 
 
 /**
@@ -113,6 +95,9 @@
     }
 }
 
+/**
+ * Event details
+ */
 .event-details {
     margin-bottom: rem($gs-baseline / 2);
 
@@ -135,6 +120,51 @@
     color: inherit;
 }
 
+
+/**
+ * Event extra bar
+ * (event status)
+ *
+ * TODO: Extract out padding on event-extra__container into a layout helper?
+ */
+.event-extra {
+    color: $white;
+    background-color: $c-neutral1;
+}
+.event-extra__container {
+    position: relative;
+    padding: rem($gs-gutter / 2);
+
+    @include mq(tablet) {
+        padding: rem($gs-baseline) rem($gs-gutter);
+    }
+
+    @include mq(mem-full) {
+        padding-left: rem(gs-span(2) + ($gs-gutter * 2));
+    }
+}
+.event-extra__item {
+    padding-bottom: rem($gs-baseline / 2);
+
+    @include mq(tablet) {
+        display: inline-block;
+        vertical-align: middle;
+        padding-bottom: 0;
+        padding-right: rem($gs-gutter);
+    }
+}
+.event-extra__message {
+    @include fs-data(4);
+}
+.event-extra__status {
+    @include fs-textSans(2);
+    font-weight: bold;
+
+    @include mq(tablet) {
+        @include fs-header(5);
+    }
+}
+
 /* ==========================================================================
    Event Location Summary
    ========================================================================== */
@@ -145,28 +175,6 @@
 }
 .event-location__detail {
     @include fs-data(4);
-}
-
-/* ==========================================================================
-   Event Status
-   ========================================================================== */
-
-.event-status {
-    display: inline-block;
-
-    &:after {
-        content: '/';
-        color: fade-out($c-neutral1, .8);
-        display: inline-block;
-        font-weight: normal;
-        margin-left: .2em;
-    }
-    &:hover:after {
-        text-decoration: none;
-    }
-}
-.event-status--sold-out {
-    color: $c-soldOut;
 }
 
 /* ==========================================================================
@@ -240,20 +248,6 @@
     }
 }
 
-/* Status extras
-   ========================================================================== */
-// TODO: Document and refactor
-
-.event-ticket__details__status {
-    @include fs-textSans(1);
-    font-weight: bold;
-
-    @include mq(tablet) {
-        @include fs-header(5);
-        -webkit-font-smoothing: antialiased;
-    }
-}
-
 .event-ticket__price-amount {
     @include fs-header(5);
     -webkit-font-smoothing: antialiased;
@@ -263,17 +257,9 @@
     @include fs-textSans(1);
 }
 
-.event__picture-byline {
-    clear: both;
-    @include fs-textSans(1);
-    color: $c-neutral2;
-    margin-bottom: rem($gs-gutter * 2);
-
-    @include mq(mem-full) {
-        padding: rem(8px) rem($gs-gutter) rem($gs-gutter * 2 - 4) rem(gs-span(2) + $gs-gutter * 2);
-        margin-bottom: 0;
-    }
-}
+/* Event Content
+   ========================================================================== */
+// TODO: Document and refactor
 
 .event-content {
     padding: 0;
@@ -293,6 +279,18 @@
 
     img {
         width: 100%;
+    }
+}
+
+.event__picture-byline {
+    clear: both;
+    @include fs-textSans(1);
+    color: $c-neutral2;
+    margin-bottom: rem($gs-gutter * 2);
+
+    @include mq(mem-full) {
+        padding: rem(8px) rem($gs-gutter) rem($gs-gutter * 2 - 4) rem(gs-span(2) + $gs-gutter * 2);
+        margin-bottom: 0;
     }
 }
 
@@ -416,113 +414,4 @@
         top: 0;
         z-index: 1;
     }
-}
-
-/* Event Info Panel
-   ========================================================================== */
-
-.event-info {
-    @include clearfix();
-    @include fs-textSans(3);
-    background-color: $c-neutral7;
-    margin-bottom: rem($gs-baseline);
-}
-    .event-info__inner {
-        @include clearfix;
-        padding: rem($gs-gutter / 4);
-        padding-bottom: rem($gs-baseline);
-    }
-    .event-info__name {
-        @include fs-header(2);
-        padding-bottom: rem($gs-baseline * 2);
-    }
-    .event-info__first {
-        float: left;
-        width: rem($gs-gutter * 2);
-    }
-    .event-info__second {
-        float: left;
-        width: rem(240px);
-        position: relative;
-    }
-    .event-info__price {
-        padding-bottom: 0;
-        @include fs-header(5);
-    }
-    .event-info__trail {
-        @include fs-textSans(1);
-        display: block;
-    }
-    .event-info__terms {
-        @include fs-textSans(1);
-        display: block;
-        padding-top: rem($gs-baseline/2);
-        color: $c-neutral2;
-
-        @include mq(tablet) {
-            display: inline-block;
-        }
-
-        a {
-            text-decoration: none;
-            padding-bottom: rem(2px);
-        }
-    }
-
-.event-info--bordered {
-    border-top: 1px solid;
-}
-.event-info--unavailable {
-    .event-info__inner {
-        opacity: 0.6;
-    }
-}
-
-/* Status Panel
-   ========================================================================== */
-
-.status-panel {
-   color: $white;
-   background-color: $c-neutral1;
-   padding: rem($gs-baseline);
-}
-.status-panel__header {
-   @include fs-header(2);
-}
-.status-panel__content {
-   margin-top: rem($gs-baseline / 2);
-}
-
-/* Ticket Sales
-   ========================================================================== */
-
-.ticket-sales {
-    margin-top: rem($gs-baseline / 4);
-    position: relative;
-}
-.ticket-sales__header {
-    font-weight: bold;
-}
-.ticket-sales__toggle {
-    display: block;
-}
-.ticket-sales__toggle:hover,
-.ticket-sales__toggle:active {
-    text-decoration: underline;
-}
-.ticket-sales__item {
-    @include clearfix();
-}
-.ticket-sales__item__label,
-.ticket-sales__item__date {
-    display: inline-block;
-}
-.ticket-sales__item__label {
-    float: left;
-}
-.ticket-sales__item__date {
-    float: right;
-}
-.ticket-sales__list {
-    @include fs-data(4);
 }

--- a/frontend/assets/stylesheets/components/_event-info-panel.scss
+++ b/frontend/assets/stylesheets/components/_event-info-panel.scss
@@ -1,0 +1,109 @@
+/* ==========================================================================
+   Event Details - Info Panel
+   ========================================================================== */
+
+.event-info {
+    @include clearfix();
+    @include fs-textSans(3);
+    background-color: $c-neutral7;
+    margin-bottom: rem($gs-baseline);
+}
+.event-info__inner {
+    @include clearfix;
+    padding: rem($gs-gutter / 4);
+    padding-bottom: rem($gs-baseline);
+}
+.event-info__name {
+    @include fs-header(2);
+    padding-bottom: rem($gs-baseline * 2);
+}
+.event-info__first {
+    float: left;
+    width: rem($gs-gutter * 2);
+}
+.event-info__second {
+    float: left;
+    width: rem(240px);
+    position: relative;
+}
+.event-info__price {
+    padding-bottom: 0;
+    @include fs-header(5);
+}
+.event-info__trail {
+    @include fs-textSans(1);
+    display: block;
+}
+.event-info__terms {
+    @include fs-textSans(1);
+    display: block;
+    padding-top: rem($gs-baseline/2);
+    color: $c-neutral2;
+
+    @include mq(tablet) {
+        display: inline-block;
+    }
+
+    a {
+        text-decoration: none;
+        padding-bottom: rem(2px);
+    }
+}
+
+.event-info--bordered {
+    border-top: 1px solid;
+}
+.event-info--unavailable {
+    .event-info__inner {
+        opacity: 0.6;
+    }
+}
+
+/* Status Panel
+   ========================================================================== */
+
+.status-panel {
+   color: $white;
+   background-color: $c-neutral1;
+   padding: rem($gs-baseline);
+}
+.status-panel__header {
+   @include fs-header(2);
+}
+.status-panel__content {
+   margin-top: rem($gs-baseline / 2);
+}
+
+/* Ticket Sales
+   ========================================================================== */
+
+.ticket-sales {
+    margin-top: rem($gs-baseline / 4);
+    position: relative;
+}
+.ticket-sales__header {
+    font-weight: bold;
+}
+.ticket-sales__toggle {
+    display: block;
+}
+.ticket-sales__toggle:hover,
+.ticket-sales__toggle:active {
+    text-decoration: underline;
+}
+.ticket-sales__item {
+    @include clearfix();
+}
+.ticket-sales__item__label,
+.ticket-sales__item__date {
+    display: inline-block;
+}
+.ticket-sales__item__label {
+    float: left;
+}
+.ticket-sales__item__date {
+    float: right;
+}
+.ticket-sales__list {
+    @include fs-data(4);
+}

--- a/frontend/assets/stylesheets/components/_event-items.scss
+++ b/frontend/assets/stylesheets/components/_event-items.scss
@@ -257,3 +257,26 @@
         }
     }
 }
+
+/* ==========================================================================
+   Event Status
+   = Status label/prefix on event items
+   ========================================================================== */
+
+.event-status {
+    display: inline-block;
+
+    &:after {
+        content: '/';
+        color: fade-out($c-neutral1, .8);
+        display: inline-block;
+        font-weight: normal;
+        margin-left: .2em;
+    }
+    &:hover:after {
+        text-decoration: none;
+    }
+}
+.event-status--sold-out {
+    color: $c-soldOut;
+}

--- a/frontend/assets/stylesheets/style.scss
+++ b/frontend/assets/stylesheets/style.scss
@@ -82,6 +82,7 @@
 @import 'components/event-items';
 @import 'components/event-filters';
 @import 'components/event-detail';
+@import 'components/event-info-panel';
 @import 'components/related';
 @import 'components/series';
 @import 'components/benefits';


### PR DESCRIPTION
This PR fixes a regression on past events.

**Before**

![screen shot 2015-03-25 at 15 35 13](https://cloud.githubusercontent.com/assets/123386/6828288/c87075f2-d304-11e4-8aa3-c74a2a64340e.png)

**After**

![screen shot 2015-03-25 at 15 26 12](https://cloud.githubusercontent.com/assets/123386/6828292/cc56dc4c-d304-11e4-8c31-8f21c341ea26.png)

I've also taken the opportunity to clean up a bit:

- Extracts the dark status bar out into a separate, simpler, component. Rather than using lots of modifiers.
- Splits the event info panel (sidebar panel) out into a separate `.scss` fragment to make that separation clearer.
- Fix layout regressions
