### PR TITLE
Dead style cleanup

### DIFF
--- a/frontend/app/views/testing/testUsers.scala.html
+++ b/frontend/app/views/testing/testUsers.scala.html
@@ -11,10 +11,12 @@
         @fragments.page.pageHeader("Test Users")
 
         <section class="page-section">
-            <div class="page-section__content copy">
-                <h2 class="section-body-headline">New Test User key: <strong>@userString</strong></h2>
-                <div class="text-intro">
-                    <p>Your user will be valid for the next @ValidityPeriod.pretty. When registering please populate the following fields with your new test user key.</p>
+            <div class="page-section__content">
+                <div class="copy">
+                    <h2>New Test User key: <strong>@userString</strong></h2>
+                    <div class="text-intro">
+                        <p>Your user will be valid for the next @ValidityPeriod.pretty. When registering please populate the following fields with your new test user key.</p>
+                    </div>
                 </div>
                 <div class="aside aside--panel">
                     <ul class="u-unstyled">
@@ -23,12 +25,10 @@
                         <li class="user-detail-list-item">Email: <strong>@userString@@gu.com</strong></li>
                     </ul>
                 </div>
-                <div class="signin__actions">
-                    <div class="signin__register">
-                        <a class="action u-no-bottom-margin" href="@Config.idWebAppRegisterUrl("/")" target="_blank">Register Now</a>
-                        <p class="text-note text-note--block">(Opens in new window)</p>
-                    </div>
+                <div class="action-group">
+                    <a class="action" href="@Config.idWebAppRegisterUrl("/")" target="_blank">Register Now</a>
                 </div>
+                <p class="text-note">(Opens in new window)</p>
             </div>
         </section>
 

--- a/frontend/app/views/testing/testUsers.scala.html
+++ b/frontend/app/views/testing/testUsers.scala.html
@@ -15,14 +15,17 @@
                 <div class="copy">
                     <h2>New Test User key: <strong>@userString</strong></h2>
                     <div class="text-intro">
-                        <p>Your user will be valid for the next @ValidityPeriod.pretty. When registering please populate the following fields with your new test user key.</p>
+                        <p>
+                            Your user will be valid for the next @ValidityPeriod.pretty.
+                            When registering please populate the following fields with your new test user key.
+                        </p>
                     </div>
                 </div>
                 <div class="aside aside--panel">
                     <ul class="u-unstyled">
-                        <li class="user-detail-list-item">First Name: <strong>@userString</strong></li>
-                        <li class="user-detail-list-item">Username: <strong>@userString</strong></li>
-                        <li class="user-detail-list-item">Email: <strong>@userString@@gu.com</strong></li>
+                        <li>First Name: <strong>@userString</strong></li>
+                        <li>Username: <strong>@userString</strong></li>
+                        <li>Email: <strong>@userString@@gu.com</strong></li>
                     </ul>
                 </div>
                 <div class="action-group">

--- a/frontend/assets/stylesheets/_print.scss
+++ b/frontend/assets/stylesheets/_print.scss
@@ -9,11 +9,6 @@
         background-color: $white !important;
     }
 
-    // no need for extra vertical space below
-    .page-container--with-padding {
-        padding-bottom: 0 !important;
-    }
-
     // toggle stuff we don't need
     .hidden-print,
     .page-side-margins:before,
@@ -29,10 +24,5 @@
     // prevent image colliding with text
     .event-item__media img {
         width: 100%;
-    }
-
-    // don't take up precious vertical space!
-    h1.section-headline br {
-        display: none;
     }
 }

--- a/frontend/assets/stylesheets/components/_text-helpers.scss
+++ b/frontend/assets/stylesheets/components/_text-helpers.scss
@@ -14,11 +14,6 @@
     @include fs-textSans(2);
 }
 
-// TODO: Remove?
-.text-intro {
-    margin: rem($gs-baseline * 2) 0 rem($gs-baseline * 3);
-}
-
 .text-feature {
     @include fs-headline(2);
 
@@ -38,10 +33,6 @@
     @include fs-data(3);
     color: $c-neutral2;
     margin-bottom: rem($gs-baseline / 2);
-}
-.text-note--block {
-    margin: rem($gs-baseline) 0;
-    display: block;
 }
 
 .text-highlight {
@@ -128,51 +119,4 @@
     @include fs-textSans(1);
     border-top: 1px solid $c-neutral7;
     padding: rem($gs-baseline / 2) 0;
-}
-
-/* Text Helpers - Headings
-   ========================================================================== */
-
-
-.section-headline {
-    @include fs-headline(5);
-
-    @include mq(desktop) {
-        @include fs-headline(7);
-    }
-
-    display: inline-block;
-    padding-top: rem($gs-baseline - 2);
-    margin-bottom: rem($gs-baseline * 4);
-}
-
-.section-headline--no-margin {
-    padding-top: rem(4px);
-    border-top: 0;
-    margin-bottom: 0;
-}
-
-.section-headline--padding-left {
-    border-top: 0;
-
-    @include mq(desktop) {
-        padding-left: rem(gs-span(2));
-    }
-
-    @include mq(mem-full) {
-        padding-left: rem(gs-span(2) + $gs-gutter);
-    }
-}
-
-.section-intro {
-    @include fs-bodyCopy(2);
-
-    @include mq(desktop) {
-        @include fs-bodyCopy(3);
-    }
-}
-
-.section-body-headline {
-    @include fs-headline(4);
-    background-color: $white;
 }


### PR DESCRIPTION
Few bits of style cleanup intended to remove dead or single-use styles:

- Removes a whole collection of dead `section-*` classes and one single-use `section-body-headline`
- Cleans up test users markup to remove some dead markup patterns
- Removes single-use `text-intro` and `text-note--block` classes
- Fixes bug on test users with button colour

![screen shot 2015-03-26 at 14 22 52](https://cloud.githubusercontent.com/assets/123386/6848415/0627cd08-d3c5-11e4-8d33-8313997197c4.png)
![screen shot 2015-03-26 at 14 30 44](https://cloud.githubusercontent.com/assets/123386/6848416/0639a096-d3c5-11e4-91b6-43d799119ced.png)

:skull: 

// @feedmypixel 