### PR TITLE
Add city and country to tracking data

### DIFF
--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -178,7 +178,9 @@ trait MemberService extends LazyLogging with ActivityTracking {
             deliveryPostcode = form.map(_.deliveryAddress.postCode),
             billingPostcode = form.flatMap(f => f.billingAddress.map(_.postCode)).orElse(form.map(_.deliveryAddress.postCode)),
             subscriptionPaymentAnnual = Some(annual),
-            marketingChoices = None
+            marketingChoices = None,
+            city = form.map(_.deliveryAddress.town),
+            country = form.map(_.deliveryAddress.country.name)
           )
         ))(user)
       memberId
@@ -203,8 +205,11 @@ trait MemberService extends LazyLogging with ActivityTracking {
         formData.plan.salesforceTier,
         None,
         Some(formData.deliveryAddress.postCode),
-        billingPostcode, subscriptionPaymentAnnual,
-        Some(formData.marketingChoices)
+        billingPostcode,
+        subscriptionPaymentAnnual,
+        Some(formData.marketingChoices),
+        Some(formData.deliveryAddress.town),
+        Some(formData.deliveryAddress.country.name)
     )
 
     track(MemberActivity("membershipRegistration", trackingInfo))(user)

--- a/frontend/app/tracking/ActivityTracking.scala
+++ b/frontend/app/tracking/ActivityTracking.scala
@@ -77,6 +77,8 @@ case class MemberData(salesforceContactId: String,
         deliveryPostcode.map("deliveryPostcode" -> truncatePostcode(_)) ++
         billingPostcode.map("billingPostcode" -> truncatePostcode(_)) ++
         subscriptionPlan.map("subscriptionPlan" -> _) ++
+        city.map("city" -> _) ++
+        country.map("country" -> _) ++
         marketingChoices.map { mc =>
           "marketingChoicesForm" -> ActivityTracking.setSubMap {
             Map(

--- a/frontend/app/tracking/ActivityTracking.scala
+++ b/frontend/app/tracking/ActivityTracking.scala
@@ -54,7 +54,9 @@ case class MemberData(salesforceContactId: String,
                         deliveryPostcode: Option[String] = None,
                         billingPostcode: Option[String] = None,
                         subscriptionPaymentAnnual: Option[Boolean] = None,
-                        marketingChoices: Option[MarketingChoicesForm] = None) {
+                        marketingChoices: Option[MarketingChoicesForm] = None,
+                        city: Option[String] = None,
+                        country: Option[String] = None) {
 
   val subscriptionPlan = subscriptionPaymentAnnual match {
     case Some(true) =>  Some("annual")


### PR DESCRIPTION
@jennysivapalan does this look right to you?

Should add town and country to the tracking when new members sign up (nothing more specific than that!) – so we can track signups by location.