### PR TITLE
Put non-private Touchpoint-config into source-control

### DIFF
--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -59,58 +59,10 @@ twitter.username="gdnmembership"
 
 stripe.api.url="https://api.stripe.com/v1"
 
-# Touchpoint-backend environment-specific information
-touchpoint.backend {
-
-    blank {
-        stripe {
-            api.key {
-                secret = ""
-                public = ""
-            }
-        }
-        salesforce {
-            consumer {
-                key = ""
-                secret = ""
-            }
-            api {
-                url = ""
-                username = ""
-                password = ""
-                token = ""
-            }
-        }
-
-        zuora {
-            api {
-                url = ""
-                username = ""
-                password = ""
-
-                friend = ""
-                staff = ""
-                supporter {
-                    monthly = ""
-                    annual = ""
-                }
-                partner {
-                    monthly = ""
-                    annual = ""
-                }
-                patron {
-                    monthly = ""
-                    annual = ""
-                }
-            }
-        }
-    }
-
-  environments {
-    DEV = ${touchpoint.backend.blank}
-    UAT = ${touchpoint.backend.blank}
-  }
-}
+# Touchpoint-backend environment-specific config - ***NO PRIVATE CREDENTIALS in these files***
+include "touchpoint.DEV.conf"
+include "touchpoint.UAT.conf"
+include "touchpoint.PROD.conf"
 
 google.oauth {
   // https://console.developers.google.com/project/guardian-membership/apiui/credential?authuser=1

--- a/frontend/conf/touchpoint.DEV.conf
+++ b/frontend/conf/touchpoint.DEV.conf
@@ -1,0 +1,47 @@
+# ***NO PRIVATE CREDENTIALS IN THIS FILE *** - use membership-keys.conf in S3 for private data
+touchpoint.backend.environments {
+    DEV {
+        stripe {
+            api.key {
+                secret = ""
+                public = "pk_test_Qm3CGRdrV4WfGYCpm0sftR0f"
+            }
+        }
+
+        salesforce {
+            consumer {
+                key = ""
+                secret = ""
+            }
+            api {
+                url="https://test.salesforce.com"
+                username=""
+                password=""
+                token=""
+            }
+        }
+
+        zuora {
+            api {
+                url="https://apisandbox.zuora.com/apps/services/a/58.0"
+                username=""
+                password=""
+
+                friend="2c92c0f945fee1c90146057402c7066b"
+                staff="2c92c0f849c6e58a0149c73d6f114be2"
+                partner {
+                    monthly = "2c92c0f945fee1c9014605749e450969"
+                    annual = "2c92c0f8471e22bb01471ffe9596366c"
+                }
+                patron {
+                    monthly = "2c92c0f845fed48301460578277167c3"
+                    annual = "2c92c0f9471e145d01471ffd7c304df9"
+                }
+                supporter {
+                    monthly = "2c92c0f84b079582014b2754c07c0f7d"
+                    annual = "2c92c0f84b079582014b2754bfd70f6d"
+                }
+            }
+        }
+    }
+}

--- a/frontend/conf/touchpoint.PROD.conf
+++ b/frontend/conf/touchpoint.PROD.conf
@@ -1,0 +1,47 @@
+# ***NO PRIVATE CREDENTIALS IN THIS FILE *** - use membership-keys.conf in S3 for private data
+touchpoint.backend.environments {
+    PROD {
+        stripe {
+            api.key {
+                secret = ""
+                public = "pk_live_2O6zPMHXNs2AGea4bAmq5R7Z"
+            }
+        }
+
+        salesforce {
+            consumer {
+                key = ""
+                secret = ""
+            }
+            api {
+                url="https://emea.salesforce.com"
+                username=""
+                password=""
+                token=""
+            }
+        }
+
+        zuora {
+            api {
+                url="https://api.zuora.com/apps/services/a/58.0"
+                username=""
+                password=""
+
+                friend="2c92a0f9479fb46d0147d0155c6f558b"
+                staff="2c92a0f949efde7c0149f1f18162178e"
+                partner {
+                    monthly = "2c92a0f9479fb46d0147d0155ca15595"
+                    annual = "2c92a0f9479fb46d0147d0155cb15596"
+                }
+                patron {
+                    monthly = "2c92a0f9479fb46d0147d0155bf9557a"
+                    annual = "2c92a0f9479fb46d0147d0155c245581"
+                }
+                supporter {
+                    monthly = "2c92a0fb4bb97034014bbbc562114fef"
+                    annual = "2c92a0fb4bb97034014bbbc562604ff7"
+                }
+            }
+        }
+    }
+}

--- a/frontend/conf/touchpoint.UAT.conf
+++ b/frontend/conf/touchpoint.UAT.conf
@@ -1,0 +1,47 @@
+# ***NO PRIVATE CREDENTIALS IN THIS FILE *** - use membership-keys.conf in S3 for private data
+touchpoint.backend.environments {
+    UAT {
+        stripe {
+            api.key {
+                secret = ""
+                public = "pk_test_Qm3CGRdrV4WfGYCpm0sftR0f"
+            }
+        }
+
+        salesforce {
+            consumer {
+                key = ""
+                secret = ""
+            }
+            api {
+                url="https://test.salesforce.com"
+                username=""
+                password=""
+                token=""
+            }
+        }
+
+        zuora {
+            api {
+                url="https://apisandbox.zuora.com/apps/services/a/58.0"
+                username=""
+                password=""
+
+                friend="2c92c0f848f362750148f4c2727379d7"
+                staff="2c92c0f849f118740149f1d61ad07723"
+                partner {
+                    monthly = "2c92c0f848f362750148f4c2729379db"
+                    annual = "2c92c0f848f362750148f4c2728379d9"
+                }
+                patron {
+                    monthly = "2c92c0f848f362750148f4c2726079d5"
+                    annual = "2c92c0f848f362750148f4c2724679d3"
+                }
+                supporter {
+                    monthly = "2c92c0f84bbfeca5014bc0c5a9a12427"
+                    annual = "2c92c0f84bbfeca5014bc0c5a83f241f"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
We're going to have to change a lot of Zuora rate-plan ids very soon, and I get nervous manipulating so many opaque things outside of source control where it's less easy for peopel to check my work.

Zuora rate-plan ids are not private, likewise:

* Stripe public keys - exposed to the user in their browser
* Salesforce API endpoint
* Zuora API endpoint

Usernames should not really have to be private, but I've left them out to attempt to defend against a repeated-bad-password-lockout denial-of-service

Once this goes up, DEVs will need to refresh their config from S3 with new (much shorter) files - and then the private PROD config will get the same treatment.

cc @jennysivapalan 