### PR TITLE
Update RatePlan ids to the new non-founder rate plans in DEV & UAT

### DIFF
--- a/frontend/conf/touchpoint.DEV.conf
+++ b/frontend/conf/touchpoint.DEV.conf
@@ -30,16 +30,16 @@ touchpoint.backend.environments {
                 friend="2c92c0f945fee1c90146057402c7066b"
                 staff="2c92c0f849c6e58a0149c73d6f114be2"
                 partner {
-                    monthly = "2c92c0f945fee1c9014605749e450969"
-                    annual = "2c92c0f8471e22bb01471ffe9596366c"
+                    monthly = "2c92c0f94c510a0d014c569a93194575"
+                    annual = "2c92c0f84c510081014c569a18b04e84"
                 }
                 patron {
-                    monthly = "2c92c0f845fed48301460578277167c3"
-                    annual = "2c92c0f9471e145d01471ffd7c304df9"
+                    monthly = "2c92c0f84c5100b6014c56908a63216d"
+                    annual = "2c92c0f94c510a04014c568d648d097d"
                 }
                 supporter {
-                    monthly = "2c92c0f84b079582014b2754c07c0f7d"
-                    annual = "2c92c0f84b079582014b2754bfd70f6d"
+                    monthly = "2c92c0f94c510a0d014c569ba8eb45f7"
+                    annual = "2c92c0f94c510a01014c569e2d857cfd"
                 }
             }
         }

--- a/frontend/conf/touchpoint.UAT.conf
+++ b/frontend/conf/touchpoint.UAT.conf
@@ -34,8 +34,8 @@ touchpoint.backend.environments {
                     annual = "2c92c0f84c510081014c569327003593"
                 }
                 patron {
-                    monthly = "2c92c0f848f362750148f4c2726079d5"
-                    annual = "2c92c0f848f362750148f4c2724679d3"
+                    monthly = "2c92c0f94c510a0d014c569070792fa7"
+                    annual = "2c92c0f84c510081014c568daa112d2a"
                 }
                 supporter {
                     monthly = "2c92c0f84c5100b6014c569ad3a23d10"

--- a/frontend/conf/touchpoint.UAT.conf
+++ b/frontend/conf/touchpoint.UAT.conf
@@ -30,16 +30,16 @@ touchpoint.backend.environments {
                 friend="2c92c0f848f362750148f4c2727379d7"
                 staff="2c92c0f849f118740149f1d61ad07723"
                 partner {
-                    monthly = "2c92c0f848f362750148f4c2729379db"
-                    annual = "2c92c0f848f362750148f4c2728379d9"
+                    monthly = "2c92c0f84c510073014c56948fbe6894"
+                    annual = "2c92c0f84c510081014c569327003593"
                 }
                 patron {
                     monthly = "2c92c0f848f362750148f4c2726079d5"
                     annual = "2c92c0f848f362750148f4c2724679d3"
                 }
                 supporter {
-                    monthly = "2c92c0f84bbfeca5014bc0c5a9a12427"
-                    annual = "2c92c0f84bbfeca5014bc0c5a83f241f"
+                    monthly = "2c92c0f84c5100b6014c569ad3a23d10"
+                    annual = "2c92c0f84c5100b6014c569b83b33ebd"
                 }
             }
         }


### PR DESCRIPTION
https://apisandbox.zuora.com/apps/Product.do?method=view&id=2c92c0f945fee1c9014605749e350967

This is the javascript to get the rate plan ids out of Zuora's product page:

```
var ids = [].slice.call(document.querySelectorAll("#RatePlans > div"));
ids.forEach(function(elm){
    if (elm.id.length === 32) {
        var t = elm.querySelector('.rateplan_title');
        t.innerHTML = t.innerHTML + ' ' + elm.id + ' .'
    }
});
```
