### PR TITLE
Fix spacing on homepage

### DIFF
--- a/frontend/app/views/index.scala.html
+++ b/frontend/app/views/index.scala.html
@@ -16,7 +16,7 @@
     @* ===== Introduction ===== *@
     <section class="block-description block-description--right block-description--pull tier-hidden">
         <p class="block-description__text"><a class="text-highlight" href="/join">Join the Guardian.</a> Support open, independent journalism and experience it brought to life.</p>
-        <a class="action u-no-bottom-margin" href="/join" id="qa-join">Join today</a>
+        <a class="action" href="/join" id="qa-join">Join today</a>
     </section>
 
     <section class="block-description block-description--padded block-description--right block-description--pull tier-required">

--- a/frontend/assets/stylesheets/components/_blocks.scss
+++ b/frontend/assets/stylesheets/components/_blocks.scss
@@ -28,6 +28,9 @@
         font-weight: 500;
         color: $mem-brandBlueDark;
     }
+    .block-description__text {
+        margin-bottom: rem($gs-baseline / 2);
+    }
 
 // Blocks description padded (modifier)
 .block-description--padded {


### PR DESCRIPTION
Hold onto your hats:

This PR fixes a minor spacing bug on the homepage that was a side effect of PR https://github.com/guardian/membership-frontend/pull/316

**Before**
![screen shot 2015-03-27 at 11 23 55](https://cloud.githubusercontent.com/assets/123386/6866873/6061bfb8-d474-11e4-968b-9b227b575a4d.png)

**After**
![screen shot 2015-03-27 at 11 24 36](https://cloud.githubusercontent.com/assets/123386/6866874/6082b150-d474-11e4-9f4c-6e6d98c4d0d0.png)

:tophat: :scream: 