### PR TITLE
Remove unused image widths from Config

### DIFF
--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -57,11 +57,6 @@ object Config {
   def eventImageUrlPath(id: String): String =
     config.getString("membership.event.images.url") + id
 
-  val eventImageWidths = config.getList("membership.event.images.widths").unwrapped
-  val eventImageRatios = config.getList("membership.event.images.ratios").unwrapped
-  val homeImageWidths = config.getList("membership.home.images.widths").unwrapped
-  val homeImageRatios = config.getList("membership.home.images.ratios").unwrapped
-
   val idKeys = if (config.getBoolean("identity.production.keys")) new ProductionKeys else new PreProductionKeys
 
   val idApiUrl = config.getString("identity.api.url")

--- a/frontend/app/views/fragments/javaScriptFirstSteps.scala.html
+++ b/frontend/app/views/fragments/javaScriptFirstSteps.scala.html
@@ -25,14 +25,6 @@
         }
         membership: {
             buildNumber: '@app.BuildInfo.buildNumber',
-            eventImages: {
-                widths: [@Config.eventImageWidths.mkString(",")],
-                ratios: [@Config.eventImageRatios.mkString(",")]
-            },
-            homeImages: {
-                widths: [@Config.homeImageWidths.mkString(",")],
-                ratios: [@Config.homeImageRatios.mkString(",")]
-            },
             svgSprite: "@Asset.at("images/svg-sprite.svg")"
         },
         googleAnalytics: {

--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -50,10 +50,6 @@ identity.api.url="https://idapi.theguardian.com"
 id.api.client.token=""
 
 membership.event.images.url="https://s3-eu-west-1.amazonaws.com/membership-eb-images/"
-membership.event.images.widths=[300, 460, 620, 940]
-membership.event.images.ratios=[1, 2]
-membership.home.images.widths=[500, 1000, 2000]
-membership.home.images.ratios=[1]
 
 twitter.username="gdnmembership"
 


### PR DESCRIPTION
Spotted whilst working on PR https://github.com/guardian/membership-frontend/pull/417, these config items have ben unused since the recent responsive image/srcset work went out.