### PR TITLE
Async load optimizely

### DIFF
--- a/frontend/app/views/main.scala.html
+++ b/frontend/app/views/main.scala.html
@@ -70,7 +70,9 @@
         <meta name="msapplication-TileColor" content="#214583">
         <meta name="msapplication-TileImage" content="@Asset.at("images/favicons/windows_tile_144_b.png")">
 
-        <script src="//cdn.optimizely.com/js/2012460034.js"></script>
+        @if(Config.stage == "PROD") {
+            <script src="//cdn.optimizely.com/js/2012460034.js" async defer></script>
+        }
     </head>
     <body id="top">
         <a class="u-h skip" href="#container">Skip to main content</a>


### PR DESCRIPTION
Ran the site through the wonderful [SPOF](https://chrome.google.com/webstore/detail/spof-o-matic/plikhggfbplemddobondkeogomgoodeg) chrome extension which pointed out that optimizely is currently a single-point-of failure, and loaded using a blocking script.

While I get why we'd want an A/B testing script to be blocking, given how little we use this it doesn't make sense to use a blocking script for this. This PR makes the following changes:

- Make optimizely script to [`async defer`](https://www.igvita.com/2014/05/20/script-injected-async-scripts-considered-harmful/)
- Only load optimizely in PROD

// @mattandrews 