### PR TITLE
Move email addresses into Email conf

### DIFF
--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -27,12 +27,7 @@ object Config {
   lazy val awsSecretKey = config.getString("aws.secret.key")
 
   val membershipUrl = config.getString("membership.url")
-
-  // TODO: Move to Email config object
   val membershipFeedback = config.getString("membership.feedback")
-  val membershipSupport = config.getString("membership.support")
-  val membershipSupportStaffEmail = config.getString("membership.staff.email")
-  val membershipDevEmail = config.getString("membership.dev.email")
 
   val idWebAppUrl = config.getString("identity.webapp.url")
 

--- a/frontend/app/configuration/Email.scala
+++ b/frontend/app/configuration/Email.scala
@@ -1,0 +1,8 @@
+package configuration
+
+object Email {
+  val membershipDev = "membership.dev@theguardian.com"
+  val membershipFeedback = "membershipfeedback@theguardian.com"
+  val membershipSupport = "membershipsupport@theguardian.com"
+  val staffMembership = "staff.membership@theguardian.com"
+}

--- a/frontend/app/model/Faq.scala
+++ b/frontend/app/model/Faq.scala
@@ -1,6 +1,6 @@
 package model
 
-import configuration.Config
+import configuration.{Config, Email}
 import play.twirl.api.Html
 
 object Faq {
@@ -27,7 +27,7 @@ object Faq {
       Html("Your Guardian Staff Membership will last for a long as you are a permanent member of staff")
     ),
     Item("I've got an additional question that's not listed here",
-      Html(s"Please email <a href='mailto:${Config.membershipSupportStaffEmail}'>${Config.membershipSupportStaffEmail}</a> with your question, use Guardian Staff Partners as the Subject. We will do our best to get back to you within 24 hours.")
+      Html(s"Please email <a href='mailto:${Email.staffMembership}'>${Email.staffMembership}</a> with your question, use Guardian Staff Partners as the Subject. We will do our best to get back to you within 24 hours.")
     )
   )
 
@@ -113,7 +113,7 @@ object Faq {
       "wheelchair-access-for-venue"
     ),
     Item("I've got a question",
-      Html(s"Please email <a href='mailto:${Config.membershipSupport}'>${Config.membershipSupport}</a> with your question. We will do our best to get back to you within 24 hours. Alternatively, you can call the Guardian Membership customer services team on 0330 333 6898 from 8am to 5.30pm Monday to Friday and 8.30am to 12.30pm at weekends."),
+      Html(s"Please email <a href='mailto:${Email.membershipSupport}'>${Email.membershipSupport}</a> with your question. We will do our best to get back to you within 24 hours. Alternatively, you can call the Guardian Membership customer services team on 0330 333 6898 from 8am to 5.30pm Monday to Friday and 8.30am to 12.30pm at weekends."),
       "have-a-question"
     ),
     Item("What are Guardian Masterclasses?",

--- a/frontend/app/views/fragments/oauth/staffUnauthorisedError.scala.html
+++ b/frontend/app/views/fragments/oauth/staffUnauthorisedError.scala.html
@@ -1,4 +1,4 @@
-@import configuration.Config
+@import configuration.Email
 
 <p>Unfortunately your email address has not been added to the approved staff list. This is probably for one of the following reasons:</p>
 
@@ -10,4 +10,4 @@
 <p>If you've recently joined the Guardian as a permanent employee or fixed term contractor then please try and register again at the beginning of next month.</p>
 <p>If you have been a permanent employee or fixed term contractor for more than six weeks please email <a href="mailto:hr.admin@@theguardian.com">hr.admin@@theguardian.com</a> and ask to be added to the staff google group - Once this is done you will be able to join.</p>
 
-<p><strong>If you have been added to the staff google group and are still having problems please email <a href="mailto:@Config.membershipSupportStaffEmail">@Config.membershipSupportStaffEmail</a>.</strong></p>
+<p><strong>If you have been added to the staff google group and are still having problems please email <a href="mailto:@Email.staffMembership">@Email.staffMembership</a>.</strong></p>

--- a/frontend/app/views/fragments/oauth/staffWrongGroup.scala.html
+++ b/frontend/app/views/fragments/oauth/staffWrongGroup.scala.html
@@ -1,6 +1,6 @@
-@import configuration.Config
+@import configuration.Email
 
 <p>
     You need to be added to the right Google Group to use this page - please contact
-    <a href="mailto:@Config.membershipDevEmail">@Config.membershipDevEmail</a> if you are in need of access.
+    <a href="mailto:@Email.membershipDev">@Email.membershipDev</a> if you are in need of access.
 </p>

--- a/frontend/app/views/info/giftingPlaceholder.scala.html
+++ b/frontend/app/views/info/giftingPlaceholder.scala.html
@@ -1,4 +1,4 @@
-@import configuration.Config
+@import configuration.Email
 
 @main("Gifting") {
     <main role="main" class="page-content l-constrained">
@@ -9,7 +9,7 @@
             </div>
             <div class="page-section__content copy">
                 <p>If you'd like to register your interest in gifting a friend with Guardian Membership, or give feedback about how you'd like gifting to work, just
-                    send us a message at <a href="mailto:@Config.membershipFeedback" class="u-underline">@Config.membershipFeedback</a>.</p>
+                    send us a message at <a href="mailto:@Email.membershipFeedback" class="u-underline">@Email.membershipFeedback</a>.</p>
             </div>
         </section>
     </main>

--- a/frontend/app/views/info/help.scala.html
+++ b/frontend/app/views/info/help.scala.html
@@ -1,4 +1,4 @@
-@import configuration.Config
+@import configuration.Email
 @import model.Faq
 
 @main("Help") {
@@ -13,7 +13,7 @@
             </div>
             <div class="page-section__supplementary">
                 <aside class="aside copy" role="complementary">
-                    <p>If your question is not answered here then please <a href="mailto:@Config.membershipSupport" class="u-underline">get in touch</a>.</p>
+                    <p>If your question is not answered here then please <a href="mailto:@Email.membershipSupport" class="u-underline">get in touch</a>.</p>
                 </aside>
             </div>
         </section>

--- a/frontend/app/views/tier/upgrade/unavailable.scala.html
+++ b/frontend/app/views/tier/upgrade/unavailable.scala.html
@@ -1,6 +1,6 @@
 @(currentTier: com.gu.membership.salesforce.Tier, targetTier: com.gu.membership.salesforce.Tier)
 
-@import configuration.Config
+@import configuration.Email
 
 @main("Unavailable Tier") {
 
@@ -10,7 +10,7 @@
 
         <div class="page-section">
             <div class="page-section__content copy">
-                <p>Sorry you are currently unable to change your tier from <strong>@currentTier</strong> to <strong>@targetTier</strong>. Please contact <a href="mailto:@Config.membershipSupport">@Config.membershipSupport</a> for assistance.</p>
+                <p>Sorry you are currently unable to change your tier from <strong>@currentTier</strong> to <strong>@targetTier</strong>. Please contact <a href="mailto:@Email.membershipSupport">@Email.membershipSupport</a> for assistance.</p>
             </div>
         </div>
 

--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -7,11 +7,7 @@ site.title="The Guardian Membership"
 index.title="Home Page"
 
 membership.url="https://membership.theguardian.com"
-
 membership.feedback="membershipfeedback@theguardian.com"
-membership.support="membershipsupport@theguardian.com"
-membership.staff.email="staff.membership@theguardian.com"
-membership.dev.email="membership.dev@theguardian.com"
 
 event.discountMultiplier=0.8
 


### PR DESCRIPTION
Following on from PR https://github.com/guardian/membership-frontend/pull/417 this PR moves email addresses into constants into a dedicated `Email`, these are the final config items that make more sense as constants.

`membershipFeedback` remains in `application.conf` as it configures where the feedback form submits to.

// @rtyley 