### PR TITLE
Revert "Remove founding member copy"

### DIFF
--- a/frontend/app/controllers/Info.scala
+++ b/frontend/app/controllers/Info.scala
@@ -37,6 +37,14 @@ trait Info extends Controller {
         )
       ),
       ResponsiveImageGroup(
+        name=Some("founding-members"),
+        altText=Some("Founding members: join us at the start"),
+        availableImages=ResponsiveImageGenerator(
+          id="bb922fe62efbe24af2df336dd2b621c5799246b4/0_0_1140_683",
+          sizes=List(1000,500)
+        )
+      ),
+      ResponsiveImageGroup(
         name=Some("patrons"),
         altText=Some("Become a Patron and support the Guardian's future"),
         availableImages=ResponsiveImageGenerator(

--- a/frontend/app/views/info/about.scala.html
+++ b/frontend/app/views/info/about.scala.html
@@ -12,7 +12,7 @@
                 <div class="text-feature">
                     <p>Guardian Members are changing the idea of what a news organisation does today.</p>
                     <p>Join the influential community of journalists, readers and contributors that is the Guardian, and connect to the conversations that matter.</p>
-                    <p>Join before March 31st to become a Founding Member and the price you pay will not rise.</p>
+                    <p>Join before the end of March 31st to become a Founding Member and the price you pay will not rise.</p>
                 </div>
                 <div class="action-group">
                     <a class="action" href="@routes.Joiner.tierList">Join today</a>
@@ -70,7 +70,7 @@
                     <cite class="blockquote__citation">Polly Toynbee, Guardian columnist</cite>
                 </blockquote>
                 <p class="text-feature">
-                    Join before March 31st to become a Founding Member and the price you pay will not rise.</p>
+                    Join before the end of March 31st to become a Founding Member and the price you pay will not rise.</p>
                 <a class="action" href="@routes.Joiner.tierList" id="qa-join">Join today</a>
             }
         </div>

--- a/frontend/app/views/info/about.scala.html
+++ b/frontend/app/views/info/about.scala.html
@@ -12,6 +12,7 @@
                 <div class="text-feature">
                     <p>Guardian Members are changing the idea of what a news organisation does today.</p>
                     <p>Join the influential community of journalists, readers and contributors that is the Guardian, and connect to the conversations that matter.</p>
+                    <p>Join before March 31st to become a Founding Member and the price you pay will not rise.</p>
                 </div>
                 <div class="action-group">
                     <a class="action" href="@routes.Joiner.tierList">Join today</a>
@@ -60,10 +61,25 @@
         </div>
     }
 
+    @* ===== Founding Members ===== *@
+    @for(img <- pageImages.find(_.name.contains("founding-members"))) {
+        <div class="page-slice l-constrained">
+            @fragments.promos.promoPrimary(title="Founding members: join us at the start", img=img) {
+                <blockquote class="blockquote blockquote--feature">
+                    If you read the Guardian, join the Guardian. Support fearless, open, independent journalism.
+                    <cite class="blockquote__citation">Polly Toynbee, Guardian columnist</cite>
+                </blockquote>
+                <p class="text-feature">
+                    Join before March 31st to become a Founding Member and the price you pay will not rise.</p>
+                <a class="action" href="@routes.Joiner.tierList" id="qa-join">Join today</a>
+            }
+        </div>
+    }
+
     @for(img <- pageImages.find(_.name.contains("midland-goods-shed"))) {
         @* ===== Big ideas ===== *@
-        <div class="page-slice l-constrained">
-        @fragments.promos.promoPrimary("A home for big ideas", img=img, toneClass = Some("tone-guardian-live")) {
+        <div class="page-slice page-slice--slim l-constrained">
+        @fragments.promos.promoSecondary(Html("A home for big ideas"), img=img, toneClass = Some("tone-guardian-live")) {
             <div class="text-feature">
                 <p>In 2016, the Guardian will reopen the Midland Goods Shed at London’s King’s Cross to create a new kind of civic space.</p>
                 <p>The building will be a hub for big ideas and stimulating conversations. It will host events,
@@ -84,7 +100,7 @@
     @* ===== Become a Patron ===== *@
     @for(img <- pageImages.find(_.name.contains("patrons"))) {
         <div class="page-slice l-constrained">
-            @fragments.promos.promoSecondary(title=Html("Become a Patron and support the Guardian's future"), img=img, toneClass=Some("tone-trans-brand-dark")) {
+            @fragments.promos.promoPrimary(title="Become a Patron and support the Guardian's future", img=img, toneClass=Some("tone-trans-brand-dark")) {
                 <blockquote class="blockquote blockquote--feature">
                     The only relationship our journalists have is with our readers. Membership gives the real possibility of deepening the intense bond between the producers and consumers of the Guardian.
                     <cite class="blockquote__citation">Alan Rusbridger, editor-in-chief of the Guardian</cite>

--- a/frontend/app/views/joiner/tierList.scala.html
+++ b/frontend/app/views/joiner/tierList.scala.html
@@ -5,7 +5,7 @@
 @main("Join", pageInfo=pageInfo) {
 
     <main role="main" class="page-content l-constrained">
-        @fragments.page.pageHeader("Become a member", Some("Join before March 31st to become a Founding Member and the price you pay will not rise."))
+        @fragments.page.pageHeader("Become a member", Some("Join before the end of March 31st to become a Founding Member and the price you pay will not rise."))
 
         <section class="page-section">
              <div class="page-section__content">

--- a/frontend/app/views/joiner/tierList.scala.html
+++ b/frontend/app/views/joiner/tierList.scala.html
@@ -5,7 +5,7 @@
 @main("Join", pageInfo=pageInfo) {
 
     <main role="main" class="page-content l-constrained">
-        @fragments.page.pageHeader("Become a member")
+        @fragments.page.pageHeader("Become a member", Some("Join before March 31st to become a Founding Member and the price you pay will not rise."))
 
         <section class="page-section">
              <div class="page-section__content">

--- a/frontend/conf/copy.conf
+++ b/frontend/conf/copy.conf
@@ -2,10 +2,10 @@ copy.default.title="Guardian Membership"
 copy.default.description="Guardian Membership feeds your curiosity and broadens your perspective. We introduce you to some of the world's most influential thinkers. Not only our speakers, but the community of members around you."
 
 copy.join.title="Join Guardian Membership"
-copy.join.description="Guardian Membership is launching in beta. We have ambitious plans, and new features will be added regularly. Guardian Membership will grow into a vibrant, self-organising community of free-thinkers."
+copy.join.description="Guardian Membership is launching in beta. We have ambitious plans, and new features will be added regularly. Guardian Membership will grow into a vibrant, self-organising community of free-thinkers. Help to build and shape this community by joining as a Founding Partner or Patron, with the guarantee that the price you pay today will not rise."
 
 copy.choosetier.title="Join Guardian Membership: choose your tier"
-copy.choosetier.description="Guardian Membership brings together diverse, progressive minds, journalistic skills and the best of what others create to give you a richer understanding of the world and the opportunity to shape it."
+copy.choosetier.description="Guardian Membership brings together diverse, progressive minds, journalistic skills and the best of what others create to give you a richer understanding of the world and the opportunity to shape it. Join now as a Founding Partner or Patron and guarantee that the price you pay today will not rise."
 
 copy.supporters.title="Supporters of the Guardian"
 copy.supporters.description="Supporters protect our editorial freedom and help us seek out those stories that people are determined to keep hidden."
@@ -20,4 +20,4 @@ copy.masterclasses.title="Guardian Masterclasses"
 copy.masterclasses.description="Guardian Masterclasses courses and workshops taught by award-winning professionals, with a 20% discount for partners and patrons."
 
 copy.about.title="About Guardian Membership"
-copy.about.description="Guardian Membership brings together diverse, progressive minds, journalistic skills and the best of what others create to give you a richer understanding of the world and the opportunity to shape it."
+copy.about.description="Guardian Membership brings together diverse, progressive minds, journalistic skills and the best of what others create to give you a richer understanding of the world and the opportunity to shape it. Join now as a Founding Partner or Patron and guarantee that the price you pay today will not rise."


### PR DESCRIPTION
Reverts guardian/membership-frontend#427 - Founding Member sign-up actually ends midnight tonight.

Also tweaked language to be more explicit about the Founder-member deadline. I've had questions from some users showing the old wording was being interpreted differently to the intended deadline, and Charles Minty has signed off on this new wording.

cc @davidrapson @JuliaBellis 