### PR TITLE
Fix bug with submit button disabling after error

### DIFF
--- a/frontend/assets/javascripts/src/modules/form/helper/loader.js
+++ b/frontend/assets/javascripts/src/modules/form/helper/loader.js
@@ -20,9 +20,13 @@ define(function() {
         LOADER_ELEM.textContent = msg;
     };
 
-    var disableSubmitButton = function (isDisabled) {
+    var disableSubmitButton = function (shouldDisable) {
         var submitEl = document.querySelector(SUBMIT_SELECTOR);
-        submitEl.setAttribute('disabled', !!isDisabled);
+        if(shouldDisable) {
+            submitEl.setAttribute('disabled', true);
+        } else {
+            submitEl.removeAttribute('disabled');
+        }
     };
 
     return {

--- a/frontend/test/js/spec/form/loader.spec.js
+++ b/frontend/test/js/spec/form/loader.spec.js
@@ -1,0 +1,46 @@
+define(['$', 'src/modules/form/helper/loader'], function ($, loader) {
+
+    describe('disableSubmitButton', function () {
+
+        var SUBMIT_CLASSNAME = 'js-submit-input';
+        var SUBMIT_SELECTOR = '.js-submit-input';
+        var FIXTURE_ID = 'disableSubmitButton';
+
+        var fixture = [
+            '<input class="' + SUBMIT_CLASSNAME + '" type="submit" value="Submit">'
+        ].join('');
+
+        function addFixtures(member) {
+            $(document.body).append('<div id="' + FIXTURE_ID + '">' + fixture + '</div>');
+        }
+
+        function removeFixtures() {
+            $('#' + FIXTURE_ID).remove();
+        }
+
+        beforeEach(function () {
+            addFixtures();
+        });
+
+        afterEach(function () {
+            removeFixtures();
+        });
+
+        it('should disabled an input', function () {
+            var inputElem = $(SUBMIT_SELECTOR);
+            loader.disableSubmitButton(true);
+            expect(inputElem.val()).toEqual('Submit');
+            expect(inputElem.attr('disabled')).toBe(true);
+        });
+
+        it('should re-enabled previously disabled input', function () {
+            var inputElem = $(SUBMIT_SELECTOR);
+            inputElem.attr('disabled', true);
+            expect(inputElem.attr('disabled')).toBe(true);
+            loader.disableSubmitButton(false);
+            expect(inputElem.val()).toEqual('Submit');
+            expect(inputElem.attr('disabled')).toBe(false);
+        });
+
+    });
+});


### PR DESCRIPTION
This PR, fixes a bug where the submit button would remain disabled if there was an error with the form, or with stripe payment, which prevents the user from correcting the error and re-submitting.

**Before**

![stripe-failed-before mov](https://cloud.githubusercontent.com/assets/123386/6939265/c1acf7aa-d862-11e4-88cb-ddd0e1201297.gif)

**After**

![stripe-failed-after mov](https://cloud.githubusercontent.com/assets/123386/6939270/c8524380-d862-11e4-84e6-a9d0307c84d3.gif)

@mattandrews @jamesoram 