### PR TITLE
Re-instate logos to event listings

### DIFF
--- a/frontend/app/views/event/guardianLive.scala.html
+++ b/frontend/app/views/event/guardianLive.scala.html
@@ -3,8 +3,9 @@
 @main("Events", pageInfo=pageInfo) {
     <main role="main" class="l-constrained">
         @fragments.event.headerBar(
-            "Events, discussions, debates, interviews, keynote speeches and festivals exclusively for Guardian Members",
-            "guardian-live"
+            title="Events, discussions, debates, interviews, keynote speeches and festivals exclusively for Guardian Members",
+            toneClassOpt=Some("tone-trans-guardian-live"),
+            logoOpt=Some("images/logos/guardian-live.svg")
         )
 
         @views.html.event.list(eventPortfolio, "Sorry, no matching events were found.", showPastEvents=true)

--- a/frontend/app/views/event/masterclass.scala.html
+++ b/frontend/app/views/event/masterclass.scala.html
@@ -12,8 +12,9 @@
     <main role="main" class="l-constrained">
 
     @fragments.event.headerBar(
-        "Courses and workshops taught by award-winning professionals, with discounts for Partners and Patrons",
-        "masterclasses"
+        title="Courses and workshops taught by award-winning professionals, with discounts for Partners and Patrons",
+        toneClassOpt=Some("tone-trans-masterclasses"),
+        logoOpt=Some("images/logos/guardian-masterclasses.svg")
     )
 
     <div class="event-filters">

--- a/frontend/app/views/fragments/event/headerBar.scala.html
+++ b/frontend/app/views/fragments/event/headerBar.scala.html
@@ -1,6 +1,12 @@
-@(title: String, category: String = "")
+@(title: String, toneClassOpt: Option[String] = None, logoOpt: Option[String]  = None)
 
-<section class="header-bar@if(category){ tone-trans-@category}">
+@import views.support.Asset
+
+<section class="header-bar @toneClassOpt.mkString("")">
     <h1 class="header-bar__title">@title</h1>
-    <i class="header-bar__logo@if(category){ icon-@category}"></i>
+    @for(logo <- logoOpt) {
+        <i class="header-bar__logo">
+            <img class="header-bar__logo__img" src="@Asset.at(logo)">
+        </i>
+    }
 </section>

--- a/frontend/app/views/patterns/patterns.scala.html
+++ b/frontend/app/views/patterns/patterns.scala.html
@@ -261,15 +261,17 @@
 
     @pattern("Header Bar - Guardian Live", "Header bar with guardian live tone applied") {
         @fragments.event.headerBar(
-            "Events, discussions, debates, interviews, keynote speeches and festivals exclusively for Guardian Members",
-            "guardian-live"
+            title="Events, discussions, debates, interviews, keynote speeches and festivals exclusively for Guardian Members",
+            toneClassOpt=Some("tone-trans-guardian-live"),
+            logoOpt=Some("images/logos/guardian-live.svg")
         )
     }
 
     @pattern("Header Bar - Masterclasses", "Header bar with masterclasses tone applied") {
         @fragments.event.headerBar(
-            "Courses and workshops taught by award-winning professionals, with discounts for Partners and Patrons",
-            "masterclasses"
+            title="Courses and workshops taught by award-winning professionals, with discounts for Partners and Patrons",
+            toneClassOpt=Some("tone-trans-masterclasses"),
+            logoOpt=Some("images/logos/guardian-masterclasses.svg")
         )
     }
 

--- a/frontend/assets/stylesheets/components/_header-bar.scss
+++ b/frontend/assets/stylesheets/components/_header-bar.scss
@@ -32,17 +32,19 @@
     }
     .header-bar__logo {
         float: right;
-        height: rem(44px);
-        background-position: right;
-        background-size: contain;
-        background-repeat: no-repeat;
         margin-bottom: rem($gs-gutter / 2);
 
         @include mq(tablet) {
             position: absolute;
             right: rem($gs-gutter);
             bottom: rem($gs-baseline);
-            height: rem(87px);
             margin-bottom: 0;
+        }
+    }
+    .header-bar__logo__img {
+        height: rem(44px);
+
+        @include mq(tablet) {
+            height: rem(87px);
         }
     }


### PR DESCRIPTION
Re-instate logos to event listings. Turns out some images weren't so unused after all (See https://github.com/guardian/membership-frontend/pull/426), but they did need to be moved to use new SVGs.

![screen shot 2015-04-01 at 16 10 35](https://cloud.githubusercontent.com/assets/123386/6944092/ffc72908-d889-11e4-9c18-8eba6a2d3797.png)

![screen shot 2015-04-01 at 16 10 39](https://cloud.githubusercontent.com/assets/123386/6944093/ffc7dee8-d889-11e4-8b1d-54d0fb00efc0.png)

@jennysivapalan 