### PR TITLE
Add EC2 instance-id to response header, so we can log it in CDN logs

### DIFF
--- a/frontend/app/Global.scala
+++ b/frontend/app/Global.scala
@@ -1,17 +1,16 @@
+import configuration.Config
+import controllers.Cached
+import filters.{AddEC2InstanceHeader, CheckCacheHeadersFilter, Gzipper}
+import monitoring.SentryLogging
 import play.api.Application
 import play.api.mvc.Results.{InternalServerError, NotFound}
 import play.api.mvc.{RequestHeader, Result, WithFilters}
 import play.filters.csrf._
-
-import configuration.Config
-import controllers.Cached
-import filters.{CheckCacheHeadersFilter, Gzipper}
-import monitoring.SentryLogging
 import services._
 
 import scala.concurrent.Future
 
-object Global extends WithFilters(CheckCacheHeadersFilter, CacheSensitiveCSRFFilter(), Gzipper) {
+object Global extends WithFilters(CheckCacheHeadersFilter, CacheSensitiveCSRFFilter(), Gzipper, AddEC2InstanceHeader) {
   override def onStart(app: Application) {
     SentryLogging.init()
 

--- a/frontend/app/filters/AddEC2InstanceHeader.scala
+++ b/frontend/app/filters/AddEC2InstanceHeader.scala
@@ -1,0 +1,17 @@
+package filters
+
+import com.amazonaws.internal.EC2MetadataClient
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import play.api.mvc._
+
+import scala.concurrent.Future
+
+object AddEC2InstanceHeader extends Filter {
+
+  val instanceIdF = Future { new EC2MetadataClient().readResource("instance-id") }.recover { case _ => "n/a" }
+
+  def apply(nextFilter: RequestHeader => Future[Result])(requestHeader: RequestHeader): Future[Result] = for {
+    result <- nextFilter(requestHeader)
+    instanceId <- instanceIdF
+  } yield result.withHeaders("X-EC2-instance-id" -> instanceId)
+}


### PR DESCRIPTION
Useful information for diagnosing death, the "X-EC2-instance-id" header. Has a value like "i-6c23702f" or "n/a"

I think it should be possible to remove the header from the response returned to the user by using Fastly Content Header configuration:

https://docs.fastly.com/guides/tutorials/adding-or-modifying-headers-on-http-requests-and-responses

cc @jennysivapalan 