### PR TITLE
Fix rich data tester warnings

### DIFF
--- a/frontend/app/views/fragments/event/addressSummary.scala.html
+++ b/frontend/app/views/fragments/event/addressSummary.scala.html
@@ -2,14 +2,14 @@
 
 <div class="event-location">
     @if(event.venue.name) {
-        <span class="event-location__detail event-location__name" itemprop="name">@event.venue.name</span>
+        <span class="event-location__detail event-location__name">@event.venue.name</span>
     }
     @for(location <- event.venue.address) {
         @if(location.city) {
-            <span class="event-location__detail event-location__address" itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+            <span class="event-location__detail event-location__address">
                 @if(event.venue.name) {,}
-                <span itemprop="addressLocality">@location.city</span>,
-                <span itemprop="postalCode">@location.postal_code</span>
+                @location.city,
+                @location.postal_code
             </span>
         }
     }

--- a/frontend/app/views/fragments/event/stats.scala.html
+++ b/frontend/app/views/fragments/event/stats.scala.html
@@ -18,13 +18,14 @@
         @fragments.inlineIcon("location", List("icon-inline--medium", "icon-inline--top", "icon-inline--neutral"))
     </div>
     <div class="stat-item__second copy" itemprop="location" itemscope itemtype="http://schema.org/Place">
-        @if(event.venue.name) {@event.venue.name}@if(event.venue.address){, }
+        @if(event.venue.name) {<span itemprop="name">@event.venue.name</span>}@if(event.venue.address){, }
         @for(location <- event.venue.address) {
-            @location.city @location.postal_code
+            <span itemprop="address">@location.city @location.postal_code</span>
         }
         @for(googleMapsLink <- event.venue.googleMapsLink) {
             <div class="stat-item__supplementary copy">
                 <a href="@googleMapsLink"
+                   itemprop="hasMap"
                    data-metric-trigger="click"
                    data-metric-category="events"
                    data-metric-action="map">Google map</a>

--- a/frontend/app/views/fragments/event/ticketSales.scala.html
+++ b/frontend/app/views/fragments/event/ticketSales.scala.html
@@ -13,7 +13,7 @@
     Html(s"<time class='qa-event-detail-sales-end' datetime='$endSalesDate'>${endSalesDate.pretty(needToDisplayTimes || endSalesDate.isContemporary())}</time>")
 }
 
-<div class="ticket-sales" itemprops="offers" itemscope itemtype="http://schema.org/AggregateOffer">
+<div class="ticket-sales">
     <span class="ticket-sales__header">@if(ticketing.salesDates.anyoneCanBuyTicket) {Tickets on sale now} else {Ticket release dates}</span>
     @if(ticketing.salesDates.anyoneCanBuyTicket) {
         <button class="ticket-sales__toggle u-button-reset js-toggle"

--- a/frontend/app/views/fragments/pricing/priceInfoEvent.scala.html
+++ b/frontend/app/views/fragments/pricing/priceInfoEvent.scala.html
@@ -23,8 +23,8 @@
                     @discountTicketing.generalRelease.cost.get.formattedPrice
                     </div>
                     <div class="price-info-inline__trail">
-                        <span class="js-event-price-discount qa-event-detail-price-discount" data-discount-text="Full price @discountTicketing.generalRelease.priceText" itemprop="lowPrice">
-                            Partners/Patrons @discountTicketing.member.priceText
+                        <span class="js-event-price-discount qa-event-detail-price-discount" data-discount-text="Full price @discountTicketing.generalRelease.priceText">
+                            Partners/Patrons <span itemprop="lowPrice">@discountTicketing.member.priceText</span>
                         </span>
                         <span class="js-event-price-saving" data-discount-text="(you save @discountTicketing.savingText)">
                             (save @discountTicketing.savingText)


### PR DESCRIPTION
This PR fixes a few warnings highlighted by [Google's structured data testing tool](https://developers.google.com/structured-data/testing-tool/) 

- Address was incorrectly scoped (and duplicated) so was being counted as `PostalAddress` rather than being considered part of the event
- Low price included 'Partner/Patron`
- Adds [hasMap](http://schema.org/hasMap) for the map URL to note the relation to the address

![screen shot 2015-04-01 at 17 47 14](https://cloud.githubusercontent.com/assets/123386/6946485/84beffa6-d898-11e4-883b-fc0160445172.png)

![screen shot 2015-04-01 at 17 46 05](https://cloud.githubusercontent.com/assets/123386/6946487/887137e0-d898-11e4-9a81-621ed331c94f.png)

![screen shot 2015-04-01 at 17 45 57](https://cloud.githubusercontent.com/assets/123386/6946489/8a9b1266-d898-11e4-8102-86c22789a041.png)

This PR fixes the immediate issues with our structured data, but I'm going to look into moving towards [JSON-LD](http://json-ld.org/) for metadata.

**Cons of current markup based approach**
- Relies on careful massaging of markup
- We loose metadata if we hide/show various components
- Easy to end up with duplicate schema markup

**Pros of JSON-LD approach**
- Single source of truth for metadata (in the `<head`>)
- Allows us to keep full event metadata in the page even for past events, [as recommended](https://developers.google.com/structured-data/rich-snippets/events#event-specific_usage_guidelines_and_policies)
- Is [Google's recommended approach](https://developers.google.com/structured-data/rich-snippets/events#event-specific_usage_guidelines_and_policies) for events

**Cons of JSON-LD**
Might be harder to handle multiple schema objects on one page (but I might be wrong about this, I've not tried it yet)

I'm going to look at a way to trial JSON-LD in another PR.

@mattandrews