### PR TITLE
Inform users that their browser doesn't seem able to handle our Join forn

### DIFF
--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -7,24 +7,23 @@ import actions._
 import com.gu.membership.salesforce.{PaidMember, ScalaforceError, Tier}
 import com.gu.membership.stripe.Stripe
 import com.gu.membership.stripe.Stripe.Serializer._
-import com.netaporter.uri.Uri
 import com.netaporter.uri.dsl._
+import com.typesafe.scalalogging.LazyLogging
 import configuration.{Config, CopyConfig}
-import controllers.Testing.AuthorisedTester
 import forms.MemberForm.{JoinForm, friendJoinForm, paidMemberJoinForm, staffJoinForm}
 import model.RichEvent._
 import model._
+import play.api.data.Form
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json.Json
 import play.api.mvc._
-import services._
-import services.GuardianContentService
+import services.{GuardianContentService, _}
 import services.EventbriteService._
+import tracking.{ActivityTracking, EventActivity, EventData, MemberData}
 
 import scala.concurrent.Future
-import tracking.{EventData, EventActivity, MemberData, ActivityTracking}
 
-trait Joiner extends Controller with ActivityTracking {
+trait Joiner extends Controller with ActivityTracking with LazyLogging {
   val JoinReferrer = "join-referrer"
 
   val contentApiService = GuardianContentService
@@ -106,12 +105,12 @@ trait Joiner extends Controller with ActivityTracking {
   }
 
   def joinFriend() = AuthenticatedNonMemberAction.async { implicit request =>
-    friendJoinForm.bindFromRequest.fold(_ => Future.successful(BadRequest),
+    friendJoinForm.bindFromRequest.fold(redirectToUnsupportedBrowserInfo,
       makeMember(Tier.Friend, Redirect(routes.Joiner.thankyou(Tier.Friend))) )
   }
 
   def joinStaff() = AuthenticatedNonMemberAction.async { implicit request =>
-    staffJoinForm.bindFromRequest.fold(_ => Future.successful(BadRequest),
+    staffJoinForm.bindFromRequest.fold(redirectToUnsupportedBrowserInfo,
         makeMember(Tier.Partner, Redirect(routes.Joiner.thankyouStaff())) )
   }
 
@@ -132,9 +131,17 @@ trait Joiner extends Controller with ActivityTracking {
     }
   }
 
+  def unsupportedBrowser = CachedAction(Ok(views.html.joiner.unsupportedBrowser()))
+
   def joinPaid(tier: Tier) = AuthenticatedNonMemberAction.async { implicit request =>
-    paidMemberJoinForm.bindFromRequest.fold(_ => Future.successful(BadRequest),
+    paidMemberJoinForm.bindFromRequest.fold(redirectToUnsupportedBrowserInfo,
       makeMember(tier, Ok(Json.obj("redirect" -> routes.Joiner.thankyou(tier).url))) )
+  }
+
+  def redirectToUnsupportedBrowserInfo(form: Form[_])(implicit req: RequestHeader): Future[Result] = {
+    logger.error(s"Server-side form errors on joining indicates a Javascript problem: ${req.headers.get(USER_AGENT)}")
+    logger.debug(s"Server-side form errors : ${form.errors}")
+    Future.successful(Redirect(routes.Joiner.unsupportedBrowser()))
   }
 
   private def makeMember(tier: Tier, result: Result)(formData: JoinForm)(implicit request: AuthRequest[_]) = {

--- a/frontend/app/views/joiner/unsupportedBrowser.scala.html
+++ b/frontend/app/views/joiner/unsupportedBrowser.scala.html
@@ -1,0 +1,27 @@
+@main("Unsupported browser") {
+
+    <main role="main" class="page-content l-constrained">
+
+        @fragments.page.pageHeader("")
+
+        <section class="page-section">
+            <div class="page-section__content">
+                <div class="copy">
+                    <h2>Your browser doesn't seem to be up-to-date...</h2>
+                    <div class="text-intro">
+                        <p>
+                            To join Guardian Membership, you'll need a modern browser
+                            that can run Javascript - without that we can't take your payment.
+                            Unfortunately, it looks like you'll need to upgrade
+                            your browser:
+                        </p>
+                    </div>
+                </div>
+                <div class="action-group">
+                    <a class="action" href="http://www.whatbrowser.org/intl/en_uk/">Check your browser version</a>
+                </div>
+            </div>
+        </section>
+
+    </main>
+}

--- a/frontend/app/views/joiner/unsupportedBrowser.scala.html
+++ b/frontend/app/views/joiner/unsupportedBrowser.scala.html
@@ -2,12 +2,11 @@
 
     <main role="main" class="page-content l-constrained">
 
-        @fragments.page.pageHeader("")
+        @fragments.page.pageHeader("Your browser doesn't seem up-to-date...")
 
         <section class="page-section">
             <div class="page-section__content">
                 <div class="copy">
-                    <h2>Your browser doesn't seem to be up-to-date...</h2>
                     <div class="text-intro">
                         <p>
                             To join Guardian Membership, you'll need a modern browser

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -32,6 +32,8 @@ GET            /join/:tier/thankyou               controllers.Joiner.thankyou(ti
 POST           /join/staff/update-email           controllers.Joiner.updateEmailStaff
 GET            /choose-tier                       controllers.Joiner.tierChooser
 
+GET            /join/unsupported-browser          controllers.Joiner.unsupportedBrowser
+
 # Normal user signin:
 GET            /signin                            controllers.Login.chooseSigninOrRegister(returnUrl: String)
 


### PR DESCRIPTION
We do client-side validation of form entry, so any error (including the error of not sending the Stripe token) would indicate that the Javascript has failed - probably because the browser has Javascript quirks that we don't see in the modern browsers we test against.

Ideally, we will fix all Javascript issues that unnecessarily stop users from joining, including adapting ourselves to handle the [odd behaviour of Safari 5.1](https://app.getsentry.com/the-guardian/membership/group/56798670/) on `querySelector()` - but if we _don't_ catch those issues in Javascript, we should at least display a helpful message to the user when the server-side see's there's a problem.

![image](https://cloud.githubusercontent.com/assets/52038/6967033/b08fa100-d954-11e4-8e8e-721afdd1692e.png)

This text is just copy I put together myself, it's definitely better than the **entirely blank white page** we've been returning to users so far - we should tweak it later.

cc @davidrapson 