### PR TITLE
Safari 5.1 compatibility fixes

### DIFF
--- a/frontend/app/views/fragments/form/cardDetail.scala.html
+++ b/frontend/app/views/fragments/form/cardDetail.scala.html
@@ -68,7 +68,7 @@
 
                 <div class="credit-card-container">
                     <i class="credit-card--input-visualisation sprite-card sprite-card--unknown js-credit-card-image"></i>
-                    <input type="tel"
+                    <input type="text" pattern="[0-9]*"
                            size="20"
                            data-stripe="number"
                            class="input-text credit-card-input js-credit-card-number"
@@ -85,7 +85,7 @@
             <div class="form-field">
 
                 <label class="label" for="cc-cvc"><span>Security code</span></label>
-                <input type="tel"
+                <input type="text" pattern="[0-9]*"
                        size="4"
                        data-stripe="cvc"
                        class="input-text input-text--small js-credit-card-cvc"

--- a/frontend/assets/javascripts/src/modules/slideshow.js
+++ b/frontend/assets/javascripts/src/modules/slideshow.js
@@ -36,8 +36,10 @@ define(function() {
         if (slideshows.length) {
             [].forEach.call(slideshows, function(el) {
                 var items = el.querySelectorAll(SLIDESHOW_CHILDREN);
-                setCurrentItem(items, 0);
-                cycleItems(items, el.getAttribute('data-slideshow-duration') || 5000);
+                if(items.length) {
+                    setCurrentItem(items, 0);
+                    cycleItems(items, el.getAttribute('data-slideshow-duration') || 5000);
+                }
             }, false);
         }
     }

--- a/frontend/assets/javascripts/src/modules/toggle.js
+++ b/frontend/assets/javascripts/src/modules/toggle.js
@@ -9,6 +9,9 @@
 //     * data-toggle-label is optional.
 //     * data-toggle-hidden should be added to toggle elements which should be hidden on pageload
 
+/**
+ * TODO: Use pure vanlilla JS for entire module
+ */
 define(['$', 'bean'], function ($, bean) {
 
     var TOGGLE_BTN_SELECTOR = '.js-toggle',
@@ -17,14 +20,17 @@ define(['$', 'bean'], function ($, bean) {
         TOGGLE_DATA_LABEL = 'toggle-label',
         TOGGLE_DATA_ICON = 'toggle-icon',
         TOGGLE_CLASS = 'is-toggled',
-        ELEMENTS_TO_TOGGLE = '[data-toggle-hidden]';
+        ELEMENTS_TO_TOGGLE = '[data-toggle-hidden]',
+        HIDDEN_CLASS = 'is-hidden';
 
     var toggleElm = function($elem) {
         return function (e) {
             e.preventDefault();
             var toggleElmId = $elem.data(TOGGLE_DATA_ELM);
+            var toggleElm = $(document.getElementById(toggleElmId));
 
-            $(document.getElementById(toggleElmId)).toggle().toggleClass(TOGGLE_CLASS);
+            toggleElm.toggleClass(HIDDEN_CLASS);
+            toggleElm.toggleClass(TOGGLE_CLASS);
             $elem.toggleClass(TOGGLE_CLASS);
 
             toggleIcon($elem);
@@ -52,7 +58,11 @@ define(['$', 'bean'], function ($, bean) {
 
     var hideToggleElements = function() {
         var toggleContainers = document.querySelectorAll(ELEMENTS_TO_TOGGLE);
-        $(toggleContainers).hide();
+        if(toggleContainers.length) {
+            [].forEach.call(toggleContainers, function(el) {
+                el.classList.add(HIDDEN_CLASS);
+            });
+        }
     };
 
     var bindToggles = function() {

--- a/frontend/assets/stylesheets/base/_base.scss
+++ b/frontend/assets/stylesheets/base/_base.scss
@@ -28,13 +28,7 @@ body:after {
 html {
     overflow-y: scroll;
     font-family: $f-serif-text;
-
-    // Set baseline font size to 10px
-    // This is used as a baseline for rem (root ems) values
-    // Calc needed for IE11 to do the math properly
-    // See http://bit.ly/1g4X0bX — thanks @7studio and @dawitti
-    font-size: -webkit-calc(1em * .625);
-    font-size: calc(1em * .625);
+    font-size: 10px;
 }
 
 body {


### PR DESCRIPTION
This PR fixes a few issues which were preventing users in Safari 5.1 from signing up as members due to JavaScript errors.

* Bonzo `.hide()` causing a fatal error, switched to toggling class names instead of using show/hide.
* Fixes layout issues due to missing `calc` support.
* Don't use `type=tel` to trigger numeric inputs: causes noise in Safari 5.1, but is also incorrect usage as we were not using for telephone fields. Prefer plain text input with numeric pattern

**Successful payment**

![screen shot 2015-04-02 at 17 20 53](https://cloud.githubusercontent.com/assets/123386/6968343/efdbdb5e-d95d-11e4-931e-acfd38ca6700.png)

**Fixed layout**

![safari-after](https://cloud.githubusercontent.com/assets/123386/6968347/f5ac7408-d95d-11e4-95d8-0fbda86e1314.png)

**Previous broken layout**

![screen shot 2015-04-02 at 17 31 20](https://cloud.githubusercontent.com/assets/123386/6968358/17a8bde6-d95e-11e4-98d9-0ab6dd748b56.png)
