### PR TITLE
Add a test metric to isolate tracking issue

### DIFF
--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -167,6 +167,7 @@ trait Event extends Controller with ActivityTracking {
       trackAnon(EventActivity("eventThankYou", memberData, EventData(event), order.map(OrderData(_))))(request)
       event.service.wsMetrics.put("user-returned-to-thankyou-page", 1)
     }
+    event.service.wsMetrics.put("user-returned-to-thankyou-page-no-cookie", 1)
   }
 
   def thankyou(id: String, orderIdOpt: Option[String]) = MemberAction.async { implicit request =>

--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -162,12 +162,12 @@ trait Event extends Controller with ActivityTracking {
   // log a conversion if the user came from a membership event page
   private def trackConversionToThankyou(request: Request[_], event: RichEvent, order: Option[EBOrder],
                                         member: Option[Member]) {
+    val memberData = member.map(m => MemberData(m.salesforceContactId, m.identityId, m.tier.name))
+    trackAnon(EventActivity("eventThankYou", memberData, EventData(event), order.map(OrderData(_))))(request)
+    event.service.wsMetrics.put("user-returned-to-thankyou-page-no-cookie", 1)
     request.cookies.get(eventCookie(event)).foreach { _ =>
-      val memberData = member.map(m => MemberData(m.salesforceContactId, m.identityId, m.tier.name))
-      trackAnon(EventActivity("eventThankYou", memberData, EventData(event), order.map(OrderData(_))))(request)
       event.service.wsMetrics.put("user-returned-to-thankyou-page", 1)
     }
-    event.service.wsMetrics.put("user-returned-to-thankyou-page-no-cookie", 1)
   }
 
   def thankyou(id: String, orderIdOpt: Option[String]) = MemberAction.async { implicit request =>


### PR DESCRIPTION
cc @jennysivapalan 

We've noticed that our tracking of event sales is about half the number EventBrite say it is. We reckon this is because of the cookie check here (which, ironically, was added by me to make sure we were tracking Masterclass event sales). This change adds some more tracking independently of the cookie, which will confirm that the numbers are diverging because of the cookie check.

(background: the cookie check was added so that we knew if someone had clicked the "Buy tickets" button on Membership and then completed the purchase via EventBrite – if they did this for Masterclasses they ended up on theguardian.com (not Membership) so we serve them an "ad" on that page which checks for the cookie and if found, tracks the sale)