### PR TITLE
Add manual Sentry logging to third-party scripts

### DIFF
--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -147,8 +147,6 @@ object Config {
 
   val stage = config.getString("stage")
 
-  val ophanJsUrl = config.getString("ophan.js.url")
-
   val googleAuthConfig = {
     val con = config.getConfig("google.oauth")
     GoogleAuthConfig(

--- a/frontend/app/views/fragments/javaScriptLaterSteps.scala.html
+++ b/frontend/app/views/fragments/javaScriptLaterSteps.scala.html
@@ -8,7 +8,6 @@
         apiName: 'require',
         paths: {
             zxcvbn: '@Asset.at("javascripts/lib/zxcvbn/zxcvbn.js")',
-            'ophan/membership': '@Config.ophanJsUrl',
             omniture: '@Asset.at("javascripts/lib/omniture/omniture.js")'
         }
     };

--- a/frontend/assets/javascripts/src/modules/analytics/omniture.js
+++ b/frontend/assets/javascripts/src/modules/analytics/omniture.js
@@ -1,3 +1,4 @@
+/*global Raven */
 define([
     'src/utils/user'
 ], function (user) {
@@ -7,43 +8,46 @@ define([
     var MEMBERSHIP_STRING = 'Membership';
 
     function init() {
+        require('js!omniture').then(onSuccess, function(err) {
+            Raven.captureException(err);
+            Raven.captureMessage('Omniture failed to load');
+        });
+    }
 
-        require(['js!omniture'], function () {
+    function onSuccess() {
+        /*global s_gi: true */
+        var s = s_gi('guardiangu-network');
+        var s_code;
+        var identityUser = user.getUserFromCookie();
+        var identityId = identityUser && identityUser.id;
+        var referrerArray = document.referrer.split('/');
+        var referrerDomain;
 
-            /*global s_gi: true */
-            var s = s_gi('guardiangu-network');
-            var s_code;
-            var identityUser = user.getUserFromCookie();
-            var identityId = identityUser && identityUser.id;
-            var referrerArray = document.referrer.split('/');
-            var referrerDomain;
+        if (referrerArray.length > 2) {
+            referrerDomain = referrerArray[2];
+            if (referrerDomain !== document.location.host) {
+                s.eVar14 = document.referrer;
+            }
+        }
 
-            if (referrerArray.length > 2) {
-                referrerDomain = referrerArray[2];
-                if (referrerDomain !== document.location.host) {
-                    s.eVar14 = document.referrer;
+        s.pageName = document.title;
+        s.channel = MEMBERSHIP_STRING;
+        s.eVar5 = NONE_STRING;
+
+        user.getMemberDetail(function (memberDetail) {
+            if (memberDetail) {
+                var tier = memberDetail && (memberDetail.tier && memberDetail.tier.toLowerCase());
+                if (tier) {
+                    s.eVar5 = tier;
                 }
             }
+            s.prop2 = GU_ID_STRING + ':' + (identityId ? identityId : NONE_STRING);
+            s_code = s.t();
 
-            s.pageName = document.title;
-            s.channel = MEMBERSHIP_STRING;
-            s.eVar5 = NONE_STRING;
-
-            user.getMemberDetail(function (memberDetail) {
-                if (memberDetail) {
-                    var tier = memberDetail && (memberDetail.tier && memberDetail.tier.toLowerCase());
-                    if (tier) {
-                        s.eVar5 = tier;
-                    }
-                }
-                s.prop2 = GU_ID_STRING + ':' + (identityId ? identityId : NONE_STRING);
-                s_code = s.t();
-
-                if (s_code) {
-                    /*jslint evil: true */
-                    document.write(s_code);
-                }
-            });
+            if (s_code) {
+                /*jslint evil: true */
+                document.write(s_code);
+            }
         });
     }
 

--- a/frontend/assets/javascripts/src/modules/analytics/ophan.js
+++ b/frontend/assets/javascripts/src/modules/analytics/ophan.js
@@ -1,0 +1,15 @@
+/*global Raven */
+define(function() {
+
+    function init() {
+        var ophanUrl = '//j.ophan.co.uk/ophan.membership.js';
+        require('js!' + ophanUrl).then(null, function(err) {
+            Raven.captureException(err);
+            Raven.captureMessage('Ophan failed to load');
+        });
+    }
+
+    return {
+        init: init
+    };
+});

--- a/frontend/assets/javascripts/src/modules/analytics/setup.js
+++ b/frontend/assets/javascripts/src/modules/analytics/setup.js
@@ -20,7 +20,6 @@ define([
             guardian.analyticsEnabled = false;
         }
 
-        guardian.analyticsEnabled = true;
         if (guardian.analyticsEnabled) {
             ophanAnalytics.init();
             omnitureAnalytics.init();

--- a/frontend/assets/javascripts/src/modules/analytics/setup.js
+++ b/frontend/assets/javascripts/src/modules/analytics/setup.js
@@ -2,11 +2,13 @@
 define([
     'src/utils/cookie',
     'src/modules/analytics/ga',
+    'src/modules/analytics/ophan',
     'src/modules/analytics/omniture',
     'src/modules/analytics/crazyegg'
 ], function (
     cookie,
     googleAnalytics,
+    ophanAnalytics,
     omnitureAnalytics,
     crazyegg
 ) {
@@ -18,8 +20,9 @@ define([
             guardian.analyticsEnabled = false;
         }
 
+        guardian.analyticsEnabled = true;
         if (guardian.analyticsEnabled) {
-            require('ophan/membership', function () {});
+            ophanAnalytics.init();
             omnitureAnalytics.init();
             googleAnalytics.init();
 

--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -108,5 +108,3 @@ include "benefits"
 
 # cache static assets for a year
 assets.defaultCache="max-age=31536000"
-
-ophan.js.url="//j.ophan.co.uk/ophan.membership"


### PR DESCRIPTION
This PR aims to give some more visibility to our [network timeout errors](https://app.getsentry.com/the-guardian/membership/group/31302609/) in Sentry. By adding explicit error handlers we can at least flag that an error definitely happened because the script failed to load.

This is definitely a symptom, rather than cause. But is at least one place we can try and get some more information from.

- Add `Raven` error handler to Ophan and Omniture script
- Remove `ophanJsUrl` from config (config was specifying AMD name, feels clearer to just inline URL in JS module)

As this touches how Omniture is loaded, attached is a screenshot of the Omniture Testing Tool confirming settings after change:

![screen shot 2015-04-08 at 12 38 31](https://cloud.githubusercontent.com/assets/123386/7044637/665589e0-dded-11e4-849b-790b981a174f.png)
