### PR TITLE
Fixed ticket sale date test

### DIFF
--- a/frontend/test/model/TicketSaleDatesTest.scala
+++ b/frontend/test/model/TicketSaleDatesTest.scala
@@ -8,6 +8,8 @@ import model.EventbriteTestObjects._
 import org.specs2.mutable.Specification
 import org.specs2.time.NoTimeConversions
 import utils.Resource
+import org.joda.time.DateTimeZone.UTC
+import org.joda.time.Instant
 
 class TicketSaleDatesTest extends Specification with NoTimeConversions {
 
@@ -45,11 +47,11 @@ class TicketSaleDatesTest extends Specification with NoTimeConversions {
 
       datesByTier(Patron) must be_==(saleStart)
 
-      // val partnerTicketSale = datesByTier(Partner).toDateTime
-      // dateMustBeToStartOfDay(partnerTicketSale) must be_==(true)
-//
-//      val friendTicketSale = datesByTier(Friend).toDateTime
-//      dateMustBeToStartOfDay(friendTicketSale) must be_==(true)
+      val partnerTicketSale = datesByTier(Partner).toDateTime(UTC)
+      dateMustBeToStartOfDay(partnerTicketSale) must be_==(true)
+
+      val friendTicketSale = datesByTier(Friend).toDateTime(UTC)
+      dateMustBeToStartOfDay(friendTicketSale) must be_==(true)
     }
 
     "give set advance tickets to be available a specific time if sale dates between tiers is less than a day" in {


### PR DESCRIPTION
Used Date time zone UTC in the test. We seem to do this in the code too: https://github.com/guardian/membership-frontend/blob/master/frontend/app/model/TicketSaleDates.scala#L71

cc/ @davidrapson @rtyley 