### PR TITLE
Fix event conversion tracking

### DIFF
--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -186,7 +186,7 @@ trait Event extends Controller with ActivityTracking {
     EventbriteService.getEvent(id).map { event =>
       // only log a conversion if the user came from a membership event page
       request.cookies.get(eventCookie(event)).foreach { _ =>
-        trackConversionToThankyou(request, event, None, None, true)
+        trackConversionToThankyou(request, event, None, None)
       }
       NoContent.discardingCookies(DiscardingCookie(eventCookie(event)))
     }.getOrElse(NotFound)

--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -155,7 +155,7 @@ trait Event extends Controller with ActivityTracking {
           val memberData = MemberData(request.member.salesforceContactId, request.user.id, request.member.tier.name)
           track(EventActivity("redirectToEventbrite", Some(memberData), EventData(event)))(request.user)
         Found(event.url ? ("discount" -> discountOpt.map(_.code)))
-          .withCookies(Cookie(eventCookie(event), ""))
+          .withCookies(Cookie(eventCookie(event), "", Some(3600)))
       }
     }
 

--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -159,15 +159,10 @@ trait Event extends Controller with ActivityTracking {
       }
     }
 
-  // log a conversion if the user came from a membership event page
   private def trackConversionToThankyou(request: Request[_], event: RichEvent, order: Option[EBOrder],
                                         member: Option[Member]) {
     val memberData = member.map(m => MemberData(m.salesforceContactId, m.identityId, m.tier.name))
     trackAnon(EventActivity("eventThankYou", memberData, EventData(event), order.map(OrderData(_))))(request)
-    event.service.wsMetrics.put("user-returned-to-thankyou-page-no-cookie", 1)
-    request.cookies.get(eventCookie(event)).foreach { _ =>
-      event.service.wsMetrics.put("user-returned-to-thankyou-page", 1)
-    }
   }
 
   def thankyou(id: String, orderIdOpt: Option[String]) = MemberAction.async { implicit request =>
@@ -189,7 +184,10 @@ trait Event extends Controller with ActivityTracking {
 
   def thankyouPixel(id: String) = NoCacheAction { implicit request =>
     EventbriteService.getEvent(id).map { event =>
-      trackConversionToThankyou(request, event, None, None)
+      // only log a conversion if the user came from a membership event page
+      request.cookies.get(eventCookie(event)).foreach { _ =>
+        trackConversionToThankyou(request, event, None, None, true)
+      }
       NoContent.discardingCookies(DiscardingCookie(eventCookie(event)))
     }.getOrElse(NotFound)
   }


### PR DESCRIPTION
We had some issues where the number of event ticket purchases we were seeing in Cloudwatch/Elasticsearch didn't tally with the EventBrite numbers (they were under 50% of what they should've been).

I investigated a bit and found that Google Analytics had the correct number of impressions to the `/event/$id/thankyou` page (eg. the same as EventBrite suggested), so we knew people were making it to this page. 

The tracking on that page depended on the user having a cookie of `mem-event-$id` which is set when they click "Buy tickets" on Membership, so I [added a test metric](https://github.com/guardian/membership-frontend/pull/451) which didn't test for this cookie, which revealed this discrepancy:

![screen shot 2015-04-08 at 15 13 51](https://cloud.githubusercontent.com/assets/394376/7064977/1f63b48a-deab-11e4-9f89-e450e58a2a77.png)

The orange dots show someone making an event purchase (regardless of whether they had the cookie) and the blue dots show people who *do* have the cookie. As you can see, there are quite a few purchases who don't have the cookie.

This PR, then, removes the requirement for the cookie – **except** for the "pixel" tracking, eg. the "ad" served on the NGW thankyou page used for Masterclasses, as we don't have any other way of knowing when a purchase began on Membership. Since we've already proven that the cookie method is unreliable, I've also changed the cookie from a session cookie (immediate expiry) to a 1 hour expiry. My working theory here was that some browsers dropped the session cookie as soon as the user navigated off Membership and onto Eventbrite, so hopefully this will keep tracking those numbers accurately.

Anyway, this is a really long-winded way of saying that I've removed the requirement for a cookie to track event sales. Thanks to @jennysivapalan for helping me with this one!

:cookie: 
