### PR TITLE
Use current tier name instead of plan name for summaries

### DIFF
--- a/frontend/app/views/fragments/tier/summary.scala.html
+++ b/frontend/app/views/fragments/tier/summary.scala.html
@@ -1,16 +1,18 @@
-@(currentSubscription: model.Zuora.SubscriptionDetails)
+@(currentSubscription: model.Zuora.SubscriptionDetails, currentTierOpt: Option[com.gu.membership.salesforce.Tier])
 
 @import views.support.Dates._
 @import views.support.Prices._
 
 <table class="table table--striped" role="grid">
     <tr role="row">
-        <th role="rowheader">
-            Tier
-        </th>
-        <td id="qa-tier-summary-tier">
-            @currentSubscription.planName
-        </td>
+        @for(currentTier <- currentTierOpt) {
+            <th role="rowheader">
+                Tier
+            </th>
+            <td id="qa-tier-summary-tier">
+                @currentTier.name
+            </td>
+        }
     </tr>
     <tr role="row">
         <th role="rowheader">

--- a/frontend/app/views/tier/cancel/summary.scala.html
+++ b/frontend/app/views/tier/cancel/summary.scala.html
@@ -1,4 +1,4 @@
-@(subscriptionDetailsOpt: Option[model.Zuora.SubscriptionDetails])
+@(subscriptionDetailsOpt: Option[model.Zuora.SubscriptionDetails], currentTierOpt: Option[com.gu.membership.salesforce.Tier])
 
 @import configuration.Config
 @import views.support.Dates._
@@ -16,7 +16,7 @@
             <div class="page-section__content">
 
                 @for(subscriptionDetails <- subscriptionDetailsOpt) {
-                    @fragments.tier.summary(subscriptionDetails)
+                    @fragments.tier.summary(subscriptionDetails, currentTierOpt)
                 }
 
                 @if(subscriptionDetailsOpt.isEmpty) {

--- a/frontend/app/views/tier/downgrade/summary.scala.html
+++ b/frontend/app/views/tier/downgrade/summary.scala.html
@@ -1,10 +1,15 @@
-@(currentSubscription: model.Zuora.SubscriptionDetails, futureSubscription: model.Zuora.SubscriptionDetails)
+@(
+    currentSubscription: model.Zuora.SubscriptionDetails,
+    futureSubscription: model.Zuora.SubscriptionDetails,
+    currentTier: com.gu.membership.salesforce.Tier,
+    futureTierName: String
+)
 
 @import configuration.Config
 @import views.support.Dates._
 @import views.support.Prices._
 
-@main("Change Tier Summary | " + futureSubscription.planName + " from " + currentSubscription.planName) {
+@main("Change Tier Summary | " + futureTierName + " from " + currentTier.name) {
 
     <main role="main" class="page-content l-constrained">
 
@@ -15,7 +20,7 @@
                 <h2 class="page-section__headline">Current Membership summary</h2>
             </div>
             <div class="page-section__content">
-                @fragments.tier.summary(currentSubscription)
+                @fragments.tier.summary(currentSubscription, Some(currentTier))
             </div>
         </section>
 
@@ -30,7 +35,7 @@
                             Tier
                         </th>
                         <td id="qa-downgrade-summary-tier">
-                            Friend
+                            @futureTierName
                         </td>
                     </tr>
                     <tr role="row">

--- a/frontend/app/views/tier/upgrade/paidToPaid.scala.html
+++ b/frontend/app/views/tier/upgrade/paidToPaid.scala.html
@@ -54,7 +54,7 @@
                 <table class="table table--striped" role="grid">
                     <tr role="row">
                         <th role="rowheader">Tier</th>
-                        <td id="qa-upgrade-current-tier">@currentSubscription.planName</td>
+                        <td id="qa-upgrade-current-tier">@currentTier.name</td>
                     </tr>
                     <tr role="row">
                         <th role="rowheader">Start date</th>


### PR DESCRIPTION
This PR fixes an issues where "Non Founding Member" was being displayed as the Tier name when downgrading, cancelling or paid to paid upgrades. We don't really want to use the planName here so updating to use the tier name.

## Before

![unnamed](https://cloud.githubusercontent.com/assets/123386/7065534/ba4aacec-deb0-11e4-8a75-62969c0adc0f.png)

![screen shot 2015-04-09 at 12 07 58](https://cloud.githubusercontent.com/assets/123386/7065574/1788bd72-deb1-11e4-9bf6-b95018554132.png)

## After

![after](https://cloud.githubusercontent.com/assets/123386/7065531/b2dd3466-deb0-11e4-93c6-c4bbf09714d2.png)

![screen shot 2015-04-09 at 12 13 17](https://cloud.githubusercontent.com/assets/123386/7065650/d2fff228-deb1-11e4-85f1-8c46b6c798a1.png)

@jennysivapalan 