### PR TITLE
Improve UX of video player

### DIFF
--- a/frontend/app/configuration/Videos.scala
+++ b/frontend/app/configuration/Videos.scala
@@ -1,6 +1,31 @@
 package configuration
 
+import com.netaporter.uri.dsl._
+import model.{Video, ResponsiveImageGroup, ResponsiveImageGenerator}
+
 object Videos {
-  val whatIsMembership = "https://www.youtube.com/embed/7JnYthFvYEk"
-  val supporters = "https://www.youtube.com/embed/uTm3spGwpFI"
+  val whatIsMembership = Video(
+    srcUrl="//www.youtube.com/embed/7JnYthFvYEk?enablejsapi=1",
+    posterImage=Some(
+      ResponsiveImageGroup(
+        altText=Some("If you read the Guardian, join the Guardian"),
+        availableImages=ResponsiveImageGenerator(
+          id="9c47cb6060bbbd7b5eed5c87fd2bbbdeb1585a11/0_0_2280_1368",
+          sizes=List(1000, 500)
+        )
+      )
+    )
+  )
+  val supporters = Video(
+    srcUrl="//www.youtube.com/embed/uTm3spGwpFI?enablejsapi=1",
+    posterImage=Some(
+      ResponsiveImageGroup(
+        altText=Some("If you read the Guardian, join the Guardian"),
+        availableImages=ResponsiveImageGenerator(
+          id="9c47cb6060bbbd7b5eed5c87fd2bbbdeb1585a11/0_0_2280_1368",
+          sizes=List(1000, 500)
+        )
+      )
+    )
+  )
 }

--- a/frontend/app/configuration/Videos.scala
+++ b/frontend/app/configuration/Videos.scala
@@ -22,7 +22,7 @@ object Videos {
       ResponsiveImageGroup(
         altText=Some("If you read the Guardian, join the Guardian"),
         availableImages=ResponsiveImageGenerator(
-          id="9c47cb6060bbbd7b5eed5c87fd2bbbdeb1585a11/0_0_2280_1368",
+          id="76c306a5c0fed576a7fa3fa18c246ca52f671ad3/0_0_2280_1368",
           sizes=List(1000, 500)
         )
       )

--- a/frontend/app/model/Video.scala
+++ b/frontend/app/model/Video.scala
@@ -1,0 +1,6 @@
+package model
+
+case class Video(
+  srcUrl: com.netaporter.uri.Uri,
+  posterImage: Option[model.ResponsiveImageGroup]
+)

--- a/frontend/app/views/fragments/media/videoPlayer.scala.html
+++ b/frontend/app/views/fragments/media/videoPlayer.scala.html
@@ -1,0 +1,18 @@
+@(video: model.Video)
+
+<div class="video-player js-video">
+    <iframe class="video-player__iframe js-video__iframe"  src="@video.srcUrl" width="560" height="315" frameborder="0" allowfullscreen></iframe>
+    @for(posterImage <- video.posterImage) {
+        <div class="video-player__overlay js-video__overlay">
+            <div class="video-player__overlay__image">
+                <img src="@posterImage.defaultImage" srcset="@posterImage.srcset" sizes="100vw" alt="@posterImage.altText" class="responsive-img" />
+            </div>
+            <div class="video-player__overlay__action">
+                <span class="playback">
+                    @fragments.inlineIcon("play", List("playback__icon"))
+                    <span class="u-h">Play video</span>
+                </span>
+            </div>
+        </div>
+    }
+</div>

--- a/frontend/app/views/fragments/promos/promoAltVideo.scala.html
+++ b/frontend/app/views/fragments/promos/promoAltVideo.scala.html
@@ -1,6 +1,6 @@
 @(
     title: String,
-    videoUrl: String,
+    video: model.Video,
     toneClassOpt: Option[String] = None
 )(content: Html)
 
@@ -8,14 +8,12 @@
     <div class="promo-alt__panel @toneClassOpt.mkString(" ")">
         <div class="promo-alt__header">
             <h2 class="promo-alt__title h-promo">
-                @fragments.inlineIcon("video", classes=List("icon-inline--scale"))
+                @fragments.inlineIcon("video", List("icon-inline--scale"))
                 @title
             </h2>
         </div>
         <div class="promo-alt__media">
-            <div class="responsive-video responsive-video--gu">
-                <iframe class="responsive-video__iframe"  src="@videoUrl" width="560" height="315" frameborder="0" allowfullscreen></iframe>
-            </div>
+            @fragments.media.videoPlayer(video)
         </div>
     </div>
     <div class="promo-alt__description">

--- a/frontend/app/views/fragments/promos/promoVideoSecondary.scala.html
+++ b/frontend/app/views/fragments/promos/promoVideoSecondary.scala.html
@@ -1,6 +1,6 @@
 @(
     title: Html,
-    videoUrl: String,
+    video: model.Video,
     toneClass: Option[String] = None
 )(content: Html)
 
@@ -10,9 +10,7 @@
             <h2 class="promo-secondary__title h-promo">@title</h2>
         </div>
         <div class="promo-secondary__video">
-            <div class="responsive-video">
-                <iframe class="responsive-video__iframe" width="715" height="429" src="@videoUrl" frameborder="0" allowfullscreen></iframe>
-            </div>
+            @fragments.media.videoPlayer(video)
         </div>
     </div>
     <div class="promo-secondary__description">

--- a/frontend/app/views/info/about.scala.html
+++ b/frontend/app/views/info/about.scala.html
@@ -28,7 +28,7 @@
     <div id="what-is-guardian-membership" class="page-slice page-slice--slim l-constrained">
         @fragments.promos.promoVideoSecondary(
             Html("If you believe in Guardian journalism, become a Guardian Member"),
-            videoUrl=Videos.whatIsMembership,
+            video=Videos.whatIsMembership,
             toneClass=Some("tone-trans-brand-dark")){
             <div class="text-feature">
                 <p>Alan Rusbridger, Polly Toynbee, Jonathan Freedland, Owen Jones and Zoe Williams introduce Guardian Membership.</p>

--- a/frontend/app/views/info/subscriberOffer.scala.html
+++ b/frontend/app/views/info/subscriberOffer.scala.html
@@ -54,7 +54,7 @@
                 <div class="page-slice page-slice--slim l-constrained">
                     @fragments.promos.promoAltVideo(
                         title="“If you read the Guardian, join the Guardian”",
-                        videoUrl=Videos.whatIsMembership,
+                        video=Videos.whatIsMembership,
                         toneClassOpt=Some("tone-brand")
                     ) {
                         <p class="text-feature">

--- a/frontend/app/views/info/supporter.scala.html
+++ b/frontend/app/views/info/supporter.scala.html
@@ -22,7 +22,7 @@
     <div id="supporter-video" class="page-slice page-slice--slim l-constrained">
         @fragments.promos.promoVideoSecondary(
             Html("Support open, independent journalism"),
-            videoUrl=Videos.supporters,
+            video=Videos.supporters,
             toneClass=Some("tone-trans-brand-dark")){
             <div class="text-feature">
                 <p>Watch Guardian journalists explain why the Guardian’s unique approach to journalism is worth defending.</p>

--- a/frontend/app/views/patterns/patterns.scala.html
+++ b/frontend/app/views/patterns/patterns.scala.html
@@ -299,8 +299,8 @@
         <div class="page-slice page-slice--slim l-constrained">
             @fragments.promos.promoVideoSecondary(
                 Html("If you believe in Guardian journalism, become a Guardian Member"),
-                videoUrl = Videos.whatIsMembership,
-                toneClass = Some("tone-trans-brand-dark")) {
+                video=Videos.whatIsMembership,
+                toneClass=Some("tone-trans-brand-dark")) {
                 <div class="text-feature">
                     <p> Alan Rusbridger, Polly Toynbee, Jonathan Freedland, Owen Jones and Zoe Williams talk about why readers play such an important part of the Guardian.</p>
                     <p>Sign up as a member, you’ll be supporting free, independent journalism and helping us create original, compelling stories.</p>
@@ -310,12 +310,8 @@
         </div>
     }
 
-    @pattern("Offer - Option", "Image with a letter box crop and call out") {
-        @fragments.offer.option(
-            "Pay annually",
-            s"Pay nothing for 6 months then pay £00",
-            s"£00.00/year"
-        )
+    @pattern("Video Player", "Video with poster image overlay") {
+        @fragments.media.videoPlayer(Videos.whatIsMembership)
     }
 
     @pattern("Event – Hero", "Used to highlight a single event at the top of the /events listing") {

--- a/frontend/assets/images/inline-svgs/raw/play.svg
+++ b/frontend/assets/images/inline-svgs/raw/play.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="38" height="31.848" viewBox="0 0 38 31.848"><path fill="#fff" d="M38 15.12l-36.72-15.12-1.28.987v29.919l1.287.942 36.713-15.117z"/></svg>

--- a/frontend/assets/javascripts/src/main.js
+++ b/frontend/assets/javascripts/src/main.js
@@ -9,14 +9,15 @@ require([
     'src/modules/sticky',
     'src/modules/navigation',
     'src/modules/UserDetails',
+    'src/modules/videoOverlay',
     'src/modules/events/eventPriceEnhance',
-    'src/modules/patterns',
     'src/modules/modal',
     'src/modules/form',
     'src/modules/form/processSubmit',
-    'src/modules/metrics',
     'src/modules/identityPopup',
     'src/modules/identityPopupDetails',
+    'src/modules/metrics',
+    'src/modules/patterns',
     // Add new dependencies ABOVE this
     'raven',
     'modernizr'
@@ -31,14 +32,15 @@ require([
     sticky,
     navigation,
     UserDetails,
+    videoOverlay,
     eventPriceEnhance,
     modal,
-    patterns,
     processSubmit,
     form,
-    metrics,
     identityPopup,
-    identityPopupDetails
+    identityPopupDetails,
+    metrics,
+    patterns
 ) {
     'use strict';
 
@@ -62,6 +64,7 @@ require([
     identityPopupDetails.init();
     navigation.init();
     (new UserDetails()).init();
+    videoOverlay.init();
 
     // Events
     cta.init();
@@ -75,10 +78,10 @@ require([
     // Modal
     modal.init();
 
-    // Pattern library
-    patterns.init();
-
     // Metrics
     metrics.init();
+
+    // Pattern library
+    patterns.init();
 
 });

--- a/frontend/assets/javascripts/src/modules/videoOverlay.js
+++ b/frontend/assets/javascripts/src/modules/videoOverlay.js
@@ -1,0 +1,59 @@
+/* global YT: true */
+/**
+ * Play video when clicking on a video overlay image
+ */
+define(['src/utils/loadJS'], function (loadJS) {
+
+    var SELECTOR_PLAYER = '.js-video';
+    var SELECTOR_PLAYER_IFRAME = '.js-video__iframe';
+    var SELECTOR_PLAYER_OVERLAY = '.js-video__overlay';
+    var CLASSNAME_IS_PLAYING = 'is-playing';
+
+    var playerEls = document.querySelectorAll(SELECTOR_PLAYER);
+
+    /**
+     * Nasty UA detection but calling `playVideo` on iOS
+     * results in blank player.
+     */
+    function iOSDevice() {
+        return /(iPad|iPhone|iPod)/g.test(navigator.userAgent);
+    }
+
+    /**
+     * YouTube API is initialised using global callback function
+     */
+    window.onYouTubeIframeAPIReady = function() {
+        [].forEach.call(playerEls, function(player){
+            var playerIframe = player.querySelector(SELECTOR_PLAYER_IFRAME);
+            var playerOverlay = player.querySelector(SELECTOR_PLAYER_OVERLAY);
+            var playerApi;
+
+            if(playerIframe && playerOverlay) {
+                playerApi = new YT.Player(playerIframe);
+                playerOverlay.addEventListener('click', function(e) {
+                    e.preventDefault();
+
+                    if(!iOSDevice()) {
+                        playerApi.playVideo();
+                    }
+                    player.classList.add(CLASSNAME_IS_PLAYING);
+                    setTimeout(function() {
+                        playerOverlay.parentNode.removeChild(playerOverlay);
+                    }, 2000);
+                });
+            }
+
+        });
+    };
+
+    function init() {
+        if (playerEls.length) {
+            loadJS('//www.youtube.com/iframe_api');
+        }
+    }
+
+    return {
+        init: init
+    };
+
+});

--- a/frontend/assets/javascripts/src/utils/loadJS.js
+++ b/frontend/assets/javascripts/src/utils/loadJS.js
@@ -1,0 +1,15 @@
+/*! loadJS: load a JS file asynchronously. [c]2014 @scottjehl, Filament Group, Inc. (Based on http://goo.gl/REQGQ by Paul Irish). Licensed MIT */
+define(function () {
+    return function(src, cb){
+        'use strict';
+        var ref = window.document.getElementsByTagName( 'script' )[ 0 ];
+        var script = window.document.createElement( 'script' );
+        script.src = src;
+        script.async = true;
+        ref.parentNode.insertBefore( script, ref );
+        if (cb && typeof(cb) === 'function') {
+            script.onload = cb;
+        }
+        return script;
+    };
+});

--- a/frontend/assets/stylesheets/components/_video.scss
+++ b/frontend/assets/stylesheets/components/_video.scss
@@ -1,23 +1,69 @@
 /* ==========================================================================
-   Responsive Video
+   Video Player
    ========================================================================== */
-/**
- * Example usage:
- * <div class="responsive-video">
- *     <iframe class="responsive-video__iframe"></iframe>
- * </div>
- **/
-.responsive-video {
+
+.video-player {
     position: relative;
     padding-bottom: 56.25%;
-    padding-top: rem(35px);
     height: 0;
     overflow: hidden;
 }
-.responsive-video__iframe {
+.video-player__iframe {
     position: absolute;
     top: 0;
     left: 0;
     width: 100%;
     height: 100%;
+    opacity: 0;
+}
+.video-player__overlay {
+    cursor: pointer;
+    position: absolute;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    opacity: 1;
+    transition: 1s opacity ease 300ms;
+}
+.video-player__overlay__action {
+    display: block;
+    position: absolute;
+    top: 50%; left: 50%;
+    transform: translateX(-50%) translateY(-50%);
+    z-index: 2;
+}
+.video-player.is-playing {
+    .video-player__iframe {
+        opacity: 1;
+    }
+    .video-player__overlay {
+        opacity: 0;
+    }
+}
+
+.playback {
+    color: $white;
+    background-color: rgba(0,0,0,0.6);
+    border-radius: 100%;
+    border: 0 none;
+    outline: none;
+    padding: 0;
+    margin: 0;
+    display: inline-block;
+    vertical-align: middle;
+    width: 90px;
+    height: 90px;
+    position: relative;
+    transition: background-color .5s ease;
+}
+.playback__icon {
+    position: absolute;
+    top: 50%; left: 50%;
+    transform: translateX(-40%) translateY(-50%);
+    width: 32px; height: 32px;
+}
+
+.playback:hover,
+.video-player__overlay:hover .playback {
+    background-color: $mem-brandBlue;
 }


### PR DESCRIPTION
This PR adds an overlay effect to videos. Uses the YouTube API to start playback of the video when the user clicks on the overlay.

![video-2 mov](https://cloud.githubusercontent.com/assets/123386/7067612/8f04293c-dec4-11e4-8700-65d286dc3fa9.gif)

- Adds new `Video` model and models individual videos in the config
- Add `videoOverlay` component, YT API is lazyloaded only when needed
- Extract out new `videoPlayer` fragment and adds to pattern library

**Caveats**

- We have to load the YouTube iFrame API to trigger video playback
- iOS does not like us triggering playback, so there's a bit of nasty UA detection in here to only start playback on non iOS devices.

This is a medium-term solution until we can use the Guardian player over HTTPS in a couple of months. Are the trade-offs with this approach worth it?

@mattandrews 