### PR TITLE
Re-add Krux

### DIFF
--- a/frontend/assets/javascripts/src/modules/analytics/krux.js
+++ b/frontend/assets/javascripts/src/modules/analytics/krux.js
@@ -1,0 +1,16 @@
+/*global Raven */
+define(function() {
+
+    var KRUX_ID = 'JglooLwn';
+
+    function load() {
+        require(['js!//cdn.krxd.net/controltag?confid=' + KRUX_ID]).then(null, function(err) {
+            Raven.captureException(err);
+            Raven.captureMessage('Krux failed to load');
+        });
+    }
+
+    return {
+        load: load
+    };
+});

--- a/frontend/assets/javascripts/src/modules/analytics/setup.js
+++ b/frontend/assets/javascripts/src/modules/analytics/setup.js
@@ -4,12 +4,14 @@ define([
     'src/modules/analytics/ga',
     'src/modules/analytics/ophan',
     'src/modules/analytics/omniture',
+    'src/modules/analytics/krux',
     'src/modules/analytics/crazyegg'
 ], function (
     cookie,
     googleAnalytics,
     ophanAnalytics,
     omnitureAnalytics,
+    krux,
     crazyegg
 ) {
 
@@ -19,6 +21,8 @@ define([
         if (cookie.getCookie(ANALYTICS_OFF_KEY)) {
             guardian.analyticsEnabled = false;
         }
+
+        krux.load();
 
         if (guardian.analyticsEnabled) {
             ophanAnalytics.init();


### PR DESCRIPTION
We've had confirmation from Ads team that any non-https tags have been disabled so re-adding Krux. 

@jamesoram Before this goes out I'd appreciate your eyes on it, looking out for any mixed-content warnings. I've enabled Krux in DEV for now so you can test for this. Will put it behind the check again before this goes out.