### PR TITLE
Add in annual renewal date for those in free period offer

### DIFF
--- a/frontend/app/model/MembershipSummary.scala
+++ b/frontend/app/model/MembershipSummary.scala
@@ -12,9 +12,6 @@ case class MembershipSummary(startDate: DateTime,
                              initialFreePeriodOffer: Boolean) {
 
 
-  val annual = {
-    if (initialFreePeriodOffer) nextPaymentPrice % planAmount != 0
-    else firstPaymentEndDate.plusDays(1) == startDate.plusYears(1)
-  }
+  val annual = startDate.plusYears(1) == renewalDate
 
 }

--- a/frontend/app/model/MembershipSummary.scala
+++ b/frontend/app/model/MembershipSummary.scala
@@ -8,6 +8,7 @@ case class MembershipSummary(startDate: DateTime,
                              planAmount: Float,
                              nextPaymentPrice: Float,
                              nextPaymentDate: DateTime,
+                             renewalDate: DateTime,
                              initialFreePeriodOffer: Boolean) {
 
 

--- a/frontend/app/services/SubscriptionService.scala
+++ b/frontend/app/services/SubscriptionService.scala
@@ -180,7 +180,7 @@ class SubscriptionService(val tierPlanRateIds: Map[ProductRatePlan, String], val
         val firstPreviewInvoice = result.invoiceItems.sortBy(_.serviceStartDate).head
 
         MembershipSummary(latestSubscription.termStartDate, firstPreviewInvoice.serviceEndDate, 0f,
-          subscriptionDetails.planAmount, firstPreviewInvoice.price, firstPreviewInvoice.serviceStartDate, initialFreePeriodOffer = true )
+          subscriptionDetails.planAmount, firstPreviewInvoice.price, firstPreviewInvoice.serviceStartDate, firstPreviewInvoice.renewalDate, initialFreePeriodOffer = true )
 
       }
     }
@@ -190,7 +190,7 @@ class SubscriptionService(val tierPlanRateIds: Map[ProductRatePlan, String], val
         paymentSummary <- getPaymentSummary(memberId)
 
       } yield MembershipSummary(paymentSummary.current.serviceStartDate, paymentSummary.current.serviceEndDate,
-        paymentSummary.totalPrice, paymentSummary.current.price, paymentSummary.current.price, paymentSummary.current.nextPaymentDate, initialFreePeriodOffer = false)
+        paymentSummary.totalPrice, paymentSummary.current.price, paymentSummary.current.price, paymentSummary.current.nextPaymentDate, paymentSummary.current.nextPaymentDate, initialFreePeriodOffer = false)
     }
 
     for {

--- a/frontend/app/views/joiner/thankyou.scala.html
+++ b/frontend/app/views/joiner/thankyou.scala.html
@@ -65,9 +65,9 @@
                         <th role="rowheader">Next payment</th>
                         <td id="qa-joiner-summary-next">
                             @if(summary.initialFreePeriodOffer) {
-                            @summary.nextPaymentPrice.pretty (@summary.nextPaymentDate.pretty)
+                                @summary.nextPaymentPrice.pretty (@summary.nextPaymentDate.pretty)
                             } else {
-                            @summary.nextPaymentDate.pretty
+                                @summary.nextPaymentDate.pretty
                             }
                         </td>
                     </tr>

--- a/frontend/app/views/joiner/thankyou.scala.html
+++ b/frontend/app/views/joiner/thankyou.scala.html
@@ -62,21 +62,30 @@
                         <td id="qa-joiner-summary-today">@summary.amountPaidToday.pretty</td>
                     </tr>
                     <tr role="row">
+                        <th role="rowheader">Next payment</th>
+                        <td id="qa-joiner-summary-next">
+                            @if(summary.initialFreePeriodOffer) {
+                            @summary.nextPaymentPrice.pretty (@summary.nextPaymentDate.pretty)
+                            } else {
+                            @summary.nextPaymentDate.pretty
+                            }
+                        </td>
+                    </tr>
+                    <tr role="row">
                         <th role="rowheader">
                             @if(summary.annual) { Annual } else { Monthly } payment
                         </th>
                         <td id="qa-joiner-summary-recurring">@summary.planAmount.pretty</td>
                     </tr>
-                    <tr role="row">
-                        <th role="rowheader">Next payment</th>
-                        <td id="qa-joiner-summary-next">
-                        @if(summary.initialFreePeriodOffer) {
-                            @summary.nextPaymentPrice.pretty (@summary.nextPaymentDate.pretty)
-                        } else {
-                            @summary.nextPaymentDate.pretty
-                        }
-                        </td>
-                    </tr>
+                    @if(summary.annual && summary.initialFreePeriodOffer) {
+                        <tr role="row">
+                            <th role="rowheader">
+                                Next Annual payment
+                            </th>
+                            <td id="qa-joiner-summary-annual-date">@summary.renewalDate.pretty</td>
+                        </tr>
+                    }
+
                     @for(card <- cardOpt) {
 
                     <tr role="row">

--- a/frontend/test/model/MembershipSummaryTest.scala
+++ b/frontend/test/model/MembershipSummaryTest.scala
@@ -10,24 +10,25 @@ class MembershipSummaryTest extends Specification  {
 
     "have an annual setting of true for annual subscriptions when payment made at start of plan" in {
       val firstPaymentEndDate = termStartDate.plusYears(1).minusDays(1)
-
-      val partnerAnnualSummary = MembershipSummary(termStartDate, firstPaymentEndDate, 135f, 135f, 135f, firstPaymentEndDate.plusDays(1), false)
+      val nextPaymentDate = firstPaymentEndDate.plusDays(1)
+      val partnerAnnualSummary = MembershipSummary(termStartDate, firstPaymentEndDate, 135f, 135f, 135f, nextPaymentDate, nextPaymentDate, false)
       partnerAnnualSummary.annual mustEqual  true
     }
 
     "have an annual setting of false for monthly subscriptions when payment made at start of plan" in {
       val firstPaymentEndDate = termStartDate.plusMonths(1).minusDays(1)
-
-      val partnerMonthlySummary = MembershipSummary(termStartDate, firstPaymentEndDate, 15f, 15f, 15f, firstPaymentEndDate.plusDays(1), false)
+      val nextPaymentDate = firstPaymentEndDate.plusDays(1)
+      val partnerMonthlySummary = MembershipSummary(termStartDate, firstPaymentEndDate, 15f, 15f, 15f, nextPaymentDate, nextPaymentDate, false)
       partnerMonthlySummary.annual mustEqual  false
     }
 
     "have an annual setting of true for annual subscriptions with free period offer" in {
-      val initalDelayMonths = 6
-      val firstPaymentStartDate = termStartDate.plusMonths(initalDelayMonths)
-      val firstPaymentEndDate = firstPaymentStartDate.plusMonths(12 - initalDelayMonths).minusDays(1)
+      val initialDelay = 6
+      val firstPaymentStartDate = termStartDate.plusMonths(initialDelay)
+      val firstPaymentEndDate = firstPaymentStartDate.plusMonths(12 - initialDelay).minusDays(1)
+      val renewalDate = termStartDate.plusYears(1)
 
-      val partnerAnnualSummary = MembershipSummary(termStartDate, firstPaymentEndDate, 0f, 135f, 67.5f, firstPaymentStartDate, true)
+      val partnerAnnualSummary = MembershipSummary(termStartDate, firstPaymentEndDate, 0f, 135f, 67.5f, firstPaymentStartDate, renewalDate, true)
       partnerAnnualSummary.annual mustEqual  true
     }
 
@@ -36,7 +37,8 @@ class MembershipSummaryTest extends Specification  {
       val firstPaymentStartDate = termStartDate.plusMonths(initalDelayMonths)
       val firstPaymentEndDate = termStartDate.plusMonths(1).minusDays(1)
 
-      val partnerMonthlySummary = MembershipSummary(termStartDate, firstPaymentEndDate, 0f, 15f, 15f, firstPaymentStartDate, false)
+
+      val partnerMonthlySummary = MembershipSummary(termStartDate, firstPaymentEndDate, 0f, 15f, 15f, firstPaymentStartDate, firstPaymentStartDate, false)
       partnerMonthlySummary.annual mustEqual  false
     }
   }


### PR DESCRIPTION
This addresses the issue that the annual payment date for subscribers is not clear. I have added this as a new row on the confirmation summary (Jira ticket: https://jira.gutools.co.uk/browse/MEM-709)

Note this is PR off `add-subscriber` branch (PR: https://github.com/guardian/membership-frontend/pull/449).

cc/ @jamesoram 