### PR TITLE
Event container spike

### DIFF
--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -8,11 +8,12 @@ import com.gu.membership.util.Timing
 import com.netaporter.uri.dsl._
 import configuration.{Config, CopyConfig, Links}
 import model.Eventbrite.{EBOrder, EBEvent}
+import model.RichEvent.RichEvent
 import model.RichEvent._
-import model.{IdMinimalUser, EventPortfolio, Eventbrite, PageInfo}
+import model._
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.mvc._
-import services.{EventbriteService, GuardianLiveEventService, MasterclassEventService, LocalEventService, MemberService}
+import services._
 import services.EventbriteService._
 import com.github.nscala_time.time.Imports._
 import tracking._
@@ -92,6 +93,55 @@ trait Event extends Controller with ActivityTracking {
 
   private def chronologicalSort(events: Seq[model.RichEvent.RichEvent]) = {
     events.sortWith(_.event.start < _.event.start)
+  }
+
+  def whatsOn = GoogleAuthenticatedStaffAction { implicit request =>
+
+    val pageInfo = PageInfo(
+      CopyConfig.copyTitleEvents,
+      request.path,
+      Some(CopyConfig.copyDescriptionEvents)
+    )
+
+    val now = DateTime.now
+
+    val events = EventCollections(
+      // unstruct_event_1.eventSource:"viewEventDetails"
+      trending=guLiveEvents.getEventsByIds(List(
+        "15926171608",
+        "16351430569",
+        "15351696337",
+        "15756402825",
+        "16253355223",
+        "16234171845",
+        "16349419554",
+        "15597340064",
+        "16253236869",
+        "16430264363"
+      )),
+      // unstruct_event_1.eventSource:"eventThankYou"
+      topSelling=guLiveEvents.getEventsByIds(List(
+        "16253236869",
+        "16253494640",
+        "16234171845",
+        "16351430569",
+        "15351696337",
+        "16252865759",
+        "16253323127",
+        "15926171608",
+        "15597340064",
+        "16380673034"
+      )),
+      thisWeek=guLiveEvents.getEventsBetween(new Interval(now, now + 1.week)),
+      nextWeek=guLiveEvents.getEventsBetween(new Interval(now + 1.week, now + 2.weeks)),
+      recentlyCreated=guLiveEvents.getRecentlyCreated(now - 1.weeks),
+      partnersOnly=guLiveEvents.getEvents.filter(_.internalTicketing.exists(_.isCurrentlyAvailableToPaidMembersOnly)),
+      programmingPartnerEvents=guLiveEvents.getPartnerEvents
+    )
+
+    val latestArticles = GuardianContentService.membershipFrontContent.map(MembersOnlyContent)
+
+    Ok(views.html.event.whatson(pageInfo, events, latestArticles))
   }
 
   def list = CachedAction { implicit request =>

--- a/frontend/app/model/EventPortfolio.scala
+++ b/frontend/app/model/EventPortfolio.scala
@@ -14,3 +14,13 @@ case class EventPortfolio(
   lazy val heroOpt = orderedEvents.headOption
   lazy val priority = orderedEvents.drop(1)
 }
+
+case class EventCollections(
+    trending: Seq[RichEvent],
+    topSelling: Seq[RichEvent],
+    thisWeek: Seq[RichEvent],
+    nextWeek: Seq[RichEvent],
+    recentlyCreated: Seq[RichEvent],
+    partnersOnly: Seq[RichEvent],
+    programmingPartnerEvents: Option[EventGroup]
+)

--- a/frontend/app/model/Eventbrite.scala
+++ b/frontend/app/model/Eventbrite.scala
@@ -190,7 +190,7 @@ object Eventbrite {
     }
 
     val limitedAvailabilityText = "Last tickets remaining"
-    val isLimitedAvailability = internalTicketing.exists(_.ticketsNotSold <= 15)
+    val isLimitedAvailability = internalTicketing.exists(item => item.ticketsNotSold <= 15 && !item.isSoldOut)
     val ticketsNotSold = internalTicketing.map(_.ticketsNotSold)
 
     val isSoldOut = internalTicketing.exists(_.isSoldOut)

--- a/frontend/app/services/EventbriteService.scala
+++ b/frontend/app/services/EventbriteService.scala
@@ -2,18 +2,18 @@ package services
 
 import com.gu.membership.util.WebServiceHelper
 import configuration.Config
-import model.EventGroup
+import model.{TicketSaleDates, EventGroup}
 import model.Eventbrite._
 import model.EventbriteDeserializer._
 import model.RichEvent._
 import monitoring.EventbriteMetrics
+import org.joda.time.{Interval, Period, DateTime}
 import play.api.Logger
 import play.api.Play.current
 import play.api.cache.Cache
 import play.api.libs.json.Reads
 import play.api.libs.ws._
 import utils.ScheduledTask
-
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -73,6 +73,11 @@ trait EventbriteService extends WebServiceHelper[EBObject, EBError] {
 
   def getBookableEvent(id: String): Option[RichEvent] = events.find(_.id == id)
   def getEvent(id: String): Option[RichEvent] = (events ++ eventsArchive).find(_.id == id)
+
+  def getEventsByIds(ids: Seq[String]): Seq[RichEvent] = events.filter(e => ids.contains(e.event.id))
+  def getLimitedAvailability: Seq[RichEvent] = events.filter(_.event.isLimitedAvailability)
+  def getRecentlyCreated(start: DateTime): Seq[RichEvent] = events.filter(_.created.isAfter(start))
+  def getEventsBetween(interval: Interval): Seq[RichEvent] = events.filter(event => interval.contains(event.start))
 
   def createOrGetAccessCode(event: RichEvent, code: String, ticketClasses: Seq[EBTicketClass]): Future[EBAccessCode] = {
     val uri = s"events/${event.id}/access_codes"

--- a/frontend/app/services/GuardianContentService.scala
+++ b/frontend/app/services/GuardianContentService.scala
@@ -132,11 +132,10 @@ trait GuardianContent {
 
   def membershipFrontContentQuery(page: Int): Future[ItemResponse] = {
     val itemQuery = ItemQuery("/membership")
-      .showFields("all")
-      .showElements("all")
-      .pageSize(50)
-      .page(page)
+      .showElements("image")
       .tag("type/article")
+      .pageSize(20)
+      .page(page)
 
     client.getResponse(itemQuery).andThen {
       case Failure(GuardianContentApiError(status, message)) =>

--- a/frontend/app/views/event/whatson.scala.html
+++ b/frontend/app/views/event/whatson.scala.html
@@ -5,68 +5,32 @@
 
         <section class="page-slice l-inset">
             <h3 class="h-section h-section--lead">Trending</h3>
-            <ul class="grid grid--4up grid--bordered grid--single-row">
-            @for(event <- eventPortfolio.trending.take(4)) {
-                <li class="grid__item">
-                @fragments.event.item(event)
-                </li>
-            }
-            </ul>
+            @fragments.event.eventCollection(eventPortfolio.trending, 4)
         </section>
 
         <section class="page-slice l-inset">
             <h3 class="h-section h-section--lead">This week</h3>
-            <ul class="grid grid--4up grid--bordered grid--single-row">
-                @for(event <- eventPortfolio.thisWeek.take(4)) {
-                    <li class="grid__item">
-                        @fragments.event.item(event)
-                    </li>
-                }
-            </ul>
+            @fragments.event.eventCollection(eventPortfolio.thisWeek, 4)
         </section>
 
         <section class="page-slice l-inset">
             <h3 class="h-section h-section--lead">Next Week</h3>
-            <ul class="grid grid--4up grid--bordered grid--single-row">
-            @for(event <- eventPortfolio.nextWeek.take(4)) {
-                <li class="grid__item">
-                @fragments.event.item(event)
-                </li>
-            }
-            </ul>
+            @fragments.event.eventCollection(eventPortfolio.nextWeek, 4)
         </section>
 
         <section class="page-slice l-inset">
             <h3 class="h-section h-section--lead">What's Hot</h3>
-            <ul class="grid grid--4up grid--bordered grid--single-row">
-                @for(event <- eventPortfolio.topSelling.take(4)) {
-                    <li class="grid__item">
-                        @fragments.event.item(event)
-                    </li>
-                }
-            </ul>
+            @fragments.event.eventCollection(eventPortfolio.topSelling, 4)
         </section>
 
         <section class="page-slice l-inset">
             <h3 class="h-section h-section--lead">Just Added</h3>
-            <ul class="grid grid--4up grid--bordered grid--single-row">
-                @for(event <- eventPortfolio.recentlyCreated.take(4)) {
-                    <li class="grid__item">
-                        @fragments.event.item(event)
-                    </li>
-                }
-            </ul>
+            @fragments.event.eventCollection(eventPortfolio.recentlyCreated, 4)
         </section>
 
         <section class="page-slice l-inset">
             <h3 class="h-section h-section--lead">Available to Members</h3>
-            <ul class="grid grid--4up grid--bordered grid--single-row">
-            @for(event <- eventPortfolio.partnersOnly.take(4)) {
-                <li class="grid__item">
-                @fragments.event.item(event)
-                </li>
-            }
-            </ul>
+            @fragments.event.eventCollection(eventPortfolio.partnersOnly, 4)
         </section>
 
         <section class="page-slice l-inset">
@@ -101,13 +65,13 @@
 
         </section>
 
-        @eventPortfolio.programmingPartnerEvents.map { programmingPartnerEvents =>
+        @for(eventGroup <- eventPortfolio.programmingPartnerEvents) {
             <section class="page-slice l-inset">
                 <h3 class="h-section h-section--lead">Events and courses from institutions we admire</h3>
                 <ul class="grid grid--2up grid--bordered">
-                    @for(event <- programmingPartnerEvents.events.take(4)) {
+                    @for(event <- eventGroup.events.take(4)) {
                         <li class="grid__item">
-                        @fragments.event.itemMinimal(event, isCard=true)
+                            @fragments.event.itemMinimal(event, isCard=true)
                         </li>
                     }
                 </ul>

--- a/frontend/app/views/event/whatson.scala.html
+++ b/frontend/app/views/event/whatson.scala.html
@@ -1,0 +1,118 @@
+@(pageInfo: model.PageInfo, eventPortfolio: model.EventCollections, membershipFrontArticles: Seq[model.MembersOnlyContent])
+
+@main("Events", pageInfo=pageInfo) {
+    <main role="main" class="l-constrained">
+
+        <section class="page-slice l-inset">
+            <h3 class="h-section h-section--lead">Trending</h3>
+            <ul class="grid grid--4up grid--bordered grid--single-row">
+            @for(event <- eventPortfolio.trending.take(4)) {
+                <li class="grid__item">
+                @fragments.event.item(event)
+                </li>
+            }
+            </ul>
+        </section>
+
+        <section class="page-slice l-inset">
+            <h3 class="h-section h-section--lead">This week</h3>
+            <ul class="grid grid--4up grid--bordered grid--single-row">
+                @for(event <- eventPortfolio.thisWeek.take(4)) {
+                    <li class="grid__item">
+                        @fragments.event.item(event)
+                    </li>
+                }
+            </ul>
+        </section>
+
+        <section class="page-slice l-inset">
+            <h3 class="h-section h-section--lead">Next Week</h3>
+            <ul class="grid grid--4up grid--bordered grid--single-row">
+            @for(event <- eventPortfolio.nextWeek.take(4)) {
+                <li class="grid__item">
+                @fragments.event.item(event)
+                </li>
+            }
+            </ul>
+        </section>
+
+        <section class="page-slice l-inset">
+            <h3 class="h-section h-section--lead">What's Hot</h3>
+            <ul class="grid grid--4up grid--bordered grid--single-row">
+                @for(event <- eventPortfolio.topSelling.take(4)) {
+                    <li class="grid__item">
+                        @fragments.event.item(event)
+                    </li>
+                }
+            </ul>
+        </section>
+
+        <section class="page-slice l-inset">
+            <h3 class="h-section h-section--lead">Just Added</h3>
+            <ul class="grid grid--4up grid--bordered grid--single-row">
+                @for(event <- eventPortfolio.recentlyCreated.take(4)) {
+                    <li class="grid__item">
+                        @fragments.event.item(event)
+                    </li>
+                }
+            </ul>
+        </section>
+
+        <section class="page-slice l-inset">
+            <h3 class="h-section h-section--lead">Available to Members</h3>
+            <ul class="grid grid--4up grid--bordered grid--single-row">
+            @for(event <- eventPortfolio.partnersOnly.take(4)) {
+                <li class="grid__item">
+                @fragments.event.item(event)
+                </li>
+            }
+            </ul>
+        </section>
+
+        <section class="page-slice l-inset">
+            <ul class="grid grid--2up grid--bordered grid--single-row">
+                <li class="grid__item">
+                    <h3 class="h-section h-section--lead">Latest news</h3>
+                    <ul class="u-unstyled">
+                    @for(article <- membershipFrontArticles.take(5)) {
+                        <li class="l-pad-bottom">
+                            <a href="@article.content.webUrl" class="event-item  event-item--card">
+                                @for(img <- article.imgOpt) {
+                                    <div class="event-item__media">
+                                        <img src="@img.defaultImage" srcset="@img.srcset" sizes="20vw" alt="@img.altText" class="responsive-img" />
+                                    </div>
+                                }
+                                <div class="event-item__content">
+                                    <div class="event-item__meta">
+                                        <h4 class="event-item__title">@article.content.webTitle</h4>
+                                    </div>
+                                </div>
+                            </a>
+                        </li>
+                    }
+                    </ul>
+                </li>
+                <li class="grid__item">
+                    <h3 class="h-section h-section--lead">Twitter</h3>
+                   <a class="twitter-timeline" href="https://twitter.com/gdnmembership" data-widget-id="586480706009886720">Tweets by @@gdnmembership</a>
+<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
+                </li>
+            </ul>
+
+        </section>
+
+        @eventPortfolio.programmingPartnerEvents.map { programmingPartnerEvents =>
+            <section class="page-slice l-inset">
+                <h3 class="h-section h-section--lead">Events and courses from institutions we admire</h3>
+                <ul class="grid grid--2up grid--bordered">
+                    @for(event <- programmingPartnerEvents.events.take(4)) {
+                        <li class="grid__item">
+                        @fragments.event.itemMinimal(event, isCard=true)
+                        </li>
+                    }
+                </ul>
+            </section>
+        }
+
+    </main>
+}

--- a/frontend/app/views/fragments/event/eventCollection.scala.html
+++ b/frontend/app/views/fragments/event/eventCollection.scala.html
@@ -1,0 +1,9 @@
+@(events: Seq[model.RichEvent.RichEvent], limit: Int = 4)
+
+<ul class="grid grid--4up grid--bordered grid--single-row">
+    @for(event <- events.take(limit)) {
+        <li class="grid__item">
+            @fragments.event.item(event)
+        </li>
+    }
+</ul>

--- a/frontend/assets/stylesheets/components/_grid.scss
+++ b/frontend/assets/stylesheets/components/_grid.scss
@@ -61,7 +61,6 @@
             padding-left: $gutter-width-fluid / 2;
             margin-bottom: rem($gs-baseline);
             width: 50% - ($gutter-width-fluid / 2);
-            &:nth-of-type(2n+1) { clear: left; }
         }
         @include mq(tablet) {
             border-style: solid;

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -54,7 +54,7 @@ POST           /subscription/update-card          controllers.Subscription.updat
 OPTIONS        /subscription/update-card          controllers.Subscription.updateCardPreflight
 
 # Events
-GET            /whatson                           controllers.Event.whatsOn
+GET            /whats-on                          controllers.Event.whatsOn
 GET            /events                            controllers.Event.list
 GET            /events/:tag                       controllers.Event.listFilteredBy(tag)
 GET            /masterclasses                     controllers.Event.masterclasses

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -54,6 +54,7 @@ POST           /subscription/update-card          controllers.Subscription.updat
 OPTIONS        /subscription/update-card          controllers.Subscription.updateCardPreflight
 
 # Events
+GET            /whatson                           controllers.Event.whatsOn
 GET            /events                            controllers.Event.list
 GET            /events/:tag                       controllers.Event.listFilteredBy(tag)
 GET            /masterclasses                     controllers.Event.masterclasses

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,5 +1,5 @@
 User-agent: *
 Disallow: /patterns
-Disallow: /whatson
+Disallow: /whats-on
 
 Allow: /

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,4 +1,5 @@
 User-agent: *
 Disallow: /patterns
+Disallow: /whatson
 
 Allow: /


### PR DESCRIPTION
This is a spike to explore different containers for a What's On landing page:

![whatson-spike](https://cloud.githubusercontent.com/assets/123386/7114108/705c0624-e1d2-11e4-99be-7bc9ad3387d1.png)

## Containers

- Trending - Most viewed events
- This week
- Next week
- What's Hot - Top-selling events
- Just added
- Available to members - On-sale to paid members only 

## Caveats

Trending and What's Hot are hardcoded based on current data based on Kibana queries. To take this further we would want to get a list of IDs from this event data to populate these lists.

@jennysivapalan @mattandrews 

[Jira MEM-700](https://jira.gutools.co.uk/browse/MEM-700)