### PR TITLE
Limited availability fix

### DIFF
--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -58,6 +58,7 @@ object Config {
   val eventbriteRefreshTime = config.getInt("eventbrite.api.refresh-time-seconds")
   val eventbriteRefreshTimeForPriorityEvents = config.getInt("eventbrite.api.refresh-time-priority-events-seconds")
   val eventbriteWaitlistUrl = config.getString("eventbrite.waitlist.url")
+  val eventbriteLimitedAvailabilityCutoff = config.getInt("eventbrite.limitedAvailabilityCutoff")
 
   def eventbriteWaitlistUrl(event: EBEvent): String =
     eventbriteWaitlistUrl ? ("eid" -> event.id) & ("tid" -> 0)

--- a/frontend/app/model/Eventbrite.scala
+++ b/frontend/app/model/Eventbrite.scala
@@ -190,7 +190,7 @@ object Eventbrite {
     }
 
     val limitedAvailabilityText = "Last tickets remaining"
-    val isLimitedAvailability = internalTicketing.exists(item => item.ticketsNotSold <= 15 && !item.isSoldOut)
+    val isLimitedAvailability = internalTicketing.exists(event => event.ticketsNotSold <= Config.eventbriteLimitedAvailabilityCutoff && !event.isSoldOut)
     val ticketsNotSold = internalTicketing.map(_.ticketsNotSold)
 
     val isSoldOut = internalTicketing.exists(_.isSoldOut)

--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -25,6 +25,7 @@ eventbrite.api.iframe-url="https://www.eventbrite.com/tickets-external?ref=etckt
 eventbrite.api.refresh-time-seconds=59
 eventbrite.api.refresh-time-priority-events-seconds=29
 eventbrite.waitlist.url="https://www.eventbrite.co.uk/waitlist"
+eventbrite.limitedAvailabilityCutoff=15
 
 event.ordering.json="http://s3-eu-west-1.amazonaws.com/membership-eb-images/order/order.json"
 

--- a/frontend/test/model/EBEventTest.scala
+++ b/frontend/test/model/EBEventTest.scala
@@ -20,6 +20,7 @@ class EBEventTest extends PlaySpecification {
   val nonTicketedEvent = ebResponse.data.find(_.id == "13602460325").get
   val soldOutEvent = ebResponse.data.find(_.id == "12238163677").get
   val startedEvent = ebResponse.data.find(_.id == "12972720757").get
+  val limitedAvailabilityEvent = ebResponse.data.find(_.id == "12718560557").get
 
   val ticketedEvent = ebLiveEvent;
 
@@ -40,6 +41,13 @@ class EBEventTest extends PlaySpecification {
     }
     "should display sold out text" in {
       soldOutEvent.statusText mustEqual("Sold out")
+    }
+    "not be limited availability when sold out" in {
+      limitedAvailabilityEvent.isSoldOut mustEqual(false)
+      soldOutEvent.isLimitedAvailability mustEqual(false)
+    }
+    "should be flagged as limited availability when limited tickets available" in {
+      limitedAvailabilityEvent.isLimitedAvailability mustEqual(true)
     }
     "should display draft status in event" in {
       ebDraftEvent.statusText mustEqual("Preview of Draft Event")


### PR DESCRIPTION
Whilst working on https://github.com/guardian/membership-frontend/pull/464 I spotted that sold out events are included in the `isLimitedAvailability` check.

This doesn't currently affect anyone as the sold out banner trumps the limited availability banner in the view, but still worth fixing for when we want to use it for something else.

Initial failing test:

![screen shot 2015-04-13 at 12 04 13](https://cloud.githubusercontent.com/assets/123386/7114478/99174472-e1d5-11e4-9087-87433f57fabf.png)

@jennysivapalan @jamesoram 