### PR TITLE
Add new endpoint to return event data JSON

### DIFF
--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -61,19 +61,6 @@ trait Event extends Controller with ActivityTracking {
     eventOpt.getOrElse(Redirect(Links.membershipFront))
   }
 
-  case class EmbedData(title: String,
-                       image: Option[String],
-                       venue: Option[String],
-                       location: Option[String],
-                       price: Option[String],
-                       identifier: String,
-                       start: String,
-                       end: String)
-  case class EmbedResponse(status: String, result: Option[EmbedData])
-
-  implicit val writesEmbedData = Json.writes[EmbedData]
-  implicit val writesResponse = Json.writes[EmbedResponse]
-
   /*
    * This endpoint is hit by Composer when embedding Membership events.
    * Changes here will need to be reflected in the flexible-content repo.

--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -84,8 +84,7 @@ trait Event extends Controller with ActivityTracking {
       end = event.end.toString(standardFormat)
     )
 
-    val json = Json.toJson(EmbedResponse(eventDataOpt.fold("error")(_ => "success"), eventDataOpt))
-    Ok(Jsonp(callback, json))
+    Ok(Jsonp(callback, eventToJson(eventDataOpt)))
   }
 
   private def eventDetail(event: RichEvent)(implicit request: RequestHeader) = {

--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -3,25 +3,25 @@ package controllers
 import actions.AnyMemberTierRequest
 import actions.Fallbacks._
 import actions.Functions._
-import com.gu.membership.salesforce.{MemberId, Member, Tier}
+import com.github.nscala_time.time.Imports._
+import com.gu.membership.salesforce.{Member, Tier}
 import com.gu.membership.util.Timing
 import com.netaporter.uri.dsl._
-import configuration.{Config, CopyConfig, Links}
-import model.Eventbrite.{EBOrder, EBEvent}
+import configuration.{CopyConfig, Links}
+import model.EmbedSerializer._
+import model.Eventbrite.{EBEvent, EBOrder}
 import model.RichEvent._
-import model.{IdMinimalUser, EventPortfolio, Eventbrite, PageInfo}
-import org.joda.time.Instant
+import model.{EmbedData, EmbedResponse, EventPortfolio, Eventbrite, PageInfo}
 import org.joda.time.format.ISODateTimeFormat
 import play.api.libs.Jsonp
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
-import play.api.libs.json.Json.JsValueWrapper
-import play.api.mvc._
-import services.{EventbriteService, GuardianLiveEventService, MasterclassEventService, LocalEventService, MemberService}
-import services.EventbriteService._
-import com.github.nscala_time.time.Imports._
-import tracking._
-import scala.concurrent.Future
 import play.api.libs.json._
+import play.api.mvc._
+import services.{EventbriteService, GuardianLiveEventService, LocalEventService, MasterclassEventService, MemberService}
+import services.EventbriteService._
+import tracking._
+
+import scala.concurrent.Future
 
 trait Event extends Controller with ActivityTracking {
 

--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -68,7 +68,7 @@ trait Event extends Controller with ActivityTracking {
    * (eg. updates to event details will not be reflected post-embed)
    */
   def embedData(slug: String, callback: String) = CachedAction { implicit request =>
-  val standardFormat = ISODateTimeFormat.dateTime.withZoneUTC
+    val standardFormat = ISODateTimeFormat.dateTime.withZoneUTC
 
     val eventDataOpt = for {
       id <- EBEvent.slugToId(slug)

--- a/frontend/app/model/EventEmbed.scala
+++ b/frontend/app/model/EventEmbed.scala
@@ -21,5 +21,8 @@ case class EmbedResponse(status: String, result: Option[EmbedData])
 object EmbedSerializer {
   implicit val writesEmbedData = Json.writes[EmbedData]
   implicit val writesResponse = Json.writes[EmbedResponse]
-}
 
+  def eventToJson(embedData: Option[EmbedData]) = {
+    Json.toJson(EmbedResponse(embedData.fold("error")(_ => "success"), embedData))
+  }
+}

--- a/frontend/app/model/EventEmbed.scala
+++ b/frontend/app/model/EventEmbed.scala
@@ -1,0 +1,25 @@
+package model
+
+import play.api.libs.json.Json
+
+/*
+ * used to provide event data to Composer for embedded Membership
+ * events on theguardian.com articles – be wary of changing this
+ * without changing those services, too.
+ */
+case class EmbedData(title: String,
+                     image: Option[String],
+                     venue: Option[String],
+                     location: Option[String],
+                     price: Option[String],
+                     identifier: String,
+                     start: String,
+                     end: String)
+
+case class EmbedResponse(status: String, result: Option[EmbedData])
+
+object EmbedSerializer {
+  implicit val writesEmbedData = Json.writes[EmbedData]
+  implicit val writesResponse = Json.writes[EmbedResponse]
+}
+

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -62,6 +62,7 @@ GET            /masterclasses/:tag                controllers.Event.masterclasse
 GET            /masterclasses/:tag/:subTag        controllers.Event.masterclassesByTag(tag, subTag)
 
 GET            /event/:id                         controllers.Event.details(id)
+GET            /event/:id/embed                   controllers.Event.embedData(id, callback: String)
 GET            /event/:id/buy                     controllers.Event.buy(id)
 GET            /event/:id/thankyou                controllers.Event.thankyou(id, oid: Option[String])
 GET            /event/:id/thankyou/pixel          controllers.Event.thankyouPixel(id)

--- a/frontend/test/model/EventEmbedTest/EventEmbedTest.scala
+++ b/frontend/test/model/EventEmbedTest/EventEmbedTest.scala
@@ -1,0 +1,37 @@
+package model
+
+import model.EmbedSerializer._
+import model.EventbriteDeserializer._
+import play.api.test.PlaySpecification
+import utils.Resource
+
+class EventEmbedTest extends PlaySpecification {
+
+  "EventEmbed" should {
+
+    "produce the expected JSON output for a valid event" in {
+      val embed = EmbedData(
+        title = "Member Book Event",
+        image = Some("https://media.guim.co.uk/7364090799a4b1725380c9f479e910989710ef48/0_222_1890_1134/500.jpg"),
+        venue = Some("Grimsby"),
+        location = Some("Grimsby, England"),
+        price = Some("£3.14"),
+        identifier = "local",
+        start = "2016-03-04T03:00:00.000Z",
+        end = "2016-03-04T03:30:00.000Z"
+      )
+
+      val jsonExpected = Resource.getJson("model/embed/expected.json")
+      val jsonActual = eventToJson(Some(embed))
+
+      jsonActual === jsonExpected
+    }
+
+    "give an error status in JSON for a nonexistent event" in {
+      val jsonActual = eventToJson(None)
+      (jsonActual \ "status").as[String] === "error"
+    }
+
+  }
+
+}

--- a/frontend/test/resources/model/embed/expected.json
+++ b/frontend/test/resources/model/embed/expected.json
@@ -1,0 +1,13 @@
+{
+    "status": "success",
+    "result": {
+        "title": "Member Book Event",
+        "image": "https://media.guim.co.uk/7364090799a4b1725380c9f479e910989710ef48/0_222_1890_1134/500.jpg",
+        "venue": "Grimsby",
+        "location": "Grimsby, England",
+        "price": "£3.14",
+        "identifier": "local",
+        "start": "2016-03-04T03:00:00.000Z",
+        "end": "2016-03-04T03:30:00.000Z"
+    }
+}


### PR DESCRIPTION
This is part one of three when it comes to implementing Twitter-style cards for embedding Membership events in Composer:

1. [x] Add endpoint to Membership which returns JSON[P] event data (or an error)
2. [ ] Add support to Composer for querying Membership for valid event URLs `(in progress)`
3. [ ] Add design work to NGW to show Membership widget where embedded `(not yet started)`

One thing I could do with help with here is testing: not really sure where/how to test this. I think it's important we have it covered, as if this endpoint breaks/changes it'll break the above flow in turn. @jamesoram / @jennysivapalan, any time/tips for how/where to write these tests? I basically want to hit the endpoint and confirm the returned JSON structure matches what I expect.