### PR TITLE
Add Omniture property for tracking ticket count

### DIFF
--- a/frontend/app/views/event/thankyou.scala.html
+++ b/frontend/app/views/event/thankyou.scala.html
@@ -45,7 +45,7 @@
             </div>
         </section>
 
-        @fragments.analytics.eventConversion(event)
+        @fragments.analytics.eventConversion(event, order)
 
     </main>
 }

--- a/frontend/app/views/fragments/analytics/eventConversion.scala.html
+++ b/frontend/app/views/fragments/analytics/eventConversion.scala.html
@@ -1,9 +1,11 @@
-@(event: model.Eventbrite.EBEvent)
+@(event: model.RichEvent.RichEvent, order: model.Eventbrite.EBOrder)
+
 <script type="text/javascript">
     if (guardian.analyticsEnabled) {
         require(['js!omniture'], function () {
             s.products = 'event;@event.id;';
             s.events = 'order';
+            s.eVar19 = @order.ticketCount;
         });
     }
 </script>


### PR DESCRIPTION
By request of the Membership team, this adds the number of tickets purchased to Omniture's `v19` property (in this example, 5):

![screen shot 2015-04-14 at 11 39 04](https://cloud.githubusercontent.com/assets/394376/7135056/e08ae3ac-e29a-11e4-8481-fe48f040ae91.png)

Okay with you @davidrapson / @jamesoram?