### PR TITLE
Add `public` to Cache-Control header to encourage browser disk-caching

### DIFF
--- a/frontend/app/controllers/Cached.scala
+++ b/frontend/app/controllers/Cached.scala
@@ -24,7 +24,7 @@ object Cached {
     val now = DateTime.now
     val staleWhileRevalidateSeconds = max(maxAge / 10, 1)
     result.withHeaders(
-      "Cache-Control" -> s"max-age=$maxAge, stale-while-revalidate=$staleWhileRevalidateSeconds, stale-if-error=$tenDaysInSeconds",
+      "Cache-Control" -> s"public, max-age=$maxAge, stale-while-revalidate=$staleWhileRevalidateSeconds, stale-if-error=$tenDaysInSeconds",
       "Expires" -> toHttpDateTimeString(now + maxAge.seconds),
       "Date" -> toHttpDateTimeString(now)
     )


### PR DESCRIPTION
This follows on from a change in the Grid to encourage browser disk-caching of images:

https://github.com/guardian/grid-infra/pull/32#issuecomment-92754321

Thanks to @sihil, who tells me that (although behaviour varies) there are browsers that _would_ disk-cache an HTTP response with a simple `Cache-Control:max-age=60`, that **wouldn't** disk cache the same response if it came over HTTPS. You have to set 'public' to encourage them to do that.

