### PR TITLE
Make SBT resolve dependencies faster with cached resolution

### DIFF
--- a/project/Membership.scala
+++ b/project/Membership.scala
@@ -37,6 +37,7 @@ trait Membership {
     sources in (Compile,doc) := Seq.empty,
     publishArtifact in (Compile, packageDoc) := false,
     parallelExecution in Global := false,
+    updateOptions := updateOptions.value.withCachedResolution(true),
     javaOptions in Test += "-Dconfig.resource=dev.conf"
   ) ++ buildInfoPlugin
 


### PR DESCRIPTION
There's a one-off-hit for the first time, after that, the resolve step is much faster.

http://www.scala-sbt.org/0.13/docs/sbt-0.13-Tech-Previews.html#Cached+resolution+%28minigraph+caching%29

http://www.scala-sbt.org/0.13/docs/Cached-Resolution.html

cc @dominickendrick 