### PR TITLE
Add payment delay and casId if present

### DIFF
--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -78,7 +78,7 @@ trait MemberService extends LazyLogging with ActivityTracking {
     )
   }.getOrElse(Json.obj())
 
-  def createMember(user: IdMinimalUser, formData: JoinForm, identityRequest: IdentityRequest, paymentDelay: Option[Period] = None): Future[MemberId] = {
+  def createMember(user: IdMinimalUser, formData: JoinForm, identityRequest: IdentityRequest, paymentDelay: Option[Period] = None, casId: Option[String] = None): Future[MemberId] = {
     val touchpointBackend = TouchpointBackend.forUser(user)
     val identityService = IdentityService(IdentityApi)
 
@@ -95,7 +95,7 @@ trait MemberService extends LazyLogging with ActivityTracking {
         customerOpt <- futureCustomerOpt
         userData = initialData(fullUser, formData)
         memberId <- touchpointBackend.memberRepository.upsert(user.id, userData)
-        subscription <- touchpointBackend.subscriptionService.createSubscription(memberId, formData, customerOpt, paymentDelay)
+        subscription <- touchpointBackend.subscriptionService.createSubscription(memberId, formData, customerOpt, paymentDelay, casId)
 
         // Set some fields once subscription has been successful
         updatedMember <- touchpointBackend.memberRepository.upsert(user.id, memberData(formData.plan, customerOpt))

--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -11,17 +11,15 @@ import controllers.IdentityRequest
 import forms.MemberForm._
 import model.Benefits.DiscountTicketTiers
 import model.Eventbrite.EBCode
-import model.RichEvent.RichEvent
 import model.RichEvent._
 import model.Zuora.PreviewInvoiceItem
-import model.{IdMinimalUser, IdUser, PaidTierPlan, ProductRatePlan}
 import model._
 import monitoring.MemberMetrics
-import play.api.libs.json.{JsObject, Json}
+import org.joda.time.Period
+import play.api.libs.json.Json
 import services.EventbriteService._
 import tracking._
 import utils.ScheduledTask
-import views.html.fragments.form.marketingChoices
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -80,7 +78,7 @@ trait MemberService extends LazyLogging with ActivityTracking {
     )
   }.getOrElse(Json.obj())
 
-  def createMember(user: IdMinimalUser, formData: JoinForm, identityRequest: IdentityRequest): Future[MemberId] = {
+  def createMember(user: IdMinimalUser, formData: JoinForm, identityRequest: IdentityRequest, paymentDelay: Option[Period] = None): Future[MemberId] = {
     val touchpointBackend = TouchpointBackend.forUser(user)
     val identityService = IdentityService(IdentityApi)
 
@@ -97,7 +95,7 @@ trait MemberService extends LazyLogging with ActivityTracking {
         customerOpt <- futureCustomerOpt
         userData = initialData(fullUser, formData)
         memberId <- touchpointBackend.memberRepository.upsert(user.id, userData)
-        subscription <- touchpointBackend.subscriptionService.createSubscription(memberId, formData, customerOpt)
+        subscription <- touchpointBackend.subscriptionService.createSubscription(memberId, formData, customerOpt, paymentDelay)
 
         // Set some fields once subscription has been successful
         updatedMember <- touchpointBackend.memberRepository.upsert(user.id, memberData(formData.plan, customerOpt))

--- a/frontend/app/services/SubscriptionService.scala
+++ b/frontend/app/services/SubscriptionService.scala
@@ -122,8 +122,8 @@ class SubscriptionService(val tierPlanRateIds: Map[ProductRatePlan, String], val
     } yield result
   }
 
-  def createSubscription(memberId: MemberId, joinData: JoinForm, customerOpt: Option[Stripe.Customer]): Future[SubscribeResult] = {
-    zuora.request(Subscribe(memberId, customerOpt, tierPlanRateIds(joinData.plan), joinData.name, joinData.deliveryAddress))
+  def createSubscription(memberId: MemberId, joinData: JoinForm, customerOpt: Option[Stripe.Customer], paymentDelay: Option[Period]): Future[SubscribeResult] = {
+    zuora.request(Subscribe(memberId, customerOpt, tierPlanRateIds(joinData.plan), joinData.name, joinData.deliveryAddress, paymentDelay))
   }
 
   def getPaymentSummary(memberId: MemberId): Future[PaymentSummary] = {

--- a/frontend/app/services/SubscriptionService.scala
+++ b/frontend/app/services/SubscriptionService.scala
@@ -122,8 +122,8 @@ class SubscriptionService(val tierPlanRateIds: Map[ProductRatePlan, String], val
     } yield result
   }
 
-  def createSubscription(memberId: MemberId, joinData: JoinForm, customerOpt: Option[Stripe.Customer], paymentDelay: Option[Period]): Future[SubscribeResult] = {
-    zuora.request(Subscribe(memberId, customerOpt, tierPlanRateIds(joinData.plan), joinData.name, joinData.deliveryAddress, paymentDelay))
+  def createSubscription(memberId: MemberId, joinData: JoinForm, customerOpt: Option[Stripe.Customer], paymentDelay: Option[Period], casId: Option[String]): Future[SubscribeResult] = {
+    zuora.request(Subscribe(memberId, customerOpt, tierPlanRateIds(joinData.plan), joinData.name, joinData.deliveryAddress, paymentDelay, casId))
   }
 
   def getPaymentSummary(memberId: MemberId): Future[PaymentSummary] = {

--- a/frontend/app/services/zuora/ZuoraActions.scala
+++ b/frontend/app/services/zuora/ZuoraActions.scala
@@ -89,12 +89,16 @@ case class Query(query: String) extends ZuoraAction[QueryResult] {
 }
 
 case class Subscribe(memberId: MemberId, customerOpt: Option[Stripe.Customer], ratePlanId: String, name: NameForm,
-                     address: Address, paymentDelay: Option[Period]) extends ZuoraAction[SubscribeResult] {
+                     address: Address, paymentDelay: Option[Period], casIdOpt: Option[String]) extends ZuoraAction[SubscribeResult] {
 
   val body = {
     val now = DateTime.now
     val effectiveDate = formatDateTime(now)
     val contractAcceptanceDate = paymentDelay.map(delay => formatDateTime(now + delay)).getOrElse(effectiveDate)
+
+    val casId = casIdOpt.map { id =>
+      <ns2:CASSubscriberID__c>{id}</ns2:CASSubscriberID__c>
+    }.getOrElse(Null)
 
     val payment = customerOpt.map { customer =>
       <ns1:PaymentMethod xsi:type="ns2:PaymentMethod">
@@ -147,6 +151,7 @@ case class Subscribe(memberId: MemberId, customerOpt: Option[Stripe.Customer], r
             <ns2:RenewalTerm>12</ns2:RenewalTerm>
             <ns2:TermStartDate>{effectiveDate}</ns2:TermStartDate>
             <ns2:TermType>TERMED</ns2:TermType>
+            {casId}
           </ns1:Subscription>
           <ns1:RatePlanData>
             <ns1:RatePlan xsi:type="ns2:RatePlan">


### PR DESCRIPTION
In attempt to break out more code from #449 I've separated the code that we need to add the subscription on creating a member. The two fields are a delayedPayment and casId, both are optional so for now I've defaulted them to None. 

@rtyley is this useful? We won't see it be used for real until we add the code to allow users to enter a subscriber ID.