### PR TITLE
Correct next payment field value on thank you summary page 

### DIFF
--- a/frontend/app/views/joiner/thankyou.scala.html
+++ b/frontend/app/views/joiner/thankyou.scala.html
@@ -64,9 +64,9 @@
                     <tr role="row">
                         <th role="rowheader">Next payment</th>
                         <td id="qa-joiner-summary-next">
-                            @summary.nextPaymentPrice.pretty @if(summary.initialFreePeriodOffer) {
-                                (@summary.nextPaymentDate.pretty)
-                            }
+                            @if(summary.initialFreePeriodOffer) {
+                                @summary.nextPaymentPrice.pretty (@summary.nextPaymentDate.pretty)
+                            } else { @summary.nextPaymentDate.pretty }
                         </td>
                     </tr>
                     <tr role="row">


### PR DESCRIPTION
I put a bug in https://github.com/guardian/membership-frontend/pull/454

The Next payment is currently displaying price rather than date. This PR fixes that.

Currently on PROD
![screen shot 2015-04-15 at 15 26 20](https://cloud.githubusercontent.com/assets/944375/7161022/9b4fc4f2-e384-11e4-8eec-b162e28e395f.png)

Fixed in this PR:
![screen shot 2015-04-15 at 15 29 23](https://cloud.githubusercontent.com/assets/944375/7161028/a4fc11c2-e384-11e4-908e-01ddc8435e4f.png)

