### PR TITLE
Update embed endpoint to use CORS

### DIFF
--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -66,7 +66,7 @@ trait Event extends Controller with ActivityTracking {
    * Note that Composer will index this data, which is in turn indexed by CAPI.
    * (eg. updates to event details will not be reflected post-embed)
    */
-  def embedData(slug: String, callback: String) = CachedAction { implicit request =>
+  def embedData(slug: String) = Cors.andThen(CachedAction) { implicit request =>
     val standardFormat = ISODateTimeFormat.dateTime.withZoneUTC
 
     val eventDataOpt = for {
@@ -83,7 +83,7 @@ trait Event extends Controller with ActivityTracking {
       end = event.end.toString(standardFormat)
     )
 
-    Ok(Jsonp(callback, eventToJson(eventDataOpt)))
+    Ok(eventToJson(eventDataOpt))
   }
 
   private def eventDetail(event: RichEvent)(implicit request: RequestHeader) = {

--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -13,7 +13,6 @@ import model.Eventbrite.{EBEvent, EBOrder}
 import model.RichEvent.{RichEvent, _}
 import model.{EmbedData, EventPortfolio, Eventbrite, PageInfo, _}
 import org.joda.time.format.ISODateTimeFormat
-import play.api.libs.Jsonp
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.mvc._
 import services.{EventbriteService, GuardianLiveEventService, LocalEventService, MasterclassEventService, MemberService, _}

--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -13,7 +13,7 @@ event.discountMultiplier=0.8
 
 content.api.key=""
 
-cors.allow.origin="https://profile.theguardian.com,http://www.theguardian.com,https://composer.gutools.co.uk,https://composer.code.gutools.co.uk,https://composer.qa.gutools.co.uk,https://composer.release.gutools.co.uk,https://composer.local.dev-gutools.co.uk"
+cors.allow.origin="https://profile.theguardian.com,http://www.theguardian.com,https://composer.gutools.co.uk,https://composer.code.dev-gutools.co.uk,https://composer.qa.dev-gutools.co.uk,https://composer.release.dev-gutools.co.uk,https://composer.local.dev-gutools.co.uk"
 
 eventbrite.url="http://www.eventbrite.co.uk"
 

--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -13,7 +13,7 @@ event.discountMultiplier=0.8
 
 content.api.key=""
 
-cors.allow.origin="https://profile.theguardian.com,http://www.theguardian.com"
+cors.allow.origin="https://profile.theguardian.com,http://www.theguardian.com,https://composer.gutools.co.uk,https://composer.code.gutools.co.uk,https://composer.qa.gutools.co.uk,https://composer.release.gutools.co.uk,https://composer.local.dev-gutools.co.uk"
 
 eventbrite.url="http://www.eventbrite.co.uk"
 

--- a/frontend/conf/dev.conf
+++ b/frontend/conf/dev.conf
@@ -25,7 +25,7 @@ ws.acceptAnyCertificate=true
 membership.url="https://mem.thegulocal.com"
 membership.feedback="membership.dev@theguardian.com"
 
-cors.allow.origin="https://profile.thegulocal.com,http://www.thegulocal.com,https://composer.gutools.co.uk,https://composer.code.gutools.co.uk,https://composer.qa.gutools.co.uk,https://composer.release.gutools.co.uk,https://composer.local.dev-gutools.co.uk"
+cors.allow.origin="https://profile.thegulocal.com,http://www.thegulocal.com,https://composer.gutools.co.uk,https://composer.code.dev-gutools.co.uk,https://composer.qa.dev-gutools.co.uk,https://composer.release.dev-gutools.co.uk,https://composer.local.dev-gutools.co.uk"
 
 # This is the current exception to putting credentials into this file, for now.
 aws.access.key=${?AWS_ACCESS_KEY}

--- a/frontend/conf/dev.conf
+++ b/frontend/conf/dev.conf
@@ -25,7 +25,7 @@ ws.acceptAnyCertificate=true
 membership.url="https://mem.thegulocal.com"
 membership.feedback="membership.dev@theguardian.com"
 
-cors.allow.origin="https://profile.thegulocal.com,http://www.thegulocal.com"
+cors.allow.origin="https://profile.thegulocal.com,http://www.thegulocal.com,https://composer.gutools.co.uk,https://composer.code.gutools.co.uk,https://composer.qa.gutools.co.uk,https://composer.release.gutools.co.uk,https://composer.local.dev-gutools.co.uk"
 
 # This is the current exception to putting credentials into this file, for now.
 aws.access.key=${?AWS_ACCESS_KEY}

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -63,7 +63,7 @@ GET            /masterclasses/:tag                controllers.Event.masterclasse
 GET            /masterclasses/:tag/:subTag        controllers.Event.masterclassesByTag(tag, subTag)
 
 GET            /event/:id                         controllers.Event.details(id)
-GET            /event/:id/embed                   controllers.Event.embedData(id, callback: String)
+GET            /event/:id/embed                   controllers.Event.embedData(id)
 GET            /event/:id/buy                     controllers.Event.buy(id)
 GET            /event/:id/thankyou                controllers.Event.thankyou(id, oid: Option[String])
 GET            /event/:id/thankyou/pixel          controllers.Event.thankyouPixel(id)


### PR DESCRIPTION
This (by request from @theefer and @davidrapson, and indeed, the modern HTTP standard...) removes the JSONP callback from the new `/embed` endpoint in favour of CORS, and whitelists the various Composer domains so they can embed our events. Hooray!