### PR TITLE
Subscriber offer

### DIFF
--- a/frontend/app/actions/Functions.scala
+++ b/frontend/app/actions/Functions.scala
@@ -90,11 +90,13 @@ object Functions extends LazyLogging {
       override def refine[A](request: AuthRequest[A]) = Future.successful {
         //Copy the private helper method in play-googleauth to ensure the user is Google auth'd
         //see https://github.com/guardian/play-googleauth/blob/master/module/src/main/scala/com/gu/googleauth/actions.scala#L59-60
-        val userIdentityOpt = UserIdentity.fromRequest(request).filter(_.isValid || !OAuthActions.authConfig.enforceValidity).map(IdentityGoogleAuthRequest(_, request))
+        val userIdentityOpt = googleAuthUserOpt(request).map(IdentityGoogleAuthRequest(_, request))
         userIdentityOpt.toRight(onNonAuthentication(request))
       }
     }
   }
+
+  def googleAuthUserOpt(request: RequestHeader) = UserIdentity.fromRequest(request).filter(_.isValid || !OAuthActions.authConfig.enforceValidity)
 
   def matchingGuardianEmail(onNonGuEmail: RequestHeader => Result = joinStaffMembership(_).flashing("error" -> "Identity email must match Guardian email")) = new ActionFilter[IdentityGoogleAuthRequest] {
     override def filter[A](request: IdentityGoogleAuthRequest[A]) = {

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -88,7 +88,8 @@ trait Joiner extends Controller with ActivityTracking with LazyLogging {
         case Tier.Friend => Ok(views.html.joiner.form.address(privateFields, marketingChoices, passwordExists))
         case paidTier =>
           val pageInfo = PageInfo.default.copy(stripePublicKey = Some(request.touchpointBackend.stripeService.publicKey))
-          Ok(views.html.joiner.form.payment(paidTier, privateFields, marketingChoices, passwordExists, pageInfo))
+          val showSubscriberFields = googleAuthUserOpt(request).isDefined && tier == Tier.Partner
+          Ok(views.html.joiner.form.payment(paidTier, privateFields, marketingChoices, passwordExists, pageInfo, showSubscriberFields))
       }
 
     }

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -4,13 +4,14 @@ package controllers
 
 import actions.Functions._
 import actions._
+import com.gu.cas.CAS.CASSuccess
 import com.gu.membership.salesforce.{PaidMember, ScalaforceError, Tier}
 import com.gu.membership.stripe.Stripe
 import com.gu.membership.stripe.Stripe.Serializer._
 import com.netaporter.uri.dsl._
 import com.typesafe.scalalogging.LazyLogging
-import configuration.{Config, CopyConfig}
-import forms.MemberForm.{JoinForm, friendJoinForm, paidMemberJoinForm, staffJoinForm}
+import configuration.{Email, Config, CopyConfig}
+import forms.MemberForm._
 import model.RichEvent._
 import model._
 import play.api.data.Form
@@ -20,6 +21,9 @@ import play.api.mvc._
 import services.{GuardianContentService, _}
 import services.EventbriteService._
 import tracking.{ActivityTracking, EventActivity, EventData, MemberData}
+import com.github.nscala_time.time.Imports
+import com.github.nscala_time.time.Imports._
+
 
 import scala.concurrent.Future
 
@@ -29,6 +33,10 @@ trait Joiner extends Controller with ActivityTracking with LazyLogging {
   val contentApiService = GuardianContentService
 
   val memberService: MemberService
+
+  val subscriberOfferDelayPeriod = 6.months
+
+  val casService = CASService
 
   val EmailMatchingGuardianAuthenticatedStaffNonMemberAction = AuthenticatedStaffNonMemberAction andThen matchingGuardianEmail()
 
@@ -146,22 +154,54 @@ trait Joiner extends Controller with ActivityTracking with LazyLogging {
 
   private def makeMember(tier: Tier, result: Result)(formData: JoinForm)(implicit request: AuthRequest[_]) = {
 
-    MemberService.createMember(request.user, formData, IdentityRequest(request))
-      .map { member =>
-        for {
-          eventId <- PreMembershipJoiningEventFromSessionExtractor.eventIdFrom(request)
-          event <- EventbriteService.getBookableEvent(eventId)
-        } {
-          event.service.wsMetrics.put(s"join-$tier-event", 1)
-          val memberData = MemberData(member.salesforceContactId, request.user.id, tier.name)
-          track(EventActivity("membershipRegistrationViaEvent", Some(memberData), EventData(event)))(request.user)
-        }
-        result
-      }.recover {
-        case error: Stripe.Error => Forbidden(Json.toJson(error))
-        case error: Zuora.ResultError => Forbidden
-        case error: ScalaforceError => Forbidden
+    def checkCASIfRequiredAndReturnPaymentDelay(formData: JoinForm)(implicit request: AuthRequest[_]): Future[Either[String,Option[Period]]] = {
+      formData match {
+        case paidMemberJoinForm: PaidMemberJoinForm => {
+          paidMemberJoinForm.casId map { casId =>
+            for {
+              casResult <- casService.check(casId, Some(formData.deliveryAddress.postCode), formData.name.last)
+              casIdNotUsed <- request.touchpointBackend.subscriptionService.getSubscriptionsByCasId(casId)
+            } yield {
+              casResult match {
+                case success: CASSuccess if new DateTime(success.expiryDate).isAfterNow && casIdNotUsed.isEmpty => Right(Some(subscriberOfferDelayPeriod))
+                case _ => Left(s"Subscriber details invalid. Please contact ${Email.membershipSupport} for further assistance.")
+              }
+            }
+          }
+        }.getOrElse(Future.successful(Right(None)))
+        case _ => Future.successful(Right(None))
       }
+    }
+
+    def makeMemberAfterValidation(subscriberValidation: Either[String, Option[Imports.Period]]) = {
+      subscriberValidation.fold({ errorString: String =>
+        Future.successful(Forbidden)
+      },{ paymentDelayOpt: Option[Period] =>
+        MemberService.createMember(request.user, formData, IdentityRequest(request), paymentDelayOpt)
+          .map { member =>
+          for {
+            eventId <- PreMembershipJoiningEventFromSessionExtractor.eventIdFrom(request)
+            event <- EventbriteService.getBookableEvent(eventId)
+          } {
+            event.service.wsMetrics.put(s"join-$tier-event", 1)
+            val memberData = MemberData(member.salesforceContactId, request.user.id, tier.name)
+            track(EventActivity("membershipRegistrationViaEvent", Some(memberData), EventData(event)))(request.user)
+          }
+          result
+        }.recover {
+          case error: Stripe.Error => Forbidden(Json.toJson(error))
+          case error: Zuora.ResultError => Forbidden
+          case error: ScalaforceError => Forbidden
+          case error: MemberServiceError => Forbidden
+        }
+      })
+    }
+
+    for {
+      subscriberValidation <- checkCASIfRequiredAndReturnPaymentDelay(formData)
+      member <- makeMemberAfterValidation(subscriberValidation)
+    } yield member
+
   }
 
   def thankyou(tier: Tier, upgrade: Boolean = false) = MemberAction.async { implicit request =>

--- a/frontend/app/forms/MemberForm.scala
+++ b/frontend/app/forms/MemberForm.scala
@@ -37,7 +37,7 @@ object MemberForm {
 
   case class PaidMemberJoinForm(tier: Tier, name: NameForm, payment: PaymentForm, deliveryAddress: Address,
                                 billingAddress: Option[Address], marketingChoices: MarketingChoicesForm,
-                                password: Option[String]) extends JoinForm {
+                                password: Option[String], casId: Option[String], subscriberOffer: Boolean) extends JoinForm {
     val plan = PaidTierPlan(tier, payment.annual)
   }
 
@@ -83,7 +83,7 @@ object MemberForm {
   )(MarketingChoicesForm.apply)(MarketingChoicesForm.unapply)
 
   val paymentMapping: Mapping[PaymentForm] = mapping(
-    "type" -> nonEmptyText.transform[Boolean](_ == "annual", x => if (x) "annual" else "month"),
+    "type" -> nonEmptyText.transform[Boolean]((b => b == "annual" || b == "subscriberOfferAnnual"), x => if (x) "annual" else "month"),
     "token" -> nonEmptyText
   )(PaymentForm.apply)(PaymentForm.unapply)
 
@@ -121,7 +121,9 @@ object MemberForm {
       "deliveryAddress" -> paidAddressMapping,
       "billingAddress" -> optional(paidAddressMapping),
       "marketingChoices" -> marketingChoicesMapping,
-      "password" -> optional(nonEmptyText)
+      "password" -> optional(nonEmptyText),
+      "casId" -> optional(nonEmptyText),
+      "subscriberOffer" -> default(boolean, false)
     )(PaidMemberJoinForm.apply)(PaidMemberJoinForm.unapply)
   )
 

--- a/frontend/app/model/MembershipSummary.scala
+++ b/frontend/app/model/MembershipSummary.scala
@@ -12,6 +12,6 @@ case class MembershipSummary(startDate: DateTime,
 
   val initialFreePeriodOffer = amountPaidToday.isEmpty
 
-  val annual = startDate.plusYears(1) == renewalDate
+  val annual = startDate.plusYears(1).toLocalDate == renewalDate.toLocalDate
 
 }

--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -78,7 +78,7 @@ trait MemberService extends LazyLogging with ActivityTracking {
     )
   }.getOrElse(Json.obj())
 
-  def createMember(user: IdMinimalUser, formData: JoinForm, identityRequest: IdentityRequest, paymentDelay: Option[Period] = None, casId: Option[String] = None): Future[MemberId] = {
+  def createMember(user: IdMinimalUser, formData: JoinForm, identityRequest: IdentityRequest, paymentDelay: Option[Period]): Future[MemberId] = {
     val touchpointBackend = TouchpointBackend.forUser(user)
     val identityService = IdentityService(IdentityApi)
 
@@ -89,6 +89,11 @@ trait MemberService extends LazyLogging with ActivityTracking {
       }
 
       formData.password.map(identityService.updateUserPassword(_, identityRequest, user.id))
+
+      val casId = formData match {
+        case paidMemberJoinForm: PaidMemberJoinForm => paidMemberJoinForm.casId
+        case _ => None
+      }
 
       for {
         fullUser <- identityService.getFullUserDetails(user, identityRequest)

--- a/frontend/app/views/fragments/form/paymentOptions.scala.html
+++ b/frontend/app/views/fragments/form/paymentOptions.scala.html
@@ -2,7 +2,7 @@
 
 @import model.Benefits
 
-<fieldset class="fieldset">
+<fieldset class="fieldset js-payment-options-container">
 
     <div class="fieldset__heading">
         <h2 class="fieldset__headline">Select payment option</h2>
@@ -11,7 +11,7 @@
 
     <div class="fieldset__fields">
 
-        <div class="form-field js-payment-options-container">
+        <div class="form-field">
 
             <label class="label" for="annual">
                 @Benefits.details(tier).pricing.fold{

--- a/frontend/app/views/fragments/form/paymentOptionsForSubscribers.scala.html
+++ b/frontend/app/views/fragments/form/paymentOptionsForSubscribers.scala.html
@@ -1,0 +1,39 @@
+<fieldset class="fieldset js-subscriber-payment-options-container" hidden>
+
+    <div class="fieldset__heading">
+        <h2 class="fieldset__headline">Select payment option</h2>
+        <div class="fieldset__note">Price includes VAT</div>
+    </div>
+
+    <div class="fieldset__fields">
+
+        <div class="form-field">
+
+            <label class="label" for="subscriberOfferAnnual">
+                <input type="radio"
+                       class="is-hidden"
+                       name="payment.type"
+                       id="subscriberOfferAnnual"
+                       value="subscriberOfferAnnual"  />
+
+                <div class="pseudo-radio">
+                    <div class="pseudo-radio__header">Pay nothing for 6 months then £67.50</div>
+                </div>
+
+            </label>
+
+            <label class="label" for="subscriberOfferMonthly">
+                <input type="radio"
+                       class="is-hidden"
+                       name="payment.type"
+                       id="subscriberOfferMonthly"
+                       value="subscriberOfferMonthly" />
+
+                <div class="pseudo-radio">
+                    <div class="pseudo-radio__header">Pay nothing for 6 months then £15/month</div>
+                </div>
+            </label>
+            <input type="hidden" name="subscriberOffer" value="false" class="js-hidden-subscriber-input">
+        </div>
+    </div>
+</fieldset>

--- a/frontend/app/views/fragments/form/subscriberNumber.scala.html
+++ b/frontend/app/views/fragments/form/subscriberNumber.scala.html
@@ -1,0 +1,30 @@
+@import configuration.Email
+
+<fieldset class="fieldset">
+
+    <div class="fieldset__heading">
+        <h2 class="fieldset__headline">Subscribers pay nothing for 6 months</h2>
+        <div class="fieldset__note">
+            <p>Need help redeeming this offer?</p>
+            <p>Email @Email.membershipSupport</p>
+            <p>Call 0330 333 6898</p>
+            <p>(Lines open 08:00 to 17:30 Mon - Fri, 08.30 to 12.30 weekends)</p>
+        </div>
+    </div>
+
+
+    <div class="fieldset__fields">
+
+        <div class="form-field">
+            <label class="label optional-marker" for="casId">Subscriber account number</label>
+            <input type="text"
+                   name="casId"
+                   id="casId"
+                   value=""
+                   class="input-text js-subscriber-id-input" />
+            <button class="action js-subscriber-id-submit l-pad-vertical"> Apply discount </button>
+            @fragments.form.errorMessage("There was an error applying your discount, please try again.")
+        </div>
+    </div>
+
+</fieldset>

--- a/frontend/app/views/joiner/form/payment.scala.html
+++ b/frontend/app/views/joiner/form/payment.scala.html
@@ -3,7 +3,8 @@
     userFields: model.PrivateFields,
     marketingChoices: model.StatusFields,
     passwordExists: Boolean,
-    pageInfo: model.PageInfo
+    pageInfo: model.PageInfo,
+    showSubscriberFields: Boolean
 )(implicit token: play.filters.csrf.CSRF.Token)
 
 @import com.gu.membership.salesforce.Tier
@@ -52,13 +53,13 @@
                     @if(!passwordExists) {
                         @fragments.form.createPassword()
                     }
-                    @if(tier == Tier.Partner) {
+                    @if(showSubscriberFields) {
                         @fragments.form.subscriberNumber()
                      }
                     
                     @fragments.form.paymentOptions(tier)
                     
-                     @if(tier == Tier.Partner) {
+                     @if(showSubscriberFields) {
                          @fragments.form.paymentOptionsForSubscribers()
                      }
 

--- a/frontend/app/views/joiner/form/payment.scala.html
+++ b/frontend/app/views/joiner/form/payment.scala.html
@@ -6,6 +6,7 @@
     pageInfo: model.PageInfo
 )(implicit token: play.filters.csrf.CSRF.Token)
 
+@import com.gu.membership.salesforce.Tier
 @import views.html.helper._
 
 @main("Payment | " + tier, pageInfo=pageInfo) {
@@ -51,8 +52,16 @@
                     @if(!passwordExists) {
                         @fragments.form.createPassword()
                     }
-
+                    @if(tier == Tier.Partner) {
+                        @fragments.form.subscriberNumber()
+                     }
+                    
                     @fragments.form.paymentOptions(tier)
+                    
+                     @if(tier == Tier.Partner) {
+                         @fragments.form.paymentOptionsForSubscribers()
+                     }
+
                     @fragments.form.billingAddress("Billing address")
                     @fragments.form.addressDetail(
                         formType = "billingAddress",

--- a/frontend/assets/javascripts/src/modules/form.js
+++ b/frontend/assets/javascripts/src/modules/form.js
@@ -60,8 +60,9 @@ define([
     'src/modules/form/helper/formUtil',
     'src/modules/form/payment',
     'src/modules/form/address',
+    'src/modules/form/subscriber',
     'src/modules/form/helper/password'
-], function (validation, form, payment, address, password) {
+], function (validation, form, payment, address, subscriber, password) {
     'use strict';
 
     var init = function () {
@@ -69,6 +70,7 @@ define([
             validation.init();
             address.init();
             password.init();
+            subscriber.init();
 
             if (form.hasPayment) {
                 payment.init();

--- a/frontend/assets/javascripts/src/modules/form/subscriber.js
+++ b/frontend/assets/javascripts/src/modules/form/subscriber.js
@@ -23,7 +23,7 @@ define(['bean', 'ajax', 'src/modules/form/validation/display'], function (bean, 
 
                 if(subscriberId !== '') {
                     ajax({
-                        url: '/user/check-subscriber?id=' + subscriberId + '&lastName=' + lastName + buildQueryString(postcode)
+                        url: '/user/check-subscriber?' + buildQueryString(subscriberId, lastName, postcode)
                     }).then(function (response) {
                         if (response.valid) {
                             handleSuccess(response);
@@ -42,8 +42,8 @@ define(['bean', 'ajax', 'src/modules/form/validation/display'], function (bean, 
         }
     }
 
-    function buildQueryString(postcode) {
-        var identifierQueryString = '';
+    function buildQueryString(subscriberId, lastName, postcode) {
+        var identifierQueryString = 'id=' + subscriberId + '&lastName=' + lastName;
         if(postcode) {
             identifierQueryString += '&postcode=' + postcode;
         }

--- a/frontend/assets/javascripts/src/modules/form/subscriber.js
+++ b/frontend/assets/javascripts/src/modules/form/subscriber.js
@@ -1,0 +1,104 @@
+define(['bean', 'ajax', 'src/modules/form/validation/display'], function (bean, ajax, display) {
+    'use strict';
+
+    var PAYMENT_OPTIONS_CONTAINER_ELEM = document.querySelector('.js-payment-options-container');
+    var SUBSCRIBER_PAYMENT_OPTIONS_CONTAINER_ELEM = document.querySelector('.js-subscriber-payment-options-container');
+    var SUBSCRIBER_ID_INPUT_ELEM = document.querySelector('.js-subscriber-id-input');
+    var SUBSCRIBER_ID_SUBMIT_ELEM = document.querySelector('.js-subscriber-id-submit');
+    var POSTCODE_ELEM = document.querySelector('.js-postcode');
+    var LAST_NAME_ELEM = document.querySelector('.js-name-last');
+    var SUBMIT_INPUT_ELEM = document.querySelector('.js-submit-input');
+    var HIDDEN_SUBSCRIBER_INPUT_ELEM = document.querySelector('.js-hidden-subscriber-input');
+
+    function init() {
+        if (SUBSCRIBER_ID_INPUT_ELEM && SUBSCRIBER_ID_SUBMIT_ELEM) {
+            bean.on(SUBSCRIBER_ID_SUBMIT_ELEM, 'click', function(event) {
+
+                event.preventDefault();
+
+                var subscriberId = SUBSCRIBER_ID_INPUT_ELEM.value,
+                    postcode = POSTCODE_ELEM.value,
+                    lastName = LAST_NAME_ELEM.value;
+
+                ajax({
+                    url: '/user/check-subscriber?id='+ subscriberId + '&lastName=' + lastName + buildQueryString(postcode)
+                }).then(function(response) {
+                    if(response.valid) {
+                        handleSuccess(response);
+                    } else {
+                        handleError(response);
+                    }
+                }).fail(handleError);
+            });
+        }
+    }
+
+    function buildQueryString(postcode) {
+        var identifierQueryString = '';
+        if(postcode) {
+            identifierQueryString += '&postcode=' + postcode;
+        }
+        return identifierQueryString;
+    }
+
+    function handleSuccess(response) {
+        /**
+         * Disable subscriber number fields
+         */
+        SUBSCRIBER_ID_SUBMIT_ELEM.setAttribute('disabled', true);
+        SUBSCRIBER_ID_INPUT_ELEM.setAttribute('readonly', true);
+
+        /**
+         * Toggle payment options
+         */
+        PAYMENT_OPTIONS_CONTAINER_ELEM.setAttribute('hidden', true);
+        SUBSCRIBER_PAYMENT_OPTIONS_CONTAINER_ELEM.removeAttribute('hidden');
+
+        /**
+         * Deselect any currently selected options,
+         *  select first subscriber option.
+         */
+        PAYMENT_OPTIONS_CONTAINER_ELEM.querySelector('[checked]').removeAttribute('checked');
+        SUBSCRIBER_PAYMENT_OPTIONS_CONTAINER_ELEM.querySelectorAll('[type="radio"]')[0].setAttribute('checked', true);
+
+        /**
+         * Update submit label
+         */
+        SUBMIT_INPUT_ELEM.textContent = 'Join Now';
+
+        /**
+         * Update the subscriberOffer hidden input to true
+         */
+        HIDDEN_SUBSCRIBER_INPUT_ELEM.setAttribute('value', true);
+
+        display.toggleErrorState({
+            isValid: response.valid,
+            elem: SUBSCRIBER_ID_INPUT_ELEM
+        });
+    }
+
+    function handleError(response) {
+        display.toggleErrorState({
+            isValid: response.valid,
+            elem: SUBSCRIBER_ID_INPUT_ELEM,
+            msg: response.msg
+        });
+
+        display.toggleErrorState({
+            isValid: POSTCODE_ELEM.value !== '',
+            elem: POSTCODE_ELEM,
+            msg: 'Please provide your Postcode'
+        });
+
+        display.toggleErrorState({
+            isValid: LAST_NAME_ELEM.value !== '',
+            elem: LAST_NAME_ELEM,
+            msg: 'Please provide your last name'
+        });
+    }
+
+    return {
+        init: init
+    };
+
+});

--- a/frontend/assets/javascripts/src/modules/form/subscriber.js
+++ b/frontend/assets/javascripts/src/modules/form/subscriber.js
@@ -20,15 +20,24 @@ define(['bean', 'ajax', 'src/modules/form/validation/display'], function (bean, 
                     postcode = POSTCODE_ELEM.value,
                     lastName = LAST_NAME_ELEM.value;
 
-                ajax({
-                    url: '/user/check-subscriber?id='+ subscriberId + '&lastName=' + lastName + buildQueryString(postcode)
-                }).then(function(response) {
-                    if(response.valid) {
-                        handleSuccess(response);
-                    } else {
-                        handleError(response);
-                    }
-                }).fail(handleError);
+
+                if(subscriberId !== '') {
+                    ajax({
+                        url: '/user/check-subscriber?id=' + subscriberId + '&lastName=' + lastName + buildQueryString(postcode)
+                    }).then(function (response) {
+                        if (response.valid) {
+                            handleSuccess(response);
+                        } else {
+                            handleError(response);
+                        }
+                    }).fail(handleError);
+                } else {
+                    display.toggleErrorState({
+                        isValid: false,
+                        elem: SUBSCRIBER_ID_INPUT_ELEM,
+                        msg: 'Please provide your subscriber ID'
+                    });
+                }
             });
         }
     }

--- a/frontend/assets/stylesheets/base/_form.scss
+++ b/frontend/assets/stylesheets/base/_form.scss
@@ -64,6 +64,11 @@ form {
 .fieldset__note {
     @include fs-textSans(2);
     color: $c-neutral2;
+    margin-top: rem($gs-baseline / 2);
+
+    p {
+        margin-bottom: 0;
+    }
 }
 
 .fieldset__fields {

--- a/frontend/assets/stylesheets/layout/_layout.scss
+++ b/frontend/assets/stylesheets/layout/_layout.scss
@@ -50,8 +50,8 @@ body {
 }
 
 .l-pad-vertical {
-    margin-top: rem($gs-baseline / 2);
-    margin-bottom: rem($gs-baseline / 2);
+    margin-top: rem($gs-baseline);
+    margin-bottom: rem($gs-baseline);
 }
 
 .l-pad-top {

--- a/frontend/test/services/IdentityServiceTest.scala
+++ b/frontend/test/services/IdentityServiceTest.scala
@@ -58,7 +58,9 @@ class IdentityServiceTest extends Specification with Mockito {
         Address("line one", "line 2", "town", "country", "postcode", Countries.UK),
         Some(Address("line one", "line 2", "town", "country", "postcode", Countries.UK)),
         MarketingChoicesForm(Some(false), Some(false)),
-        None
+        None,
+        None,
+        false
       )
 
       identityService.updateUserFieldsBasedOnJoining(user, paidForm, identityRequest)


### PR DESCRIPTION
The final part that has been extracted from #449 is provide subscriber offer to Partners. Note this is also now behind OAuth meaning we can test and release this early but not make it available to the public until the business is ready.

We have already put into production all the work to handle free period offers, the impact on changes to tiers and the validation checks for subscriber offer. None if is used though until now.

@davidrapson I implemented your suggestions for https://github.com/guardian/membership-frontend/pull/449#discussion_r28316830 and https://github.com/guardian/membership-frontend/pull/449#discussion_r28316733 in this PR.

@jamesoram This will need a re-test with Jason. You'll need to hit test-users endpoint to ensure the OAuth is dropped into the cookie but then you should see the subscriber fields.

~~I think we still need to change the rate plan in Zuora production before we can go live with this.~~

