### PR TITLE
Merge cross domain origins

### DIFF
--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -140,7 +140,21 @@ object Config {
   val googleAdwordsJoinerConversionLabel =
     Tier.allPublic.map { tier => tier -> config.getString(s"google.adwords.joiner.conversion.${tier.slug}") }.toMap
 
-  val corsAllowOrigin: Set[String] = config.getString("cors.allow.origin").split(",").toSet
+  val corsAllowOrigin = Set(
+    // identity
+    "https://profile.thegulocal.com",
+    "https://profile.code.dev-theguardian.com",
+    "https://profile.theguardian.com",
+    // theguardian.com
+    "http://www.thegulocal.com",
+    "http://www.theguardian.com",
+    // composer
+    "https://composer.gutools.co.uk",
+    "https://composer.code.dev-gutools.co.uk",
+    "https://composer.qa.dev-gutools.co.uk",
+    "https://composer.release.dev-gutools.co.uk",
+    "https://composer.local.dev-gutools.co.uk"
+  )
 
   val discountMultiplier = config.getDouble("event.discountMultiplier")
 

--- a/frontend/conf/CODE.conf
+++ b/frontend/conf/CODE.conf
@@ -8,8 +8,6 @@ ws.acceptAnyCertificate=true
 
 membership.url="https://membership.code.dev-theguardian.com"
 
-cors.allow.origin="https://profile.code.dev-theguardian.com"
-
 # This is the current exception to putting credentials into this file, for now.
 aws.access.key=${?AWS_ACCESS_KEY}
 aws.secret.key=${?AWS_SECRET_KEY}

--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -13,8 +13,6 @@ event.discountMultiplier=0.8
 
 content.api.key=""
 
-cors.allow.origin="https://profile.theguardian.com,http://www.theguardian.com,https://composer.gutools.co.uk,https://composer.code.dev-gutools.co.uk,https://composer.qa.dev-gutools.co.uk,https://composer.release.dev-gutools.co.uk,https://composer.local.dev-gutools.co.uk"
-
 eventbrite.url="http://www.eventbrite.co.uk"
 
 eventbrite.api.url="https://www.eventbriteapi.com/v3"

--- a/frontend/conf/dev.conf
+++ b/frontend/conf/dev.conf
@@ -25,8 +25,6 @@ ws.acceptAnyCertificate=true
 membership.url="https://mem.thegulocal.com"
 membership.feedback="membership.dev@theguardian.com"
 
-cors.allow.origin="https://profile.thegulocal.com,http://www.thegulocal.com,https://composer.gutools.co.uk,https://composer.code.dev-gutools.co.uk,https://composer.qa.dev-gutools.co.uk,https://composer.release.dev-gutools.co.uk,https://composer.local.dev-gutools.co.uk"
-
 # This is the current exception to putting credentials into this file, for now.
 aws.access.key=${?AWS_ACCESS_KEY}
 aws.secret.key=${?AWS_SECRET_KEY}


### PR DESCRIPTION
We've had issues where **local** Guardian frontend can't query our new `/card` endpoint because the CORS headers only allow **prod** Guardian frontend.

This PR merges together all of the CORS domains we support as one global list rather than per-environment. 