### PR TITLE
Fix staff google-group config so US & Australian staff can join

### DIFF
--- a/frontend/app/actions/GuardianDomains.scala
+++ b/frontend/app/actions/GuardianDomains.scala
@@ -1,10 +1,12 @@
 package actions
 
+import configuration.Config.GuardianGoogleAppsDomain
+
 object GuardianDomains {
 
   def emailsMatch(guardianEmail: String, email: String) = {
     val emailName = guardianEmail.split("@").head.toLowerCase
-    val validGuardianEmails = Seq("guardian.co.uk", "theguardian.com").map(domain => s"$emailName@$domain")
+    val validGuardianEmails = Seq(GuardianGoogleAppsDomain, "theguardian.com").map(domain => s"$emailName@$domain")
     validGuardianEmails.contains(email)
   }
 }

--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -148,13 +148,15 @@ object Config {
 
   val stage = config.getString("stage")
 
+  val GuardianGoogleAppsDomain = "guardian.co.uk"
+
   val googleAuthConfig = {
     val con = config.getConfig("google.oauth")
     GoogleAuthConfig(
       con.getString("client.id"),
       con.getString("client.secret"),
       con.getString("callback"),
-      Some("guardian.co.uk")        // Google App domain to restrict login
+      Some(GuardianGoogleAppsDomain)        // Google App domain to restrict login
     )
   }
 
@@ -163,12 +165,12 @@ object Config {
     GoogleGroupConfig(
       con.getString("client.username"),
       con.getString("client.password"),
-      "guardian.co.uk",
+      GuardianGoogleAppsDomain,
       ""
     )
   }
 
-  val staffAuthorisedEmailGroups = config.getString("staff.authorised.emails.groups").split(",").toSet
+  val staffAuthorisedEmailGroups = config.getString("staff.authorised.emails.groups").split(",").map(group => s"$group@$GuardianGoogleAppsDomain").toSet
 
   val contentApiKey = config.getString("content.api.key")
 

--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -70,7 +70,7 @@ google.groups {
   client.password=""
 }
 
-staff.authorised.emails.groups = "permanent.ftc.staff@guardian.co.uk,all.staff.usa@theguardian.com,all.staff.australia@theguardian.com,freestaff.membership@guardian.co.uk"
+staff.authorised.emails.groups = "permanent.ftc.staff,all.staff.usa,all.staff.australia,freestaff.membership"
 
 grid.images {
   media.url=""

--- a/frontend/conf/dev.conf
+++ b/frontend/conf/dev.conf
@@ -43,7 +43,7 @@ stage="DEV"
 touchpoint.backend.default=DEV
 touchpoint.backend.test=UAT
 
-staff.authorised.emails.groups = "membership.dev@guardian.co.uk"
+staff.authorised.emails.groups = "membership.dev"
 
 activity.tracking.bcrypt.salt="$2a$10$oL3umggRoHlQuvgoYpWDx."
 activity.tracking.bcrypt.pepper="dummy-pepper"


### PR DESCRIPTION
When we added US and Australian groups in 188b2fb097 we mistakenly gave the Google Group domains as `@theguardian.com` - actually, as far as Google Apps for Business is concerned, the groups are still `@guardian.co.uk` so this would never have worked. Apologies to Ellie and all staff in Guardian America and Australia :earth_americas: :arrows_counterclockwise: :gift_heart: 

This change fixes that issue, but also removes the domain name from the config altogether, to remove the possibility of similar errors in the future. cc @davidrapson 