### PR TITLE
Add campaign code and use smallest image for event card

### DIFF
--- a/frontend/app/views/embeds/eventCard.scala.html
+++ b/frontend/app/views/embeds/eventCard.scala.html
@@ -1,8 +1,9 @@
 @(event: model.RichEvent.RichEvent)
 
-@import configuration.Config
 @import views.support.Asset
 @import views.support.Dates.prettyShortDateWithTimeAndDayName
+
+@cardUrl = @{ event.memUrl + "?INTCMP=MEM_EVENT_CARD_" + event.id }
 
 @for(embedCss <- Asset.inlineResource("stylesheets/event-card.css")) {
     <style>
@@ -10,7 +11,7 @@
     </style>
 }
 <figure class="membership-event" itemscope itemtype="http://schema.org/Event">
-    <a href="@event.memUrl" class="membership-event__link">
+    <a href="@cardUrl" class="membership-event__link">
         <div class="membership-event__header">
             <div class="membership-event__icon">
                 @for(icon <- Asset.inlineSvg("g-mark")) {
@@ -23,7 +24,7 @@
         </div>
         @for(img <- event.imgOpt) {
             <div class="membership-event__media">
-                <img src="@img.defaultImage" alt="@img.altText" itemprop="image">
+                <img src="@img.smallestImage" alt="@img.altText" itemprop="image">
             </div>
         }
         <div class="membership-event__body">
@@ -44,7 +45,7 @@
         </div>
     </a>
     <div class="membership-event__action">
-        <a href="@event.memUrl" class="membership-event__button" itemprop="url">
+        <a href="@cardUrl" class="membership-event__button" itemprop="url">
             Book Now
             @for(icon <- Asset.inlineSvg("arrow-right")) {
                 @icon


### PR DESCRIPTION
This PR adjusts the event card embed to add an internal campaign code and use smallest image for event card. As the design for the card is locked to one grid unit wide we can use the smallest image (which is 140px) rather than the default (which is 500px).

![event-embed-enhanced](https://cloud.githubusercontent.com/assets/123386/7186345/e07c9d98-e460-11e4-8bc2-3c9f22638c4b.png)

Need to confirm an appropriate campaign code with @JuliaBellis 

// @mattandrews 