### PR TITLE
Clean up tweet config

### DIFF
--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -128,8 +128,6 @@ object Config {
     TouchpointBackendConfig(salesforceConfig, stripeApiConfig, zuoraApiConfig)
   }
 
-  val twitterUsername = config.getString("twitter.username")
-
   val googleAnalyticsTrackingId = config.getString("google.analytics.tracking.id")
 
   val facebookJoinerConversionTrackingId =

--- a/frontend/app/configuration/Social.scala
+++ b/frontend/app/configuration/Social.scala
@@ -1,7 +1,9 @@
 package configuration
 
 object Social {
+  val twitterUsername = "gdnmembership"
+  val twitterHashtag = "#guardianmembership"
   val youtube = "https://www.youtube.com/user/guardianmembership"
   val googleplus = "https://plus.google.com/+guardianmembership/"
-  val twitter = s"http://www.twitter.com/${Config.twitterUsername}"
+  val twitter = "https://www.twitter.com/" + twitterUsername
 }

--- a/frontend/app/model/RichEvent.scala
+++ b/frontend/app/model/RichEvent.scala
@@ -130,7 +130,7 @@ object RichEvent {
   case class MasterclassEvent(event: EBEvent, data: Option[MasterclassData]) extends RichEvent {
     val imgOpt = data.flatMap(_.images)
     val socialImgUrl = imgOpt.map(_.defaultImage)
-    val socialHashTag = Some("#GuardianMasterClasses")
+    val socialHashTag = Some("#GuardianMasterclasses")
     val tags = event.description.map(_.html).flatMap(MasterclassEvent.extractTags).getOrElse(Nil)
     val metadata = masterclassMetadata
     val contentOpt = None

--- a/frontend/app/model/RichEvent.scala
+++ b/frontend/app/model/RichEvent.scala
@@ -84,6 +84,7 @@ object RichEvent {
     val event: EBEvent
     val imgOpt: Option[model.ResponsiveImageGroup]
     val socialImgUrl: Option[String]
+    val socialHashTag: Option[String]
     val tags: Seq[String]
     val metadata: Metadata
     val contentOpt: Option[Content]
@@ -96,6 +97,7 @@ object RichEvent {
     val imgOpt = image.map(ResponsiveImageGroup(_))
 
     val socialImgUrl = imgOpt.map(_.defaultImage)
+    val socialHashTag = Some("#GuardianLive")
 
     val tags = Nil
 
@@ -122,11 +124,13 @@ object RichEvent {
     val metadata = {
       localMetadata.copy(highlightsOpt = highlight)
     }
+    override val socialHashTag = Some("#GuardianLocal")
   }
 
   case class MasterclassEvent(event: EBEvent, data: Option[MasterclassData]) extends RichEvent {
     val imgOpt = data.flatMap(_.images)
     val socialImgUrl = imgOpt.map(_.defaultImage)
+    val socialHashTag = Some("#GuardianMasterClasses")
     val tags = event.description.map(_.html).flatMap(MasterclassEvent.extractTags).getOrElse(Nil)
     val metadata = masterclassMetadata
     val contentOpt = None

--- a/frontend/app/views/fragments/social.scala.html
+++ b/frontend/app/views/fragments/social.scala.html
@@ -1,6 +1,6 @@
 @(social: views.support.Social)
 
-@import configuration.Config
+@import configuration.{Social => SocialConfig}
 
 <ul class="social-list">
     <li class="social-list__item">
@@ -30,7 +30,7 @@
     <li class="social-list__item">
         <a class="social-action social-action--twitter"
            target="_blank"
-           href="https://twitter.com/intent/tweet?text=@social.encodedTwitterMessage&amp;related=@Config.twitterUsername"
+           href="https://twitter.com/intent/tweet?text=@social.encodedTwitterMessage&amp;related=@SocialConfig.twitterUsername"
            data-metric-trigger="click"
            data-metric-category="social"
            data-metric-action="twitter"

--- a/frontend/app/views/main.scala.html
+++ b/frontend/app/views/main.scala.html
@@ -29,7 +29,7 @@
 
         <meta property="og:type" content="website"/>
         <meta property="fb:app_id" content="@Config.facebookAppId"/>
-        <meta name="twitter:site" content="@@@Config.twitterUsername"/>
+        <meta name="twitter:site" content="@@@Social.twitterUsername"/>
         <meta name="twitter:card" content="summary"/>
         <meta name="google-site-verification" content="qf7V0ceP_mY_0jTl7R7C1wZSKn2gK7TlharWVLr8Ea0" />
 

--- a/frontend/app/views/support/Social.scala
+++ b/frontend/app/views/support/Social.scala
@@ -2,37 +2,35 @@ package views.support
 
 import java.net.URLEncoder
 
-import configuration.Config
-import model.Eventbrite.EBEvent
+import configuration.{Config, Social => SocialConfig}
+import model.RichEvent.RichEvent
 
 case class Social(emailSubject: String, emailMessage: String, facebookUrl: String, twitterMessage: String) {
   def encode(str: String) = URLEncoder.encode(str, "UTF-8")
-
   val encodedFacebookUrl = encode(facebookUrl)
   val encodedTwitterMessage = encode(twitterMessage)
 }
 
 object Social {
-  val twitterHandle = "@" + Config.twitterUsername
 
-  def eventDetail(event: EBEvent) = Social(
+  def eventDetail(event: RichEvent) = Social(
     emailSubject=event.name.text,
     emailMessage=s"The Guardian is coming to life through Guardian Live events like this one. Shall we go?\n\n${event.name.text}\n${event.memUrl}",
     facebookUrl=event.memUrl,
-    twitterMessage=s"${event.name.text} ${event.memUrl} $twitterHandle #GuardianLive"
+    twitterMessage=s"${event.name.text} ${event.memUrl} ${event.socialHashTag.mkString}"
   )
 
-  def eventThankyou(event: EBEvent) = Social(
+  def eventThankyou(event: RichEvent) = Social(
     emailSubject=s"I'm going to ${event.name.text}!",
     emailMessage=s"I've just booked my ticket for ${event.name.text}. Come along too!\n\n${event.memUrl}",
     facebookUrl=event.memUrl,
-    twitterMessage=s"I'm going to: ${event.name.text} ${event.memUrl} $twitterHandle #GuardianLive"
+    twitterMessage=s"I'm going to: ${event.name.text} ${event.memUrl} ${event.socialHashTag.mkString}"
   )
 
   val joinThankyou = Social(
     emailSubject="I'm the newest Guardian member",
     emailMessage=s"I'm the newest Guardian member ${Config.membershipUrl}${controllers.routes.Info.about()}",
     facebookUrl=Config.membershipUrl + controllers.routes.Info.about(),
-    twitterMessage=s"I'm the newest Guardian member ${Config.membershipUrl}${controllers.routes.Info.about()} @gdnmembership #guardianmembership"
+    twitterMessage=s"I'm the newest Guardian member ${Config.membershipUrl}${controllers.routes.Info.about()} ${SocialConfig.twitterHashtag}"
   )
 }

--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -47,8 +47,6 @@ id.api.client.token=""
 
 membership.event.images.url="https://s3-eu-west-1.amazonaws.com/membership-eb-images/"
 
-twitter.username="gdnmembership"
-
 stripe.api.url="https://api.stripe.com/v1"
 
 # Touchpoint-backend environment-specific config - ***NO PRIVATE CREDENTIALS in these files***

--- a/frontend/test/model/EventbriteTestObjects.scala
+++ b/frontend/test/model/EventbriteTestObjects.scala
@@ -17,6 +17,7 @@ object EventbriteTestObjects {
   case class TestRichEvent(event: EBEvent) extends RichEvent {
     val imgOpt = None
     val socialImgUrl = None
+    val socialHashTag = None
     val imageMetadata = None
     val tags = Nil
     val contentOpt = None


### PR DESCRIPTION
This PR does a bit of cleanup on twitter sharing:

- Moves twitter username into `Social` config
- Configures a per event type hashtag (rather than hardcoding `GuardianLive`
- Only display hashtag, not hashtag + `@gdnmembership` on event tweets, leaves more room for event titles, and having both is redundant.

![screen shot 2015-04-17 at 11 39 05](https://cloud.githubusercontent.com/assets/123386/7200609/9b5cbb94-e4f6-11e4-8edd-d77c2d896d3b.png)

Goes a small way to improving [MEM-721](https://jira.gutools.co.uk/browse/MEM-721)