### PR TITLE
Refactor event image to better handle no image

### DIFF
--- a/frontend/app/views/fragments/event/image.scala.html
+++ b/frontend/app/views/fragments/event/image.scala.html
@@ -1,8 +1,7 @@
 @(img: model.ResponsiveImageGroup, sizes: Option[String] = None, lazyLoad: Boolean = true)
 
 <img
-    @if(!lazyLoad){src="@img.defaultImage"}
-    @if(lazyLoad){data-srcset="@img.srcset"} else {srcset="@img.srcset"}
+    @if(lazyLoad){data-srcset="@img.srcset"} else {src="@img.defaultImage" srcset="@img.srcset"}
     sizes="@sizes.getOrElse("100vw")"
     alt="@img.altText"
     class="responsive-img @if(lazyLoad) { js-lazyload} "

--- a/frontend/app/views/fragments/event/image.scala.html
+++ b/frontend/app/views/fragments/event/image.scala.html
@@ -1,12 +1,10 @@
-@(event: model.RichEvent.RichEvent, sizes: Option[String] = None, lazyLoad: Boolean = true)
+@(img: model.ResponsiveImageGroup, sizes: Option[String] = None, lazyLoad: Boolean = true)
 
-@for(img <- event.imgOpt) {
-    <img
-        @if(!lazyLoad){src="@img.defaultImage"}
-        @if(lazyLoad){data-srcset="@img.srcset"} else {srcset="@img.srcset"}
-        sizes="@sizes.getOrElse("100vw")"
-        alt="@img.altText"
-        class="responsive-img @if(lazyLoad) { js-lazyload} "
-        itemprop="image"
-    />
-}
+<img
+    @if(!lazyLoad){src="@img.defaultImage"}
+    @if(lazyLoad){data-srcset="@img.srcset"} else {srcset="@img.srcset"}
+    sizes="@sizes.getOrElse("100vw")"
+    alt="@img.altText"
+    class="responsive-img @if(lazyLoad) { js-lazyload} "
+    itemprop="image"
+/>

--- a/frontend/app/views/fragments/event/item.scala.html
+++ b/frontend/app/views/fragments/event/item.scala.html
@@ -4,9 +4,11 @@
 
 <a href="@routes.Event.details(event.slug)" class="event-item@if(event.isBookable){ qa-available-event-item}" itemscope itemtype="http://schema.org/Event">
     <meta itemprop="url" content="@event.memUrl">
-    <div class="event-item__media">
-        @fragments.event.image(event, sizes=Some("(min-width: 739px) 33.3vw, (min-width: 479px) 50vw, 100vw"))
-    </div>
+    @for(img <- event.imgOpt) {
+        <div class="event-item__media">
+            @fragments.event.image(img, sizes=Some("(min-width: 739px) 33.3vw, (min-width: 479px) 50vw, 100vw"))
+        </div>
+    }
     <div class="event-item__content">
         <div class="event-item__meta">
             @fragments.event.itemMetaTitle(event)

--- a/frontend/app/views/fragments/event/itemHero.scala.html
+++ b/frontend/app/views/fragments/event/itemHero.scala.html
@@ -26,7 +26,9 @@
             </div>
         </div>
     </div>
-    <div class="event-item__media">
-        @fragments.event.image(event, lazyLoad=false)
-    </div>
+    @for(img <- event.imgOpt) {
+        <div class="event-item__media">
+            @fragments.event.image(img, lazyLoad=false)
+        </div>
+    }
 </a>

--- a/frontend/app/views/fragments/event/itemMinimal.scala.html
+++ b/frontend/app/views/fragments/event/itemMinimal.scala.html
@@ -4,9 +4,11 @@
 
 <a href="@routes.Event.details(event.slug)" class="event-item @if(isCard){ event-item--card} else { event-item--minimal}" itemscope itemtype="http://schema.org/Event">
     <meta itemprop="url" content="@event.memUrl">
-    <div class="event-item__media">
-        @fragments.event.image(event, sizes=Some(sizesVal))
-    </div>
+    @for(img <- event.imgOpt) {
+        <div class="event-item__media">
+            @fragments.event.image(img, sizes=Some(sizesVal))
+        </div>
+    }
     <div class="event-item__content">
         <div class="event-item__meta">
             @fragments.event.itemMetaTitle(event)

--- a/frontend/app/views/fragments/event/itemSnapshot.scala.html
+++ b/frontend/app/views/fragments/event/itemSnapshot.scala.html
@@ -1,9 +1,11 @@
 @(event: model.RichEvent.RichEvent, isStacked: Boolean = false)
 
 <div class="event-snapshot@if(isStacked){ event-snapshot--stack}" itemscope itemtype="http://schema.org/Event">
-    <div class="event-snapshot__media">
-        @fragments.event.image(event)
-    </div>
+    @for(img <- event.imgOpt) {
+        <div class="event-snapshot__media">
+            @fragments.event.image(img)
+        </div>
+    }
     <div class="event-snapshot__content">
         <h2 class="event-snapshot__title">
             @if(event.isSoldOut){

--- a/frontend/app/views/fragments/event/itemSnapshotOrder.scala.html
+++ b/frontend/app/views/fragments/event/itemSnapshotOrder.scala.html
@@ -5,9 +5,11 @@
 @import views.support.Prices._
 
 <div class="event-snapshot event-snapshot--wide" itemscope itemtype="http://schema.org/Event">
-    <div class="event-snapshot__media">
-        @fragments.event.image(event)
-    </div>
+    @for(img <- event.imgOpt) {
+        <div class="event-snapshot__media">
+            @fragments.event.image(img)
+        </div>
+    }
     <div class="event-snapshot__content">
         <h2 class="event-snapshot__title">
             @if(event.isSoldOut){


### PR DESCRIPTION
Refactor event image to better handle no image case.

- Don't need to pass the the whole `RichEvent` in to the image fragment
- Moves `for` comprehension outside the image fragment to allow us to cope better with no image on event items.

**Before**

![screen shot 2015-04-17 at 11 59 30](https://cloud.githubusercontent.com/assets/123386/7200865/38f409fa-e4f9-11e4-9616-6e24fedcc701.png)

**After**

![screen shot 2015-04-17 at 11 49 17](https://cloud.githubusercontent.com/assets/123386/7200760/e04f798e-e4f7-11e4-87e2-917296dcc7af.png)
