### PR TITLE
Use JSON-LD 

### DIFF
--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -107,7 +107,8 @@ trait Event extends Controller with ActivityTracking {
       event.name.text,
       request.path,
       event.description.map(_.blurb),
-      event.socialImgUrl
+      event.socialImgUrl,
+      Some(event.schema)
     )
     Ok(views.html.event.page(event, pageInfo))
   }

--- a/frontend/app/model/Eventbrite.scala
+++ b/frontend/app/model/Eventbrite.scala
@@ -238,10 +238,6 @@ object Eventbrite {
 
     lazy val memUrl = Config.membershipUrl + controllers.routes.Event.details(slug)
 
-    val c = Json.obj(
-      "name" -> venue.name.mkString,
-      "address" -> venue.addressLine.mkString
-    )
   }
 
   object EBEvent {

--- a/frontend/app/model/PageInfo.scala
+++ b/frontend/app/model/PageInfo.scala
@@ -1,4 +1,5 @@
 package model
+
 import views.support.Asset
 import configuration.{Config, CopyConfig}
 
@@ -7,6 +8,7 @@ case class PageInfo(
   url: String,
   description: Option[String],
   image: Option[String] = Some(PageInfo.defaultImage),
+  schemaOpt: Option[EventSchema] = None,
   stripePublicKey: Option[String] = None
 )
 

--- a/frontend/app/model/RichEvent.scala
+++ b/frontend/app/model/RichEvent.scala
@@ -1,7 +1,7 @@
 package model
 
-import com.gu.contentapi.client.model.{Asset, Content}
-import configuration.{Links, Config}
+import com.gu.contentapi.client.model.{Content}
+import configuration.{Links}
 import model.Eventbrite.EBEvent
 import services.MasterclassData
 
@@ -85,6 +85,7 @@ object RichEvent {
     val imgOpt: Option[model.ResponsiveImageGroup]
     val socialImgUrl: Option[String]
     val socialHashTag: Option[String]
+    val schema: EventSchema
     val tags: Seq[String]
     val metadata: Metadata
     val contentOpt: Option[Content]
@@ -93,22 +94,16 @@ object RichEvent {
   }
 
   abstract class LiveEvent(image: Option[GridImage], contentOpt: Option[Content]) extends RichEvent {
-
     val imgOpt = image.map(ResponsiveImageGroup(_))
-
     val socialImgUrl = imgOpt.map(_.defaultImage)
+    val schema = EventSchema.from(this)
     val socialHashTag = Some("#GuardianLive")
-
     val tags = Nil
-
     val fallbackHighlightsMetadata = HighlightsMetadata("Watch highlights of past events",
       Links.membershipFront + "#video")
-
     val highlight = contentOpt.map(c => HighlightsMetadata("Read more about this event", c.webUrl))
       .orElse(Some(fallbackHighlightsMetadata))
-
     val pastImageOpt = contentOpt.flatMap(ResponsiveImageGroup(_))
-
     def deficientGuardianMembersTickets = event.internalTicketing.flatMap(_.memberDiscountOpt).exists(_.fewerMembersTicketsThanGeneralTickets)
   }
 
@@ -130,6 +125,7 @@ object RichEvent {
   case class MasterclassEvent(event: EBEvent, data: Option[MasterclassData]) extends RichEvent {
     val imgOpt = data.flatMap(_.images)
     val socialImgUrl = imgOpt.map(_.defaultImage)
+    val schema = EventSchema.from(this)
     val socialHashTag = Some("#GuardianMasterclasses")
     val tags = event.description.map(_.html).flatMap(MasterclassEvent.extractTags).getOrElse(Nil)
     val metadata = masterclassMetadata

--- a/frontend/app/model/Schema.scala
+++ b/frontend/app/model/Schema.scala
@@ -1,0 +1,69 @@
+package model
+
+import model.RichEvent.RichEvent
+import play.api.libs.json.Json
+
+object LocationSchema {
+  implicit val writesSchema = Json.writes[LocationSchema]
+}
+
+case class LocationSchema(
+  name: String,
+  address: Option[String],
+  hasMap: Option[String],
+  `@type`: String = "Place"
+)
+
+object OfferSchema {
+  implicit val writesSchema = Json.writes[OfferSchema]
+}
+
+case class OfferSchema(
+  url: String,
+  category: String,
+  price: String,
+  availability: Option[String],
+  `@type`: String = "Offer"
+)
+
+case class EventSchema(
+  name: String,
+  description: Option[String],
+  startDate: String,
+  endDate: String,
+  url: String,
+  image: Option[String],
+  location: Option[LocationSchema],
+  offers: Option[OfferSchema],
+  `@context`: String = "http://schema.org",
+  `@type`: String = "Event"
+)
+
+object EventSchema {
+
+  implicit val writesSchema = Json.writes[EventSchema]
+
+  private def locationOpt(event: RichEvent): Option[LocationSchema] = {
+    event.venue.name.map { name =>
+      LocationSchema(name, event.venue.addressLine, event.venue.googleMapsLink)
+    }
+  }
+
+  // TODO: Generate all offers, not just primary
+  private def offerOpt(event: RichEvent): Option[OfferSchema] = {
+    event.generalReleasePrice.map { price =>
+      OfferSchema(event.memUrl, "primary", price, event.statusSchema)
+    }
+  }
+
+  def from(event: RichEvent): EventSchema = EventSchema(
+    event.name.text,
+    event.description.map(_.text),
+    event.start.toString,
+    event.end.toString,
+    event.memUrl,
+    event.socialImgUrl,
+    locationOpt(event),
+    offerOpt(event)
+  )
+}

--- a/frontend/app/views/event/page.scala.html
+++ b/frontend/app/views/event/page.scala.html
@@ -89,12 +89,12 @@
         </div>
     }
 
-    <div class="event-content" itemscope itemtype="http://schema.org/Event">
+    <div class="event-content">
 
         @if(event.metadata.largeImg) {
             @for(img <- event.imgOpt) {
                 <div class="event-content__image">
-                    <img src="@img.defaultImage" srcset="@img.srcset" sizes="100vw" alt="@img.altText" class="responsive-img" itemprop="image" />
+                    <img src="@img.defaultImage" srcset="@img.srcset" sizes="100vw" alt="@img.altText" class="responsive-img">
                 </div>
                 @for(imgMetadata <- img.metadata) {
                     <div class="event-image-credit u-event-content-width">
@@ -114,7 +114,7 @@
 
             <div class="event-content__body">
                 @for(description <- event.description) {
-                    <div class="event__description copy qa-event-detail-description" itemprop="description">
+                    <div class="event__description copy qa-event-detail-description">
                         @Html(description.cleanHtml)
                     </div>
                 }

--- a/frontend/app/views/fragments/event/image.scala.html
+++ b/frontend/app/views/fragments/event/image.scala.html
@@ -4,6 +4,5 @@
     @if(lazyLoad){data-srcset="@img.srcset"} else {src="@img.defaultImage" srcset="@img.srcset"}
     sizes="@sizes.getOrElse("100vw")"
     alt="@img.altText"
-    class="responsive-img @if(lazyLoad) { js-lazyload} "
-    itemprop="image"
-/>
+    class="responsive-img @if(lazyLoad) { js-lazyload}"
+>

--- a/frontend/app/views/fragments/event/infoPanel.scala.html
+++ b/frontend/app/views/fragments/event/infoPanel.scala.html
@@ -17,7 +17,7 @@
 
     <div class="event-info__inner">
 
-        <h4 class="event-info__name" itemprop="name">@event.name.text</h4>
+        <h4 class="event-info__name">@event.name.text</h4>
 
         <div class="stats-listing">
             @fragments.event.stats(event, showTicketSales=true)

--- a/frontend/app/views/fragments/event/itemSnapshotOrder.scala.html
+++ b/frontend/app/views/fragments/event/itemSnapshotOrder.scala.html
@@ -15,7 +15,7 @@
             @if(event.isSoldOut){
                 <span class="event-status event-status--sold-out">Sold out</span>
             }
-            <span itemprop="name">@event.name.text</span>
+            @event.name.text
         </h2>
         <div class="stats-listing">
             @fragments.event.stats(event)

--- a/frontend/app/views/fragments/event/stats.scala.html
+++ b/frontend/app/views/fragments/event/stats.scala.html
@@ -8,7 +8,7 @@
         @fragments.inlineIcon("time", List("icon-inline--medium", "icon-inline--top", "icon-inline--neutral"))
     </div>
     <div class="stat-item__second">
-        <span itemprop="startDate" content="@event.start" class="qa-event-detail-datetime">@prettyDateWithTimeAndDayName(event.start)</span>
+        <span class="qa-event-detail-datetime">@prettyDateWithTimeAndDayName(event.start)</span>
     </div>
 </div>
 
@@ -17,15 +17,14 @@
     <div class="stat-item__first">
         @fragments.inlineIcon("location", List("icon-inline--medium", "icon-inline--top", "icon-inline--neutral"))
     </div>
-    <div class="stat-item__second copy" itemprop="location" itemscope itemtype="http://schema.org/Place">
-        @if(event.venue.name) {<span itemprop="name">@event.venue.name</span>}@if(event.venue.address){, }
+    <div class="stat-item__second copy">
+        @if(event.venue.name) {@event.venue.name}@if(event.venue.address){, }
         @for(location <- event.venue.address) {
-            <span itemprop="address">@location.city @location.postal_code</span>
+            @location.city @location.postal_code
         }
         @for(googleMapsLink <- event.venue.googleMapsLink) {
             <div class="stat-item__supplementary copy">
                 <a href="@googleMapsLink"
-                   itemprop="hasMap"
                    data-metric-trigger="click"
                    data-metric-category="events"
                    data-metric-action="map">Google map</a>

--- a/frontend/app/views/fragments/event/ticketCta.scala.html
+++ b/frontend/app/views/fragments/event/ticketCta.scala.html
@@ -1,10 +1,8 @@
 @(event: model.RichEvent.RichEvent, extraClasses: Seq[String] = Nil)
 
-@import model.RichEvent._
-
 <a class="js-ticket-cta action @extraClasses.mkString(" ")"
    href="@routes.Event.buy(event.id)"
    data-metric-trigger="click"
    data-metric-category="events"
    data-metric-action="book-tickets:@event.metadata.identifier.toLowerCase"
-   itemprop="url">Book tickets</a>
+>Book tickets</a>

--- a/frontend/app/views/fragments/event/ticketSales.scala.html
+++ b/frontend/app/views/fragments/event/ticketSales.scala.html
@@ -6,7 +6,7 @@
 @import views.support.Dates._
 
 @ticketDateForTier(tier: Tier, salesDate: Instant, needToDisplayTimes: Boolean) = @{
-    Html(s"<time class='js-ticket-sale-start-${tier.slug}' datetime='$salesDate' itemprop='availabilityStarts' content='$salesDate'>${salesDate.pretty(needToDisplayTimes)}</time>")
+    Html(s"<time class='js-ticket-sale-start-${tier.slug}' datetime='$salesDate'>${salesDate.pretty(needToDisplayTimes)}</time>")
 }
 
 @ticketEndSaleDate(endSalesDate: Instant, needToDisplayTimes: Boolean) = @{

--- a/frontend/app/views/fragments/meta/jsonLd.scala.html
+++ b/frontend/app/views/fragments/meta/jsonLd.scala.html
@@ -1,3 +1,0 @@
-@(schema: String)
-
-<script type="application/ld+json">@Html(schema)</script>

--- a/frontend/app/views/fragments/meta/jsonLd.scala.html
+++ b/frontend/app/views/fragments/meta/jsonLd.scala.html
@@ -1,0 +1,3 @@
+@(schema: String)
+
+<script type="application/ld+json">@Html(schema)</script>

--- a/frontend/app/views/fragments/pricing/priceInfoEvent.scala.html
+++ b/frontend/app/views/fragments/pricing/priceInfoEvent.scala.html
@@ -1,30 +1,23 @@
 @(event: model.RichEvent.RichEvent, isPrimary: Boolean = false, showLimited: Boolean = false)
 
 @for(ticketing <- event.internalTicketing) {
-    <div class="price-info-inline@if(isPrimary){ price-info-inline--primary}" itemprop="offers" itemscope itemtype="http://schema.org/AggregateOffer">
-
-        <meta itemprop="url" content="@event.memUrl">
-        @if(ticketing.isSoldOut) {
-            <meta itemprop="availability" content="http://schema.org/SoldOut">
-        } else {
-            <meta itemprop="availability" content="http://schema.org/InStock">
-        }
+    <div class="price-info-inline@if(isPrimary){ price-info-inline--primary}">
 
         @if(ticketing.isFree) {
             <div class="price-info-inline__value">Free</div>
         } else {
             @ticketing.memberDiscountOpt.fold {
-                <div class="price-info-inline__value qa-event-detail-price" itemprop="highPrice">
+                <div class="price-info-inline__value qa-event-detail-price">
                     @ticketing.generalReleaseTicketOpt.map(_.priceText)
                 </div>
             } { discountTicketing =>
                 <div class="js-event-price">
-                    <div class="price-info-inline__value js-event-price-value qa-event-detail-price" data-discount-text="@discountTicketing.member.priceText" itemprop="highPrice">
+                    <div class="price-info-inline__value js-event-price-value qa-event-detail-price" data-discount-text="@discountTicketing.member.priceText">
                     @discountTicketing.generalRelease.cost.get.formattedPrice
                     </div>
                     <div class="price-info-inline__trail">
                         <span class="js-event-price-discount qa-event-detail-price-discount" data-discount-text="Full price @discountTicketing.generalRelease.priceText">
-                            Partners/Patrons <span itemprop="lowPrice">@discountTicketing.member.priceText</span>
+                            Partners/Patrons @discountTicketing.member.priceText
                         </span>
                         <span class="js-event-price-saving" data-discount-text="(you save @discountTicketing.savingText)">
                             (save @discountTicketing.savingText)

--- a/frontend/app/views/main.scala.html
+++ b/frontend/app/views/main.scala.html
@@ -3,6 +3,7 @@
     htmlClass: String = "",
     pageInfo: model.PageInfo = model.PageInfo.default
 )(content: Html)
+@import play.api.libs.json.Json
 
 @import configuration.{Config, Social}
 @import views.support.Asset
@@ -47,6 +48,10 @@
                 ]
             }
         </script>
+
+        @for(schema <- pageInfo.schemaOpt) {
+            @fragments.meta.jsonLd(Json.toJson(schema).toString)
+        }
 
         @fragments.javaScriptFirstSteps(pageInfo)
 

--- a/frontend/app/views/main.scala.html
+++ b/frontend/app/views/main.scala.html
@@ -50,7 +50,9 @@
         </script>
 
         @for(schema <- pageInfo.schemaOpt) {
-            @fragments.meta.jsonLd(Json.toJson(schema).toString)
+            <script type="application/ld+json">
+                @Json.toJson(schema)
+            </script>
         }
 
         @fragments.javaScriptFirstSteps(pageInfo)

--- a/frontend/app/views/main.scala.html
+++ b/frontend/app/views/main.scala.html
@@ -51,7 +51,7 @@
 
         @for(schema <- pageInfo.schemaOpt) {
             <script type="application/ld+json">
-                @Json.toJson(schema)
+                @Html(Json.toJson(schema).toString)
             </script>
         }
 

--- a/frontend/app/views/offer/offersandcomps.scala.html
+++ b/frontend/app/views/offer/offersandcomps.scala.html
@@ -16,21 +16,20 @@
                 <ul class="grid grid--bordered grid--3up">
                 @for(memberContent <- membersOnlyContent) {
                     <li class="grid__item">
-                        <a href="@memberContent.content.webUrl" class="article-front" itemscope itemtype="http://schema.org/Event">
-                            <meta itemprop="url" content="@memberContent.content.webUrl">
+                        <a href="@memberContent.content.webUrl" class="article-front">
                             <div class="article-front__media">
                             @for(img <- memberContent.imgOpt) {
                                 <img class="responsive-img"
-                                src="@img.defaultImage"
-                                sizes="(min-width: 739px) 33.3vw, (min-width: 479px) 50vw, 100vw"
-                                srcset="@img.srcset"
-                                alt="@img.altText"
-                                itemprop="image"/>
+                                    src="@img.defaultImage"
+                                    sizes="(min-width: 739px) 33.3vw, (min-width: 479px) 50vw, 100vw"
+                                    srcset="@img.srcset"
+                                    alt="@img.altText"
+                                />
                             }
                             </div>
                             <div class="article-front__content">
                                 <div class="article-front__meta">
-                                    <h4 class="article-front__title" itemprop="name">
+                                    <h4 class="article-front__title">
                                         <span class="link-outbound">
                                         @fragments.inlineIcon("outbound-link", Seq("icon-inline--brand-dark"))
                                             @if(memberContent.tagTitle) {

--- a/frontend/test/model/EventbriteTestObjects.scala
+++ b/frontend/test/model/EventbriteTestObjects.scala
@@ -19,6 +19,7 @@ object EventbriteTestObjects {
     val socialImgUrl = None
     val socialHashTag = None
     val imageMetadata = None
+    val schema = EventSchema.from(this)
     val tags = Nil
     val contentOpt = None
     val pastImageOpt = None

--- a/frontend/test/model/SchemaTest.scala
+++ b/frontend/test/model/SchemaTest.scala
@@ -1,0 +1,25 @@
+package model
+
+import model.RichEvent.GuLiveEvent
+import play.api.test.PlaySpecification
+import play.api.libs.json.{Json}
+import model.EventbriteTestObjects._
+
+class SchemaTest extends PlaySpecification {
+
+  "EventSchema" should {
+
+    "generate JSON-LD schema data for an event" in {
+
+      val event = GuLiveEvent(eventWithName("Test Event"), None, None)
+      val json = Json.toJson(event.schema)
+
+      (json \ "@context").as[String] === "http://schema.org"
+      (json \ "@type").as[String] === "Event"
+      (json \ "name").as[String] === "Test Event"
+      (json \ "description").as[String] === "Event Description"
+    }
+
+  }
+
+}


### PR DESCRIPTION
This is first-pass as using [JSON-LD for linked data](https://developers.google.com/structured-data/events/ticketers) over annotated markup / microdata.

Main benefits:

1. Metadata is separate to markup so less likely to be broken due to common markup refactoring
1. As it's modelled can be more easily tested for regressions.
1. Rich data remains even when certain markup is not rendered (useful for past events, different on-sale periods)
1. We can provide additional meta data without having to worry about the markup that's output / using empty inline meta tags

Tested against the [Structured Data Testing Tool](https://developers.google.com/structured-data/testing-tool/)

![screen shot 2015-04-20 at 12 18 55](https://cloud.githubusercontent.com/assets/123386/7229135/33a7dd94-e758-11e4-9f5c-cb76a9b32747.png)

**Note**: We have to remove the markup properties in this same pull request as keeping them results in duplicate data being extracted.

I've got this to the point of feature parity with the markup based solution, but there's definitely more information we could provide using this approach.

// @mattandrews @rtyley   