### PR TITLE
No trailing slash on cors config

### DIFF
--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -147,9 +147,9 @@ object Config {
     "https://profile.theguardian.com",
     // theguardian.com
     "http://www.thegulocal.com",
-    "http://m.code.dev-theguardian.com/",
-    "http://preview.gutools.co.uk/",
-    "https://preview.gutools.co.uk/",
+    "http://m.code.dev-theguardian.com",
+    "http://preview.gutools.co.uk",
+    "https://preview.gutools.co.uk",
     "http://www.theguardian.com",
     // composer
     "https://composer.gutools.co.uk",


### PR DESCRIPTION
Defeated by a trailing `/`

@mattandrews 