### PR TITLE
Access-Control-Allow-Origin * on event card endpoint

### DIFF
--- a/frontend/app/actions/CommonActions.scala
+++ b/frontend/app/actions/CommonActions.scala
@@ -85,8 +85,6 @@ trait CommonActions {
 
   val PaidMemberAction = MemberAction andThen paidMemberRefiner()
 
-  val CorsCachedAction = Cors andThen CachedAction
-
   val CorsPublicCachedAction = CorsPublic andThen CachedAction
 
   val AjaxAuthenticatedAction = Cors andThen NoCacheAction andThen authenticated(onUnauthenticated = createBasicGuMemCookie(_))

--- a/frontend/app/actions/CommonActions.scala
+++ b/frontend/app/actions/CommonActions.scala
@@ -46,6 +46,13 @@ trait CommonActions {
     }
   }
 
+  val CorsPublic = resultModifier { result =>
+    result.withHeaders(
+      ACCESS_CONTROL_ALLOW_ORIGIN -> "*",
+      ACCESS_CONTROL_ALLOW_CREDENTIALS -> "true"
+    )
+  }
+
   val AuthenticatedAction = NoCacheAction andThen authenticated()
 
   val AuthenticatedNonMemberAction = AuthenticatedAction andThen onlyNonMemberFilter()
@@ -78,7 +85,9 @@ trait CommonActions {
 
   val PaidMemberAction = MemberAction andThen paidMemberRefiner()
 
-  val AjaxCachedAction = Cors andThen CachedAction
+  val CorsCachedAction = Cors andThen CachedAction
+
+  val CorsPublicCachedAction = CorsPublic andThen CachedAction
 
   val AjaxAuthenticatedAction = Cors andThen NoCacheAction andThen authenticated(onUnauthenticated = createBasicGuMemCookie(_))
 

--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -89,12 +89,12 @@ trait Event extends Controller with ActivityTracking {
   /**
    * This endpoint is hit by .com to enhance an embedded event.
    */
-  def embedCard(slug: String) = AjaxCachedAction { implicit request =>
+  def embedCard(slug: String) = CorsPublicCachedAction { implicit request =>
     val eventOpt = for {
       id <- EBEvent.slugToId(slug)
       event <- EventbriteService.getEvent(id)
     } yield event
-    
+
     Ok(eventOpt.fold {
       Json.obj("status" -> "error")
     } { event =>


### PR DESCRIPTION
Combining Cors / `Access-Control-Allow-Origin` headers on a cached actions results in Fastly caching arbitrary `Access-Control-Allow-Origin` headers depending on the last cached request.

For the new event card endpoint we can serve this with `Access-Control-Allow-Origin *` instead.

We could probably configure something on Fastly to vary based on the `Access-Control-Allow-Origin` but in this case there's no reason the endpoint can't be public.

![screen shot 2015-04-20 at 15 27 16](https://cloud.githubusercontent.com/assets/123386/7232464/a4448d5c-e773-11e4-96e9-488f8faf6d37.png)


@mattandrews @jennysivapalan @rtyley 