### PR TITLE
Added tests around logic for Destination 

### DIFF
--- a/frontend/app/services/DestinationService.scala
+++ b/frontend/app/services/DestinationService.scala
@@ -1,0 +1,48 @@
+package services
+
+import actions._
+import configuration.Config
+import model.{Destination, EventDestination, MembersOnlyContent, ContentDestination}
+import com.netaporter.uri.dsl._
+import play.api.mvc.Session
+import scala.concurrent.Future
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+
+
+trait DestinationService {
+
+  val JoinReferrer = "join-referrer"
+  val contentApiService: GuardianContentService
+
+  def returnDestinationFor(request: AnyMemberTierRequest[_]): Future[Option[Destination]] = {
+    Future.sequence(Seq(contentDestinationFor(request), eventDestinationFor(request))).map(_.flatten.headOption)
+  }
+
+  def contentDestinationFor(request: AnyMemberTierRequest[_]): Future[Option[ContentDestination]] = {
+    request.session.get(JoinReferrer).map { referer =>
+      if(referer.host.contains(Config.guardianHost)) {
+        contentApiService.contentItemQuery(referer.path).map { resp =>
+          resp.content.map(MembersOnlyContent).map(ContentDestination(_))
+        } recover { case _ => None }
+      } else {
+        Future.successful(None)
+      }
+    }.getOrElse(Future.successful(None))
+  }
+
+  def eventDestinationFor(request: AnyMemberTierRequest[_]): Future[Option[EventDestination]] = {
+    val optFuture = for {
+      eventId <- PreMembershipJoiningEventFromSessionExtractor.eventIdFrom(request)
+      event <- EventbriteService.getBookableEvent(eventId)
+    } yield MemberService.createDiscountForMember(request.member, event).map { discountOpt =>
+        EventDestination(event, (Config.eventbriteApiIframeUrl ? ("eid" -> event.id) & ("discount" -> discountOpt.map(_.code))))
+      }
+
+    Future.sequence(optFuture.toSeq).map(_.headOption)
+  }
+}
+
+object DestinationService extends DestinationService {
+  val contentApiService = GuardianContentService
+}
+

--- a/frontend/app/services/EventbriteService.scala
+++ b/frontend/app/services/EventbriteService.scala
@@ -188,7 +188,7 @@ object EventbriteServiceHelpers {
   }
 }
 
-object EventbriteService {
+trait EventbriteCollectiveServices {
   val services = Seq(GuardianLiveEventService, LocalEventService, MasterclassEventService)
 
   implicit class RichEventProvider(event: RichEvent) {
@@ -217,3 +217,5 @@ object EventbriteService {
   def getBookableEvent(id: String) = searchServices(_.getBookableEvent(id))
   def getEvent(id: String) = searchServices(_.getEvent(id))
 }
+
+object EventbriteService extends EventbriteCollectiveServices

--- a/frontend/test/resources/model/content.api/item.json
+++ b/frontend/test/resources/model/content.api/item.json
@@ -1,0 +1,568 @@
+{"response": {
+    "status": "ok",
+    "userTier": "internal",
+    "total": 1,
+    "content": {
+        "elements": [
+            {
+                "id": "f0ed86f9d4c4e82d8e1fc8989b9e1dd37aaf8329",
+                "relation": "main",
+                "type": "image",
+                "assets": [
+                    {
+                        "type": "image",
+                        "file": "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429189244296/19be516a-aa85-4498-9189-4478e91eb142-220x132.jpeg",
+                        "typeData": {
+                            "displayCredit": "true",
+                            "secureFile": "https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429189244296/19be516a-aa85-4498-9189-4478e91eb142-220x132.jpeg",
+                            "source": "Guardian",
+                            "photographer": "James Turner",
+                            "imageType": "Photograph",
+                            "altText": "Dreda Say Mitchell backstage before Guardian Live: Diversity in the arts, 15 April 2015",
+                            "height": "132",
+                            "credit": "Photograph: James Turner/Guardian",
+                            "caption": "Dreda Say Mitchell backstage before Guardian Live: Diversity in the arts, 15 April 2015.",
+                            "mediaId": "f0ed86f9d4c4e82d8e1fc8989b9e1dd37aaf8329",
+                            "width": "220"
+                        }
+                    },
+                    {
+                        "type": "image",
+                        "file": "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429189244465/37c2924b-ce9f-4439-9e1c-5c1be592c32a-460x276.jpeg",
+                        "typeData": {
+                            "displayCredit": "true",
+                            "secureFile": "https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429189244465/37c2924b-ce9f-4439-9e1c-5c1be592c32a-460x276.jpeg",
+                            "source": "Guardian",
+                            "photographer": "James Turner",
+                            "imageType": "Photograph",
+                            "altText": "Dreda Say Mitchell backstage before Guardian Live: Diversity in the arts, 15 April 2015",
+                            "height": "276",
+                            "credit": "Photograph: James Turner/Guardian",
+                            "caption": "Dreda Say Mitchell backstage before Guardian Live: Diversity in the arts, 15 April 2015.",
+                            "mediaId": "f0ed86f9d4c4e82d8e1fc8989b9e1dd37aaf8329",
+                            "width": "460"
+                        }
+                    },
+                    {
+                        "type": "image",
+                        "file": "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429189244671/d4858896-c260-4c74-a6a8-7f081f79b94a-540x324.jpeg",
+                        "typeData": {
+                            "displayCredit": "true",
+                            "secureFile": "https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429189244671/d4858896-c260-4c74-a6a8-7f081f79b94a-540x324.jpeg",
+                            "source": "Guardian",
+                            "photographer": "James Turner",
+                            "imageType": "Photograph",
+                            "altText": "Dreda Say Mitchell backstage before Guardian Live: Diversity in the arts, 15 April 2015",
+                            "height": "324",
+                            "credit": "Photograph: James Turner/Guardian",
+                            "caption": "Dreda Say Mitchell backstage before Guardian Live: Diversity in the arts, 15 April 2015.",
+                            "mediaId": "f0ed86f9d4c4e82d8e1fc8989b9e1dd37aaf8329",
+                            "width": "540"
+                        }
+                    },
+                    {
+                        "type": "image",
+                        "file": "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429189244836/a4f478ed-9373-4fc7-ab59-347912e8f41f-140x84.jpeg",
+                        "typeData": {
+                            "displayCredit": "true",
+                            "secureFile": "https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429189244836/a4f478ed-9373-4fc7-ab59-347912e8f41f-140x84.jpeg",
+                            "source": "Guardian",
+                            "photographer": "James Turner",
+                            "imageType": "Photograph",
+                            "altText": "Dreda Say Mitchell backstage before Guardian Live: Diversity in the arts, 15 April 2015",
+                            "height": "84",
+                            "credit": "Photograph: James Turner/Guardian",
+                            "caption": "Dreda Say Mitchell backstage before Guardian Live: Diversity in the arts, 15 April 2015.",
+                            "mediaId": "f0ed86f9d4c4e82d8e1fc8989b9e1dd37aaf8329",
+                            "width": "140"
+                        }
+                    },
+                    {
+                        "type": "image",
+                        "file": "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429189245036/be0e2c80-6d74-465e-8c25-3af25dc3ecd5-1020x612.jpeg",
+                        "typeData": {
+                            "displayCredit": "true",
+                            "secureFile": "https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429189245036/be0e2c80-6d74-465e-8c25-3af25dc3ecd5-1020x612.jpeg",
+                            "source": "Guardian",
+                            "photographer": "James Turner",
+                            "imageType": "Photograph",
+                            "altText": "Dreda Say Mitchell backstage before Guardian Live: Diversity in the arts, 15 April 2015",
+                            "height": "612",
+                            "credit": "Photograph: James Turner/Guardian",
+                            "caption": "Dreda Say Mitchell backstage before Guardian Live: Diversity in the arts, 15 April 2015.",
+                            "mediaId": "f0ed86f9d4c4e82d8e1fc8989b9e1dd37aaf8329",
+                            "width": "1020"
+                        }
+                    },
+                    {
+                        "type": "image",
+                        "file": "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429189245348/7c26334b-9160-452c-8e9d-66cc0f8dea23-300x180.jpeg",
+                        "typeData": {
+                            "displayCredit": "true",
+                            "secureFile": "https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429189245348/7c26334b-9160-452c-8e9d-66cc0f8dea23-300x180.jpeg",
+                            "source": "Guardian",
+                            "photographer": "James Turner",
+                            "imageType": "Photograph",
+                            "altText": "Dreda Say Mitchell backstage before Guardian Live: Diversity in the arts, 15 April 2015",
+                            "height": "180",
+                            "credit": "Photograph: James Turner/Guardian",
+                            "caption": "Dreda Say Mitchell backstage before Guardian Live: Diversity in the arts, 15 April 2015.",
+                            "mediaId": "f0ed86f9d4c4e82d8e1fc8989b9e1dd37aaf8329",
+                            "width": "300"
+                        }
+                    },
+                    {
+                        "type": "image",
+                        "file": "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429189245501/c1f45bae-b6b3-41c1-8411-480d9f6ccea5-380x228.jpeg",
+                        "typeData": {
+                            "displayCredit": "true",
+                            "secureFile": "https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429189245501/c1f45bae-b6b3-41c1-8411-480d9f6ccea5-380x228.jpeg",
+                            "source": "Guardian",
+                            "photographer": "James Turner",
+                            "imageType": "Photograph",
+                            "altText": "Dreda Say Mitchell backstage before Guardian Live: Diversity in the arts, 15 April 2015",
+                            "height": "228",
+                            "credit": "Photograph: James Turner/Guardian",
+                            "caption": "Dreda Say Mitchell backstage before Guardian Live: Diversity in the arts, 15 April 2015.",
+                            "mediaId": "f0ed86f9d4c4e82d8e1fc8989b9e1dd37aaf8329",
+                            "width": "380"
+                        }
+                    },
+                    {
+                        "type": "image",
+                        "file": "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429189245639/fd85d401-9502-4f33-995d-a9ab36d1fc0d-620x372.jpeg",
+                        "typeData": {
+                            "displayCredit": "true",
+                            "secureFile": "https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429189245639/fd85d401-9502-4f33-995d-a9ab36d1fc0d-620x372.jpeg",
+                            "source": "Guardian",
+                            "photographer": "James Turner",
+                            "imageType": "Photograph",
+                            "altText": "Dreda Say Mitchell backstage before Guardian Live: Diversity in the arts, 15 April 2015",
+                            "height": "372",
+                            "credit": "Photograph: James Turner/Guardian",
+                            "caption": "Dreda Say Mitchell backstage before Guardian Live: Diversity in the arts, 15 April 2015.",
+                            "mediaId": "f0ed86f9d4c4e82d8e1fc8989b9e1dd37aaf8329",
+                            "width": "620"
+                        }
+                    },
+                    {
+                        "type": "image",
+                        "file": "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429189245963/704ffd1c-efac-4ba3-a978-89608c966fcf-2060x1236.jpeg",
+                        "typeData": {
+                            "displayCredit": "true",
+                            "secureFile": "https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429189245963/704ffd1c-efac-4ba3-a978-89608c966fcf-2060x1236.jpeg",
+                            "source": "Guardian",
+                            "photographer": "James Turner",
+                            "imageType": "Photograph",
+                            "altText": "Dreda Say Mitchell backstage before Guardian Live: Diversity in the arts, 15 April 2015",
+                            "height": "1236",
+                            "credit": "Photograph: James Turner/Guardian",
+                            "caption": "Dreda Say Mitchell backstage before Guardian Live: Diversity in the arts, 15 April 2015.",
+                            "mediaId": "f0ed86f9d4c4e82d8e1fc8989b9e1dd37aaf8329",
+                            "width": "2060"
+                        }
+                    }
+                ]
+            },
+            {
+                "id": "73cf5b325bac43a6c4be60467cf3a712a2e5344d",
+                "relation": "body",
+                "type": "image",
+                "assets": [
+                    {
+                        "type": "image",
+                        "file": "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429190123709/06f7c85b-7d75-4907-afd4-caaef94d8338-220x132.jpeg",
+                        "typeData": {
+                            "displayCredit": "true",
+                            "secureFile": "https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429190123709/06f7c85b-7d75-4907-afd4-caaef94d8338-220x132.jpeg",
+                            "source": "Guardian",
+                            "photographer": "James Turner",
+                            "imageType": "Photograph",
+                            "altText": "Guardian Live: Diversity in the arts, 15 April 2015 (l-r  Ben Stephenson, Mark Lawson, Dreda Say Mitchell, David Lan, Chris Bryant MP, Femi Oguns.",
+                            "height": "132",
+                            "credit": "Photograph: James Turner/Guardian",
+                            "caption": "Guardian Live: Diversity in the arts, 15 April 2015 (l-r Ben Stephenson, Mark Lawson, Dreda Say Mitchell, David Lan, Chris Bryant MP, Femi Oguns.",
+                            "mediaId": "73cf5b325bac43a6c4be60467cf3a712a2e5344d",
+                            "width": "220"
+                        }
+                    },
+                    {
+                        "type": "image",
+                        "file": "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429190123856/f52d2e07-3387-4b36-8821-743ca5524e7d-460x276.jpeg",
+                        "typeData": {
+                            "displayCredit": "true",
+                            "secureFile": "https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429190123856/f52d2e07-3387-4b36-8821-743ca5524e7d-460x276.jpeg",
+                            "source": "Guardian",
+                            "photographer": "James Turner",
+                            "imageType": "Photograph",
+                            "altText": "Guardian Live: Diversity in the arts, 15 April 2015 (l-r  Ben Stephenson, Mark Lawson, Dreda Say Mitchell, David Lan, Chris Bryant MP, Femi Oguns.",
+                            "height": "276",
+                            "credit": "Photograph: James Turner/Guardian",
+                            "caption": "Guardian Live: Diversity in the arts, 15 April 2015 (l-r Ben Stephenson, Mark Lawson, Dreda Say Mitchell, David Lan, Chris Bryant MP, Femi Oguns.",
+                            "mediaId": "73cf5b325bac43a6c4be60467cf3a712a2e5344d",
+                            "width": "460"
+                        }
+                    },
+                    {
+                        "type": "image",
+                        "file": "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429190123994/babd1b68-29a6-492c-a994-aba1d8f0d73d-540x324.jpeg",
+                        "typeData": {
+                            "displayCredit": "true",
+                            "secureFile": "https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429190123994/babd1b68-29a6-492c-a994-aba1d8f0d73d-540x324.jpeg",
+                            "source": "Guardian",
+                            "photographer": "James Turner",
+                            "imageType": "Photograph",
+                            "altText": "Guardian Live: Diversity in the arts, 15 April 2015 (l-r  Ben Stephenson, Mark Lawson, Dreda Say Mitchell, David Lan, Chris Bryant MP, Femi Oguns.",
+                            "height": "324",
+                            "credit": "Photograph: James Turner/Guardian",
+                            "caption": "Guardian Live: Diversity in the arts, 15 April 2015 (l-r Ben Stephenson, Mark Lawson, Dreda Say Mitchell, David Lan, Chris Bryant MP, Femi Oguns.",
+                            "mediaId": "73cf5b325bac43a6c4be60467cf3a712a2e5344d",
+                            "width": "540"
+                        }
+                    },
+                    {
+                        "type": "image",
+                        "file": "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429190124199/1aa0cdf5-bb8e-4398-9945-06e95d737558-140x84.jpeg",
+                        "typeData": {
+                            "displayCredit": "true",
+                            "secureFile": "https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429190124199/1aa0cdf5-bb8e-4398-9945-06e95d737558-140x84.jpeg",
+                            "source": "Guardian",
+                            "photographer": "James Turner",
+                            "imageType": "Photograph",
+                            "altText": "Guardian Live: Diversity in the arts, 15 April 2015 (l-r  Ben Stephenson, Mark Lawson, Dreda Say Mitchell, David Lan, Chris Bryant MP, Femi Oguns.",
+                            "height": "84",
+                            "credit": "Photograph: James Turner/Guardian",
+                            "caption": "Guardian Live: Diversity in the arts, 15 April 2015 (l-r Ben Stephenson, Mark Lawson, Dreda Say Mitchell, David Lan, Chris Bryant MP, Femi Oguns.",
+                            "mediaId": "73cf5b325bac43a6c4be60467cf3a712a2e5344d",
+                            "width": "140"
+                        }
+                    },
+                    {
+                        "type": "image",
+                        "file": "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429190124370/c0ac68aa-f5d1-42f1-a92d-e9a2096aa835-1020x612.jpeg",
+                        "typeData": {
+                            "displayCredit": "true",
+                            "secureFile": "https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429190124370/c0ac68aa-f5d1-42f1-a92d-e9a2096aa835-1020x612.jpeg",
+                            "source": "Guardian",
+                            "photographer": "James Turner",
+                            "imageType": "Photograph",
+                            "altText": "Guardian Live: Diversity in the arts, 15 April 2015 (l-r  Ben Stephenson, Mark Lawson, Dreda Say Mitchell, David Lan, Chris Bryant MP, Femi Oguns.",
+                            "height": "612",
+                            "credit": "Photograph: James Turner/Guardian",
+                            "caption": "Guardian Live: Diversity in the arts, 15 April 2015 (l-r Ben Stephenson, Mark Lawson, Dreda Say Mitchell, David Lan, Chris Bryant MP, Femi Oguns.",
+                            "mediaId": "73cf5b325bac43a6c4be60467cf3a712a2e5344d",
+                            "width": "1020"
+                        }
+                    },
+                    {
+                        "type": "image",
+                        "file": "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429190124617/efa3bf95-bfed-4d40-bc06-021cd694fb1c-300x180.jpeg",
+                        "typeData": {
+                            "displayCredit": "true",
+                            "secureFile": "https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429190124617/efa3bf95-bfed-4d40-bc06-021cd694fb1c-300x180.jpeg",
+                            "source": "Guardian",
+                            "photographer": "James Turner",
+                            "imageType": "Photograph",
+                            "altText": "Guardian Live: Diversity in the arts, 15 April 2015 (l-r  Ben Stephenson, Mark Lawson, Dreda Say Mitchell, David Lan, Chris Bryant MP, Femi Oguns.",
+                            "height": "180",
+                            "credit": "Photograph: James Turner/Guardian",
+                            "caption": "Guardian Live: Diversity in the arts, 15 April 2015 (l-r Ben Stephenson, Mark Lawson, Dreda Say Mitchell, David Lan, Chris Bryant MP, Femi Oguns.",
+                            "mediaId": "73cf5b325bac43a6c4be60467cf3a712a2e5344d",
+                            "width": "300"
+                        }
+                    },
+                    {
+                        "type": "image",
+                        "file": "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429190124772/9615ac23-59de-4a2e-95b7-87ebfb9d3bb7-380x228.jpeg",
+                        "typeData": {
+                            "displayCredit": "true",
+                            "secureFile": "https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429190124772/9615ac23-59de-4a2e-95b7-87ebfb9d3bb7-380x228.jpeg",
+                            "source": "Guardian",
+                            "photographer": "James Turner",
+                            "imageType": "Photograph",
+                            "altText": "Guardian Live: Diversity in the arts, 15 April 2015 (l-r  Ben Stephenson, Mark Lawson, Dreda Say Mitchell, David Lan, Chris Bryant MP, Femi Oguns.",
+                            "height": "228",
+                            "credit": "Photograph: James Turner/Guardian",
+                            "caption": "Guardian Live: Diversity in the arts, 15 April 2015 (l-r Ben Stephenson, Mark Lawson, Dreda Say Mitchell, David Lan, Chris Bryant MP, Femi Oguns.",
+                            "mediaId": "73cf5b325bac43a6c4be60467cf3a712a2e5344d",
+                            "width": "380"
+                        }
+                    },
+                    {
+                        "type": "image",
+                        "file": "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429190124913/b89506bf-0396-4c7c-8799-bd0771f8b4d9-620x372.jpeg",
+                        "typeData": {
+                            "displayCredit": "true",
+                            "secureFile": "https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429190124913/b89506bf-0396-4c7c-8799-bd0771f8b4d9-620x372.jpeg",
+                            "source": "Guardian",
+                            "photographer": "James Turner",
+                            "imageType": "Photograph",
+                            "altText": "Guardian Live: Diversity in the arts, 15 April 2015 (l-r  Ben Stephenson, Mark Lawson, Dreda Say Mitchell, David Lan, Chris Bryant MP, Femi Oguns.",
+                            "height": "372",
+                            "credit": "Photograph: James Turner/Guardian",
+                            "caption": "Guardian Live: Diversity in the arts, 15 April 2015 (l-r Ben Stephenson, Mark Lawson, Dreda Say Mitchell, David Lan, Chris Bryant MP, Femi Oguns.",
+                            "mediaId": "73cf5b325bac43a6c4be60467cf3a712a2e5344d",
+                            "width": "620"
+                        }
+                    },
+                    {
+                        "type": "image",
+                        "file": "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429190125266/dc5e7869-cdb7-436c-8415-cbe6d2b3ba71-2060x1236.jpeg",
+                        "typeData": {
+                            "displayCredit": "true",
+                            "secureFile": "https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429190125266/dc5e7869-cdb7-436c-8415-cbe6d2b3ba71-2060x1236.jpeg",
+                            "source": "Guardian",
+                            "photographer": "James Turner",
+                            "imageType": "Photograph",
+                            "altText": "Guardian Live: Diversity in the arts, 15 April 2015 (l-r  Ben Stephenson, Mark Lawson, Dreda Say Mitchell, David Lan, Chris Bryant MP, Femi Oguns.",
+                            "height": "1236",
+                            "credit": "Photograph: James Turner/Guardian",
+                            "caption": "Guardian Live: Diversity in the arts, 15 April 2015 (l-r Ben Stephenson, Mark Lawson, Dreda Say Mitchell, David Lan, Chris Bryant MP, Femi Oguns.",
+                            "mediaId": "73cf5b325bac43a6c4be60467cf3a712a2e5344d",
+                            "width": "2060"
+                        }
+                    }
+                ]
+            },
+            {
+                "id": "_no_ids",
+                "relation": "body",
+                "type": "embed",
+                "assets": [
+                    {
+                        "type": "embed",
+                        "file": "http://www.theguardian.com/culture/2015/apr/14/my-big-break-uk-arts-ken-loach-caitlin-moran-lennie-james-grayson-perry",
+                        "typeData": {
+                            "embedType": "rich-link",
+                            "linkText": "My big break: Ken Loach, Caitlin Moran, Lennie James, Grayson Perry and more explain how they made it",
+                            "linkPrefix": "Related: "
+                        }
+                    }
+                ]
+            },
+            {
+                "id": "_no_ids",
+                "relation": "body",
+                "type": "embed",
+                "assets": [
+                    {
+                        "type": "embed",
+                        "file": "http://www.theguardian.com/membership/2015/mar/13/extraordinary-things-happen-at-guardian-events-come-and-join-us",
+                        "typeData": {
+                            "embedType": "rich-link",
+                            "linkText": "Extraordinary things happen at Guardian events – come and join us",
+                            "linkPrefix": "Related: "
+                        }
+                    }
+                ]
+            },
+            {
+                "id": "f0ed86f9d4c4e82d8e1fc8989b9e1dd37aaf8329",
+                "relation": "thumbnail",
+                "type": "image",
+                "assets": [
+                    {
+                        "type": "image",
+                        "file": "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429189244296/19be516a-aa85-4498-9189-4478e91eb142-220x132.jpeg",
+                        "typeData": {
+                            "displayCredit": "true",
+                            "secureFile": "https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429189244296/19be516a-aa85-4498-9189-4478e91eb142-220x132.jpeg",
+                            "source": "Guardian",
+                            "photographer": "James Turner",
+                            "imageType": "Photograph",
+                            "altText": "Dreda Say Mitchell backstage before Guardian Live: Diversity in the arts, 15 April 2015",
+                            "height": "132",
+                            "credit": "Photograph: James Turner/Guardian",
+                            "mediaId": "f0ed86f9d4c4e82d8e1fc8989b9e1dd37aaf8329",
+                            "width": "220"
+                        }
+                    },
+                    {
+                        "type": "image",
+                        "file": "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429189244465/37c2924b-ce9f-4439-9e1c-5c1be592c32a-460x276.jpeg",
+                        "typeData": {
+                            "displayCredit": "true",
+                            "secureFile": "https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429189244465/37c2924b-ce9f-4439-9e1c-5c1be592c32a-460x276.jpeg",
+                            "source": "Guardian",
+                            "photographer": "James Turner",
+                            "imageType": "Photograph",
+                            "altText": "Dreda Say Mitchell backstage before Guardian Live: Diversity in the arts, 15 April 2015",
+                            "height": "276",
+                            "credit": "Photograph: James Turner/Guardian",
+                            "mediaId": "f0ed86f9d4c4e82d8e1fc8989b9e1dd37aaf8329",
+                            "width": "460"
+                        }
+                    },
+                    {
+                        "type": "image",
+                        "file": "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429189244671/d4858896-c260-4c74-a6a8-7f081f79b94a-540x324.jpeg",
+                        "typeData": {
+                            "displayCredit": "true",
+                            "secureFile": "https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429189244671/d4858896-c260-4c74-a6a8-7f081f79b94a-540x324.jpeg",
+                            "source": "Guardian",
+                            "photographer": "James Turner",
+                            "imageType": "Photograph",
+                            "altText": "Dreda Say Mitchell backstage before Guardian Live: Diversity in the arts, 15 April 2015",
+                            "height": "324",
+                            "credit": "Photograph: James Turner/Guardian",
+                            "mediaId": "f0ed86f9d4c4e82d8e1fc8989b9e1dd37aaf8329",
+                            "width": "540"
+                        }
+                    },
+                    {
+                        "type": "image",
+                        "file": "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429189244836/a4f478ed-9373-4fc7-ab59-347912e8f41f-140x84.jpeg",
+                        "typeData": {
+                            "displayCredit": "true",
+                            "secureFile": "https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429189244836/a4f478ed-9373-4fc7-ab59-347912e8f41f-140x84.jpeg",
+                            "source": "Guardian",
+                            "photographer": "James Turner",
+                            "imageType": "Photograph",
+                            "altText": "Dreda Say Mitchell backstage before Guardian Live: Diversity in the arts, 15 April 2015",
+                            "height": "84",
+                            "credit": "Photograph: James Turner/Guardian",
+                            "mediaId": "f0ed86f9d4c4e82d8e1fc8989b9e1dd37aaf8329",
+                            "width": "140"
+                        }
+                    },
+                    {
+                        "type": "image",
+                        "file": "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429189245036/be0e2c80-6d74-465e-8c25-3af25dc3ecd5-1020x612.jpeg",
+                        "typeData": {
+                            "displayCredit": "true",
+                            "secureFile": "https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429189245036/be0e2c80-6d74-465e-8c25-3af25dc3ecd5-1020x612.jpeg",
+                            "source": "Guardian",
+                            "photographer": "James Turner",
+                            "imageType": "Photograph",
+                            "altText": "Dreda Say Mitchell backstage before Guardian Live: Diversity in the arts, 15 April 2015",
+                            "height": "612",
+                            "credit": "Photograph: James Turner/Guardian",
+                            "mediaId": "f0ed86f9d4c4e82d8e1fc8989b9e1dd37aaf8329",
+                            "width": "1020"
+                        }
+                    },
+                    {
+                        "type": "image",
+                        "file": "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429189245348/7c26334b-9160-452c-8e9d-66cc0f8dea23-300x180.jpeg",
+                        "typeData": {
+                            "displayCredit": "true",
+                            "secureFile": "https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429189245348/7c26334b-9160-452c-8e9d-66cc0f8dea23-300x180.jpeg",
+                            "source": "Guardian",
+                            "photographer": "James Turner",
+                            "imageType": "Photograph",
+                            "altText": "Dreda Say Mitchell backstage before Guardian Live: Diversity in the arts, 15 April 2015",
+                            "height": "180",
+                            "credit": "Photograph: James Turner/Guardian",
+                            "mediaId": "f0ed86f9d4c4e82d8e1fc8989b9e1dd37aaf8329",
+                            "width": "300"
+                        }
+                    },
+                    {
+                        "type": "image",
+                        "file": "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429189245501/c1f45bae-b6b3-41c1-8411-480d9f6ccea5-380x228.jpeg",
+                        "typeData": {
+                            "displayCredit": "true",
+                            "secureFile": "https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429189245501/c1f45bae-b6b3-41c1-8411-480d9f6ccea5-380x228.jpeg",
+                            "source": "Guardian",
+                            "photographer": "James Turner",
+                            "imageType": "Photograph",
+                            "altText": "Dreda Say Mitchell backstage before Guardian Live: Diversity in the arts, 15 April 2015",
+                            "height": "228",
+                            "credit": "Photograph: James Turner/Guardian",
+                            "mediaId": "f0ed86f9d4c4e82d8e1fc8989b9e1dd37aaf8329",
+                            "width": "380"
+                        }
+                    },
+                    {
+                        "type": "image",
+                        "file": "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429189245639/fd85d401-9502-4f33-995d-a9ab36d1fc0d-620x372.jpeg",
+                        "typeData": {
+                            "displayCredit": "true",
+                            "secureFile": "https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429189245639/fd85d401-9502-4f33-995d-a9ab36d1fc0d-620x372.jpeg",
+                            "source": "Guardian",
+                            "photographer": "James Turner",
+                            "imageType": "Photograph",
+                            "altText": "Dreda Say Mitchell backstage before Guardian Live: Diversity in the arts, 15 April 2015",
+                            "height": "372",
+                            "credit": "Photograph: James Turner/Guardian",
+                            "mediaId": "f0ed86f9d4c4e82d8e1fc8989b9e1dd37aaf8329",
+                            "width": "620"
+                        }
+                    },
+                    {
+                        "type": "image",
+                        "file": "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429189245963/704ffd1c-efac-4ba3-a978-89608c966fcf-2060x1236.jpeg",
+                        "typeData": {
+                            "displayCredit": "true",
+                            "secureFile": "https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/16/1429189245963/704ffd1c-efac-4ba3-a978-89608c966fcf-2060x1236.jpeg",
+                            "source": "Guardian",
+                            "photographer": "James Turner",
+                            "imageType": "Photograph",
+                            "altText": "Dreda Say Mitchell backstage before Guardian Live: Diversity in the arts, 15 April 2015",
+                            "height": "1236",
+                            "credit": "Photograph: James Turner/Guardian",
+                            "mediaId": "f0ed86f9d4c4e82d8e1fc8989b9e1dd37aaf8329",
+                            "width": "2060"
+                        }
+                    }
+                ]
+            }
+        ],
+        "id": "membership/2015/apr/17/guardian-live-diversity-in-the-arts",
+        "sectionId": "membership",
+        "webTitle": "Guardian Live: Diversity in the arts",
+        "webPublicationDate": "2015-04-17T09:46:38Z",
+        "fields": {
+            "trailText": "At an animated Guardian Live event, panelists and Guardian Members discussed the lack of demographic diversity in the arts and what we should be doing to tackle the problem"
+        },
+        "webUrl": "http://www.theguardian.com/membership/2015/apr/17/guardian-live-diversity-in-the-arts",
+        "apiUrl": "http://content.guardianapis.com/membership/2015/apr/17/guardian-live-diversity-in-the-arts",
+        "sectionName": "Membership",
+        "tags": [
+            {
+                "id": "membership/membership",
+                "webTitle": "Membership",
+                "type": "keyword",
+                "sectionId": "membership",
+                "webUrl": "http://www.theguardian.com/membership/membership",
+                "apiUrl": "http://content.guardianapis.com/membership/membership",
+                "sectionName": "Membership"
+            },
+            {
+                "id": "culture/culture",
+                "webTitle": "Culture",
+                "type": "keyword",
+                "sectionId": "culture",
+                "webUrl": "http://www.theguardian.com/culture/culture",
+                "apiUrl": "http://content.guardianapis.com/culture/culture",
+                "sectionName": "Culture"
+            },
+            {
+                "id": "type/article",
+                "webTitle": "Article",
+                "type": "type",
+                "webUrl": "http://www.theguardian.com/articles",
+                "apiUrl": "http://content.guardianapis.com/type/article"
+            },
+            {
+                "id": "tone/reviews",
+                "webTitle": "Reviews",
+                "type": "tone",
+                "webUrl": "http://www.theguardian.com/tone/reviews",
+                "apiUrl": "http://content.guardianapis.com/tone/reviews"
+            },
+            {
+                "id": "profile/priyaelan",
+                "webTitle": "Priya Elan",
+                "r2ContributorId": "26368",
+                "bylineImageUrl": "http://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2014/10/17/1413566972090/Priya-Elan.jpg",
+                "bylineLargeImageUrl": "http://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2014/10/17/1413567069631/Priya-Elan-L.png",
+                "firstName": "",
+                "lastName": "elan",
+                "type": "contributor",
+                "webUrl": "http://www.theguardian.com/profile/priyaelan",
+                "apiUrl": "http://content.guardianapis.com/profile/priyaelan"
+            }
+        ]
+    }
+}}

--- a/frontend/test/services/DestinationServiceTest.scala
+++ b/frontend/test/services/DestinationServiceTest.scala
@@ -3,16 +3,18 @@ package services
 import actions.AnyMemberTierRequest
 import com.gu.contentapi.client.parser.JsonParser
 import com.gu.membership.salesforce.Member
+import model.{ContentDestination, EventDestination}
 import model.Eventbrite.EBAccessCode
 import org.scalatest.concurrent.ScalaFutures
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import play.api.mvc.Session
+import play.api.test.PlaySpecification
 import utils.Resource
 import model.EventbriteTestObjects._
 import scala.concurrent.Future
 
-class DestinationServiceTest extends Specification with Mockito with ScalaFutures {
+class DestinationServiceTest extends PlaySpecification with Mockito with ScalaFutures {
 
   "DestinationService" should {
 
@@ -25,37 +27,74 @@ class DestinationServiceTest extends Specification with Mockito with ScalaFuture
     val destinationService = DestinationServiceTest
 
     "should return a content destination url if join-referrer is in the request session" in {
-      //todo switch to using member request case class with play mock request.
+      //mock the request
       val request = mock[AnyMemberTierRequest[_]]
       request.session returns mock[Session]
       request.session.get("join-referrer") returns Some("http://www.theguardian.com/membership/2015/apr/17/guardian-live-diversity-in-the-arts")
 
+      //mock the Content API response
       val item = JsonParser.parseItem(Resource.get("model/content.api/item.json"))
       destinationService.contentApiService.contentItemQuery("/membership/2015/apr/17/guardian-live-diversity-in-the-arts") returns Future.successful(item)
 
+      //call the method under test
       val futureResult = destinationService.contentDestinationFor(request)
 
+      //verify eventDestinationFor returns a valid content destination
       whenReady(futureResult) { contentDestinationOpt =>
         contentDestinationOpt.get.item.content.id mustEqual ("membership/2015/apr/17/guardian-live-diversity-in-the-arts")
       }
     }
 
     "should return an event destination url if preJoinReturnUrl is in the request session" in {
+      //mock the request
       val request = mock[AnyMemberTierRequest[_]]
       request.session returns mock[Session]
-      val eventId = "0123456"
       request.session.get("preJoinReturnUrl") returns Some("/event/0123456/buy")
       request.member returns mock[Member]
 
-      val event = TestRichEvent(eventWithName().copy(id = eventId))
-
+      //mock the Eventbrite response and discount creation
+      val event = TestRichEvent(eventWithName().copy(id = "0123456"))
+      destinationService.eventbriteService.getBookableEvent("0123456") returns Some(event)
       destinationService.memberService.createDiscountForMember(request.member, event) returns Future.successful(Some(EBAccessCode("some-discount-code", 2)))
-      destinationService.eventbriteService.getBookableEvent(eventId) returns Some(event)
 
+      //call the method under test
       val futureResult = destinationService.eventDestinationFor(request)
 
+      //verify eventDestinationFor returns a valid event destination
       whenReady(futureResult) { eventDestinationOpt =>
-        eventDestinationOpt.get.event.id mustEqual (eventId)
+        eventDestinationOpt.get.event.id mustEqual "0123456"
+      }
+    }
+
+    "should return either content or event destination if both are supplied" in {
+      //mock the request
+      val request = mock[AnyMemberTierRequest[_]]
+      request.session returns mock[Session]
+      request.session.get("join-referrer") returns Some("http://www.theguardian.com/membership/2015/apr/17/guardian-live-diversity-in-the-arts")
+      request.session.get("preJoinReturnUrl") returns Some("/event/0123456/buy")
+      request.member returns mock[Member]
+
+      //mock the Content API response
+      val item = JsonParser.parseItem(Resource.get("model/content.api/item.json"))
+      destinationService.contentApiService.contentItemQuery("/membership/2015/apr/17/guardian-live-diversity-in-the-arts") returns Future.successful(item)
+
+      //mock the Eventbrite response and discount creation
+      val event = TestRichEvent(eventWithName().copy(id = "0123456"))
+      destinationService.eventbriteService.getBookableEvent("0123456") returns Some(event)
+      destinationService.memberService.createDiscountForMember(request.member, event) returns Future.successful(Some(EBAccessCode("some-discount-code", 2)))
+
+      //call the method under test
+      val futureResult = destinationService.returnDestinationFor(request)
+
+      //verify returnForDestination returns a valid destination
+      whenReady(futureResult) { destinationOpt =>
+        val destination = destinationOpt.get
+        destination match {
+          case eventDestination:EventDestination => eventDestination.event.id mustEqual "0123456"
+          case contentDestination: ContentDestination => contentDestination.item.content.id mustEqual "membership/2015/apr/17/guardian-live-diversity-in-the-arts"
+        }
+        val validDestination = destination.isInstanceOf[ContentDestination] || destination.isInstanceOf[EventDestination]
+        validDestination must_==(true)
       }
     }
   }

--- a/frontend/test/services/DestinationServiceTest.scala
+++ b/frontend/test/services/DestinationServiceTest.scala
@@ -2,23 +2,24 @@ package services
 
 import actions.AnyMemberTierRequest
 import com.gu.contentapi.client.parser.JsonParser
+import com.gu.membership.salesforce.Member
+import model.Eventbrite.EBAccessCode
 import org.scalatest.concurrent.ScalaFutures
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import play.api.mvc.Session
 import utils.Resource
-
+import model.EventbriteTestObjects._
 import scala.concurrent.Future
-
 
 class DestinationServiceTest extends Specification with Mockito with ScalaFutures {
 
-
   "DestinationService" should {
-
 
     object DestinationServiceTest extends DestinationService {
       override val contentApiService = mock[GuardianContentService]
+      override val memberService = mock[MemberService]
+      override val eventbriteService = mock[EventbriteCollectiveServices]
     }
 
     val destinationService = DestinationServiceTest
@@ -26,13 +27,11 @@ class DestinationServiceTest extends Specification with Mockito with ScalaFuture
     "should return a content destination url if join-referrer is in the request session" in {
       //todo switch to using member request case class with play mock request.
       val request = mock[AnyMemberTierRequest[_]]
-      val session = mock[Session]
-      request.session returns session
+      request.session returns mock[Session]
       request.session.get("join-referrer") returns Some("http://www.theguardian.com/membership/2015/apr/17/guardian-live-diversity-in-the-arts")
-      val item2 = Resource.get("model/content.api/item.json")
-      val x = JsonParser.parseItem(item2)
 
-      destinationService.contentApiService.contentItemQuery("/membership/2015/apr/17/guardian-live-diversity-in-the-arts") returns Future.successful(x)
+      val item = JsonParser.parseItem(Resource.get("model/content.api/item.json"))
+      destinationService.contentApiService.contentItemQuery("/membership/2015/apr/17/guardian-live-diversity-in-the-arts") returns Future.successful(item)
 
       val futureResult = destinationService.contentDestinationFor(request)
 
@@ -40,6 +39,24 @@ class DestinationServiceTest extends Specification with Mockito with ScalaFuture
         contentDestinationOpt.get.item.content.id mustEqual ("membership/2015/apr/17/guardian-live-diversity-in-the-arts")
       }
     }
+
+    "should return an event destination url if preJoinReturnUrl is in the request session" in {
+      val request = mock[AnyMemberTierRequest[_]]
+      request.session returns mock[Session]
+      val eventId = "0123456"
+      request.session.get("preJoinReturnUrl") returns Some("/event/0123456/buy")
+      request.member returns mock[Member]
+
+      val event = TestRichEvent(eventWithName().copy(id = eventId))
+
+      destinationService.memberService.createDiscountForMember(request.member, event) returns Future.successful(Some(EBAccessCode("some-discount-code", 2)))
+      destinationService.eventbriteService.getBookableEvent(eventId) returns Some(event)
+
+      val futureResult = destinationService.eventDestinationFor(request)
+
+      whenReady(futureResult) { eventDestinationOpt =>
+        eventDestinationOpt.get.event.id mustEqual (eventId)
+      }
+    }
   }
 }
-

--- a/frontend/test/services/DestinationServiceTest.scala
+++ b/frontend/test/services/DestinationServiceTest.scala
@@ -1,22 +1,29 @@
 package services
 
-import actions.AnyMemberTierRequest
+import actions.{AnyMemberTierRequest, MemberRequest}
+import com.github.nscala_time.time.Imports._
 import com.gu.contentapi.client.parser.JsonParser
-import com.gu.membership.salesforce.Member
-import model.{ContentDestination, EventDestination}
+import com.gu.membership.salesforce.{FreeMember, Member, Tier}
 import model.Eventbrite.EBAccessCode
+import model.EventbriteTestObjects._
+import model.{ContentDestination, EventDestination, IdMinimalUser}
 import org.scalatest.concurrent.ScalaFutures
 import org.specs2.mock.Mockito
-import org.specs2.mutable.Specification
+import play.api.{Application, GlobalSettings}
+import play.api.mvc.Security.AuthenticatedRequest
 import play.api.mvc.Session
-import play.api.test.PlaySpecification
+import play.api.test.{FakeApplication, FakeRequest, PlaySpecification}
 import utils.Resource
-import model.EventbriteTestObjects._
+
 import scala.concurrent.Future
 
 class DestinationServiceTest extends PlaySpecification with Mockito with ScalaFutures {
 
   "DestinationService" should {
+
+    val fakeApplicationWithGlobal = FakeApplication(withGlobal = Some(new GlobalSettings() {
+      override def onStart(app: Application) {}
+    }))
 
     object DestinationServiceTest extends DestinationService {
       override val contentApiService = mock[GuardianContentService]
@@ -27,75 +34,81 @@ class DestinationServiceTest extends PlaySpecification with Mockito with ScalaFu
     val destinationService = DestinationServiceTest
 
     "should return a content destination url if join-referrer is in the request session" in {
-      //mock the request
-      val request = mock[AnyMemberTierRequest[_]]
-      request.session returns mock[Session]
-      request.session.get("join-referrer") returns Some("http://www.theguardian.com/membership/2015/apr/17/guardian-live-diversity-in-the-arts")
+      running(fakeApplicationWithGlobal) {
 
-      //mock the Content API response
-      val item = JsonParser.parseItem(Resource.get("model/content.api/item.json"))
-      destinationService.contentApiService.contentItemQuery("/membership/2015/apr/17/guardian-live-diversity-in-the-arts") returns Future.successful(item)
+        val request = createRequestWithSession("join-referrer" -> "http://www.theguardian.com/membership/2015/apr/17/guardian-live-diversity-in-the-arts")
 
-      //call the method under test
-      val futureResult = destinationService.contentDestinationFor(request)
+        //mock the Content API response
+        val item = JsonParser.parseItem(Resource.get("model/content.api/item.json"))
+        destinationService.contentApiService.contentItemQuery("/membership/2015/apr/17/guardian-live-diversity-in-the-arts") returns Future.successful(item)
 
-      //verify eventDestinationFor returns a valid content destination
-      whenReady(futureResult) { contentDestinationOpt =>
-        contentDestinationOpt.get.item.content.id mustEqual ("membership/2015/apr/17/guardian-live-diversity-in-the-arts")
+        //call the method under test
+        val futureResult = destinationService.contentDestinationFor(request)
+
+        //verify eventDestinationFor returns a valid content destination
+        whenReady(futureResult) { contentDestinationOpt =>
+          contentDestinationOpt.get.item.content.id mustEqual ("membership/2015/apr/17/guardian-live-diversity-in-the-arts")
+        }
       }
     }
 
     "should return an event destination url if preJoinReturnUrl is in the request session" in {
-      //mock the request
-      val request = mock[AnyMemberTierRequest[_]]
-      request.session returns mock[Session]
-      request.session.get("preJoinReturnUrl") returns Some("/event/0123456/buy")
-      request.member returns mock[Member]
+      running(fakeApplicationWithGlobal) {
 
-      //mock the Eventbrite response and discount creation
-      val event = TestRichEvent(eventWithName().copy(id = "0123456"))
-      destinationService.eventbriteService.getBookableEvent("0123456") returns Some(event)
-      destinationService.memberService.createDiscountForMember(request.member, event) returns Future.successful(Some(EBAccessCode("some-discount-code", 2)))
+        val request = createRequestWithSession("preJoinReturnUrl" -> "/event/0123456/buy")
 
-      //call the method under test
-      val futureResult = destinationService.eventDestinationFor(request)
 
-      //verify eventDestinationFor returns a valid event destination
-      whenReady(futureResult) { eventDestinationOpt =>
-        eventDestinationOpt.get.event.id mustEqual "0123456"
+        //mock the Eventbrite response and discount creation
+        val event = TestRichEvent(eventWithName().copy(id = "0123456"))
+        destinationService.eventbriteService.getBookableEvent("0123456") returns Some(event)
+        destinationService.memberService.createDiscountForMember(request.member, event) returns Future.successful(Some(EBAccessCode("some-discount-code", 2)))
+
+        //call the method under test
+        val futureResult = destinationService.eventDestinationFor(request)
+
+        //verify eventDestinationFor returns a valid event destination
+        whenReady(futureResult) { eventDestinationOpt =>
+          eventDestinationOpt.get.event.id mustEqual "0123456"
+        }
       }
     }
 
     "should return either content or event destination if both are supplied" in {
-      //mock the request
-      val request = mock[AnyMemberTierRequest[_]]
-      request.session returns mock[Session]
-      request.session.get("join-referrer") returns Some("http://www.theguardian.com/membership/2015/apr/17/guardian-live-diversity-in-the-arts")
-      request.session.get("preJoinReturnUrl") returns Some("/event/0123456/buy")
-      request.member returns mock[Member]
+      running(fakeApplicationWithGlobal) {
 
-      //mock the Content API response
-      val item = JsonParser.parseItem(Resource.get("model/content.api/item.json"))
-      destinationService.contentApiService.contentItemQuery("/membership/2015/apr/17/guardian-live-diversity-in-the-arts") returns Future.successful(item)
+        val request = createRequestWithSession("join-referrer" -> "http://www.theguardian.com/membership/2015/apr/17/guardian-live-diversity-in-the-arts", "preJoinReturnUrl" -> "/event/0123456/buy")
 
-      //mock the Eventbrite response and discount creation
-      val event = TestRichEvent(eventWithName().copy(id = "0123456"))
-      destinationService.eventbriteService.getBookableEvent("0123456") returns Some(event)
-      destinationService.memberService.createDiscountForMember(request.member, event) returns Future.successful(Some(EBAccessCode("some-discount-code", 2)))
+        //mock the Content API response
+        val item = JsonParser.parseItem(Resource.get("model/content.api/item.json"))
+        destinationService.contentApiService.contentItemQuery("/membership/2015/apr/17/guardian-live-diversity-in-the-arts") returns Future.successful(item)
 
-      //call the method under test
-      val futureResult = destinationService.returnDestinationFor(request)
+        //mock the Eventbrite response and discount creation
+        val event = TestRichEvent(eventWithName().copy(id = "0123456"))
+        destinationService.eventbriteService.getBookableEvent("0123456") returns Some(event)
+        destinationService.memberService.createDiscountForMember(request.member, event) returns Future.successful(Some(EBAccessCode("some-discount-code", 2)))
 
-      //verify returnForDestination returns a valid destination
-      whenReady(futureResult) { destinationOpt =>
-        val destination = destinationOpt.get
-        destination match {
-          case eventDestination:EventDestination => eventDestination.event.id mustEqual "0123456"
-          case contentDestination: ContentDestination => contentDestination.item.content.id mustEqual "membership/2015/apr/17/guardian-live-diversity-in-the-arts"
+        //call the method under test with the request
+        val futureResult = destinationService.returnDestinationFor(request)
+
+        //verify returnForDestination returns a valid destination
+        whenReady(futureResult) { destinationOpt =>
+          val destination = destinationOpt.get
+          destination match {
+            case eventDestination: EventDestination => eventDestination.event.id mustEqual "0123456"
+            case contentDestination: ContentDestination => contentDestination.item.content.id mustEqual "membership/2015/apr/17/guardian-live-diversity-in-the-arts"
+          }
+          val validDestination = destination.isInstanceOf[ContentDestination] || destination.isInstanceOf[EventDestination]
+          validDestination must_== (true)
         }
-        val validDestination = destination.isInstanceOf[ContentDestination] || destination.isInstanceOf[EventDestination]
-        validDestination must_==(true)
       }
+    }
+
+    def createRequestWithSession(newSessions: (String, String)*) = {
+      val testMember = FreeMember("", "", "", Tier.Friend, None, None, "", "", DateTime.now)
+      val fakeRequest = FakeRequest().withSession(newSessions: _*)
+      val minimalUser: IdMinimalUser = IdMinimalUser("123", None)
+      MemberRequest(testMember, new AuthenticatedRequest(minimalUser, fakeRequest))
+
     }
   }
 }

--- a/frontend/test/services/DestinationServiceTest.scala
+++ b/frontend/test/services/DestinationServiceTest.scala
@@ -1,0 +1,45 @@
+package services
+
+import actions.AnyMemberTierRequest
+import com.gu.contentapi.client.parser.JsonParser
+import org.scalatest.concurrent.ScalaFutures
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import play.api.mvc.Session
+import utils.Resource
+
+import scala.concurrent.Future
+
+
+class DestinationServiceTest extends Specification with Mockito with ScalaFutures {
+
+
+  "DestinationService" should {
+
+
+    object DestinationServiceTest extends DestinationService {
+      override val contentApiService = mock[GuardianContentService]
+    }
+
+    val destinationService = DestinationServiceTest
+
+    "should return a content destination url if join-referrer is in the request session" in {
+      //todo switch to using member request case class with play mock request.
+      val request = mock[AnyMemberTierRequest[_]]
+      val session = mock[Session]
+      request.session returns session
+      request.session.get("join-referrer") returns Some("http://www.theguardian.com/membership/2015/apr/17/guardian-live-diversity-in-the-arts")
+      val item2 = Resource.get("model/content.api/item.json")
+      val x = JsonParser.parseItem(item2)
+
+      destinationService.contentApiService.contentItemQuery("/membership/2015/apr/17/guardian-live-diversity-in-the-arts") returns Future.successful(x)
+
+      val futureResult = destinationService.contentDestinationFor(request)
+
+      whenReady(futureResult) { contentDestinationOpt =>
+        contentDestinationOpt.get.item.content.id mustEqual ("membership/2015/apr/17/guardian-live-diversity-in-the-arts")
+      }
+    }
+  }
+}
+

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,10 +17,11 @@ object Dependencies {
   val awsSimpleEmail = "com.amazonaws" % "aws-java-sdk-ses" % "1.9.24"
   val snowPlow = "com.snowplowanalytics" % "snowplow-java-tracker" % "0.5.2-SNAPSHOT"
   val bCrypt = "com.github.t3hnar" %% "scala-bcrypt" % "2.4"
+  val scalaTest =  "org.scalatest" %% "scalatest" % "2.2.4" % "test"
 
   //projects
 
   val frontendDependencies = Seq(identityCookie, playGoogleAuth, identityTestUsers, scalaUri, membershipCommon,
-    contentAPI, playWS, playCache, playFilters,sentryRavenLogback, awsSimpleEmail, snowPlow, bCrypt)
+    contentAPI, playWS, playCache, playFilters,sentryRavenLogback, awsSimpleEmail, snowPlow, bCrypt, scalaTest)
 
 }


### PR DESCRIPTION
This PR  is based off #366 and adds the tests for the Destination decider :sparkle: 

I've created a DestinationService which houses all the logic (created in #366).  The tests are in DestinationServiceTest which does a lot of mocking..sorry. We mock the request*, content API service, eventbrite service, and member service and based on all these return an event or content destination. 

I wrote test for each method in DestinationService but didn't handle cases where values could be None as I wasn't sure it would be useful. Thoughts?

* @rtyley can we pair tomorrow on changing the request work as I couldn't quite get this working.

:rocket: :new_moon_with_face: 