### PR TITLE
Fix end date for Membership in free period offer 

### DIFF
--- a/frontend/app/controllers/User.scala
+++ b/frontend/app/controllers/User.scala
@@ -23,7 +23,6 @@ trait User extends Controller {
   val casService = CASService
 
   def me = AjaxMemberAction { implicit request =>
-    println("hello")
     val json = basicDetails(request.member)
     Ok(json).withCookies(Cookie("GU_MEM", GuMemCookie.encodeUserJson(json), secure = true, httpOnly = false))
   }


### PR DESCRIPTION
endDate on `user/me/details` is currently used in Guardian frontend to specify the Next Payment date on Membership details tab and End Date on the cancelled and tier change pages. For those who get a free period offer in Membership the endDate is displaying at 1 January 1970. 

I've updated the endDate on /user/me/details, if a payment has been made it is the charged through date. However if a user is in a free period then we can use the date of when the first payment will be which is the contract acceptance date.

I thought about creating a new field e.g. nextPaymentDate on user/me/details but the logic would be the same as endDate and then I'd have to update frontend too.

Before:
![screen shot 2015-04-22 at 14 21 39](https://cloud.githubusercontent.com/assets/944375/7275893/587717be-e8fe-11e4-9ba9-60ad8b1ea7f6.png)
![screen shot 2015-04-22 at 14 18 05](https://cloud.githubusercontent.com/assets/944375/7275898/60530466-e8fe-11e4-927c-9fce5a3e78ac.png)


After:
![screen shot 2015-04-22 at 14 24 09](https://cloud.githubusercontent.com/assets/944375/7275926/881b7884-e8fe-11e4-8162-94699c11ba62.png)
![screen shot 2015-04-22 at 14 16 50](https://cloud.githubusercontent.com/assets/944375/7275931/8de8ae4e-e8fe-11e4-84f0-fd158fbf541c.png)


:dancer: 