### PR TITLE
Update Friend rate plans in DEV & UAT for one-off zero-payment

### DIFF
--- a/frontend/conf/touchpoint.DEV.conf
+++ b/frontend/conf/touchpoint.DEV.conf
@@ -27,7 +27,7 @@ touchpoint.backend.environments {
                 username=""
                 password=""
 
-                friend="2c92c0f945fee1c90146057402c7066b"
+                friend="2c92c0f94c9ca1c5014c9e5c64ba4260"
                 staff="2c92c0f849c6e58a0149c73d6f114be2"
                 partner {
                     monthly = "2c92c0f94c510a0d014c569a93194575"

--- a/frontend/conf/touchpoint.UAT.conf
+++ b/frontend/conf/touchpoint.UAT.conf
@@ -27,7 +27,7 @@ touchpoint.backend.environments {
                 username=""
                 password=""
 
-                friend="2c92c0f848f362750148f4c2727379d7"
+                friend="2c92c0f94cc6ea05014cdb4b1d1f037d"
                 staff="2c92c0f849f118740149f1d61ad07723"
                 partner {
                     monthly = "2c92c0f84c510073014c56948fbe6894"


### PR DESCRIPTION
These new one-off zero-payment rate plans should create fewer 'noise' invoices in salesforce (see message below). Updating in DEV & UAT for testing.

cc @jennysivapalan

---------- Forwarded message ----------
From: Renaldo
Date: 23 April 2015 at 10:35
Subject: Friend Memberships - ProductRate Plan Id change

Hi Roberto,

We're changing the product rate plan for the Friends membership.  

The reason for this is due to the large number of zero amount invoices being created in Salesforce.  In order to reduce the number of invoices, we are switching the product rate plan from a recurring monthly zero charge, to a one-time zero charge.

I've attached the new Friend Product Rate Plan Id (highlighted in Green).  

Can you please change this Product Rate Plan Id in UAT so that we can test?