### PR TITLE
Add already a member link to choose tier page

### DIFF
--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -15,6 +15,7 @@ import services.zuora.ZuoraApiConfig
 import services._
 import com.netaporter.uri.dsl._
 import scala.util.Try
+import java.net.URLEncoder
 
 object Config {
   val logger = Logger(this.getClass())
@@ -35,8 +36,15 @@ object Config {
 
   val idWebAppUrl = config.getString("identity.webapp.url")
 
-  def idWebAppSigninUrl(uri: String): String =
-    (idWebAppUrl / "signin") ? ("returnUrl" -> s"$membershipUrl$uri") ? ("skipConfirmation" -> "true")
+  def idWebAppSigninUrl(uri: String): String = {
+    val encodedUri = URLEncoder.encode(membershipUrl + uri, "UTF-8")
+    (idWebAppUrl / "signin") ? ("returnUrl" -> s"$encodedUri") ? ("skipConfirmation" -> "true")
+  }
+
+  def idWebAppSigninUrlExternal(uri: String): String = {
+    val encodedUri = URLEncoder.encode(uri, "UTF-8")
+    (idWebAppUrl / "signin") ? ("returnUrl" -> s"$encodedUri") ? ("skipConfirmation" -> "true")
+  }
 
   def idWebAppRegisterUrl(uri: String): String =
     (idWebAppUrl / "register") ? ("returnUrl" -> s"$membershipUrl$uri") ? ("skipConfirmation" -> "true")

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -57,8 +57,9 @@ trait Joiner extends Controller with ActivityTracking with LazyLogging {
 
     val contentRefererOpt = request.headers.get(REFERER)
     val accessOpt = request.getQueryString("membershipAccess").map(MembershipAccess)
+    val returnUrl = contentRefererOpt.map(Config.idWebAppSigninUrlExternal(_)).getOrElse(Config.idWebAppSigninUrl(""))
 
-    Ok(views.html.joiner.tierChooser(pageInfo, eventOpt, accessOpt))
+    Ok(views.html.joiner.tierChooser(pageInfo, eventOpt, accessOpt, returnUrl))
       .withSession(request.session.copy(data = request.session.data ++ contentRefererOpt.map(JoinReferrer -> _)))
   }
 

--- a/frontend/app/views/joiner/tierChooser.scala.html
+++ b/frontend/app/views/joiner/tierChooser.scala.html
@@ -1,18 +1,22 @@
 @(
     pageInfo: model.PageInfo,
     eventOpt: Option[model.RichEvent.RichEvent],
-    accessOpt: Option[model.MembershipAccess]
+    accessOpt: Option[model.MembershipAccess],
+    returnUrl: String
 )(implicit token: play.filters.csrf.CSRF.Token)
 
 @import com.gu.membership.salesforce.Tier
 
 @sectionTitle = @{
+    val defaultTitle = "Choose a membership tier to continue"
     accessOpt.map {
         case i if i.isMembersOnly => "You need to be a Guardian member to view this page"
         case i if i.isPaidMembersOnly => "You need to be a Partner or a Patron to view this page"
         case _ => "Choose a membership tier to continue"
-    }.getOrElse(eventOpt.fold("Choose a membership tier to continue")(_.metadata.chooseTier.sectionTitle))
+    }.getOrElse(eventOpt.fold(defaultTitle)(_.metadata.chooseTier.sectionTitle))
 }
+
+<div class="page-section__lead-in">     @fragments.joiner.joinStepCounter(1, 3)      </div>
 
 @main("Join Choose Tier", pageInfo=pageInfo) {
 
@@ -23,6 +27,7 @@
         <section class="page-section page-section--no-padding">
             <div class="page-section__lead-in">
                 @fragments.joiner.joinStepCounter(1, 3)
+                <p class="text-note copy tier-hidden">Already a member? <a href="@returnUrl">Please sign in</a></p>
             </div>
             <div class="page-section__content">
                 <h2 class="h-section h-section--lead">

--- a/frontend/app/views/joiner/tierChooser.scala.html
+++ b/frontend/app/views/joiner/tierChooser.scala.html
@@ -12,11 +12,9 @@
     accessOpt.map {
         case i if i.isMembersOnly => "You need to be a Guardian member to view this page"
         case i if i.isPaidMembersOnly => "You need to be a Partner or a Patron to view this page"
-        case _ => "Choose a membership tier to continue"
+        case _ => defaultTitle
     }.getOrElse(eventOpt.fold(defaultTitle)(_.metadata.chooseTier.sectionTitle))
 }
-
-<div class="page-section__lead-in">     @fragments.joiner.joinStepCounter(1, 3)      </div>
 
 @main("Join Choose Tier", pageInfo=pageInfo) {
 


### PR DESCRIPTION
Adds an "already a member link" to choose tier page.

- If being redirected to this page the ID `returnUrl` should use the `Referer`.
- Should not be shown when signed in
- `returnUrl` is now URL encoded, previously requested by @markjamesbutler 

![screen shot 2015-04-23 at 11 58 24](https://cloud.githubusercontent.com/assets/123386/7295663/41701b44-e9b0-11e4-8532-d83262463ae1.png)

@jennysivapalan 