### PR TITLE
Re-add Krux

### DIFF
--- a/frontend/assets/javascripts/src/modules/analytics/krux.js
+++ b/frontend/assets/javascripts/src/modules/analytics/krux.js
@@ -1,0 +1,16 @@
+/*global Raven */
+define(function() {
+
+    var KRUX_ID = 'JglooLwn';
+
+    function load() {
+        require(['js!https://cdn.krxd.net/controltag?confid=' + KRUX_ID]).then(null, function(err) {
+            Raven.captureException(err);
+            Raven.captureMessage('Krux failed to load');
+        });
+    }
+
+    return {
+        load: load
+    };
+});

--- a/frontend/assets/javascripts/src/modules/analytics/setup.js
+++ b/frontend/assets/javascripts/src/modules/analytics/setup.js
@@ -4,12 +4,14 @@ define([
     'src/modules/analytics/ga',
     'src/modules/analytics/ophan',
     'src/modules/analytics/omniture',
+    'src/modules/analytics/krux',
     'src/modules/analytics/crazyegg'
 ], function (
     cookie,
     googleAnalytics,
     ophanAnalytics,
     omnitureAnalytics,
+    krux,
     crazyegg
 ) {
 
@@ -20,10 +22,13 @@ define([
             guardian.analyticsEnabled = false;
         }
 
+        guardian.analyticsEnabled = true;
         if (guardian.analyticsEnabled) {
             ophanAnalytics.init();
             omnitureAnalytics.init();
             googleAnalytics.init();
+
+            krux.load();
 
             if(!guardian.isDev) {
                 crazyegg.load();

--- a/frontend/assets/javascripts/src/modules/analytics/setup.js
+++ b/frontend/assets/javascripts/src/modules/analytics/setup.js
@@ -22,18 +22,15 @@ define([
             guardian.analyticsEnabled = false;
         }
 
-        guardian.analyticsEnabled = true;
         if (guardian.analyticsEnabled) {
             ophanAnalytics.init();
             omnitureAnalytics.init();
             googleAnalytics.init();
 
-            krux.load();
-
             if(!guardian.isDev) {
+                krux.load();
                 crazyegg.load();
             }
-
         }
     }
 


### PR DESCRIPTION
Re-add Krux tracking script. Having sat down with Robert Freeman and gone through the Krux configuration we've got a setup which means we can consider using is on Membership. Krux allows all tags to be configured to only support secure connections.

Having set everything to require HTTPS  I am no longer able to repeat mixed-content warnings for first time visitors.

@jamesoram Would you mind looking at this again to confirm you can't repeat any mixed content-warnings?

**Note:** Krux is enabled in Dev to allow QA testing, will be disabled once tested.