### PR TITLE
Revert #501

### DIFF
--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -15,7 +15,6 @@ import services.zuora.ZuoraApiConfig
 import services._
 import com.netaporter.uri.dsl._
 import scala.util.Try
-import java.net.URLEncoder
 
 object Config {
   val logger = Logger(this.getClass())
@@ -36,15 +35,8 @@ object Config {
 
   val idWebAppUrl = config.getString("identity.webapp.url")
 
-  def idWebAppSigninUrl(uri: String): String = {
-    val encodedUri = URLEncoder.encode(membershipUrl + uri, "UTF-8")
-    (idWebAppUrl / "signin") ? ("returnUrl" -> s"$encodedUri") ? ("skipConfirmation" -> "true")
-  }
-
-  def idWebAppSigninUrlExternal(uri: String): String = {
-    val encodedUri = URLEncoder.encode(uri, "UTF-8")
-    (idWebAppUrl / "signin") ? ("returnUrl" -> s"$encodedUri") ? ("skipConfirmation" -> "true")
-  }
+  def idWebAppSigninUrl(uri: String): String =
+    (idWebAppUrl / "signin") ? ("returnUrl" -> s"$membershipUrl$uri") ? ("skipConfirmation" -> "true")
 
   def idWebAppRegisterUrl(uri: String): String =
     (idWebAppUrl / "register") ? ("returnUrl" -> s"$membershipUrl$uri") ? ("skipConfirmation" -> "true")

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -57,9 +57,8 @@ trait Joiner extends Controller with ActivityTracking with LazyLogging {
 
     val contentRefererOpt = request.headers.get(REFERER)
     val accessOpt = request.getQueryString("membershipAccess").map(MembershipAccess)
-    val returnUrl = contentRefererOpt.map(Config.idWebAppSigninUrlExternal(_)).getOrElse(Config.idWebAppSigninUrl(""))
 
-    Ok(views.html.joiner.tierChooser(pageInfo, eventOpt, accessOpt, returnUrl))
+    Ok(views.html.joiner.tierChooser(pageInfo, eventOpt, accessOpt))
       .withSession(request.session.copy(data = request.session.data ++ contentRefererOpt.map(JoinReferrer -> _)))
   }
 

--- a/frontend/app/views/joiner/tierChooser.scala.html
+++ b/frontend/app/views/joiner/tierChooser.scala.html
@@ -1,19 +1,17 @@
 @(
     pageInfo: model.PageInfo,
     eventOpt: Option[model.RichEvent.RichEvent],
-    accessOpt: Option[model.MembershipAccess],
-    returnUrl: String
+    accessOpt: Option[model.MembershipAccess]
 )(implicit token: play.filters.csrf.CSRF.Token)
 
 @import com.gu.membership.salesforce.Tier
 
 @sectionTitle = @{
-    val defaultTitle = "Choose a membership tier to continue"
     accessOpt.map {
         case i if i.isMembersOnly => "You need to be a Guardian member to view this page"
         case i if i.isPaidMembersOnly => "You need to be a Partner or a Patron to view this page"
-        case _ => defaultTitle
-    }.getOrElse(eventOpt.fold(defaultTitle)(_.metadata.chooseTier.sectionTitle))
+        case _ => "Choose a membership tier to continue"
+    }.getOrElse(eventOpt.fold("Choose a membership tier to continue")(_.metadata.chooseTier.sectionTitle))
 }
 
 @main("Join Choose Tier", pageInfo=pageInfo) {
@@ -25,7 +23,6 @@
         <section class="page-section page-section--no-padding">
             <div class="page-section__lead-in">
                 @fragments.joiner.joinStepCounter(1, 3)
-                <p class="text-note copy tier-hidden">Already a member? <a href="@returnUrl">Please sign in</a></p>
             </div>
             <div class="page-section__content">
                 <h2 class="h-section h-section--lead">


### PR DESCRIPTION
This reverts commit a8b93d7b4da9e78f780294f449863817fd40c7fd, reversing
changes made to ec0e8172b51a4ea3f93eb3d577f7b563469722fe.

https://github.com/guardian/membership-frontend/pull/501

URL encoding `returnUrl` on PROD causes people to be redirected to `/uk` front, not intended URL.

@rtyley @jennysivapalan 