### PR TITLE
Fixed annual field on user/me/details

### DIFF
--- a/frontend/app/controllers/User.scala
+++ b/frontend/app/controllers/User.scala
@@ -38,6 +38,13 @@ trait User extends Controller {
         Future.successful(Json.obj())
     }
 
+    def endDate(subscriptionDetails: SubscriptionDetails) = {
+      subscriptionDetails.chargedThroughDate.orElse {
+        if (subscriptionDetails.inFreePeriodOffer) Some(subscriptionDetails.contractAcceptanceDate)
+        else None
+      }
+    }
+
     val futurePaymentDetails = for {
       cardDetails <- futureCardDetails
       subscriptionStatus <- request.touchpointBackend.subscriptionService.getSubscriptionStatus(request.member)

--- a/frontend/app/controllers/User.scala
+++ b/frontend/app/controllers/User.scala
@@ -49,6 +49,9 @@ trait User extends Controller {
         "subscription" -> (cardDetails ++ Json.obj(
           "start" -> membershipSummary.startDate,
           "end" -> membershipSummary.nextPaymentDate,
+          "nextPaymentPrice" -> membershipSummary.nextPaymentPrice,
+          "nextPaymentDate" -> membershipSummary.nextPaymentDate,
+          "renewalDate" -> membershipSummary.renewalDate,
           "cancelledAt" -> subscriptionStatus.future.isDefined,
           "plan" -> Json.obj(
             "name" -> subscriptionDetails.planName,

--- a/frontend/app/controllers/User.scala
+++ b/frontend/app/controllers/User.scala
@@ -38,13 +38,6 @@ trait User extends Controller {
         Future.successful(Json.obj())
     }
 
-    def endDate(subscriptionDetails: SubscriptionDetails) = {
-      subscriptionDetails.chargedThroughDate.orElse {
-        if (subscriptionDetails.inFreePeriodOffer) Some(subscriptionDetails.contractAcceptanceDate)
-        else None
-      }
-    }
-
     val futurePaymentDetails = for {
       cardDetails <- futureCardDetails
       subscriptionStatus <- request.touchpointBackend.subscriptionService.getSubscriptionStatus(request.member)

--- a/frontend/app/controllers/User.scala
+++ b/frontend/app/controllers/User.scala
@@ -55,7 +55,7 @@ trait User extends Controller {
         "optIn" -> !subscriptionStatus.cancelled,
         "subscription" -> (cardDetails ++ Json.obj(
           "start" -> membershipSummary.startDate,
-          "end" -> membershipSummary.nextPaymentDate,
+          "end" -> endDate(subscriptionDetails),
           "nextPaymentPrice" -> membershipSummary.nextPaymentPrice,
           "nextPaymentDate" -> membershipSummary.nextPaymentDate,
           "renewalDate" -> membershipSummary.renewalDate,

--- a/frontend/app/controllers/User.scala
+++ b/frontend/app/controllers/User.scala
@@ -49,19 +49,21 @@ trait User extends Controller {
       cardDetails <- futureCardDetails
       subscriptionStatus <- request.touchpointBackend.subscriptionService.getSubscriptionStatus(request.member)
       subscriptionDetails <- request.touchpointBackend.subscriptionService.getSubscriptionDetails(subscriptionStatus.current)
-    } yield Json.obj(
-      "optIn" -> !subscriptionStatus.cancelled,
-      "subscription" -> (cardDetails ++ Json.obj(
-        "start" -> subscriptionDetails.effectiveStartDate,
-        "end" -> endDate(subscriptionDetails),
-        "cancelledAt" -> subscriptionStatus.future.isDefined,
-        "plan" -> Json.obj(
-          "name" -> subscriptionDetails.planName,
-          "amount" -> subscriptionDetails.planAmount * 100,
-          "interval" -> (if (subscriptionDetails.annual) "year" else "month")
-        ))
+      membershipSummary <- request.touchpointBackend.subscriptionService.getMembershipSubscriptionSummary(request.member)
+    } yield
+      Json.obj(
+        "optIn" -> !subscriptionStatus.cancelled,
+        "subscription" -> (cardDetails ++ Json.obj(
+          "start" -> membershipSummary.startDate,
+          "end" -> membershipSummary.nextPaymentDate,
+          "cancelledAt" -> subscriptionStatus.future.isDefined,
+          "plan" -> Json.obj(
+            "name" -> subscriptionDetails.planName,
+            "amount" -> subscriptionDetails.planAmount * 100,
+            "interval" -> (if (membershipSummary.annual) "year" else "month")
+          ))
+          )
       )
-    )
 
     futurePaymentDetails.map { paymentDetails => Ok(basicDetails(request.member) ++ paymentDetails) }
   }

--- a/frontend/app/controllers/User.scala
+++ b/frontend/app/controllers/User.scala
@@ -56,7 +56,7 @@ trait User extends Controller {
         "subscription" -> (cardDetails ++ Json.obj(
           "start" -> membershipSummary.startDate,
           "end" -> endDate(subscriptionDetails),
-          "nextPaymentPrice" -> membershipSummary.nextPaymentPrice,
+          "nextPaymentPrice" -> membershipSummary.nextPaymentPrice * 100,
           "nextPaymentDate" -> membershipSummary.nextPaymentDate,
           "renewalDate" -> membershipSummary.renewalDate,
           "cancelledAt" -> subscriptionStatus.future.isDefined,

--- a/frontend/app/services/SubscriptionService.scala
+++ b/frontend/app/services/SubscriptionService.scala
@@ -173,7 +173,6 @@ class SubscriptionService(val tierPlanRateIds: Map[ProductRatePlan, String], val
         result <- zuora.request(SubscriptionDetailsViaAmend(latestSubscription.id, latestSubscription.contractAcceptanceDate))
         subscriptionDetails <- subscriptionDetailsF
       } yield {
-        logger.info(s"result from amend query: $result")
         assert(result.invoiceItems.nonEmpty, "Subscription with delayed payment returning zero invoice items in SubscriptionDetailsViaAmend call")
         val firstPreviewInvoice = result.invoiceItems.sortBy(_.serviceStartDate).head
 


### PR DESCRIPTION
This PR is best read with `w=1` parameter.

I've added a call to getMembershipSummary in ZuoraService so that we get the correct value for annual. I've swapped  start date to use membership summary. 

There are now more calls to Zuora which isn't ideal.