### PR TITLE
removing auth for 6 month subscribers

### DIFF
--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -87,7 +87,7 @@ trait Joiner extends Controller with ActivityTracking with LazyLogging {
         case Tier.Friend => Ok(views.html.joiner.form.address(privateFields, marketingChoices, passwordExists))
         case paidTier =>
           val pageInfo = PageInfo.default.copy(stripePublicKey = Some(request.touchpointBackend.stripeService.publicKey))
-          val showSubscriberFields = googleAuthUserOpt(request).isDefined && tier == Tier.Partner
+          val showSubscriberFields = tier == Tier.Partner
           Ok(views.html.joiner.form.payment(paidTier, privateFields, marketingChoices, passwordExists, pageInfo, showSubscriberFields))
       }
 


### PR DESCRIPTION
This removes google auth from the offer for subscribers.
****This should only be released on the 12th May****