### PR TITLE
Use checking card details instead of making payment

### DIFF
--- a/frontend/assets/javascripts/src/modules/form/payment/processing.js
+++ b/frontend/assets/javascripts/src/modules/form/payment/processing.js
@@ -61,7 +61,7 @@ define([
         } else {
             data = serializer(utilsHelper.toArray(form.elem.elements), { 'payment.token': response.id });
 
-            loader.setProcessingMessage('Making payment...');
+            loader.setProcessingMessage('Checking card details...');
 
             ajax({
                 url: form.elem.action,

--- a/frontend/assets/javascripts/src/modules/form/validation/listeners.js
+++ b/frontend/assets/javascripts/src/modules/form/validation/listeners.js
@@ -28,7 +28,6 @@ define([
      */
     var addSubmitListener = function () {
         bean.on(SUBMIT_ELEM, 'click', function (e) {
-            var processingMessage = 'Processing...';
             e.preventDefault();
 
             form.elems.map(function (elem) {
@@ -36,12 +35,8 @@ define([
             });
 
             if (!form.errs.length) {
-                if (form.hasPayment) {
-                    processingMessage.replace('...', ' payment...');
-                }
-
                 loader.startLoader();
-                loader.setProcessingMessage(processingMessage);
+                loader.setProcessingMessage('Processing...');
                 loader.disableSubmitButton(true);
 
                 if (form.hasPayment) {


### PR DESCRIPTION
Use **"checking card details"** instead of **"making payment"** for card processing message. Avoids explicit mention of payment which allows us to use the same message for processing subscriber offers (where they are not actually paying yet) but avoids needing to have two separate messages.

![screen shot 2015-05-05 at 17 12 26](https://cloud.githubusercontent.com/assets/123386/7477191/1db2e1fc-f34a-11e4-9589-922f57e9a0d3.png)


// @mattandrews 