### PR TITLE
Make Offers & Competitions Public

### DIFF
--- a/frontend/app/controllers/OffersAndCompetitions.scala
+++ b/frontend/app/controllers/OffersAndCompetitions.scala
@@ -6,11 +6,6 @@ import services.GuardianContentService
 
 trait OffersAndCompetitions extends Controller {
   def list = CachedAction { implicit request =>
-    /**
-     * Only show items that:
-     * - Don't have the membershipAccess field set
-     * - Have an available image
-     */
     val results = GuardianContentService.offersAndCompetitionsContent.map(ContentItemOffer)
       .filter { item =>
         item.content.fields.map(_("membershipAccess")).isEmpty

--- a/frontend/app/controllers/OffersAndCompetitions.scala
+++ b/frontend/app/controllers/OffersAndCompetitions.scala
@@ -4,11 +4,17 @@ import model.ContentItemOffer
 import play.api.mvc.Controller
 import services.GuardianContentService
 
-
 trait OffersAndCompetitions extends Controller {
-  // TODO move this to CachedAction once this work is ready to go into the wild
-  def list = GoogleAuthenticatedStaffAction { implicit request =>
+  def list = CachedAction { implicit request =>
+    /**
+     * Only show items that:
+     * - Don't have the membershipAccess field set
+     * - Have an available image
+     */
     val results = GuardianContentService.offersAndCompetitionsContent.map(ContentItemOffer)
+      .filter { item =>
+        item.content.fields.map(_("membershipAccess")).isEmpty
+      }.filter(_.imgOpt.nonEmpty)
     Ok(views.html.offer.offersandcomps(results, "Sorry, no matching items were found."))
   }
 }

--- a/frontend/app/model/Nav.scala
+++ b/frontend/app/model/Nav.scala
@@ -22,6 +22,7 @@ object Nav {
   val navigation = List(
     NavItem("events", "/events", "Events"),
     NavItem("masterclasses", "/masterclasses", "Masterclasses"),
+    NavItem("offers", "/offers-competitions", "Offers"),
     NavItem("about", "/about", "About membership"),
     NavItem("partrons", "/patrons", "Patrons"),
     NavItem("pricing", "/join", "Pricing"),

--- a/frontend/app/model/RichContent.scala
+++ b/frontend/app/model/RichContent.scala
@@ -10,6 +10,12 @@ case class ContentItem(content: Content) extends RichContent(content)
 
 case class ContentItemOffer(content: Content) extends RichContent(content) {
   val tagTitleOpt = content.tags.map { tag =>
+    /**
+     * Only show tag title if in membership-offers or membership-competitions
+     * 
+     * Remove "Membership" prefix from membership-offers and membership-competitions tag title,
+     * leaving just Offers or Competitions. Membership prefix is redundant here.
+     */
     tag.id.toLowerCase match {
       case "membership/membership-offers" | "membership/membership-competitions" => Some(tag.webTitle.replace("Membership ", ""))
       case _ => None

--- a/frontend/app/model/RichContent.scala
+++ b/frontend/app/model/RichContent.scala
@@ -9,10 +9,10 @@ abstract class RichContent(content: Content) {
 case class ContentItem(content: Content) extends RichContent(content)
 
 case class ContentItemOffer(content: Content) extends RichContent(content) {
-  val tagTitleOpt = content.tags.find { tag =>
+  val tagTitleOpt = content.tags.map { tag =>
     tag.id.toLowerCase match {
-      case "membership/membership-offers" | "membership/membership-competitions" => true
-      case _ => false
+      case "membership/membership-offers" | "membership/membership-competitions" => Some(tag.webTitle.replace("Membership ", ""))
+      case _ => None
     }
   }
 }

--- a/frontend/app/views/offer/offersandcomps.scala.html
+++ b/frontend/app/views/offer/offersandcomps.scala.html
@@ -32,8 +32,8 @@
                                     <h4 class="article-front__title">
                                         <span class="link-outbound">
                                         @fragments.inlineIcon("outbound-link", Seq("icon-inline--brand-dark"))
-                                            @for(tagTitle <- memberContent.tagTitleOpt) {
-                                                <span class="link-outbound__highlight">@tagTitle.webTitle</span>
+                                            @for(tagTitle <- memberContent.tagTitleOpt.headOption) {
+                                                <span class="link-outbound__highlight">@tagTitle</span>
                                                 <span class="link-outbound__separator"> / </span>
                                             }
                                             <span>@memberContent.content.webTitle</span>


### PR DESCRIPTION
In order of importance, from least to most important:

- Remove "Membership" prefix from tag name, only show Offer or Competition
- Filter out any content items which have `membershipAccess` field set, or have no image
- Adds Offers to the main navigation
- **Make offers & competitions page public**

![screen shot 2015-05-07 at 11 06 59](https://cloud.githubusercontent.com/assets/123386/7513092/5dc6d4d2-f4a9-11e4-9728-869214ba171b.png)

@mattandrews 
