### PR TITLE
Offers & Competitions refinements

### DIFF
--- a/frontend/app/controllers/OffersAndCompetitions.scala
+++ b/frontend/app/controllers/OffersAndCompetitions.scala
@@ -1,8 +1,8 @@
 package controllers
 
-import model.ContentItemOffer
 import play.api.mvc.Controller
 import services.GuardianContentService
+import model.ContentItemOffer
 
 trait OffersAndCompetitions extends Controller {
   def list = CachedAction { implicit request =>
@@ -10,7 +10,7 @@ trait OffersAndCompetitions extends Controller {
       .filter { item =>
         item.content.fields.map(_("membershipAccess")).isEmpty
       }.filter(_.imgOpt.nonEmpty)
-    Ok(views.html.offer.offersandcomps(results, "Sorry, no matching items were found."))
+    Ok(views.html.offer.offersandcomps(results))
   }
 }
 

--- a/frontend/app/model/PageInfo.scala
+++ b/frontend/app/model/PageInfo.scala
@@ -9,7 +9,8 @@ case class PageInfo(
   description: Option[String],
   image: Option[String] = Some(PageInfo.defaultImage),
   schemaOpt: Option[EventSchema] = None,
-  stripePublicKey: Option[String] = None
+  stripePublicKey: Option[String] = None,
+  customSignInUrl: Option[String] = None
 )
 
 object PageInfo {
@@ -17,8 +18,8 @@ object PageInfo {
 
   // url has the domain prepended in templates
   val default = PageInfo(
-    CopyConfig.copyTitleDefault,
-    "/",
-    Some(CopyConfig.copyDescriptionDefault)
+    title=CopyConfig.copyTitleDefault,
+    url="/",
+    description=Some(CopyConfig.copyDescriptionDefault)
   )
 }

--- a/frontend/app/views/fragments/header.scala.html
+++ b/frontend/app/views/fragments/header.scala.html
@@ -9,7 +9,12 @@
             <div class="header__primary">
                 <ul class="nav nav-control u-cf" role="menubar">
                     <li class="nav-control__item">
-                        <a href="@Config.idWebAppSigninUrl("")" role="menuitem" class="control no-underline js-identity-menu-cta" title="Your account" id="qa-identity-control">
+                        <a href="@pageInfo.customSignInUrl.getOrElse(Config.idWebAppSigninUrl(""))"
+                           class="control no-underline js-identity-menu-toggle@if(pageInfo.customSignInUrl.isEmpty){ js-identity-menu-url}"
+                           id="qa-identity-control"
+                           title="Your account"
+                           role="menuitem"
+                        >
                             <span class="control__item">
                                 <span class="control__icon icon-holder icon-holder--large icon-holder--neutral">
                                     @fragments.inlineIcon("user")

--- a/frontend/app/views/joiner/tierChooser.scala.html
+++ b/frontend/app/views/joiner/tierChooser.scala.html
@@ -2,10 +2,17 @@
     pageInfo: model.PageInfo,
     eventOpt: Option[model.RichEvent.RichEvent],
     accessOpt: Option[model.MembershipAccess],
-    returnUrl: String
+    signInUrl: String
 )(implicit token: play.filters.csrf.CSRF.Token)
 
 @import com.gu.membership.salesforce.Tier
+
+@pageHeaderTitle = @{
+    val default = "Choose a membership tier"
+    accessOpt.fold {
+        eventOpt.fold(default)(_.metadata.chooseTier.title)
+    } { access => default }
+}
 
 @sectionTitle = @{
     val defaultTitle = "Choose a membership tier to continue"
@@ -20,12 +27,12 @@
 
     <main role="main" class="page-content l-constrained">
 
-        @fragments.page.pageHeader(eventOpt.fold("Choose a membership tier")(_.metadata.chooseTier.title))
+        @fragments.page.pageHeader(pageHeaderTitle, None)
 
         <section class="page-section page-section--no-padding">
             <div class="page-section__lead-in">
                 @fragments.joiner.joinStepCounter(1, 3)
-                <p class="text-note copy tier-hidden">Already a member? <a href="@returnUrl">Please sign in</a></p>
+                <p class="text-note copy tier-hidden">Already a member? <a href="@signInUrl">Please sign in</a></p>
             </div>
             <div class="page-section__content">
                 <h2 class="h-section h-section--lead">
@@ -54,7 +61,7 @@
                     </ul>
                 }
             </div>
-            @for(event <- eventOpt) {
+            @for(event <- eventOpt if accessOpt.isEmpty) {
                 <div class="page-section__supplementary">
                     <div class="aside aside--section">
                         <h4 class="aside__intro">You're buying tickets for:</h4>

--- a/frontend/app/views/offer/offersandcomps.scala.html
+++ b/frontend/app/views/offer/offersandcomps.scala.html
@@ -1,4 +1,4 @@
-@(membersOnlyContent: Seq[model.ContentItemOffer], noResultText: String)
+@(membersOnlyContent: Seq[model.ContentItemOffer])
 
 @main("Offers & Competitions") {
     <main role="main" class="l-constrained">
@@ -11,7 +11,7 @@
             </div>
             <div class="listing__content">
             @if(membersOnlyContent.isEmpty) {
-                <div class="listing__empty">@noResultText</div>
+                <div class="listing__empty">Sorry, no matching items were found.</div>
             } else {
                 <ul class="grid grid--bordered grid--3up">
                 @for(memberContent <- membersOnlyContent) {

--- a/frontend/assets/javascripts/src/modules/identityPopup.js
+++ b/frontend/assets/javascripts/src/modules/identityPopup.js
@@ -11,7 +11,8 @@ define([
 
     var IS_HIDDEN = 'is-hidden';
     var IS_ACTIVE = 'is-active';
-    var IDENTITY_MENU_CTA_ELEM = document.querySelector('.js-identity-menu-cta');
+    var IDENTITY_MENU_CTA_ELEM = document.querySelector('.js-identity-menu-toggle');
+    var IDENTITY_MENU_CTA_URL = document.querySelector('.js-identity-menu-url');
     var IDENTITY_MENU_ELEM = document.querySelector('.js-identity-menu');
     var HTML_ELEM = document.documentElement;
 
@@ -53,9 +54,11 @@ define([
         var windowLocation = window.location;
         var currentUrl = windowLocation.pathname + windowLocation.search;
 
-        IDENTITY_MENU_CTA_ELEM.setAttribute('href',
-            populateReturnUrl(IDENTITY_MENU_CTA_ELEM.getAttribute('href'), currentUrl)
-        );
+        if(IDENTITY_MENU_CTA_URL) {
+            IDENTITY_MENU_CTA_URL.setAttribute('href',
+                populateReturnUrl(IDENTITY_MENU_CTA_ELEM.getAttribute('href'), currentUrl)
+            );
+        }
     }
 
     function populateReturnUrl(href, currentUrl) {

--- a/frontend/assets/javascripts/src/modules/identityPopupDetails.js
+++ b/frontend/assets/javascripts/src/modules/identityPopupDetails.js
@@ -9,7 +9,7 @@ define(['src/utils/user'], function (userUtil) {
 
     var IS_HIDDEN = 'is-hidden';
     var SIGNED_IN_TEXT = 'You are signed in as';
-    var MENU_CTA_TEXT_ELEM = document.querySelector('.js-identity-menu-cta-text');
+    var MENU_TEXT_ELEM = document.querySelector('.js-identity-menu-text');
     var MENU_EDIT_PROFILE_ELEM = document.querySelector('.js-identity-menu-edit-profile');
     var MENU_COMMENT_ACTIVITY_ELEM = document.querySelector('.js-identity-menu-comment-activity');
     var HEADER_JOIN_US_CTA_ELEM = document.querySelector('.js-header-join-us-cta');
@@ -32,8 +32,10 @@ define(['src/utils/user'], function (userUtil) {
     }
 
     function hideIdentityCtaText() {
-        MENU_CTA_TEXT_ELEM.textContent = SIGNED_IN_TEXT;
-        MENU_CTA_TEXT_ELEM.classList.add('u-h');
+        if(MENU_TEXT_ELEM) {
+            MENU_TEXT_ELEM.textContent = SIGNED_IN_TEXT;
+            MENU_TEXT_ELEM.classList.add('u-h');
+        }
     }
 
     function updateEditProfileLink() {


### PR DESCRIPTION
Fixes a couple of UX issues with offers & competitions flow:

**1. Allow customSignInUrl to override default Sign In returnUrl**

This allows users to click on the main Sign In link when being redirected from .com and be returned to the original article (currently they get dumped back on the current page). e.g., `https://profile.theguardian.com/signin?returnUrl=http://www.theguardian.com/membership/2015/may/06/win-a-luxurious-cream-blanket-made-from-100-cashmere-mop-2&skipConfirmation=true`

---

**2. Don't show event when on choose tier page with `?membershipAccess query string present`**

This prevents users being shown a 50/50 content/event  page if they've been via an event page before.

**Before**:

![screen shot 2015-05-07 at 15 18 43](https://cloud.githubusercontent.com/assets/123386/7518362/554c4980-f4d2-11e4-9a54-b2728cedea06.png)

**After**:

![screen shot 2015-05-07 at 15 18 52](https://cloud.githubusercontent.com/assets/123386/7518365/5acbeb68-f4d2-11e4-9210-63ea19210fa2.png)

// @mattandrews @davidmcdowell 
