### PR TITLE
Add config switch for optimizely

### DIFF
--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -81,6 +81,8 @@ object Config {
   val googleAdwordsJoinerConversionLabel =
     Tier.allPublic.map { tier => tier -> config.getString(s"google.adwords.joiner.conversion.${tier.slug}") }.toMap
 
+  val optimizelyEnabled = config.getBoolean("optimizely.enabled")
+
   val corsAllowOrigin = Set(
     // identity
     "https://profile.thegulocal.com",
@@ -105,6 +107,7 @@ object Config {
   val roundedDiscountPercentage: Int = math.round((1-discountMultiplier.toFloat)*100)
 
   val stage = config.getString("stage")
+  val stageProd: Boolean = stage == "PROD"
 
   val GuardianGoogleAppsDomain = "guardian.co.uk"
 

--- a/frontend/app/views/main.scala.html
+++ b/frontend/app/views/main.scala.html
@@ -76,8 +76,8 @@
         <meta name="msapplication-TileColor" content="#214583">
         <meta name="msapplication-TileImage" content="@Asset.at("images/favicons/windows_tile_144_b.png")">
 
-        @if(Config.stage == "PROD") {
-            <script src="//cdn.optimizely.com/js/2012460034.js" async defer></script>
+        @if(Config.optimizelyEnabled && Config.stageProd) {
+            <script src="https://cdn.optimizely.com/js/2012460034.js" async defer></script>
         }
     </head>
     <body id="top">

--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -85,6 +85,8 @@ snowplow.url=""
 activity.tracking.bcrypt.salt=""
 activity.tracking.bcrypt.pepper=""
 
+optimizely.enabled=false
+
 cas.url=""
 
 #### Play Configuration


### PR DESCRIPTION
As we've not being running optimizely tests for some time and we're unlikely to run any more in the near future it seems a waste to load it all the time.

This puts optimizely behind a config switch which is defaulted to `false`. Need to confirm with @JuliaBellis but it seems sensible to do this for now.

@mattandrews 