### PR TITLE
Remove unneeded schema

### DIFF
--- a/frontend/app/views/embeds/eventCard.scala.html
+++ b/frontend/app/views/embeds/eventCard.scala.html
@@ -10,7 +10,7 @@
         @Html(embedCss)
     </style>
 }
-<figure class="membership-event" itemscope itemtype="http://schema.org/Event">
+<figure class="membership-event">
     <a href="@cardUrl" class="membership-event__link">
         <div class="membership-event__header">
             <div class="membership-event__icon">
@@ -24,14 +24,14 @@
         </div>
         @for(img <- event.imgOpt) {
             <div class="membership-event__media">
-                <img src="@img.smallestImage" alt="@img.altText" itemprop="image">
+                <img src="@img.smallestImage" alt="@img.altText">
             </div>
         }
         <div class="membership-event__body">
-            <h3 class="membership-event__title" itemprop="name">@event.name.text</h3>
+            <h3 class="membership-event__title">@event.name.text</h3>
             <div class="membership-event__meta">
                 <div class="membership-event__date">
-                    <time itemprop="startDate" datetime="@event.start">@prettyShortDateWithTimeAndDayName(event.start)</time>
+                    <time datetime="@event.start">@prettyShortDateWithTimeAndDayName(event.start)</time>
                 </div>
                 @if(event.venue.venueWithCity.nonEmpty) {
                     <div class="membership-event__location">@event.venue.venueWithCity</div>
@@ -45,7 +45,7 @@
         </div>
     </a>
     <div class="membership-event__action">
-        <a href="@cardUrl" class="membership-event__button" itemprop="url">
+        <a href="@cardUrl" class="membership-event__button">
             Book Now
             @for(icon <- Asset.inlineSvg("arrow-right")) {
                 @icon

--- a/frontend/app/views/fragments/content/articleSnapshot.scala.html
+++ b/frontend/app/views/fragments/content/articleSnapshot.scala.html
@@ -1,15 +1,13 @@
 @(item: model.ContentItem)
 
-<a class="article-snapshot no-underline" itemscope itemtype="http://schema.org/Article" href="@item.content.webUrl">
+<a class="article-snapshot no-underline" href="@item.content.webUrl">
     @for(img <- item.imgOpt) {
         <div class="article-snapshot__media">
-            <img src="@img.defaultImage" srcset="@img.srcset" sizes="25vw" alt="@img.altText" class="responsive-img" itemprop="image" />
+            <img src="@img.defaultImage" srcset="@img.srcset" sizes="25vw" alt="@img.altText" class="responsive-img"/>
         </div>
     }
     <div class="article-snapshot__content">
-        <h2 class="article-snapshot__title no-underline--override">
-            <span itemprop="name">@item.content.webTitle</span>
-        </h2>
+        <h2 class="article-snapshot__title no-underline--override">@item.content.webTitle</h2>
         @for(fields <- item.content.fields) {
             <p class="article-snapshot__trail hidden-mobile">@Html(fields("trailText"))</p>
         }

--- a/frontend/app/views/fragments/event/item.scala.html
+++ b/frontend/app/views/fragments/event/item.scala.html
@@ -2,8 +2,7 @@
 
 @import views.support.Dates._
 
-<a href="@routes.Event.details(event.slug)" class="event-item@if(event.isBookable){ qa-available-event-item}" itemscope itemtype="http://schema.org/Event">
-    <meta itemprop="url" content="@event.memUrl">
+<a href="@routes.Event.details(event.slug)" class="event-item@if(event.isBookable){ qa-available-event-item}">
     @for(img <- event.imgOpt) {
         <div class="event-item__media">
             @fragments.event.image(img, sizes=Some("(min-width: 739px) 33.3vw, (min-width: 479px) 50vw, 100vw"))
@@ -12,8 +11,8 @@
     <div class="event-item__content">
         <div class="event-item__meta">
             @fragments.event.itemMetaTitle(event)
-            <div class="event-item__time" itemprop="startDate" content="@event.start">@event.start.pretty</div>
-            <div class="event-item__location" itemprop="location" itemscope itemtype="http://schema.org/Place">
+            <time="event-item__time" datetime="@event.start">@event.start.pretty</time>
+            <div class="event-item__location">
                 @fragments.event.addressSummary(event)
             </div>
             <div class="event-item__footer">

--- a/frontend/app/views/fragments/event/itemHero.scala.html
+++ b/frontend/app/views/fragments/event/itemHero.scala.html
@@ -2,17 +2,16 @@
 
 @import views.support.Dates._
 
-<a href="@routes.Event.details(event.slug)" class="event-item event-item--hero@if(event.isBookable){ qa-available-event-item}" itemscope itemtype="http://schema.org/Event">
-    <meta itemprop="url" content="@event.memUrl">
+<a href="@routes.Event.details(event.slug)" class="event-item event-item--hero@if(event.isBookable){ qa-available-event-item}">
     <div class="event-item__content">
         <div class="event-item__meta">
             @fragments.event.itemMetaTitle(event)
-            <div class="event-item__time" itemprop="startDate" content="@event.start">@event.start.pretty</div>
-            <div class="event-item__location" itemprop="location" itemscope itemtype="http://schema.org/Place">
+            <time class="event-item__time" datetime="@event.start">@event.start.pretty</time>
+            <div class="event-item__location">
                 @fragments.event.addressSummary(event)
             </div>
             @for(desc <- event.description) {
-                <div class="event-item__description" itemprop="description">
+                <div class="event-item__description">
                     @desc.blurb
                 </div>
             }

--- a/frontend/app/views/fragments/event/itemMetaTitle.scala.html
+++ b/frontend/app/views/fragments/event/itemMetaTitle.scala.html
@@ -4,5 +4,5 @@
     @if(event.isSoldOut){
         <span class="event-status event-status--sold-out" data-filter-key="status">Sold out</span>
     }
-    <span itemprop="name" data-filter-key="title" class="qa-event-item-title">@event.name.text</span>
+    <span data-filter-key="title" class="qa-event-item-title">@event.name.text</span>
 </h4>

--- a/frontend/app/views/fragments/event/itemMinimal.scala.html
+++ b/frontend/app/views/fragments/event/itemMinimal.scala.html
@@ -2,8 +2,7 @@
 
 @sizesVal = @{ if(isCard) "10vw" else "(min-width: 739px) 25vw, (min-width: 479px) 50vw, 100vw"  }
 
-<a href="@routes.Event.details(event.slug)" class="event-item @if(isCard){ event-item--card} else { event-item--minimal}" itemscope itemtype="http://schema.org/Event">
-    <meta itemprop="url" content="@event.memUrl">
+<a href="@routes.Event.details(event.slug)" class="event-item @if(isCard){ event-item--card} else { event-item--minimal}">
     @for(img <- event.imgOpt) {
         <div class="event-item__media">
             @fragments.event.image(img, sizes=Some(sizesVal))

--- a/frontend/app/views/fragments/event/itemSnapshot.scala.html
+++ b/frontend/app/views/fragments/event/itemSnapshot.scala.html
@@ -1,6 +1,6 @@
 @(event: model.RichEvent.RichEvent, isStacked: Boolean = false)
 
-<div class="event-snapshot@if(isStacked){ event-snapshot--stack}" itemscope itemtype="http://schema.org/Event">
+<div class="event-snapshot@if(isStacked){ event-snapshot--stack}">
     @for(img <- event.imgOpt) {
         <div class="event-snapshot__media">
             @fragments.event.image(img)
@@ -11,7 +11,7 @@
             @if(event.isSoldOut){
                 <span class="event-status event-status--sold-out">Sold out</span>
             }
-            <span itemprop="name">@event.name.text</span>
+            @event.name.text
         </h2>
         <div class="stats-listing">
             @fragments.event.stats(event)

--- a/frontend/app/views/fragments/event/ticketSales.scala.html
+++ b/frontend/app/views/fragments/event/ticketSales.scala.html
@@ -33,8 +33,6 @@
     >
         @for(tier <- Seq(Tier.Patron, Tier.Partner, Tier.Friend)) {
             <li class="ticket-sales__item" itemscope itemtype="http://schema.org/Offer">
-                <meta itemprop="eligibleCustomerType" content="@tier">
-                <meta itemprop="availabilityEnds" content="@ticketing.salesDates.datesByTier(tier)">
                 <span class="ticket-sales__item__label">@(tier + "s")</span>
                 <span class="ticket-sales__item__date">
                     @ticketDateForTier(tier, ticketing.salesDates.datesByTier(tier), ticketing.salesDates.needToDistinguishTimes)

--- a/frontend/app/views/fragments/header.scala.html
+++ b/frontend/app/views/fragments/header.scala.html
@@ -76,10 +76,10 @@
             </div>
 
             @* Branding *@
-            <div class="header__logo" itemscope itemtype="http://schema.org/Organization">
-                <a href="/" itemprop="url" class="header__logo__link" id="qa-header-logo">
-                    <span class="u-h" itemprop="name">@Config.siteTitle</span>
-                    <img src="@Asset.at("images/logos/membership-logo.svg")" alt="@Config.siteTitle" class="header__logo__image hidden-mobile" itemprop="logo">
+            <div class="header__logo">
+                <a href="/" class="header__logo__link" id="qa-header-logo">
+                    <span class="u-h">@Config.siteTitle</span>
+                    <img src="@Asset.at("images/logos/membership-logo.svg")" alt="@Config.siteTitle" class="header__logo__image hidden-mobile">
                     <img src="@Asset.at("images/logos/membership-logo-small.svg")" alt="@Config.siteTitle" class="header__logo__image mobile-only">
                 </a>
             </div>


### PR DESCRIPTION
Removes some unneeded schema:

- Remove `organization` schema from header as we already have it in a `json-ld` block
- Remove schema markup from event listings as it's only really meant for full event details, and results in a [boat load of schema validation errors](https://developers.google.com/structured-data/testing-tool?url=https%253A%252F%252Fmembership.theguardian.com%252Fevents) at the moment anyway.

There's now no `itemscope` / `itemprop` declarations in the markup. Everything we need is handled by `JSON-LD`.