### PR TITLE
Update eventbrite service to take new expand parameter

### DIFF
--- a/frontend/app/model/Eventbrite.scala
+++ b/frontend/app/model/Eventbrite.scala
@@ -237,7 +237,6 @@ object Eventbrite {
     val slug = slugify(name.text) + "-" + id
 
     lazy val memUrl = Config.membershipUrl + controllers.routes.Event.details(slug)
-
   }
 
   object EBEvent {
@@ -247,6 +246,16 @@ object Eventbrite {
       "csm",
       "tpg",
       "5x15"
+    )
+
+    val expansions = Seq(
+      "category",
+      "subcategory",
+      "format",
+      "venue",
+      "ticket_classes",
+      "logo",
+      "organizer"
     )
 
     def slugToId(slug: String): Option[String] = "-?(\\d+)$".r.findFirstMatchIn(slug).map(_.group(1))
@@ -265,6 +274,10 @@ object Eventbrite {
   case class EBOrder(id: String, first_name: String, email: String, costs: EBCosts, attendees: Seq[EBAttendee]) extends EBObject {
     val ticketCount = attendees.length
     val totalCost = costs.gross.value / 100f
+  }
+
+  object EBOrder {
+    val expansions = Seq("attendees")
   }
 
   case class EBCosts(gross: EBCost) extends EBObject


### PR DESCRIPTION
Update Eventbrite service to take new `expand` parameter. Calls which require new `expand` parameter:

- `users/me/owned_events` for event listings
- `events/$id` used only for querying preview events
- `orders/$id` to expand attendees for a list.

Endpoints can be previewed with new defaults by passing `?expand=none`.

@mattandrews 