### PR TITLE
Minor schema fixes

### DIFF
--- a/frontend/app/model/Schema.scala
+++ b/frontend/app/model/Schema.scala
@@ -22,6 +22,7 @@ case class OfferSchema(
   url: String,
   category: String,
   price: String,
+  priceCurrency: String,
   availability: Option[String],
   `@type`: String = "Offer"
 )
@@ -49,10 +50,9 @@ object EventSchema {
     }
   }
 
-  // TODO: Generate all offers, not just primary
   private def offerOpt(event: RichEvent): Option[OfferSchema] = {
-    event.generalReleasePrice.map { price =>
-      OfferSchema(event.memUrl, "primary", price, event.statusSchema)
+    event.generalReleaseTicket.map { ticket =>
+      OfferSchema(event.memUrl, "primary", ticket.priceValue, ticket.currencyCode, event.statusSchema)
     }
   }
 

--- a/frontend/app/views/fragments/event/ticketSales.scala.html
+++ b/frontend/app/views/fragments/event/ticketSales.scala.html
@@ -32,7 +32,7 @@
         @if(ticketing.salesDates.anyoneCanBuyTicket) { data-toggle-hidden}
     >
         @for(tier <- Seq(Tier.Patron, Tier.Partner, Tier.Friend)) {
-            <li class="ticket-sales__item" itemscope itemtype="http://schema.org/Offer">
+            <li class="ticket-sales__item">
                 <span class="ticket-sales__item__label">@(tier + "s")</span>
                 <span class="ticket-sales__item__date">
                     @ticketDateForTier(tier, ticketing.salesDates.datesByTier(tier), ticketing.salesDates.needToDistinguishTimes)


### PR DESCRIPTION
Couple of minor schema fixes off the back of https://github.com/guardian/membership-frontend/pull/524

- Remove one remaining `itemprop` in markup
- Split currency from price value for schema

Schema should be:
``` json
"price": "20",
"priceCurrency": "GBP"
```
was:
``` json
"price": "£20"
```

// @mattandrews 