### PR TITLE
[Do not merge] Initial pass at pulling grid url form DynamoDB

### DIFF
--- a/frontend/app/admin/AdminForms.scala
+++ b/frontend/app/admin/AdminForms.scala
@@ -1,0 +1,20 @@
+package admin
+
+import play.api.data.Forms._
+import play.api.data.Form
+
+object AdminForms {
+
+  case class EditForm(
+    ticketingProvider: String,
+    gridUrl: Option[String]
+  )
+
+  val editForm: Form[EditForm] = Form(
+    mapping(
+      "ticketingProvider" -> nonEmptyText,
+      "gridUrl" -> optional(text)
+    )(EditForm.apply)(EditForm.unapply)
+  )
+
+}

--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -67,6 +67,8 @@ object Config {
   def eventbriteWaitlistUrl(event: EBEvent): String =
     eventbriteWaitlistUrl ? ("eid" -> event.id) & ("tid" -> 0)
 
+  val eventMetadataEnabled = config.getBoolean("eventMetadata.enabled")
+
   val eventOrderingJsonUrl = config.getString("event.ordering.json")
 
   val facebookAppId = config.getString("facebook.app.id")

--- a/frontend/app/model/EventMetadata.scala
+++ b/frontend/app/model/EventMetadata.scala
@@ -1,0 +1,28 @@
+package model
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue
+import play.api.libs.json.Json
+import utils.awswrappers.dynamodb._
+
+case class EventMetadata(
+  id: String,
+  eventId: String,
+  gridUrl: Option[String]
+)
+
+object EventMetadata {
+
+  implicit val jsonWrites = Json.writes[EventMetadata]
+
+  def fromAttributeValueMap(xs: Map[String, AttributeValue]) = {
+    for {
+      id <- xs.getString("id")
+      eventId <- xs.getString("event_id")
+      externallyTicketed <- xs.get("externally_ticketed")
+    } yield EventMetadata(
+      id,
+      eventId,
+      xs.getString("grid_url")
+    )
+  }
+}

--- a/frontend/app/model/EventMetadata.scala
+++ b/frontend/app/model/EventMetadata.scala
@@ -5,8 +5,8 @@ import play.api.libs.json.Json
 import utils.awswrappers.dynamodb._
 
 case class EventMetadata(
-  id: String,
-  eventId: String,
+  ticketingProvider: String,
+  ticketingProviderId: String,
   gridUrl: Option[String]
 )
 
@@ -16,13 +16,12 @@ object EventMetadata {
 
   def fromAttributeValueMap(xs: Map[String, AttributeValue]) = {
     for {
-      id <- xs.getString("id")
-      eventId <- xs.getString("event_id")
-      externallyTicketed <- xs.get("externally_ticketed")
+      ticketingProvider <- xs.getString("ticketingProvider")
+      ticketingProviderId <- xs.getString("ticketingProviderId")
     } yield EventMetadata(
-      id,
-      eventId,
-      xs.getString("grid_url")
+      ticketingProvider,
+      ticketingProviderId,
+      xs.getString("gridUrl")
     )
   }
 }

--- a/frontend/app/services/EventMetadataService.scala
+++ b/frontend/app/services/EventMetadataService.scala
@@ -13,7 +13,7 @@ import scala.concurrent.Future
 object EventMetadataService {
 
   // TODO: Environment specific
-  val tableName = "metadata_TEST"
+  val tableName = "DEV_metadata"
 
   val dynamoDbClient: AmazonDynamoDBAsyncClient = {
     new AmazonDynamoDBAsyncClient(Config.awsCredentialsProvider)
@@ -34,7 +34,8 @@ object EventMetadataService {
     dynamoDbClient.getItemFuture(new GetItemRequest()
       .withTableName(tableName)
       .withKey(Map(
-        "event_id" -> new AttributeValue().withS(id)
+        "ticketingProviderId" -> new AttributeValue().withS(id),
+        "ticketingProvider" -> new AttributeValue().withS("eventbrite")
       ).asJava)
     ) map { result =>
       for {
@@ -49,10 +50,10 @@ object EventMetadataService {
     dynamoDbClient.putItemFuture(new PutItemRequest()
       .withTableName(tableName)
       .withItem(Map(
-        "id" -> new AttributeValue().withS(entry.id),
-        "event_id" -> new AttributeValue().withS(entry.eventId),
-        "grid_url" -> new AttributeValue().withS(entry.gridUrl.getOrElse("")
-      )).asJava)
+        "ticketingProvider" -> new AttributeValue().withS(entry.ticketingProvider),
+        "ticketingProviderId" -> new AttributeValue().withS(entry.ticketingProviderId),
+        "gridUrl" -> new AttributeValue().withS(entry.gridUrl.getOrElse(""))
+      ).asJava)
     )
   }
 

--- a/frontend/app/services/EventMetadataService.scala
+++ b/frontend/app/services/EventMetadataService.scala
@@ -1,0 +1,59 @@
+package services
+
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient
+import com.amazonaws.services.dynamodbv2.model.{AttributeValue, _}
+import model.EventMetadata
+import utils.awswrappers.dynamodb._
+import scala.collection.JavaConverters._
+import scala.concurrent.ExecutionContext.Implicits.global
+import configuration.Config
+import scala.concurrent.Future
+
+object EventMetadataService {
+
+  // TODO: Environment specific
+  val tableName = "metadata_TEST"
+
+  val dynamoDbClient: AmazonDynamoDBAsyncClient = {
+    new AmazonDynamoDBAsyncClient(Config.awsCredentialsProvider)
+      .withRegion(Regions.EU_WEST_1)
+  }
+
+  def list() = {
+    dynamoDbClient.scanFuture(new ScanRequest()
+      .withTableName(tableName)
+    ) map { result =>
+      (result.getItems.asScala.toSeq map { item =>
+        EventMetadata.fromAttributeValueMap(item.asScala.toMap)
+      }).flatten
+    }
+  }
+
+  def get(id: String): Future[Option[EventMetadata]] = {
+    dynamoDbClient.getItemFuture(new GetItemRequest()
+      .withTableName(tableName)
+      .withKey(Map(
+        "event_id" -> new AttributeValue().withS(id)
+      ).asJava)
+    ) map { result =>
+      for {
+        item <- Option(result.getItem)
+        entry <- EventMetadata.fromAttributeValueMap(item.asScala.toMap)
+      } yield entry
+    }
+  }
+
+  def create(entry: EventMetadata) = {
+    // TODO: Handle optional fields
+    dynamoDbClient.putItemFuture(new PutItemRequest()
+      .withTableName(tableName)
+      .withItem(Map(
+        "id" -> new AttributeValue().withS(entry.id),
+        "event_id" -> new AttributeValue().withS(entry.eventId),
+        "grid_url" -> new AttributeValue().withS(entry.gridUrl.getOrElse("")
+      )).asJava)
+    )
+  }
+
+}

--- a/frontend/app/services/EventbriteService.scala
+++ b/frontend/app/services/EventbriteService.scala
@@ -2,7 +2,7 @@ package services
 
 import com.gu.membership.util.WebServiceHelper
 import configuration.Config
-import model.{TicketSaleDates, EventGroup}
+import model.{EventMetadata, TicketSaleDates, EventGroup}
 import model.Eventbrite._
 import model.EventbriteDeserializer._
 import model.RichEvent._
@@ -103,6 +103,10 @@ abstract class LiveService extends EventbriteService {
   val gridService = GridService(Config.gridConfig.url)
   val contentApiService = GuardianContentService
 
+  def extractGridImage(event: EBEvent, metadataOpt: Option[EventMetadata]) = {
+    gridImageFromUri(metadataOpt.flatMap(_.gridUrl).orElse(event.mainImageUrl.map(_.toString)))
+  }
+
   def gridImageFromUri(uri: Option[String]) = {
     uri.fold[Future[Option[GridImage]]](Future.successful(None))(gridService.getRequestedCrop(_))
   }
@@ -123,14 +127,10 @@ object GuardianLiveEventService extends LiveService {
     } yield (ordering.json \ "order").as[Seq[String]]
   }
 
-  def mkRichEvent(event: EBEvent): Future[RichEvent] = {
-      for {
-        metadataOpt <- EventMetadataService.get(event.id)
-        gridImageOpt <- gridImageFromUri(metadataOpt.flatMap(_.gridUrl).orElse(event.mainImageUrl.map(_.toString)))
-      } yield {
-        GuLiveEvent(event, gridImageOpt, contentApiService.content(event.id))
-      }
-  }
+  def mkRichEvent(event: EBEvent): Future[RichEvent] = for {
+    metadataOpt <- EventMetadataService.get(event.id)
+    gridImageOpt <- extractGridImage(event, metadataOpt)
+  } yield GuLiveEvent(event, gridImageOpt, contentApiService.content(event.id))
 
   override def getFeaturedEvents: Seq[RichEvent] = EventbriteServiceHelpers.getFeaturedEvents(eventsOrderingTask.get(), events)
   override def getEvents: Seq[RichEvent] = events.diff(getFeaturedEvents ++ getPartnerEvents.map(_.events).getOrElse(Nil))
@@ -144,11 +144,13 @@ object GuardianLiveEventService extends LiveService {
 
 object LocalEventService extends LiveService {
   val apiToken = Config.eventbriteLocalApiToken
-  val maxDiscountQuantityAvailable = 2 //TODO are these discounts correct for local?
+  val maxDiscountQuantityAvailable = 2
   val wsMetrics = new EventbriteMetrics("Local")
 
-  def mkRichEvent(event: EBEvent): Future[RichEvent] =  for { gridImageOpt <- gridImageFor(event) }
-    yield LocalEvent(event, gridImageOpt, contentApiService.content(event.id))
+  def mkRichEvent(event: EBEvent): Future[RichEvent] = for {
+    metadataOpt <- EventMetadataService.get(event.id)
+    gridImageOpt <- extractGridImage(event, metadataOpt)
+  } yield LocalEvent(event, gridImageOpt, contentApiService.content(event.id))
 
   override def getFeaturedEvents: Seq[RichEvent] = EventbriteServiceHelpers.getFeaturedEvents(Nil, events)
   override def getEvents: Seq[RichEvent] = events

--- a/frontend/app/services/EventbriteService.scala
+++ b/frontend/app/services/EventbriteService.scala
@@ -127,7 +127,9 @@ object GuardianLiveEventService extends LiveService {
       for {
         metadataOpt <- EventMetadataService.get(event.id)
         gridImageOpt <- gridImageFromUri(metadataOpt.flatMap(_.gridUrl).orElse(event.mainImageUrl.map(_.toString)))
-      } yield GuLiveEvent(event, gridImageOpt, contentApiService.content(event.id))
+      } yield {
+        GuLiveEvent(event, gridImageOpt, contentApiService.content(event.id))
+      }
   }
 
   override def getFeaturedEvents: Seq[RichEvent] = EventbriteServiceHelpers.getFeaturedEvents(eventsOrderingTask.get(), events)

--- a/frontend/app/utils/UUID.scala
+++ b/frontend/app/utils/UUID.scala
@@ -1,0 +1,7 @@
+package utils
+
+import java.util.{UUID => JUUID}
+
+object UUID {
+  def next() = JUUID.randomUUID().toString
+}

--- a/frontend/app/utils/awswrappers/DynamoDB.scala
+++ b/frontend/app/utils/awswrappers/DynamoDB.scala
@@ -1,0 +1,53 @@
+package utils.awswrappers
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient
+import com.amazonaws.services.dynamodbv2.model._
+import org.joda.time.DateTime
+import play.api.Logger
+import play.api.libs.json.{Format, Json}
+import scala.util.Try
+
+object dynamodb {
+  implicit class RichDynamoDbClient(dynamoDbClient: AmazonDynamoDBAsyncClient) {
+
+    def updateItemFuture(updateItemRequest: UpdateItemRequest) =
+      asFuture[UpdateItemRequest, UpdateItemResult](dynamoDbClient.updateItemAsync(updateItemRequest, _))
+
+    def getItemFuture(getItemRequest: GetItemRequest) =
+      asFuture[GetItemRequest, GetItemResult](dynamoDbClient.getItemAsync(getItemRequest, _))
+
+    def queryFuture(queryRequest: QueryRequest) =
+      asFuture[QueryRequest, QueryResult](dynamoDbClient.queryAsync(queryRequest, _))
+
+    def scanFuture(scanRequest: ScanRequest) =
+      asFuture[ScanRequest, ScanResult](dynamoDbClient.scanAsync(scanRequest, _))
+
+    def putItemFuture(putItemRequest: PutItemRequest) =
+      asFuture[PutItemRequest, PutItemResult](dynamoDbClient.putItemAsync(putItemRequest, _))
+
+    def deleteItemFuture(deleteItemRequest: DeleteItemRequest) =
+      asFuture[DeleteItemRequest, DeleteItemResult](dynamoDbClient.deleteItemAsync(deleteItemRequest, _))
+  }
+
+  implicit class RichAttributeMap(map: Map[String, AttributeValue]) {
+
+    def getString(k: String): Option[String] =
+      map.get(k).flatMap(v => Option(v.getS))
+
+    def getLong(k: String): Option[Long] = {
+      map.get(k).flatMap({ v =>
+        val x = Try(v.getN.toLong)
+        x.failed foreach { error => Logger.error(s"Error de-serializing $k as Long", error) }
+        x.toOption
+      })
+    }
+
+    def getDateTime(k: String): Option[DateTime] =
+      getLong(k).map(n => new DateTime(n))
+
+    def getJson(k: String) = getString(k).flatMap(s => Try(Json.parse(s)).toOption)
+
+    def getSerializedJson[A](k: String)(implicit formatter: Format[A]) =
+      getJson(k).flatMap(x => formatter.reads(x).asOpt)
+  }
+}

--- a/frontend/app/utils/awswrappers/package.scala
+++ b/frontend/app/utils/awswrappers/package.scala
@@ -1,0 +1,24 @@
+package utils
+
+import com.amazonaws.handlers.AsyncHandler
+
+import scala.concurrent.{Future, Promise}
+import scala.util.{Failure, Success}
+import java.util.concurrent.{Future => JavaFuture}
+
+package object awswrappers {
+  private [awswrappers] def createHandler[A <: com.amazonaws.AmazonWebServiceRequest, B]() = {
+    val promise = Promise[B]()
+    val handler = new AsyncHandler[A, B] {
+      override def onSuccess(request: A, result: B): Unit = promise.complete(Success(result))
+      override def onError(exception: Exception): Unit = promise.complete(Failure(exception))
+    }
+    (promise.future, handler)
+  }
+
+  private [awswrappers] def asFuture[A <: com.amazonaws.AmazonWebServiceRequest, B](block: AsyncHandler[A, B] => JavaFuture[B]): Future[B] = {
+    val (future, handler) = createHandler[A, B]()
+    block(handler)
+    future
+  }
+}

--- a/frontend/app/views/staff/admin/adminTool.scala.html
+++ b/frontend/app/views/staff/admin/adminTool.scala.html
@@ -1,6 +1,8 @@
-@(path: String)
+@(eventOpt: Option[model.RichEvent.RichEvent])(implicit token: play.filters.csrf.CSRF.Token)
+
 @import configuration.Config
 @import views.support.Asset
+@import views.html.helper.CSRF
 
 @staff.admin.template("Event Overview") {
     <div class="container">
@@ -18,15 +20,6 @@
         <div class="pane pane--tools">
 
             <div class="tool-list">
-
-                <div class="tool-list__pane tool-list__pane--menu">
-                    <h2>Quick links</h2>
-                    <ul class="option-list u-list-unstyled">
-                        <li class="option-list__item"><a href="#" class="cta">Create a new event</a></li>
-                        <li class="option-list__item"><a href="#" class="cta">Edit hero events</a></li>
-                        <li class="option-list__item"><a href="#" class="cta">Bulk edit events</a></li>
-                    </ul>
-                </div>
                 <div class="tool-list__pane">
                     <h2>Live events</h2>
                     <ul class="event-list event-list--scroll">
@@ -123,65 +116,21 @@
         </div>
 
         <div class="pane pane--main">
-            <h3>Essentials of pigeon grooming with Will Franklin</h3>
-            <div class="row m-b-l u-margin-bottom">
 
-                <div class="col-md-6">
-                    <h2>Tags</h2>
-                    <ul class="tag-list u-list-unstyled">
-                        <li>Will <span class="tag-list__remove">x</span></li>
-                        <li>Pigeons <span class="tag-list__remove">x</span></li>
-                        <li>Grooming <span class="tag-list__remove">x</span></li>
-                        <li>Self-help <span class="tag-list__remove">x</span></li>
-                        <li>Something else<span class="tag-list__remove">x</span></li>
-                        <li>A tag goes here<span class="tag-list__remove">x</span></li>
-                        <li>This is a long name which will go onto a new line<span class="tag-list__remove">x</span></li>
-                    </ul>
-                    <a href="#" class="cta cta--primary">Add a new tag...</a>
-                </div>
+            @for(event <- eventOpt) {
+                <h3>@event.name.text</h3>
+                <form action="@routes.Staff.adminUpdate(event.id)" method="POST" novalidate>
+                    @CSRF.formField
+                    <input type="hidden" name="ticketingProvider" id="ticketingProvider" value="eventbrite" />
+                    <label for="gridUrl">Grid URL</label>
+                    <input type="text" name="gridUrl" id="gridUrl" />
+                    <input type="submit" value="Save" class="cta" />
+                </form>
+            }
 
-                <div class="col-md-6">
-                    <h2>Event main photo</h2>
-                    <div class="row m-b-l">
-                        <div class="col-md-4">
-                        <img src="@Asset.at("images/admin/pigeon.jpg")" class="photo" />
-                        </div>
-                        <div class="col-md-8">
-                            <label>Caption</label>
-                            <input type="text" />
-                            <label>Photographer</label>
-                            <input type="text" />
-                        </div>
-                    </div>
-                    <div class="row m-b-l">
-                        <div class="col-md-4">
-                            <a href="#" class="cta cta--secondary">Change photo?</a>
-                        </div>
-                        <div class="col-md-8">
-                            <a href="#" class="cta cta--primary">Update caption/photographer</a>
-                        </div>
-                    </div>
-                </div>
-            </div>
 
-            <div class="row m-b-l u-margin-bottom">
-                <div class="col-md-6">
-                    <h2>Partner</h2>
-                    <select>
-                        <option>None</option>
-                        <option>Birkbeck</option>
-                        <option>Central St. Martin's</option>
-                        <option>Idler Academy</option>
-                    </select>
-                    <a href="#" class="cta cta--primary u-margin-right">Save</a>
-                    <a href="#" class="cta cta--secondary">Add a new partner...</a>
-                </div>
-                <div class="col-md-6">
-                    <h2>Custom description</h2>
-                    <textarea rows="10"></textarea>
-                    <a href="#" class="cta cta--primary">Save</a>
-                </div>
-            </div>
+
+
         </div>
 
     </div>

--- a/frontend/app/views/staff/admin/template.scala.html
+++ b/frontend/app/views/staff/admin/template.scala.html
@@ -15,7 +15,7 @@
         <title>@(title + " | " + Config.siteTitle)</title>
 
         <link rel="stylesheet" media="all" href="@Asset.at("stylesheets/admin/admin.css")">
-        <link href='http://fonts.googleapis.com/css?family=Ubuntu:400,300,400italic,500,700,300italic,500italic,700italic' rel='stylesheet' type='text/css'>
+        <link href='https://fonts.googleapis.com/css?family=Ubuntu:400,300,400italic,500,700,300italic,500italic,700italic' rel='stylesheet' type='text/css'>
     </head>
     <body>
         @content

--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -27,6 +27,8 @@ eventbrite.api.refresh-time-priority-events-seconds=29
 eventbrite.waitlist.url="https://www.eventbrite.co.uk/waitlist"
 eventbrite.limitedAvailabilityCutoff=15
 
+eventMetadata.enabled=false
+
 event.ordering.json="http://s3-eu-west-1.amazonaws.com/membership-eb-images/order/order.json"
 
 facebook.app.id=180444840287

--- a/frontend/conf/dev.conf
+++ b/frontend/conf/dev.conf
@@ -32,6 +32,8 @@ aws.secret.key=${?AWS_SECRET_KEY}
 eventbrite.api.refresh-time-seconds=360
 eventbrite.api.refresh-time-priority-events-seconds=300
 
+eventMetadata.enabled=true
+
 facebook.app.id=232588266837342
 
 google.analytics.tracking.id="UA-51507017-4"

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -48,7 +48,8 @@ GET            /staff/local-overview              controllers.Staff.localOvervie
 GET            /staff/masterclass-overview        controllers.Staff.masterclassOverview
 GET            /staff/event-details               controllers.Staff.eventDetails
 GET            /staff/admin                       controllers.Staff.admin
-
+GET            /staff/admin/eventbrite/:id        controllers.Staff.adminEdit(id)
+POST           /staff/admin/eventbrite/:id        controllers.Staff.adminUpdate(id)
 
 # Subscription
 POST           /subscription/update-card          controllers.Subscription.updateCard

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,11 +20,12 @@ object Dependencies {
   val snowPlow = "com.snowplowanalytics" % "snowplow-java-tracker" % "0.5.2-SNAPSHOT"
   val bCrypt = "com.github.t3hnar" %% "scala-bcrypt" % "2.4"
   val s3 =  "com.amazonaws" % "aws-java-sdk-s3" % awsClientVersion
+  val dynamoDb = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val scalaTest =  "org.scalatest" %% "scalatest" % "2.2.4" % "test"
 
   //projects
 
   val frontendDependencies = Seq(identityCookie, playGoogleAuth, identityTestUsers, scalaUri, membershipCommon,
-    contentAPI, playWS, playCache, playFilters,sentryRavenLogback, awsSimpleEmail, snowPlow, bCrypt, s3, scalaTest)
+    contentAPI, playWS, playCache, playFilters,sentryRavenLogback, awsSimpleEmail, snowPlow, bCrypt, s3, dynamoDb, scalaTest)
 
 }


### PR DESCRIPTION
This is an initial pass at using DynamoDB as a datastore for additional metadata. Uses the grid image URL from `dynamodb` if available, otherwise falls back to default behaviour.

Not in a position to be merged but wanted to get some opinions on it as a first pass.

(The pigeon comes from dynamodb)
![screen shot 2015-05-15 at 12 33 48](https://cloud.githubusercontent.com/assets/123386/7652012/f9f9cade-fafe-11e4-8ba5-72b4f4f70598.png)

// @dominickendrick @mattandrews @rtyley 