### PR TITLE
Sanitise whitespace for CAS lookup

### DIFF
--- a/frontend/assets/javascripts/src/modules/form/subscriber.js
+++ b/frontend/assets/javascripts/src/modules/form/subscriber.js
@@ -1,4 +1,10 @@
-define(['bean', 'ajax', 'src/modules/form/validation/display'], function (bean, ajax, display) {
+define([
+    'bean',
+    'ajax',
+    'src/utils/text',
+    'src/modules/form/validation/display'
+], function (bean, ajax, textUtils, display) {
+
     'use strict';
 
     var PAYMENT_OPTIONS_CONTAINER_ELEM = document.querySelector('.js-payment-options-container');
@@ -16,12 +22,11 @@ define(['bean', 'ajax', 'src/modules/form/validation/display'], function (bean, 
 
                 event.preventDefault();
 
-                var subscriberId = SUBSCRIBER_ID_INPUT_ELEM.value,
-                    postcode = POSTCODE_ELEM.value,
+                var subscriberId = textUtils.removeWhitespace(SUBSCRIBER_ID_INPUT_ELEM.value),
+                    postcode = textUtils.trimWhitespace(POSTCODE_ELEM.value),
                     lastName = LAST_NAME_ELEM.value;
 
-
-                if(subscriberId !== '') {
+                if(subscriberId) {
                     ajax({
                         url: '/user/check-subscriber?' + buildQueryString(subscriberId, lastName, postcode)
                     }).then(function (response) {

--- a/frontend/assets/javascripts/src/utils/text.js
+++ b/frontend/assets/javascripts/src/utils/text.js
@@ -1,0 +1,10 @@
+define(function() {
+    return {
+        trimWhitespace: function(str) {
+            return str.replace(/(^\s+|\s+$)/g,'');
+        },
+        removeWhitespace: function(str) {
+            return str.replace(/\s+/g, '');
+        }
+    };
+});

--- a/frontend/test/js/spec/utils/text.spec.js
+++ b/frontend/test/js/spec/utils/text.spec.js
@@ -1,0 +1,31 @@
+define(['src/utils/text'], function (textUtils) {
+
+    describe('textUtils', function() {
+
+        describe('#trimWhitespace', function() {
+            it('should trim whitespace from the start and end of a string', function() {
+                expect(textUtils.trimWhitespace("abcd")).toEqual("abcd");
+                expect(textUtils.trimWhitespace("a b c d")).toEqual("a b c d");
+                expect(textUtils.trimWhitespace(" a b c d  ")).toEqual("a b c d");
+                expect(textUtils.trimWhitespace(" a bc d  e")).toEqual("a bc d  e");
+                expect(textUtils.trimWhitespace(" abc")).toEqual("abc");
+            });
+        });
+
+        describe('#removeWhitespace', function() {
+            it('remove all whitespace from a string', function() {
+                expect(textUtils.removeWhitespace("a")).toEqual("a");
+                expect(textUtils.removeWhitespace("abcd")).toEqual("abcd");
+                expect(textUtils.removeWhitespace("                 a")).toEqual("a");
+                expect(textUtils.removeWhitespace("b                 ")).toEqual("b");
+                expect(textUtils.removeWhitespace("a b c d")).toEqual("abcd");
+                expect(textUtils.removeWhitespace(" a b c d  ")).toEqual("abcd");
+                expect(textUtils.removeWhitespace(" a bc d  e")).toEqual("abcde");
+                expect(textUtils.removeWhitespace(" abc")).toEqual("abc");
+            });
+        });
+
+    });
+
+});
+


### PR DESCRIPTION
This PR fixes an issue where subscribers were submitting subscriber IDs with additional whitespace causing the CAS lookup to fail.

- Subscriber ID can have all whitespace stripped
- CAS requires whitespace in postcode so only trim whitespace for either end

**Before**
Submitting a valid CAS id with extra whitespace causes the lookup to fail

![screen shot 2015-05-15 at 12 56 39](https://cloud.githubusercontent.com/assets/123386/7652236/6578b588-fb02-11e4-82dd-4f8c742bdc23.png)

**After**
Whitespace is trimmed and the lookup is successful. Not here that the CAS ID is valid but the offer has already been reedemed.

![screen shot 2015-05-15 at 12 55 28](https://cloud.githubusercontent.com/assets/123386/7652245/85bbf602-fb02-11e4-8ca9-c62ffadeee6c.png)

@nlindblad @emma-p Either of you mind taking a look at this one as there is no-one else in today on my team?