### PR TITLE
Remove unused config

### DIFF
--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -44,9 +44,6 @@ object Config {
   def idWebAppSignOutThenInUrl(uri: String): String =
     (idWebAppUrl / "signout") ? ("returnUrl" -> idWebAppSigninUrl(uri)) ? ("skipConfirmation" -> "true")
 
-  def eventImageUrlPath(id: String): String =
-    config.getString("membership.event.images.url") + id
-
   val idKeys = if (config.getBoolean("identity.production.keys")) new ProductionKeys else new PreProductionKeys
 
   val idApiUrl = config.getString("identity.api.url")

--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -47,8 +47,6 @@ identity.production.keys=true
 identity.api.url="https://idapi.theguardian.com"
 id.api.client.token=""
 
-membership.event.images.url="https://s3-eu-west-1.amazonaws.com/membership-eb-images/"
-
 # Touchpoint-backend environment-specific config - ***NO PRIVATE CREDENTIALS in these files***
 include "touchpoint.DEV.conf"
 include "touchpoint.UAT.conf"


### PR DESCRIPTION
Removes a line of unused config for the old image tool. Not to be confused with the remaining [ordering.json](https://github.com/guardian/membership-frontend/blob/master/frontend/conf/application.conf#L30) from that tool.

@mattandrews 