### PR TITLE
Removing email address from event order confirmation page

### DIFF
--- a/frontend/app/views/fragments/event/itemSnapshotOrder.scala.html
+++ b/frontend/app/views/fragments/event/itemSnapshotOrder.scala.html
@@ -30,8 +30,7 @@
                             @order.ticketCount ticket@if(order.ticketCount > 1){s}
                             @if(order.totalCost > 0) { @order.totalCost.pretty } else { free }
                         </div>
-                        <div class="order-summary__recipient">Sent to <strong>@order.email</strong></div>
-                        <div class="order-summary__reference copy">The order has been saved in <a href="@(Config.eventbriteUrl + "/gettickets")">MyTickets</a> on Eventbrite</div>
+                        <div class="order-summary__reference copy">The order has been saved in <a href="@(Config.eventbriteUrl + "/gettickets")">MyTickets</a> on Eventbrite. We've also sent confirmation to your registered email address.</div>
                         <img class="l-pad-top" src="@Asset.at("images/logos/eventbrite.svg")">
                     </div>
                 </div>

--- a/frontend/app/views/fragments/event/itemSnapshotOrder.scala.html
+++ b/frontend/app/views/fragments/event/itemSnapshotOrder.scala.html
@@ -30,7 +30,7 @@
                             @order.ticketCount ticket@if(order.ticketCount > 1){s}
                             @if(order.totalCost > 0) { @order.totalCost.pretty } else { free }
                         </div>
-                        <div class="order-summary__reference copy">The order has been saved in <a href="@(Config.eventbriteUrl + "/gettickets")">MyTickets</a> on Eventbrite. We've also sent confirmation to your registered email address.</div>
+                        <div class="order-summary__reference copy">The order has been saved in <a href="@(Config.eventbriteUrl + "/gettickets")">MyTickets</a> on Eventbrite. We've also sent confirmation to your registered EventBrite email address.</div>
                         <img class="l-pad-top" src="@Asset.at("images/logos/eventbrite.svg")">
                     </div>
                 </div>


### PR DESCRIPTION
This removes the users email address from being displayed on the confirmation page, as this can be used to extract user data from our site :cry: 

**Before:** 
![image](https://cloud.githubusercontent.com/assets/1289259/7859328/d31a80c8-0537-11e5-9497-3e9fa32c3c49.png)

**After:**
![image](https://cloud.githubusercontent.com/assets/1289259/7859342/f2145508-0537-11e5-8bbb-1b8f3c24a314.png)

The text wrapping is intentional

