### PR TITLE
Add campaign tracking

### DIFF
--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -19,6 +19,7 @@ import play.api.mvc._
 import services.{EventbriteService, GuardianLiveEventService, LocalEventService, MasterclassEventService, MemberService, _}
 import services.EventbriteService._
 import tracking._
+import utils.CampaignCode.extractCampaignCode
 
 import scala.concurrent.Future
 

--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -199,7 +199,7 @@ trait Event extends Controller with ActivityTracking {
       for {
         discountOpt <- memberService.createDiscountForMember(request.member, event)
       } yield {
-          val memberData = MemberData(request.member.salesforceContactId, request.user.id, request.member.tier.name)
+          val memberData = MemberData(request.member.salesforceContactId, request.user.id, request.member.tier.name, campaignCode=extractCampaignCode(request))
           track(EventActivity("redirectToEventbrite", Some(memberData), EventData(event)))(request.user)
         Found(event.url ? ("discount" -> discountOpt.map(_.code)))
           .withCookies(Cookie(eventCookie(event), "", Some(3600)))
@@ -208,7 +208,7 @@ trait Event extends Controller with ActivityTracking {
 
   private def trackConversionToThankyou(request: Request[_], event: RichEvent, order: Option[EBOrder],
                                         member: Option[Member]) {
-    val memberData = member.map(m => MemberData(m.salesforceContactId, m.identityId, m.tier.name, request=Some(request)))
+    val memberData = member.map(m => MemberData(m.salesforceContactId, m.identityId, m.tier.name, campaignCode=extractCampaignCode(request)))
     trackAnon(EventActivity("eventThankYou", memberData, EventData(event), order.map(OrderData(_))))(request)
   }
 

--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -208,7 +208,7 @@ trait Event extends Controller with ActivityTracking {
 
   private def trackConversionToThankyou(request: Request[_], event: RichEvent, order: Option[EBOrder],
                                         member: Option[Member]) {
-    val memberData = member.map(m => MemberData(m.salesforceContactId, m.identityId, m.tier.name))
+    val memberData = member.map(m => MemberData(m.salesforceContactId, m.identityId, m.tier.name, request=Some(request)))
     trackAnon(EventActivity("eventThankYou", memberData, EventData(event), order.map(OrderData(_))))(request)
   }
 

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -183,14 +183,14 @@ trait Joiner extends Controller with ActivityTracking with LazyLogging {
       subscriberValidation.fold({ errorString: String =>
         Future.successful(Forbidden)
       },{ paymentDelayOpt: Option[Period] =>
-        MemberService.createMember(request.user, formData, IdentityRequest(request), paymentDelayOpt)
+        MemberService.createMember(request.user, formData, IdentityRequest(request), paymentDelayOpt, extractCampaignCode(request))
           .map { member =>
           for {
             eventId <- PreMembershipJoiningEventFromSessionExtractor.eventIdFrom(request)
             event <- EventbriteService.getBookableEvent(eventId)
           } {
             event.service.wsMetrics.put(s"join-$tier-event", 1)
-            val memberData = MemberData(member.salesforceContactId, request.user.id, tier.name)
+            val memberData = MemberData(member.salesforceContactId, request.user.id, tier.name, campaignCode=extractCampaignCode(request))
             track(EventActivity("membershipRegistrationViaEvent", Some(memberData), EventData(event)))(request.user)
           }
           result

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -21,6 +21,9 @@ import play.api.mvc._
 import services.{GuardianContentService, _}
 import services.EventbriteService._
 import tracking.{ActivityTracking, EventActivity, EventData, MemberData}
+import com.github.nscala_time.time.Imports
+import com.github.nscala_time.time.Imports._
+import utils.CampaignCode.extractCampaignCode
 
 import scala.concurrent.Future
 

--- a/frontend/app/controllers/TierController.scala
+++ b/frontend/app/controllers/TierController.scala
@@ -14,6 +14,7 @@ import services.{IdentityApi, IdentityService, MemberService}
 import play.api.mvc.{AnyContent, Result, Controller, DiscardingCookie}
 import services.{SubscriptionService, IdentityApi, IdentityService, MemberService}
 import tracking.ActivityTracking
+import utils.CampaignCode.extractCampaignCode
 
 import scala.concurrent.Future
 

--- a/frontend/app/controllers/TierController.scala
+++ b/frontend/app/controllers/TierController.scala
@@ -11,10 +11,13 @@ import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json.Json
 import play.api.mvc.{Controller, DiscardingCookie, Result}
 import services.{IdentityApi, IdentityService, MemberService}
+import play.api.mvc.{AnyContent, Result, Controller, DiscardingCookie}
+import services.{SubscriptionService, IdentityApi, IdentityService, MemberService}
+import tracking.ActivityTracking
 
 import scala.concurrent.Future
 
-trait DowngradeTier {
+trait DowngradeTier extends ActivityTracking {
   self: TierController =>
 
   def downgradeToFriend() = PaidMemberAction { implicit request =>
@@ -23,7 +26,7 @@ trait DowngradeTier {
 
   def downgradeToFriendConfirm() = PaidMemberAction.async { implicit request => // POST
     for {
-      cancelledSubscription <- request.touchpointBackend.downgradeSubscription(request.member, request.user)
+      cancelledSubscription <- request.touchpointBackend.downgradeSubscription(request.member, request.user, extractCampaignCode(request))
     } yield Redirect(routes.TierController.downgradeToFriendSummary)
   }
 
@@ -96,7 +99,7 @@ trait UpgradeTier {
     val identityRequest = IdentityRequest(request)
 
     def handleFree(freeMember: FreeMember)(form: FreeMemberChangeForm) = for {
-      memberId <- MemberService.upgradeFreeSubscription(freeMember, request.user, tier, form, identityRequest)
+      memberId <- MemberService.upgradeFreeSubscription(freeMember, request.user, tier, form, identityRequest, extractCampaignCode(request))
     } yield Ok(Json.obj("redirect" -> routes.TierController.upgradeThankyou(tier).url))
 
     def handlePaid(paidMember: PaidMember)(form: PaidMemberChangeForm) = {
@@ -107,7 +110,7 @@ trait UpgradeTier {
       }
 
       def doUpgrade: Future[Result] = {
-        MemberService.upgradePaidSubscription(paidMember, request.user, tier, identityRequest).map {
+        MemberService.upgradePaidSubscription(paidMember, request.user, tier, identityRequest, extractCampaignCode(request)).map {
           _ => Redirect(routes.TierController.upgradeThankyou(tier))
         }
       }
@@ -146,7 +149,7 @@ trait CancelTier {
 
   def cancelTierConfirm() = MemberAction.async { implicit request =>
     for {
-      _ <- request.touchpointBackend.cancelSubscription(request.member, request.user)
+      _ <- request.touchpointBackend.cancelSubscription(request.member, request.user, extractCampaignCode(request))
     } yield {
       Redirect("/tier/cancel/summary")
     }

--- a/frontend/app/tracking/ActivityTracking.scala
+++ b/frontend/app/tracking/ActivityTracking.scala
@@ -221,12 +221,6 @@ trait ActivityTracking {
     new Tracker(emitter, subject, "membership", "membership-frontend")
   }
 
-  def extractCampaignCode(request: Request[_]): Option[String] = {
-    request.cookies.get("s_sess").flatMap{ cookie: Cookie =>
-      val cookieVal = UriEncoding.decodePathSegment(cookie.value, "utf-8")
-      "campaign=(.+?);".r.findFirstIn(cookieVal)
-    }
-  }
 }
 
 object ActivityTracking {

--- a/frontend/app/tracking/ActivityTracking.scala
+++ b/frontend/app/tracking/ActivityTracking.scala
@@ -62,7 +62,7 @@ case class MemberData(salesforceContactId: String,
                         marketingChoices: Option[MarketingChoicesForm] = None,
                         city: Option[String] = None,
                         country: Option[String] = None,
-                        request: Option[Request[_]] = None) extends CookieBaker {
+                        request: Option[Request[_]] = None) {
 
   val subscriptionPlan = subscriptionPaymentAnnual match {
     case Some(true) =>  Some("annual")
@@ -114,7 +114,8 @@ case class MemberData(salesforceContactId: String,
 
   def extractCampaignCode(request: Request[_]): Option[String] = {
     request.cookies.get("s_sess").flatMap{ cookie: Cookie =>
-      decode(cookie.value).get("s_campaign")
+      val cookieVal = UriEncoding.decodePathSegment(cookie.value, "utf-8")
+      "campaign=(.+?);".r.findFirstIn(cookieVal)
     }
   }
 

--- a/frontend/app/tracking/ActivityTracking.scala
+++ b/frontend/app/tracking/ActivityTracking.scala
@@ -62,7 +62,7 @@ case class MemberData(salesforceContactId: String,
                         marketingChoices: Option[MarketingChoicesForm] = None,
                         city: Option[String] = None,
                         country: Option[String] = None,
-                        request: Option[Request[_]] = None) {
+                        campaignCode: Option[String] = None) {
 
   val subscriptionPlan = subscriptionPaymentAnnual match {
     case Some(true) =>  Some("annual")
@@ -103,20 +103,13 @@ case class MemberData(salesforceContactId: String,
             tierAmend.effectiveFromDate.map("startDate" -> _.getMillis)
           }
         } ++
-        request.map { r =>
-          "campaignCode" -> extractCampaignCode(r)
+        campaignCode.map { code =>
+          "campaignCode" -> code
         }
 
     val memberMap = Map("member" -> ActivityTracking.setSubMap(dataMap))
 
     ActivityTracking.setSubMap(memberMap)
-  }
-
-  def extractCampaignCode(request: Request[_]): Option[String] = {
-    request.cookies.get("s_sess").flatMap{ cookie: Cookie =>
-      val cookieVal = UriEncoding.decodePathSegment(cookie.value, "utf-8")
-      "campaign=(.+?);".r.findFirstIn(cookieVal)
-    }
   }
 
   def truncatePostcode(postcode: String) = {
@@ -226,6 +219,13 @@ trait ActivityTracking {
     emitter.setRequestMethod(RequestMethod.Asynchronous)
     val subject = new Subject
     new Tracker(emitter, subject, "membership", "membership-frontend")
+  }
+
+  def extractCampaignCode(request: Request[_]): Option[String] = {
+    request.cookies.get("s_sess").flatMap{ cookie: Cookie =>
+      val cookieVal = UriEncoding.decodePathSegment(cookie.value, "utf-8")
+      "campaign=(.+?);".r.findFirstIn(cookieVal)
+    }
   }
 }
 

--- a/frontend/app/tracking/ActivityTracking.scala
+++ b/frontend/app/tracking/ActivityTracking.scala
@@ -18,7 +18,9 @@ import play.api.Logger
 import play.api.mvc.RequestHeader
 import utils.TestUsers.isTestUser
 
+import play.api.mvc.{RequestHeader, Request}
 import scala.collection.JavaConversions._
+import play.utils.UriEncoding
 
 case class MemberActivity (source: String, member: MemberData) extends TrackerData {
   def toMap: JMap[String, Object] =
@@ -57,7 +59,8 @@ case class MemberData(salesforceContactId: String,
                         subscriptionPaymentAnnual: Option[Boolean] = None,
                         marketingChoices: Option[MarketingChoicesForm] = None,
                         city: Option[String] = None,
-                        country: Option[String] = None) {
+                        country: Option[String] = None,
+                        request: Option[Request[_]] = None) {
 
   val subscriptionPlan = subscriptionPaymentAnnual match {
     case Some(true) =>  Some("annual")
@@ -96,6 +99,14 @@ case class MemberData(salesforceContactId: String,
               "to" -> tierAmend.tierTo.name
             ) ++
             tierAmend.effectiveFromDate.map("startDate" -> _.getMillis)
+          }
+        } ++
+        request.map { r =>
+          "campaignCode" -> r.cookies.get("s_sess").map { cookie =>
+            // eg "%20s_campaign%3Dfoo%3B"
+            val x = UriEncoding.decodePathSegment(cookie.value, "utf-8")
+            println(x)
+            x
           }
         }
 

--- a/frontend/app/utils/CampaignCode.scala
+++ b/frontend/app/utils/CampaignCode.scala
@@ -1,0 +1,15 @@
+package utils
+
+import play.api.mvc.{Cookie, Request}
+import play.utils.UriEncoding
+
+object CampaignCode {
+
+  def extractCampaignCode(request: Request[_]): Option[String] = {
+    request.cookies.get("s_sess").flatMap{ cookie: Cookie =>
+      val cookieVal = UriEncoding.decodePathSegment(cookie.value, "utf-8")
+      "campaign=(.+?);".r.findFirstMatchIn(cookieVal).map(_.group(1))
+    }
+  }
+
+}

--- a/frontend/app/views/fragments/tier/friendTeaser.scala.html
+++ b/frontend/app/views/fragments/tier/friendTeaser.scala.html
@@ -5,6 +5,7 @@
     @Benefits.details(Tier.Friend).desc <br/>
     <a
       href="@routes.Joiner.enterDetails(Tier.Friend)"
+      class="qa-friend-join"
       aria-title="Join as a Friend for free"
       data-metric-trigger="click"
       data-metric-category="join"

--- a/functional-tests/src/main/scala/com/gu/membership/pages/JoinPage.scala
+++ b/functional-tests/src/main/scala/com/gu/membership/pages/JoinPage.scala
@@ -2,15 +2,10 @@ package com.gu.membership.pages
 
 import org.openqa.selenium.{By, WebDriver}
 
-/**
- * Created by jao on 29/05/2014.
- */
 class JoinPage(driver: WebDriver) extends BaseMembershipPage(driver) {
 
-  private def becomeAFriendLink = driver.findElement(By.cssSelector(".qa-package-friend"))
-
+  private def becomeAFriendLink = driver.findElement(By.cssSelector(".qa-friend-join"))
   private def becomeAPartnerLink = driver.findElement(By.cssSelector(".qa-package-partner"))
-
   private def becomeAPatronLink = driver.findElement(By.cssSelector(".qa-package-patron"))
 
   def clickBecomeAFriend = {

--- a/functional-tests/src/main/scala/com/gu/membership/tags/Tags.scala
+++ b/functional-tests/src/main/scala/com/gu/membership/tags/Tags.scala
@@ -5,3 +5,4 @@ import org.scalatest.Tag
 object EventListTest extends Tag("EventListTest")
 object EventDetailTest extends Tag("EventDetailTest")
 object EventTicketPurchase extends Tag("EventTicketPurchase")
+object UserChangeTier extends Tag("UserChangeTier")

--- a/functional-tests/src/test/scala/MembershipChangeTierTests.scala
+++ b/functional-tests/src/test/scala/MembershipChangeTierTests.scala
@@ -1,15 +1,13 @@
+import com.gu.membership.tags._
 
 
-/**
- * Created by jao on 07/07/2014.
- */
 class MembershipChangeTierTests extends BaseMembershipTest {
 
   info("Tests for changing tier")
 
   feature("A user can downgrade") {
 
-    scenarioWeb("30. A Partner can downgrade to a Friend") {
+    scenarioWeb("30. A Partner can downgrade to a Friend", UserChangeTier) {
       implicit driver =>
       given {
         MembershipSteps().IAmLoggedInAsAPartner
@@ -22,7 +20,7 @@ class MembershipChangeTierTests extends BaseMembershipTest {
       }
     }
 
-    scenarioWeb("31. A Patron can downgrade to a Friend") {
+    scenarioWeb("31. A Patron can downgrade to a Friend", UserChangeTier) {
       implicit driver =>
         given {
           MembershipSteps().IAmLoggedInAsAPatron
@@ -38,7 +36,7 @@ class MembershipChangeTierTests extends BaseMembershipTest {
 
   feature("A user can upgrade") {
 
-    scenarioWeb("34. A friend can upgrade to a partner") {
+    scenarioWeb("34. A friend can upgrade to a partner", UserChangeTier) {
       implicit driver =>
         given {
           MembershipSteps().IAmLoggedInAsAFriend
@@ -51,20 +49,7 @@ class MembershipChangeTierTests extends BaseMembershipTest {
         }
     }
 
-//    scenarioWeb("35. A Partner can upgrade to a Patron") {
-//      implicit driver =>
-//        given {
-//          MembershipSteps().IAmLoggedInAsAPartner
-//        }
-//        .when {
-//          _.IChooseToUpgradeToAPatron
-//        }
-//        .then {
-//          _.IAmAPatron
-//        }
-//    }
-
-    scenarioWeb("36. A Friend can upgrade to a Patron") {
+    scenarioWeb("36. A Friend can upgrade to a Patron", UserChangeTier) {
       implicit driver =>
         given {
           MembershipSteps().IAmLoggedInAsAFriend
@@ -78,7 +63,7 @@ class MembershipChangeTierTests extends BaseMembershipTest {
     }
   }
 
-  scenarioWeb("37. A Partner can cancel membership") {
+  scenarioWeb("37. A Partner can cancel membership", UserChangeTier) {
     implicit driver =>
       given {
         MembershipSteps().IAmLoggedInAsAPartner
@@ -91,7 +76,7 @@ class MembershipChangeTierTests extends BaseMembershipTest {
       }
   }
 
-  scenarioWeb("43. An existing friend cannot become a friend again") {
+  scenarioWeb("43. An existing friend cannot become a friend again", UserChangeTier) {
     implicit driver =>
       given {
         MembershipSteps().IAmLoggedInAsAFriend
@@ -104,7 +89,7 @@ class MembershipChangeTierTests extends BaseMembershipTest {
       }
   }
 
-  scenarioWeb("44. An existing partner cannot become a partner again") {
+  scenarioWeb("44. An existing partner cannot become a partner again", UserChangeTier) {
     implicit driver =>
       given {
         MembershipSteps().IAmLoggedInAsAPartner
@@ -117,7 +102,7 @@ class MembershipChangeTierTests extends BaseMembershipTest {
       }
   }
 
-  scenarioWeb("45. An existing patron cannot become a patron again") {
+  scenarioWeb("45. An existing patron cannot become a patron again", UserChangeTier) {
     implicit driver =>
       given {
         MembershipSteps().IAmLoggedInAsAPatron


### PR DESCRIPTION
This PR (done in partnership with @dominickendrick) extends our ElasticSearch tracking to recognise when a user has entered the site with a `?CMP=foo` or `?INTCMP=bar` marketing campaign ID in the URL. If this string is present on any pageload event, Omniture will add it to its `s_sess` cookie. We take advantage of this and read back that cookie and parse the campaign ID. We then send this campaign code (in a field called, er, `campaignCode`) with several events in ElasticSearch: signup, cancel, upgrade, downgrade and event ticket purchase. This means we can start to graph campaigns on the dashboard in terms of revenue and conversions.

Would appreciate some of your time, @jennysivapalan and @rtyley, in just looking over this.