### PR TITLE
[Deploy on 29/06/2015] Remove 'Event Detail | ' from event pages

### DIFF
--- a/frontend/app/views/event/page.scala.html
+++ b/frontend/app/views/event/page.scala.html
@@ -6,7 +6,7 @@
 @import views.support.Dates._
 @import views.support.Social.eventDetail
 
-@main("Event Detail | " + event.name.text, pageInfo=pageInfo) {
+@main(event.name.text, pageInfo=pageInfo) {
 
     @* Event Name *@
     <div class="event-header tone-@event.metadata.identifier">


### PR DESCRIPTION
Remove 'Event Detail | ' from event pages so we're not starting all event page titles with the same text. Affects Omniture tracking so need to check with @JuliaBellis before this goes out.

![screen shot 2015-06-02 at 11 13 29](https://cloud.githubusercontent.com/assets/123386/7933631/6930e1fe-0918-11e5-8fc4-f30a93023753.png)