### PR TITLE
Reduce z-index on roundel

### DIFF
--- a/frontend/assets/stylesheets/components/_header-bar.scss
+++ b/frontend/assets/stylesheets/components/_header-bar.scss
@@ -75,13 +75,13 @@
 
 .roundel {
     background-color: #D14029;
-    border-radius: 100px;
-    z-index: 100;
+    @include circular();
 
     left: 0;
     right: 0;
     margin: 0 auto;
     position: absolute;
+    z-index: 1;
     bottom: -80px;
     width: 130px;
     height: 130px;


### PR DESCRIPTION
Stops roundel appearing over navigation on small screens. @mattandrews 

Before:
![screen shot 2015-06-02 at 12 32 14](https://cloud.githubusercontent.com/assets/123386/7934877/8cfda40e-0923-11e5-86c3-bee3e5557a94.png)

After:
![screen shot 2015-06-02 at 12 32 37](https://cloud.githubusercontent.com/assets/123386/7934878/8d10730e-0923-11e5-84bd-13843eeafdda.png)
