### PR TITLE
Improve handling of long running events

### DIFF
--- a/frontend/test/model/EBEventTest.scala
+++ b/frontend/test/model/EBEventTest.scala
@@ -20,6 +20,7 @@ class EBEventTest extends PlaySpecification {
   val nonTicketedEvent = ebResponse.data.find(_.id == "13602460325").get
   val soldOutEvent = ebResponse.data.find(_.id == "12238163677").get
   val startedEvent = ebResponse.data.find(_.id == "12972720757").get
+  val completedEvent = ebResponse.data.find(_.id == "13024577863").get
   val limitedAvailabilityEvent = ebResponse.data.find(_.id == "12718560557").get
 
   val ticketedEvent = ebLiveEvent;
@@ -56,10 +57,12 @@ class EBEventTest extends PlaySpecification {
       ebLiveEvent.statusText mustEqual("")
     }
     "not be bookable when it has started" in {
-      startedEvent.isBookable mustEqual(false)
+      ebLiveEvent.isBookable mustEqual(true)
+      startedEvent.isBookable mustEqual(true)
+      completedEvent.isBookable mustEqual(false)
     }
     "should display past event text" in {
-      startedEvent.statusText mustEqual("Past event")
+      completedEvent.statusText mustEqual("Past event")
       ebCompletedEvent.statusText mustEqual("Past event")
     }
     "not be bookable when it is in draft mode" in {


### PR DESCRIPTION
Improves handling of multi-day events. Previously events were only sellable when the eventbrite status was `live`. This causes issues with pseudo multi-day events where an event may be classed as `started` but there are still some ticket types available to buy (due to them being used to model future dates).

Having spoken to @rtyley a suitable fix for this is to use the `sales_end` dates from the events `ticket_classes`. If a ticket type is still for sale then it's OK to show the booking button.

![screen shot 2015-06-02 at 15 45 18](https://cloud.githubusercontent.com/assets/123386/7938610/6242321e-093e-11e5-9c51-f3f3c4f43453.png)

This also updates the sales end date to work with multi-day events. Previously this would show the sales end of the first ticket type.

![screen shot 2015-06-02 at 15 48 37](https://cloud.githubusercontent.com/assets/123386/7938731/f9788fac-093e-11e5-8e17-2d6db2934d1a.png)

@mattandrews 