### PR TITLE
Add analytics event tracking to new Friend link

### DIFF
--- a/frontend/app/views/fragments/tier/friendTeaser.scala.html
+++ b/frontend/app/views/fragments/tier/friendTeaser.scala.html
@@ -3,7 +3,13 @@
 
 <p class="text-trail copy">
     @Benefits.details(Tier.Friend).desc
-    <a href="@routes.Joiner.enterDetails(Tier.Friend)" aria-title="Join as a Friend for free">
+    <a href="@routes.Joiner.enterDetails(Tier.Friend)"
+       aria-title="Join as a Friend for free"
+       data-metric-trigger="click"
+       data-metric-category="join"
+       data-metric-action="friend"
+       data-metric-label="Join for free"
+    >
         Join for free &rarr;
     </a>
 </p>


### PR DESCRIPTION
So we can explicitly track how many people click on this through analytics @rtyley 