### PR TITLE
Add user-specific tagging to Sentry-logged events

### DIFF
--- a/frontend/app/monitoring/SentryLogging.scala
+++ b/frontend/app/monitoring/SentryLogging.scala
@@ -12,6 +12,10 @@ import scala.util.{Failure, Success}
 
 object SentryLogging {
 
+  val UserIdentityId = "userIdentityId"
+  val UserGoogleId = "userGoogleId"
+  val AllMDCTags = Seq(UserIdentityId, UserGoogleId)
+
   def init() {
     Config.sentryDsn match {
       case Failure(ex) =>
@@ -28,6 +32,7 @@ object SentryLogging {
         val sentryAppender = new SentryAppender(RavenFactory.ravenInstance(dsn)) {
           addFilter(filter)
           setTags(tagsString)
+          setExtraTags(AllMDCTags.mkString(","))
           setContext(LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext])
         }
         sentryAppender.start()

--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -3,6 +3,8 @@ include "copy"
 
 session.secure=true
 
+play.http.errorHandler = "monitoring.ErrorHandler"
+
 site.title="The Guardian Membership"
 index.title="Home Page"
 


### PR DESCRIPTION
This allows us to see Identity user-id & Guardian Google-authed-id  as a tags on Sentry reports, and even filter by those tags, eg:

https://app.getsentry.com/the-guardian/membership/?userIdentityId=176650053

Doing this is much easier in Play 2.4, thanks to https://github.com/playframework/playframework/pull/3780 ...so we can get rid of the `AuthenticatedException` stuff, and a bunch of guff.

https://github.com/getsentry/raven-java/tree/master/raven-logback#additional-data-and-information

Note that MDC is threadlocal stuff, so should always be used with caution in an async-server like Play - ie don't expect it to persist across mapped Futures - best to set it, log it, and immediately clear it again.

http://logback.qos.ch/manual/mdc.html

https://www.playframework.com/documentation/2.4.x/ScalaErrorHandling

cc @jennysivapalan @davidrapson 