### PR TITLE
Make savings text contextual on payment forms

### DIFF
--- a/frontend/app/model/Benefits.scala
+++ b/frontend/app/model/Benefits.scala
@@ -32,7 +32,11 @@ object Benefits {
     BenefitItem("unique_experiences", "Unique experiences", "Get behind the scenes of our journalism", "benefit-experiences")
   )
 
-  case class Pricing(yearly: Int, monthly: Int) {
+  case class Pricing(
+    yearly: Int,
+    monthly: Int,
+    yearlySavingsNote: Option[String]
+  ) {
     lazy val yearlyMonthlyCost = 12 * monthly
     lazy val yearlySaving = yearlyMonthlyCost - yearly
     lazy val yearlyWith6MonthSaving = yearly / 2f
@@ -83,17 +87,33 @@ object Benefits {
     "video_highlights"
   )
 
-  val friendBenefits = Benefits("Benefits", friendBenefitsList,
-    None, "Become a Friend", "Become a Friend to book tickets to Guardian Live events and access the Guardian members area.")
-
-  val supporterBenefits = Benefits("Benefits", supporterBenefitsList,
-    Some(Pricing(50, 5)), "Become a Supporter", "Supporters keep our journalism fearless, open and free from interference.")
-
-  val partnerBenefits = Benefits("Supporter benefits, plus…", partnerBenefitsList,
-    Some(Pricing(135, 15)), "Become a Partner", "Support the Guardian and experience it brought to life, with early booking and discounted tickets")
-
-  val patronBenefits = Benefits("Partner benefits, plus…", patronBenefitsList,
-    Some(Pricing(540, 60)), "Become a Patron", "Defend the Guardian’s independence and promote the open exchange of ideas, with a backstage pass to the Guardian")
+  val friendBenefits = Benefits("Benefits",
+    friendBenefitsList,
+    None,
+    "Become a Friend",
+    "Become a Friend to book tickets to Guardian Live events and access the Guardian members area."
+  )
+  val supporterBenefits = Benefits(
+    "Benefits",
+    supporterBenefitsList,
+    Some(Pricing(50, 5, Some("1 year membership, 2 months free"))),
+    "Become a Supporter",
+    "Supporters keep our journalism fearless, open and free from interference."
+  )
+  val partnerBenefits = Benefits(
+    "Supporter benefits, plus…",
+    partnerBenefitsList,
+    Some(Pricing(135, 15, Some("1 year membership, 3 months free"))),
+    "Become a Partner",
+    "Support the Guardian and experience it brought to life, with early booking and discounted tickets"
+  )
+  val patronBenefits = Benefits(
+    "Partner benefits, plus…",
+    patronBenefitsList,
+    Some(Pricing(540, 60, Some("1 year membership, 3 months free"))),
+    "Become a Patron",
+    "Defend the Guardian’s independence and promote the open exchange of ideas, with a backstage pass to the Guardian"
+  )
 
   def details(tier: Tier) = tier match {
     case Tier.Friend => friendBenefits

--- a/frontend/app/views/fragments/form/paymentOptions.scala.html
+++ b/frontend/app/views/fragments/form/paymentOptions.scala.html
@@ -28,7 +28,9 @@
                         <div class="pseudo-radio__header">Pay £@pricing.yearly/year</div>
                         @if(pricing.hasYearlySaving) {
                             <p class="pseudo-radio__note">£@pricing.yearly one off annual payment (save £@pricing.yearlySaving per year)</p>
-                            <p class="pseudo-radio__note">1 year membership, 3 months free</p>
+                            @for(yearlySavingsNote <- pricing.yearlySavingsNote) {
+                                <p class="pseudo-radio__note">@yearlySavingsNote</p>
+                            }
                         } else {
                             <p class="pseudo-radio__note">One-off annual payment</p>
                         }


### PR DESCRIPTION
Make savings text contextual on payment forms.

**Supporter:**
![screen shot 2015-06-11 at 13 59 05](https://cloud.githubusercontent.com/assets/123386/8107577/4563ce18-1042-11e5-8253-04bc9f7fa9d7.png)

**Partner**
![screen shot 2015-06-11 at 13 58 45](https://cloud.githubusercontent.com/assets/123386/8107579/4d2ca322-1042-11e5-865b-232f0957ee3d.png)

// @jennysivapalan 
