### PR TITLE
Increase Eventbrite API refresh time to 15 min

### DIFF
--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -24,8 +24,8 @@ eventbrite.api.token=""
 eventbrite.masterclasses.api.token=""
 eventbrite.local.api.token=""
 eventbrite.api.iframe-url="https://www.eventbrite.com/tickets-external?ref=etckt&v=2"
-eventbrite.api.refresh-time-seconds=59
-eventbrite.api.refresh-time-priority-events-seconds=29
+eventbrite.api.refresh-time-seconds=900
+eventbrite.api.refresh-time-priority-events-seconds=900
 eventbrite.waitlist.url="https://www.eventbrite.co.uk/waitlist"
 eventbrite.limitedAvailabilityCutoff=15
 


### PR DESCRIPTION
Increase Eventbrite API refresh time to 15 min to reduce calls due to current rate limiting. @jennysivapalan 