### PR TITLE
Fix error pages to look nice again

### DIFF
--- a/frontend/app/monitoring/ErrorHandler.scala
+++ b/frontend/app/monitoring/ErrorHandler.scala
@@ -3,11 +3,12 @@ package monitoring
 import javax.inject._
 
 import com.gu.googleauth.UserIdentity
-import controllers.Cached
+import controllers.{Cached, NoCache}
 import monitoring.SentryLogging.{UserGoogleId, UserIdentityId}
 import org.slf4j.MDC
 import play.api._
 import play.api.http.DefaultHttpErrorHandler
+import play.api.mvc.Results._
 import play.api.mvc._
 import play.api.routing.Router
 import services.AuthenticationService
@@ -35,4 +36,11 @@ class ErrorHandler @Inject() (
   override def onClientError(request: RequestHeader, statusCode: Int, message: String = ""): Future[Result] = {
     super.onClientError(request, statusCode, message).map(Cached(_))
   }
+
+  override protected def onNotFound(request: RequestHeader, message: String): Future[Result] = {
+    Future.successful(Cached(NotFound(views.html.error404())))
+  }
+
+  override protected def onProdServerError(request: RequestHeader, exception: UsefulException): Future[Result] =
+    Future.successful(NoCache(InternalServerError(views.html.error500(exception))))
 }


### PR DESCRIPTION
I broke the 404 page & error pages with [my changes](https://github.com/guardian/membership-frontend/pull/575/files#diff-a47b5dceb8454ddf38fb158321488805) in https://github.com/guardian/membership-frontend/pull/575 ...this reinstates those nice-looking pages, using the Play 2.4 way of a configured `HttpErrorHandler`.

https://www.playframework.com/documentation/2.4.x/ScalaErrorHandling

These breakages became obvious when the recent Eventbrite API-quota outage occurred, with users seeing the default Play error pages.

Also, I'm going to say that we don't cache internal server errors, partially out of concern that two different users may get this on 'private' pages.

![image](https://cloud.githubusercontent.com/assets/52038/8213429/a9ff75bc-1519-11e5-8658-d2095f2f2912.png)


cc @davidrapson @afiore 