### PR TITLE
Tag tests core

### DIFF
--- a/functional-tests/README.md
+++ b/functional-tests/README.md
@@ -7,12 +7,31 @@
 3. You will need to create a config file in `functional-tests/local.conf` with the the template below.
 4. In `functional-tests` you can then run `sbt test` to start the tests
 
-## Running Tagged Tests
+## Tagged Tests
+### Adding Tags
+The tag is added as a comma separated list for each scenario after the scenario name, e.g. `scenarioWeb("Example test that is essential but unstable", CoreTest, Unstable)`
 
-To run a tagged set of tests, e.g., only tests related to event detail pages, you need to run the following commands:
+###  Running in SBT
+To run the tagged tests in the SBT console you will need the local environment to be running for frontend, identity, and membership
 
-1. `sbt` to enter SBT console
-2. `test-only -- -n TAG_NAME` where `TAG_NAME` is the tag you want to run e.g., `EventListTest`
+1. `sbt` to enter SBT console  
+2. `test-only -- -n TAG_VALUE` where `TAG_VALUE` is the tag you want to run e.g., `EventListTest`
+
+### Running in Run/Debug configuration
+To run the tagged tests in the IDE, useful for debugging, you will need the local environment to be running for frontend, identity, and membership
+
+1. Edit the `Run/Debug configuration` for the test(s) - if there are none then right click on the tests package or class and select `Run`   
+2. In the field `Test options:` enter the tag value, e.g. `-n CoreTest -l OptionalTest -l Unstable`
+  
+### Running in TeamCity
+To run the tagged tests as part of a CI or distributed automation suite you will need the code environment to be running for frontend, identity, and membership
+
+1. Select the project  
+2. Navigate to `Edit Configuration Settings` -> `Build Step`   
+3. In `SBT Commands` enter the following `"project functional-tests" clean compile "test-only -- -l unstable -l OptionalTest"`    
+*NOTE:* Ideally you should not use `-n` as this will ignore tests that are untagged. By only using `-l` these untagged tests will also be run
+
+If the trigger is set up correctly then the build will run the tagged tests whenever a build is deployed to the environment or at periodic times during the day, depending on what is most useful.
 
 ### Available tags
 
@@ -20,24 +39,21 @@ The full list of available tags can be found in [Tags.scala](src/main/scala/com.
 
 ### local.conf
 
-```
-"browserEnvironment" : "local"
-"environment" : "local"
-"local" : {
-  "browser" : "phantomjs"
-  "webDriverRemoteUrl" : "http://localhost:4444/wd/hub"
-  "testBaseUrl" : "https://mem.thegulocal.com/"
-}
-
-"user" : {
-  "identityReturn" : "https://profile.thegulocal.com/signin?returnUrl=https%3A%2F%2Fmem.thegulocal.com&skipConfirmation=true",
-  "partnerPayment" : "https://mem.thegulocal.com/join/partner/payment",
-  "accountEdit"    : "https://profile.thegulocal.com/account/edit",
-  "membershipEdit" : "https://profile.thegulocal.com/membership/edit",
-  "identity"       : "https://profile.thegulocal.com/signin?skipConfirmation=true",
-  "browser"        : "chrome"
-}
-```
+  "browserEnvironment" : "local"  
+  "environment" : "local"  
+  "local" : {  
+      "browser" : "phantomjs"  
+      "webDriverRemoteUrl" : "http://localhost:4444/wd/hub"  
+      "testBaseUrl" : "https://mem.thegulocal.com/"  
+  }   
+  "user" : {  
+      "identityReturn" : "https://profile.thegulocal.com/signin?returnUrl=https%3A%2F%2Fmem.thegulocal.com&skipConfirmation=true",  
+      "partnerPayment" : "https://mem.thegulocal.com/join/partner/payment",  
+      "accountEdit"    : "https://profile.thegulocal.com/account/edit",  
+      "membershipEdit" : "https://profile.thegulocal.com/membership/edit",  
+      "identity"       : "https://profile.thegulocal.com/signin?skipConfirmation=true",  
+      "browser"        : "chrome"  
+  }
 
 ## Sauce Connect
 

--- a/functional-tests/README.md
+++ b/functional-tests/README.md
@@ -38,7 +38,7 @@ If the trigger is set up correctly then the build will run the tagged tests when
 The full list of available tags can be found in [Tags.scala](src/main/scala/com.gu.membership/tags/Tags.scala)
 
 ### local.conf
-
+```
   "browserEnvironment" : "local"  
   "environment" : "local"  
   "local" : {  
@@ -54,6 +54,7 @@ The full list of available tags can be found in [Tags.scala](src/main/scala/com.
       "identity"       : "https://profile.thegulocal.com/signin?skipConfirmation=true",  
       "browser"        : "chrome"  
   }
+```
 
 ## Sauce Connect
 

--- a/functional-tests/src/main/scala/com/gu/membership/pages/ChooseTierPage.scala
+++ b/functional-tests/src/main/scala/com/gu/membership/pages/ChooseTierPage.scala
@@ -7,7 +7,7 @@ import org.openqa.selenium.{JavascriptExecutor, By, WebDriver}
  */
 class ChooseTierPage(driver: WebDriver) extends BaseMembershipPage(driver) {
 
-  private def friendInput = driver.findElement(By.id("qa-friend"))
+  private def friendInput = driver.findElement(By.cssSelector(".qa-friend-join"))
 
   private def partnerInput = driver.findElement(By.id("qa-partner"))
 

--- a/functional-tests/src/main/scala/com/gu/membership/tags/Tags.scala
+++ b/functional-tests/src/main/scala/com/gu/membership/tags/Tags.scala
@@ -2,7 +2,23 @@ package com.gu.membership.tags
 
 import org.scalatest.Tag
 
+/* Usage: The tag is added as a comma separated list for each scenario after the scenario name
+e.g. scenarioWeb("Example test that is unstable but quick", Small, Unstable)
+  Running tests locally:  The Run/Debug configuration can specify which tags you want to run or ignore using the tag
+  text e.g. to run only core tests but ignore unstable or optional tests you would use the following in Test Options
+  -n CoreTest -l OptionalTest -l Unstable
+  Running tests TeamCity: In Edit Configuration Settings -> Build Step -> SBT Commands enter the following
+  "project functional-tests" clean compile "test-only -- -l unstable"
+  to add further tags use this format "test-only -- -l Unstable -l OptionalTest"
+  NOTE: Ideally you should not use -n as this will ignore tests that are untagged. By only using -l these untagged
+  tests will also be run
+*/
+
 object EventListTest extends Tag("EventListTest")
 object EventDetailTest extends Tag("EventDetailTest")
 object EventTicketPurchase extends Tag("EventTicketPurchase")
 object UserChangeTier extends Tag("UserChangeTier")
+
+object Unstable extends Tag("Unstable") //A test which fails intermittently giving false negatives
+object CoreTest extends Tag("CoreTest") //A test which must pass for the site to be functional
+object OptionalTest extends Tag("OptionalTest") //test is important but this feature can be missing for a short time

--- a/functional-tests/src/main/scala/com/gu/membership/tags/Tags.scala
+++ b/functional-tests/src/main/scala/com/gu/membership/tags/Tags.scala
@@ -14,6 +14,15 @@ e.g. scenarioWeb("Example test that is unstable but quick", Small, Unstable)
   tests will also be run
 */
 
+/* CoreTest:
+    + Non-members are up-sold on the identity membership tab (MB6)
+    + A Partner's membership details are displayed on the identity membership tab (MB3)
+    + A logged in user can see the full events list (ME1)
+    + A friend can upgrade to a partner (MCT3)
+    + Non-members are shown the potential membership discount on event prices (MB1)
+
+*/
+
 object EventListTest extends Tag("EventListTest")
 object EventDetailTest extends Tag("EventDetailTest")
 object EventTicketPurchase extends Tag("EventTicketPurchase")

--- a/functional-tests/src/test/scala/steps/Assert.scala
+++ b/functional-tests/src/test/scala/steps/Assert.scala
@@ -1,3 +1,5 @@
+package steps
+
 import org.scalatest.Matchers._
 
 /**

--- a/functional-tests/src/test/scala/steps/CookieHandler.scala
+++ b/functional-tests/src/test/scala/steps/CookieHandler.scala
@@ -1,0 +1,53 @@
+package steps
+
+import java.io.FileInputStream
+import java.util.{Properties, Random}
+
+import com.gu.automation.support.Config
+import com.gu.identity.testing.usernames.{Encoder, TestUsernames}
+import com.gu.membership.pages.{LoginPage, RegisterPage}
+import org.openqa.selenium.{Cookie, JavascriptExecutor, WebDriver}
+
+/**
+ * Created by spike on 19/06/15.
+ */
+object CookieHandler {
+
+  var loginCookie: Option[Cookie] = None
+  var secureCookie: Option[Cookie] = None
+  val surveyCookie = new Cookie("gu.test", "test")
+
+  def login(driver: WebDriver) {
+    driver.get(Config().getUserValue("identityReturn"))
+    disableAnalytics(driver)
+    new LoginPage(driver).clickRegister
+    register(driver)
+  }
+
+  def register(driver: WebDriver) {
+    driver.manage().addCookie(surveyCookie)
+    val propertyName="identity.test.users.secret"
+
+    val file: String = "/etc/gu/membership-keys.conf"
+
+    val prop = new Properties()
+    prop.load(new FileInputStream(file))
+
+    val secret = prop.getProperty(propertyName).replace("\"","")
+
+    val usernames = TestUsernames(Encoder.withSecret(secret))
+
+    val salt: Array[Byte] = new Array[Byte](2)
+
+    new Random().nextBytes(salt)
+    val user = usernames.generate(salt)
+    val password = scala.util.Random.alphanumeric.take(10).mkString
+    val email = user + "@testme.com"
+    new RegisterPage(driver).enterFirstName(user).enterLastName(user).enterEmail(email)
+      .enterPassword(password).enterUserName(user).clickSubmit
+  }
+
+  def disableAnalytics(driver: WebDriver): Unit = {
+    driver.asInstanceOf[JavascriptExecutor].executeScript("document.cookie = \"ANALYTICS_OFF_KEY=1; domain=.thegulocal.com; path=/; secure\"")
+  }
+}

--- a/functional-tests/src/test/scala/steps/MembershipSteps.scala
+++ b/functional-tests/src/test/scala/steps/MembershipSteps.scala
@@ -1,12 +1,15 @@
-import java.io.FileInputStream
+package steps
+
 import java.text.SimpleDateFormat
-import java.util.{Random, Date, Properties}
+import java.util.Date
 
 import com.gu.automation.support.{Config, TestLogger}
-import com.gu.identity.testing.usernames.{Encoder, TestUsernames}
 import com.gu.membership.pages._
-import org.openqa.selenium.{Cookie, JavascriptExecutor, WebDriver}
+import org.openqa.selenium.WebDriver
 
+/**
+ * Created by spike on 19/06/15.
+ */
 case class MembershipSteps(implicit driver: WebDriver, logger: TestLogger) {
 
   val validCardNumber = "4242424242424242"
@@ -468,46 +471,5 @@ case class MembershipSteps(implicit driver: WebDriver, logger: TestLogger) {
 
   private def isNotInPast(dateTime: String) = {
     isInFuture(dateTime) || new SimpleDateFormat("d MMMM yyyy").format(new Date()).equals(dateTime)
-  }
-}
-
-object CookieHandler {
-
-  var loginCookie: Option[Cookie] = None
-  var secureCookie: Option[Cookie] = None
-  val surveyCookie = new Cookie("gu.test", "test")
-
-  def login(driver: WebDriver) {
-    driver.get(Config().getUserValue("identityReturn"))
-    disableAnalytics(driver)
-    new LoginPage(driver).clickRegister
-    register(driver)
-  }
-
-  def register(driver: WebDriver) {
-    driver.manage().addCookie(surveyCookie)
-    val propertyName="identity.test.users.secret"
-
-    val file: String = "/etc/gu/membership-keys.conf"
-
-    val prop = new Properties()
-    prop.load(new FileInputStream(file))
-
-    val secret = prop.getProperty(propertyName).replace("\"","")
-
-    val usernames = TestUsernames(Encoder.withSecret(secret))
-
-    val salt: Array[Byte] = new Array[Byte](2)
-
-    new Random().nextBytes(salt)
-    val user = usernames.generate(salt)
-    val password = scala.util.Random.alphanumeric.take(10).mkString
-    val email = user + "@testme.com"
-    new RegisterPage(driver).enterFirstName(user).enterLastName(user).enterEmail(email)
-      .enterPassword(password).enterUserName(user).clickSubmit
-  }
-
-  def disableAnalytics(driver: WebDriver): Unit = {
-    driver.asInstanceOf[JavascriptExecutor].executeScript("document.cookie = \"ANALYTICS_OFF_KEY=1; domain=.thegulocal.com; path=/; secure\"")
   }
 }

--- a/functional-tests/src/test/scala/steps/MembershipSteps.scala
+++ b/functional-tests/src/test/scala/steps/MembershipSteps.scala
@@ -15,8 +15,8 @@ case class MembershipSteps(implicit driver: WebDriver, logger: TestLogger) {
   val validCardNumber = "4242424242424242"
   val cardWithNoFunds = "4000000000000341"
   val secondaryCard   = "5555555555554444"
-  val partnerAnnualPrice = "£136.00"
-  val patronAnnualPrice = "£541.00"
+  val partnerAnnualPrice = "£135.00"
+  val patronAnnualPrice = "£540.00"
 
   def IAmLoggedIn = {
     CookieHandler.login(driver)

--- a/functional-tests/src/test/scala/tests/BaseMembershipTest.scala
+++ b/functional-tests/src/test/scala/tests/BaseMembershipTest.scala
@@ -1,8 +1,9 @@
+package tests
+
 import java.util.concurrent.TimeUnit
 
 import com.gu.automation.core.{GivenWhenThen, WebDriverFeatureSpec}
-import com.gu.automation.support.{Browser, TestRetries}
-import com.gu.automation.support.Config
+import com.gu.automation.support.{Browser, Config, TestRetries}
 
 /**
  * Created by jao on 20/06/2014.

--- a/functional-tests/src/test/scala/tests/MasterclassTests.scala
+++ b/functional-tests/src/test/scala/tests/MasterclassTests.scala
@@ -1,4 +1,7 @@
+package tests
+
 import com.gu.membership.tags._
+import steps.MembershipSteps
 
 class MasterclassTests extends BaseMembershipTest {
 
@@ -6,7 +9,7 @@ class MasterclassTests extends BaseMembershipTest {
 
   feature("User sees a list of events") {
 
-    scenarioWeb("47. Visitor sees a Masterclass list", EventListTest) {
+    scenarioWeb("47. Visitor sees a Masterclass list", EventListTest, OptionalTest) {
       implicit driver =>
         given {
           MembershipSteps().IGoToMasterclasses
@@ -19,7 +22,7 @@ class MasterclassTests extends BaseMembershipTest {
         }
     }
 
-    scenarioWeb("48. Member sees a Masterclass list", EventListTest) {
+    scenarioWeb("48. Member sees a Masterclass list", EventListTest, OptionalTest) {
       implicit driver =>
         given {
           MembershipSteps().IAmLoggedInAsAPartner
@@ -35,7 +38,7 @@ class MasterclassTests extends BaseMembershipTest {
 
   feature("Masterclass event details") {
 
-    scenarioWeb("49. Visitor sees the details for a Masterclass", EventDetailTest) {
+    scenarioWeb("49. Visitor sees the details for a Masterclass", EventDetailTest, OptionalTest) {
       implicit driver =>
         given {
           MembershipSteps().IGoToMasterclasses
@@ -48,7 +51,7 @@ class MasterclassTests extends BaseMembershipTest {
         }
     }
 
-    scenarioWeb("50. Member sees the details for a Masterclass", EventDetailTest) {
+    scenarioWeb("50. Member sees the details for a Masterclass", EventDetailTest, OptionalTest) {
       implicit driver =>
         given {
           MembershipSteps().IAmLoggedInAsAPatron

--- a/functional-tests/src/test/scala/tests/MasterclassTests.scala
+++ b/functional-tests/src/test/scala/tests/MasterclassTests.scala
@@ -9,7 +9,7 @@ class MasterclassTests extends BaseMembershipTest {
 
   feature("User sees a list of events") {
 
-    scenarioWeb("47. Visitor sees a Masterclass list", EventListTest, OptionalTest) {
+    scenarioWeb("M1. Visitor sees a Masterclass list", EventListTest, OptionalTest) {
       implicit driver =>
         given {
           MembershipSteps().IGoToMasterclasses
@@ -22,7 +22,7 @@ class MasterclassTests extends BaseMembershipTest {
         }
     }
 
-    scenarioWeb("48. Member sees a Masterclass list", EventListTest, OptionalTest) {
+    scenarioWeb("M2. Member sees a Masterclass list", EventListTest, OptionalTest) {
       implicit driver =>
         given {
           MembershipSteps().IAmLoggedInAsAPartner
@@ -38,7 +38,7 @@ class MasterclassTests extends BaseMembershipTest {
 
   feature("Masterclass event details") {
 
-    scenarioWeb("49. Visitor sees the details for a Masterclass", EventDetailTest, OptionalTest) {
+    scenarioWeb("M3. Visitor sees the details for a Masterclass", EventDetailTest, OptionalTest) {
       implicit driver =>
         given {
           MembershipSteps().IGoToMasterclasses
@@ -51,7 +51,7 @@ class MasterclassTests extends BaseMembershipTest {
         }
     }
 
-    scenarioWeb("50. Member sees the details for a Masterclass", EventDetailTest, OptionalTest) {
+    scenarioWeb("M4. Member sees the details for a Masterclass", EventDetailTest, OptionalTest) {
       implicit driver =>
         given {
           MembershipSteps().IAmLoggedInAsAPatron

--- a/functional-tests/src/test/scala/tests/MembershipBenefitTests.scala
+++ b/functional-tests/src/test/scala/tests/MembershipBenefitTests.scala
@@ -1,6 +1,6 @@
 package tests
 
-import com.gu.membership.tags.OptionalTest
+import com.gu.membership.tags.{CoreTest, OptionalTest}
 import steps.MembershipSteps
 
 /**
@@ -12,7 +12,7 @@ class MembershipBenefitTests extends BaseMembershipTest {
 
   feature("User gets benefits from being a member") {
 
-    scenarioWeb("25. Member gets a discount", OptionalTest) { implicit driver =>
+    scenarioWeb("MB1. Member gets a discount", CoreTest) { implicit driver =>
       given {
         MembershipSteps().IAmNotLoggedIn
       }
@@ -24,7 +24,7 @@ class MembershipBenefitTests extends BaseMembershipTest {
       }
     }
 
-    scenarioWeb("26. Discount gets compared to non-discounted price", OptionalTest) {
+    scenarioWeb("MB2. Discount gets compared to non-discounted price", OptionalTest) {
       implicit driver =>
       given {
         MembershipSteps().IAmLoggedIn
@@ -40,7 +40,7 @@ class MembershipBenefitTests extends BaseMembershipTest {
 
   feature("Membership tab") {
 
-    scenarioWeb("28. Membership tab appears if you are a Partner", OptionalTest) {
+    scenarioWeb("MB3. Membership tab appears if you are a Partner", CoreTest) {
       implicit driver =>
       given {
         MembershipSteps().IAmLoggedIn
@@ -53,7 +53,7 @@ class MembershipBenefitTests extends BaseMembershipTest {
       }
     }
 
-    scenarioWeb("32. Membership tab appears if you are a Patron", OptionalTest) {
+    scenarioWeb("MB4. Membership tab appears if you are a Patron", OptionalTest) {
       implicit driver =>
         given {
           MembershipSteps().IAmLoggedIn
@@ -66,7 +66,7 @@ class MembershipBenefitTests extends BaseMembershipTest {
         }
     }
 
-    scenarioWeb("33. Membership tab appears if you are a Friend", OptionalTest) {
+    scenarioWeb("MB5. Membership tab appears if you are a Friend", OptionalTest) {
       implicit driver =>
         given {
           MembershipSteps().IAmLoggedIn
@@ -79,7 +79,7 @@ class MembershipBenefitTests extends BaseMembershipTest {
         }
     }
 
-    scenarioWeb("29. Membership tab is an upsell if you are not a member", OptionalTest) {
+    scenarioWeb("MB6. Membership tab is an upsell if you are not a member", CoreTest) {
       implicit driver =>
       given {
         MembershipSteps().IAmLoggedIn

--- a/functional-tests/src/test/scala/tests/MembershipBenefitTests.scala
+++ b/functional-tests/src/test/scala/tests/MembershipBenefitTests.scala
@@ -1,4 +1,7 @@
+package tests
 
+import com.gu.membership.tags.OptionalTest
+import steps.MembershipSteps
 
 /**
  * Created by jao on 06/06/2014.
@@ -9,7 +12,7 @@ class MembershipBenefitTests extends BaseMembershipTest {
 
   feature("User gets benefits from being a member") {
 
-    scenarioWeb("25. Member gets a discount") { implicit driver =>
+    scenarioWeb("25. Member gets a discount", OptionalTest) { implicit driver =>
       given {
         MembershipSteps().IAmNotLoggedIn
       }
@@ -21,7 +24,7 @@ class MembershipBenefitTests extends BaseMembershipTest {
       }
     }
 
-    scenarioWeb("26. Discount gets compared to non-discounted price") {
+    scenarioWeb("26. Discount gets compared to non-discounted price", OptionalTest) {
       implicit driver =>
       given {
         MembershipSteps().IAmLoggedIn
@@ -37,7 +40,7 @@ class MembershipBenefitTests extends BaseMembershipTest {
 
   feature("Membership tab") {
 
-    scenarioWeb("28. Membership tab appears if you are a Partner") {
+    scenarioWeb("28. Membership tab appears if you are a Partner", OptionalTest) {
       implicit driver =>
       given {
         MembershipSteps().IAmLoggedIn
@@ -50,7 +53,7 @@ class MembershipBenefitTests extends BaseMembershipTest {
       }
     }
 
-    scenarioWeb("32. Membership tab appears if you are a Patron") {
+    scenarioWeb("32. Membership tab appears if you are a Patron", OptionalTest) {
       implicit driver =>
         given {
           MembershipSteps().IAmLoggedIn
@@ -63,7 +66,7 @@ class MembershipBenefitTests extends BaseMembershipTest {
         }
     }
 
-    scenarioWeb("33. Membership tab appears if you are a Friend") {
+    scenarioWeb("33. Membership tab appears if you are a Friend", OptionalTest) {
       implicit driver =>
         given {
           MembershipSteps().IAmLoggedIn
@@ -76,7 +79,7 @@ class MembershipBenefitTests extends BaseMembershipTest {
         }
     }
 
-    scenarioWeb("29. Membership tab is an upsell if you are not a member") {
+    scenarioWeb("29. Membership tab is an upsell if you are not a member", OptionalTest) {
       implicit driver =>
       given {
         MembershipSteps().IAmLoggedIn

--- a/functional-tests/src/test/scala/tests/MembershipCardDetailsTests.scala
+++ b/functional-tests/src/test/scala/tests/MembershipCardDetailsTests.scala
@@ -1,4 +1,7 @@
+package tests
 
+import com.gu.membership.tags.OptionalTest
+import steps.MembershipSteps
 
 /**
 * Created by jao on 19/06/2014.
@@ -9,7 +12,7 @@ class MembershipCardDetailsTests extends BaseMembershipTest {
 
   feature("Manage card payment details") {
 
-    scenarioWeb("39. User can update card details") { implicit driver =>
+    scenarioWeb("39. User can update card details", OptionalTest) { implicit driver =>
       given {
         MembershipSteps().IAmLoggedInAsAPartner
       }
@@ -21,7 +24,7 @@ class MembershipCardDetailsTests extends BaseMembershipTest {
       }
     }
 
-    scenarioWeb("40. User can't add an incorrect card") { implicit driver =>
+    scenarioWeb("40. User can't add an incorrect card", OptionalTest) { implicit driver =>
       given {
         MembershipSteps().IAmLoggedInAsAPartner
       }
@@ -33,7 +36,7 @@ class MembershipCardDetailsTests extends BaseMembershipTest {
       }
     }
 
-    scenarioWeb("41. User can't add a card with invalid expiry date") {
+    scenarioWeb("41. User can't add a card with invalid expiry date", OptionalTest) {
       implicit driver =>
       given {
         MembershipSteps().IAmLoggedInAsAPartner

--- a/functional-tests/src/test/scala/tests/MembershipCardDetailsTests.scala
+++ b/functional-tests/src/test/scala/tests/MembershipCardDetailsTests.scala
@@ -12,7 +12,7 @@ class MembershipCardDetailsTests extends BaseMembershipTest {
 
   feature("Manage card payment details") {
 
-    scenarioWeb("39. User can update card details", OptionalTest) { implicit driver =>
+    scenarioWeb("MCD1. User can update card details", OptionalTest) { implicit driver =>
       given {
         MembershipSteps().IAmLoggedInAsAPartner
       }
@@ -24,7 +24,7 @@ class MembershipCardDetailsTests extends BaseMembershipTest {
       }
     }
 
-    scenarioWeb("40. User can't add an incorrect card", OptionalTest) { implicit driver =>
+    scenarioWeb("MCD2. User can't add an incorrect card", OptionalTest) { implicit driver =>
       given {
         MembershipSteps().IAmLoggedInAsAPartner
       }
@@ -36,7 +36,7 @@ class MembershipCardDetailsTests extends BaseMembershipTest {
       }
     }
 
-    scenarioWeb("41. User can't add a card with invalid expiry date", OptionalTest) {
+    scenarioWeb("MCD3. User can't add a card with invalid expiry date", OptionalTest) {
       implicit driver =>
       given {
         MembershipSteps().IAmLoggedInAsAPartner

--- a/functional-tests/src/test/scala/tests/MembershipChangeTierTests.scala
+++ b/functional-tests/src/test/scala/tests/MembershipChangeTierTests.scala
@@ -10,7 +10,7 @@ class MembershipChangeTierTests extends BaseMembershipTest {
 
   feature("A user can downgrade") {
 
-    scenarioWeb("30. A Partner can downgrade to a Friend", UserChangeTier, OptionalTest) {
+    scenarioWeb("MCT1. A Partner can downgrade to a Friend", UserChangeTier, OptionalTest) {
       implicit driver =>
       given {
         MembershipSteps().IAmLoggedInAsAPartner
@@ -23,7 +23,7 @@ class MembershipChangeTierTests extends BaseMembershipTest {
       }
     }
 
-    scenarioWeb("31. A Patron can downgrade to a Friend", UserChangeTier, OptionalTest) {
+    scenarioWeb("MCT2. A Patron can downgrade to a Friend", UserChangeTier, OptionalTest) {
       implicit driver =>
         given {
           MembershipSteps().IAmLoggedInAsAPatron
@@ -39,7 +39,7 @@ class MembershipChangeTierTests extends BaseMembershipTest {
 
   feature("A user can upgrade") {
 
-    scenarioWeb("34. A friend can upgrade to a partner", UserChangeTier, OptionalTest) {
+    scenarioWeb("MCT3. A friend can upgrade to a partner", UserChangeTier, CoreTest) {
       implicit driver =>
         given {
           MembershipSteps().IAmLoggedInAsAFriend
@@ -52,7 +52,7 @@ class MembershipChangeTierTests extends BaseMembershipTest {
         }
     }
 
-    scenarioWeb("36. A Friend can upgrade to a Patron", UserChangeTier, OptionalTest) {
+    scenarioWeb("MCT4. A Friend can upgrade to a Patron", UserChangeTier, OptionalTest) {
       implicit driver =>
         given {
           MembershipSteps().IAmLoggedInAsAFriend
@@ -66,7 +66,7 @@ class MembershipChangeTierTests extends BaseMembershipTest {
     }
   }
 
-  scenarioWeb("37. A Partner can cancel membership", UserChangeTier, OptionalTest) {
+  scenarioWeb("MCT5. A Partner can cancel membership", UserChangeTier, OptionalTest) {
     implicit driver =>
       given {
         MembershipSteps().IAmLoggedInAsAPartner
@@ -79,7 +79,7 @@ class MembershipChangeTierTests extends BaseMembershipTest {
       }
   }
 
-  scenarioWeb("43. An existing friend cannot become a friend again", UserChangeTier, OptionalTest) {
+  scenarioWeb("MCT6. An existing friend cannot become a friend again", UserChangeTier, OptionalTest) {
     implicit driver =>
       given {
         MembershipSteps().IAmLoggedInAsAFriend
@@ -92,7 +92,7 @@ class MembershipChangeTierTests extends BaseMembershipTest {
       }
   }
 
-  scenarioWeb("44. An existing partner cannot become a partner again", UserChangeTier, OptionalTest) {
+  scenarioWeb("MCT7. An existing partner cannot become a partner again", UserChangeTier, OptionalTest) {
     implicit driver =>
       given {
         MembershipSteps().IAmLoggedInAsAPartner
@@ -105,7 +105,7 @@ class MembershipChangeTierTests extends BaseMembershipTest {
       }
   }
 
-  scenarioWeb("45. An existing patron cannot become a patron again", UserChangeTier, OptionalTest) {
+  scenarioWeb("MCT8. An existing patron cannot become a patron again", UserChangeTier, OptionalTest) {
     implicit driver =>
       given {
         MembershipSteps().IAmLoggedInAsAPatron

--- a/functional-tests/src/test/scala/tests/MembershipChangeTierTests.scala
+++ b/functional-tests/src/test/scala/tests/MembershipChangeTierTests.scala
@@ -1,4 +1,7 @@
+package tests
+
 import com.gu.membership.tags._
+import steps.MembershipSteps
 
 
 class MembershipChangeTierTests extends BaseMembershipTest {
@@ -7,7 +10,7 @@ class MembershipChangeTierTests extends BaseMembershipTest {
 
   feature("A user can downgrade") {
 
-    scenarioWeb("30. A Partner can downgrade to a Friend", UserChangeTier) {
+    scenarioWeb("30. A Partner can downgrade to a Friend", UserChangeTier, OptionalTest) {
       implicit driver =>
       given {
         MembershipSteps().IAmLoggedInAsAPartner
@@ -20,7 +23,7 @@ class MembershipChangeTierTests extends BaseMembershipTest {
       }
     }
 
-    scenarioWeb("31. A Patron can downgrade to a Friend", UserChangeTier) {
+    scenarioWeb("31. A Patron can downgrade to a Friend", UserChangeTier, OptionalTest) {
       implicit driver =>
         given {
           MembershipSteps().IAmLoggedInAsAPatron
@@ -36,7 +39,7 @@ class MembershipChangeTierTests extends BaseMembershipTest {
 
   feature("A user can upgrade") {
 
-    scenarioWeb("34. A friend can upgrade to a partner", UserChangeTier) {
+    scenarioWeb("34. A friend can upgrade to a partner", UserChangeTier, OptionalTest) {
       implicit driver =>
         given {
           MembershipSteps().IAmLoggedInAsAFriend
@@ -49,7 +52,7 @@ class MembershipChangeTierTests extends BaseMembershipTest {
         }
     }
 
-    scenarioWeb("36. A Friend can upgrade to a Patron", UserChangeTier) {
+    scenarioWeb("36. A Friend can upgrade to a Patron", UserChangeTier, OptionalTest) {
       implicit driver =>
         given {
           MembershipSteps().IAmLoggedInAsAFriend
@@ -63,7 +66,7 @@ class MembershipChangeTierTests extends BaseMembershipTest {
     }
   }
 
-  scenarioWeb("37. A Partner can cancel membership", UserChangeTier) {
+  scenarioWeb("37. A Partner can cancel membership", UserChangeTier, OptionalTest) {
     implicit driver =>
       given {
         MembershipSteps().IAmLoggedInAsAPartner
@@ -76,7 +79,7 @@ class MembershipChangeTierTests extends BaseMembershipTest {
       }
   }
 
-  scenarioWeb("43. An existing friend cannot become a friend again", UserChangeTier) {
+  scenarioWeb("43. An existing friend cannot become a friend again", UserChangeTier, OptionalTest) {
     implicit driver =>
       given {
         MembershipSteps().IAmLoggedInAsAFriend
@@ -89,7 +92,7 @@ class MembershipChangeTierTests extends BaseMembershipTest {
       }
   }
 
-  scenarioWeb("44. An existing partner cannot become a partner again", UserChangeTier) {
+  scenarioWeb("44. An existing partner cannot become a partner again", UserChangeTier, OptionalTest) {
     implicit driver =>
       given {
         MembershipSteps().IAmLoggedInAsAPartner
@@ -102,7 +105,7 @@ class MembershipChangeTierTests extends BaseMembershipTest {
       }
   }
 
-  scenarioWeb("45. An existing patron cannot become a patron again", UserChangeTier) {
+  scenarioWeb("45. An existing patron cannot become a patron again", UserChangeTier, OptionalTest) {
     implicit driver =>
       given {
         MembershipSteps().IAmLoggedInAsAPatron

--- a/functional-tests/src/test/scala/tests/MembershipEventTests.scala
+++ b/functional-tests/src/test/scala/tests/MembershipEventTests.scala
@@ -7,133 +7,133 @@ class MembershipEventTests extends BaseMembershipTest {
 
   feature("See event list") {
 
-      /*
-       I order to view an event's details
-       As a user
-       I want to see a list of events
-       */
-      scenarioWeb("1. Logged in user sees event list", EventListTest, OptionalTest) {
-        implicit driver =>
+    /*
+     I order to view an event's details
+     As a user
+     I want to see a list of events
+     */
+    scenarioWeb("ME1. Logged in user sees event list", EventListTest, CoreTest) {
+      implicit driver =>
         given {
           MembershipSteps().IAmLoggedIn
         }
-        .when {
+          .when {
           _.IGoToTheEventsPage
         }
-        .then {
+          .then {
           _.ISeeAListOfEvents
         }
-      }
-
-      scenarioWeb("2. Non logged in user sees event list", EventListTest, OptionalTest) {
-        implicit driver =>
-        given {
-          MembershipSteps().IAmNotLoggedIn
-        }
-        .when {
-          _.IGoToTheEventsPage
-        }
-        .then {
-          _.ISeeAListOfEvents
-        }
-      }
     }
 
-    feature("See details for an event") {
-      /*
-       In order to choose an event that I like
-       As a user
-       I want to see the details of an event
-       */
-      scenarioWeb("3. Logged in user sees details for an event", EventDetailTest, OptionalTest) {
-        implicit driver =>
-        given {
-          MembershipSteps().IAmLoggedIn
-        }
-        .when {
-          _.IClickOnAnEvent
-        }
-        .then {
-          _.ISeeTheEventDetails
-        }
-      }
-
-      scenarioWeb("4. Non logged in user sees details for an event", EventDetailTest, OptionalTest) {
-        implicit driver =>
+    scenarioWeb("ME2. Non logged in user sees event list", EventListTest, OptionalTest) {
+      implicit driver =>
         given {
           MembershipSteps().IAmNotLoggedIn
         }
-        .when {
+          .when {
+          _.IGoToTheEventsPage
+        }
+          .then {
+          _.ISeeAListOfEvents
+        }
+    }
+  }
+
+  feature("See details for an event") {
+    /*
+     In order to choose an event that I like
+     As a user
+     I want to see the details of an event
+     */
+    scenarioWeb("ME3. Logged in user sees details for an event", EventDetailTest, OptionalTest) {
+      implicit driver =>
+        given {
+          MembershipSteps().IAmLoggedIn
+        }
+          .when {
           _.IClickOnAnEvent
         }
-        .then {
+          .then {
           _.ISeeTheEventDetails
         }
-      }
+    }
 
-      scenarioWeb("5. Event details are the same as on the event provider", EventDetailTest, OptionalTest) {
-        implicit driver =>
+    scenarioWeb("ME4. Non logged in user sees details for an event", EventDetailTest, OptionalTest) {
+      implicit driver =>
+        given {
+          MembershipSteps().IAmNotLoggedIn
+        }
+          .when {
+          _.IClickOnAnEvent
+        }
+          .then {
+          _.ISeeTheEventDetails
+        }
+    }
+
+    scenarioWeb("ME5. Event details are the same as on the event provider", EventDetailTest, OptionalTest) {
+      implicit driver =>
         given {
           MembershipSteps().IAmLoggedInAsAFriend
         }
-        .when {
+          .when {
           _.IClickOnAnEvent
         }
-        .then {
+          .then {
           _.TheDetailsAreTheSameAsOnTheEventProvider
         }
-      }
     }
+  }
 
-    feature("Require login for purchase") {
-      /*
-       In order to purchase a ticket
-       As a user
-       I need to be logged in
-       */
-      scenarioWeb("6. Logged in user can purchase a ticket", EventTicketPurchase, OptionalTest) {
-        implicit driver =>
+  feature("Require login for purchase") {
+    /*
+     In order to purchase a ticket
+     As a user
+     I need to be logged in
+     */
+    scenarioWeb("ME6. Logged in user can purchase a ticket", EventTicketPurchase, OptionalTest) {
+      implicit driver =>
         given {
           MembershipSteps().IAmLoggedInAsAFriend
         }
-        .when {
+          .when {
           _.IClickThePurchaseButton
         }
-        .then {
+          .then {
           _.ICanPurchaseATicket
         }
-      }
+    }
 
-      // buy button is disabled for non members
-//    scenarioWeb("7. Non logged in user has to login in order to purchase a ticket", OptionalTest) {
+    // buy button is disabled for non members
+//    scenarioWeb("ME7. Non logged in user has to login in order to purchase a ticket", OptionalTest) {
 //      implicit driver =>
-//      given {
-//        steps.MembershipSteps().IAmNotLoggedIn
-//      }
-//      .when {
-//        _.IClickThePurchaseButton
-//      }
-//      .then {
-//        _.IAmRedirectedToTheChooseTierPage
-//      }
-////    }
-//
-//    scenarioWeb("27. Non-registered user can become a friend and purchase a ticket", OptionalTest) {
-//      implicit driver =>
-//      given {
-//        steps.MembershipSteps().IAmNotLoggedIn
-//      }
-//      .when {
-//        _.IClickThePurchaseButton
-//      }
-//      .then {
-//        _.IAmRedirectedToTheChooseTierPage
-//        .ICanBecomeAFriend
-//        .ICanSeeTheTicketIframe
-//      }
+//        given {
+//          steps.MembershipSteps().IAmNotLoggedIn
+//        }
+//          .when {
+//          _.IClickThePurchaseButton
+//        }
+//          .then {
+//          _.IAmRedirectedToTheChooseTierPage
+//        }
 //    }
 //
-//    scenarioWeb("38. Non-registered user can become a partner and purchase a ticket", OptionalTest) {
+//    scenarioWeb("ME8. Non-registered user can become a friend and purchase a ticket", OptionalTest) {
+//      implicit driver =>
+//        given {
+//          steps.MembershipSteps().IAmNotLoggedIn
+//        }
+//          .when {
+//          _.IClickThePurchaseButton
+//        }
+//          .then {
+//          _.IAmRedirectedToTheChooseTierPage
+//            .ICanBecomeAFriend
+//            .ICanSeeTheTicketIframe
+//        }
+//    }
+//
+//    scenarioWeb("ME9. Non-registered user can become a partner and purchase a ticket", OptionalTest) {
 //      implicit driver =>
 //        given {
 //          steps.MembershipSteps().IAmNotLoggedIn

--- a/functional-tests/src/test/scala/tests/MembershipEventTests.scala
+++ b/functional-tests/src/test/scala/tests/MembershipEventTests.scala
@@ -1,4 +1,7 @@
+package tests
+
 import com.gu.membership.tags._
+import steps.MembershipSteps
 
 class MembershipEventTests extends BaseMembershipTest {
 
@@ -9,7 +12,7 @@ class MembershipEventTests extends BaseMembershipTest {
        As a user
        I want to see a list of events
        */
-      scenarioWeb("1. Logged in user sees event list", EventListTest) {
+      scenarioWeb("1. Logged in user sees event list", EventListTest, OptionalTest) {
         implicit driver =>
         given {
           MembershipSteps().IAmLoggedIn
@@ -22,7 +25,7 @@ class MembershipEventTests extends BaseMembershipTest {
         }
       }
 
-      scenarioWeb("2. Non logged in user sees event list", EventListTest) {
+      scenarioWeb("2. Non logged in user sees event list", EventListTest, OptionalTest) {
         implicit driver =>
         given {
           MembershipSteps().IAmNotLoggedIn
@@ -42,7 +45,7 @@ class MembershipEventTests extends BaseMembershipTest {
        As a user
        I want to see the details of an event
        */
-      scenarioWeb("3. Logged in user sees details for an event", EventDetailTest) {
+      scenarioWeb("3. Logged in user sees details for an event", EventDetailTest, OptionalTest) {
         implicit driver =>
         given {
           MembershipSteps().IAmLoggedIn
@@ -55,7 +58,7 @@ class MembershipEventTests extends BaseMembershipTest {
         }
       }
 
-      scenarioWeb("4. Non logged in user sees details for an event", EventDetailTest) {
+      scenarioWeb("4. Non logged in user sees details for an event", EventDetailTest, OptionalTest) {
         implicit driver =>
         given {
           MembershipSteps().IAmNotLoggedIn
@@ -68,7 +71,7 @@ class MembershipEventTests extends BaseMembershipTest {
         }
       }
 
-      scenarioWeb("5. Event details are the same as on the event provider", EventDetailTest) {
+      scenarioWeb("5. Event details are the same as on the event provider", EventDetailTest, OptionalTest) {
         implicit driver =>
         given {
           MembershipSteps().IAmLoggedInAsAFriend
@@ -88,7 +91,7 @@ class MembershipEventTests extends BaseMembershipTest {
        As a user
        I need to be logged in
        */
-      scenarioWeb("6. Logged in user can purchase a ticket", EventTicketPurchase) {
+      scenarioWeb("6. Logged in user can purchase a ticket", EventTicketPurchase, OptionalTest) {
         implicit driver =>
         given {
           MembershipSteps().IAmLoggedInAsAFriend
@@ -102,10 +105,10 @@ class MembershipEventTests extends BaseMembershipTest {
       }
 
       // buy button is disabled for non members
-//    scenarioWeb("7. Non logged in user has to login in order to purchase a ticket") {
+//    scenarioWeb("7. Non logged in user has to login in order to purchase a ticket", OptionalTest) {
 //      implicit driver =>
 //      given {
-//        MembershipSteps().IAmNotLoggedIn
+//        steps.MembershipSteps().IAmNotLoggedIn
 //      }
 //      .when {
 //        _.IClickThePurchaseButton
@@ -115,10 +118,10 @@ class MembershipEventTests extends BaseMembershipTest {
 //      }
 ////    }
 //
-//    scenarioWeb("27. Non-registered user can become a friend and purchase a ticket") {
+//    scenarioWeb("27. Non-registered user can become a friend and purchase a ticket", OptionalTest) {
 //      implicit driver =>
 //      given {
-//        MembershipSteps().IAmNotLoggedIn
+//        steps.MembershipSteps().IAmNotLoggedIn
 //      }
 //      .when {
 //        _.IClickThePurchaseButton
@@ -130,10 +133,10 @@ class MembershipEventTests extends BaseMembershipTest {
 //      }
 //    }
 //
-//    scenarioWeb("38. Non-registered user can become a partner and purchase a ticket") {
+//    scenarioWeb("38. Non-registered user can become a partner and purchase a ticket", OptionalTest) {
 //      implicit driver =>
 //        given {
-//          MembershipSteps().IAmNotLoggedIn
+//          steps.MembershipSteps().IAmNotLoggedIn
 //        }
 //          .when {
 //          _.IClickThePurchaseButton

--- a/functional-tests/src/test/scala/tests/MembershipPaymentTests.scala
+++ b/functional-tests/src/test/scala/tests/MembershipPaymentTests.scala
@@ -1,6 +1,6 @@
 package tests
 
-import com.gu.membership.tags.OptionalTest
+import com.gu.membership.tags.{CoreTest, OptionalTest}
 import steps.MembershipSteps
 
 /**
@@ -17,7 +17,7 @@ class MembershipPaymentTests extends BaseMembershipTest {
      As a user
      I want to be able to pay a subscription
      */
-    scenarioWeb("9. Non-logged in registered user purchase a subscription", OptionalTest) {
+    scenarioWeb("MP1. Non-logged in registered user purchase a subscription", OptionalTest) {
       implicit driver =>
       given {
         MembershipSteps().IAmNotLoggedIn
@@ -32,7 +32,7 @@ class MembershipPaymentTests extends BaseMembershipTest {
       }
     }
 
-    scenarioWeb("10. Logged in user can purchase a subscription", OptionalTest) {
+    scenarioWeb("MP2. Logged in user can purchase a subscription", CoreTest) {
       implicit driver =>
       given {
         MembershipSteps().IAmLoggedIn
@@ -45,7 +45,7 @@ class MembershipPaymentTests extends BaseMembershipTest {
       }
     }
 
-    scenarioWeb("11. A user who pays should be able to see the payment details", OptionalTest) {
+    scenarioWeb("MP3. A user who pays should be able to see the payment details", OptionalTest) {
       implicit driver =>
       given {
         MembershipSteps().IAmLoggedIn
@@ -58,7 +58,7 @@ class MembershipPaymentTests extends BaseMembershipTest {
       }
     }
 
-    scenarioWeb("20. User with incorrect card number cannot make a purchase", OptionalTest) {
+    scenarioWeb("MP4. User with incorrect card number cannot make a purchase", OptionalTest) {
       implicit driver =>
       given {
         MembershipSteps().IAmLoggedIn
@@ -71,7 +71,7 @@ class MembershipPaymentTests extends BaseMembershipTest {
       }
     }
 
-    scenarioWeb("21. User with no funds in account cannot make a purchase", OptionalTest) {
+    scenarioWeb("MP5. User with no funds in account cannot make a purchase", OptionalTest) {
       implicit driver =>
       given {
         MembershipSteps().IAmLoggedIn
@@ -84,7 +84,7 @@ class MembershipPaymentTests extends BaseMembershipTest {
       }
     }
 
-    scenarioWeb("22. User with incorrect CVC in card cannot make a purchase", OptionalTest) {
+    scenarioWeb("MP6. User with incorrect CVC in card cannot make a purchase", OptionalTest) {
       implicit driver =>
       given {
         MembershipSteps().IAmLoggedIn
@@ -97,7 +97,7 @@ class MembershipPaymentTests extends BaseMembershipTest {
       }
     }
 
-    scenarioWeb("24. User with invalid expiry date in card cannot make a purchase", OptionalTest) {
+    scenarioWeb("MP7. User with invalid expiry date in card cannot make a purchase", OptionalTest) {
       implicit driver =>
       given {
         MembershipSteps().IAmLoggedIn

--- a/functional-tests/src/test/scala/tests/MembershipPaymentTests.scala
+++ b/functional-tests/src/test/scala/tests/MembershipPaymentTests.scala
@@ -1,4 +1,7 @@
+package tests
 
+import com.gu.membership.tags.OptionalTest
+import steps.MembershipSteps
 
 /**
  * Created by jao on 29/05/2014.
@@ -14,7 +17,7 @@ class MembershipPaymentTests extends BaseMembershipTest {
      As a user
      I want to be able to pay a subscription
      */
-    scenarioWeb("9. Non-logged in registered user purchase a subscription") {
+    scenarioWeb("9. Non-logged in registered user purchase a subscription", OptionalTest) {
       implicit driver =>
       given {
         MembershipSteps().IAmNotLoggedIn
@@ -29,7 +32,7 @@ class MembershipPaymentTests extends BaseMembershipTest {
       }
     }
 
-    scenarioWeb("10. Logged in user can purchase a subscription") {
+    scenarioWeb("10. Logged in user can purchase a subscription", OptionalTest) {
       implicit driver =>
       given {
         MembershipSteps().IAmLoggedIn
@@ -42,7 +45,7 @@ class MembershipPaymentTests extends BaseMembershipTest {
       }
     }
 
-    scenarioWeb("11. A user who pays should be able to see the payment details") {
+    scenarioWeb("11. A user who pays should be able to see the payment details", OptionalTest) {
       implicit driver =>
       given {
         MembershipSteps().IAmLoggedIn
@@ -55,7 +58,7 @@ class MembershipPaymentTests extends BaseMembershipTest {
       }
     }
 
-    scenarioWeb("20. User with incorrect card number cannot make a purchase") {
+    scenarioWeb("20. User with incorrect card number cannot make a purchase", OptionalTest) {
       implicit driver =>
       given {
         MembershipSteps().IAmLoggedIn
@@ -68,7 +71,7 @@ class MembershipPaymentTests extends BaseMembershipTest {
       }
     }
 
-    scenarioWeb("21. User with no funds in account cannot make a purchase") {
+    scenarioWeb("21. User with no funds in account cannot make a purchase", OptionalTest) {
       implicit driver =>
       given {
         MembershipSteps().IAmLoggedIn
@@ -81,7 +84,7 @@ class MembershipPaymentTests extends BaseMembershipTest {
       }
     }
 
-    scenarioWeb("22. User with incorrect CVC in card cannot make a purchase") {
+    scenarioWeb("22. User with incorrect CVC in card cannot make a purchase", OptionalTest) {
       implicit driver =>
       given {
         MembershipSteps().IAmLoggedIn
@@ -94,7 +97,7 @@ class MembershipPaymentTests extends BaseMembershipTest {
       }
     }
 
-    scenarioWeb("24. User with invalid expiry date in card cannot make a purchase") {
+    scenarioWeb("24. User with invalid expiry date in card cannot make a purchase", OptionalTest) {
       implicit driver =>
       given {
         MembershipSteps().IAmLoggedIn

--- a/functional-tests/src/test/scala/tests/MembershipSubscriptionTests.scala
+++ b/functional-tests/src/test/scala/tests/MembershipSubscriptionTests.scala
@@ -1,3 +1,8 @@
+package tests
+
+import com.gu.membership.tags.OptionalTest
+import steps.MembershipSteps
+
 /**
  * Created by jao on 30/09/2014.
  */
@@ -5,7 +10,7 @@ class MembershipSubscriptionTests extends BaseMembershipTest {
 
   feature("A user's information should be pre-populated") {
 
-    scenarioWeb("46. A user's Identity information is pre-populated in the membership subscription form") {
+    scenarioWeb("46. A user's Identity information is pre-populated in the membership subscription form", OptionalTest) {
       implicit driver =>
         given {
           MembershipSteps().IHaveInformationInIdentity


### PR DESCRIPTION
I've added some new test tags and added them to the tests.  If only the core tests are run then the test suite takes about 3 minutes to run.

I've also moved the tests and steps into packages of their own to make the separation more obvious.

When running the core tests some tests were failing because of changes made to the tier prices (test prices in line with production prices now) and a field that had a css selector updated because of the supporter tier changes.