### PR TITLE
turn of async tracking

### DIFF
--- a/frontend/app/tracking/ActivityTracking.scala
+++ b/frontend/app/tracking/ActivityTracking.scala
@@ -216,7 +216,6 @@ trait ActivityTracking {
 
   private def getTracker: Tracker = {
     val emitter = new Emitter(ActivityTracking.url, HttpMethod.GET)
-    emitter.setRequestMethod(RequestMethod.Asynchronous)
     val subject = new Subject
     new Tracker(emitter, subject, "membership", "membership-frontend")
   }


### PR DESCRIPTION
This stops async requests for membership event tracking. It seems to be causing file handle limit issues so this is to fix that in the short term.