### PR TITLE
Update intro image on Supporter page

### DIFF
--- a/frontend/app/controllers/Info.scala
+++ b/frontend/app/controllers/Info.scala
@@ -77,7 +77,7 @@ trait Info extends Controller {
         name=Some("intro"),
         altText=Some("Introducing Supporter Membership"),
         availableImages=ResponsiveImageGenerator(
-          id="a0e123f3289d26e0cf30153e64b89f4655a7e0d2/0_0_1999_1200",
+          id="f55167b65375c2f078a88d09856bc46670d21f57/0_0_2000_1200",
           sizes=List(1000,500)
         )
       ),


### PR DESCRIPTION
Update intro image on Supporter page

**Before**
![screen shot 2015-06-25 at 12 06 52](https://cloud.githubusercontent.com/assets/123386/8353113/bee40c6c-1b32-11e5-9389-28d1cb2d1732.png)

**After**
![screen shot 2015-06-25 at 12 06 43](https://cloud.githubusercontent.com/assets/123386/8353117/c488c4c8-1b32-11e5-9569-0d2b20168211.png)

@jennysivapalan 
