### PR TITLE
Switch to px-to-rem

### DIFF
--- a/frontend/Gruntfile.js
+++ b/frontend/Gruntfile.js
@@ -50,10 +50,7 @@ module.exports = function (grunt) {
             options: {
                 outputStyle: 'compressed',
                 sourceMap: isDev,
-                precision: 5,
-                includePaths: [
-                    '<%= dirs.assets.stylesheets %>/components/sass-mq'
-                ]
+                precision: 5
             },
             dist: {
                 files: [{
@@ -64,9 +61,27 @@ module.exports = function (grunt) {
                         'ie9.style.scss',
                         'tools.style.scss',
                         'event-card.scss',
-                        'admin/admin.style.scss'],
+                        'admin/admin.style.scss'
+                    ],
                     dest: '<%= dirs.publicDir.stylesheets %>',
                     ext: '.css'
+                }]
+            }
+        },
+
+        px_to_rem: {
+            dist: {
+                options: {
+                    map: isDev,
+                    base: 16,
+                    fallback: false,
+                    max_decimals: 5
+                },
+                files: [{
+                    expand: true,
+                    cwd: '<%= dirs.publicDir.stylesheets %>',
+                    src: ['*.css'],
+                    dest: '<%= dirs.publicDir.stylesheets %>'
                 }]
             }
         },
@@ -367,6 +382,30 @@ module.exports = function (grunt) {
 
     grunt.registerTask('validate', ['eslint']);
 
+    grunt.registerTask('build:images', ['svgSprite', 'copy:images', 'imagemin']);
+    grunt.registerTask('build:css', ['sass', 'px_to_rem', 'postcss']);
+
+    grunt.registerTask('compile:css', [
+        'clean:css',
+        'clean:images',
+        'build:images',
+        'build:css'
+    ]);
+    grunt.registerTask('compile:js', function() {
+        if (!isDev) {
+            grunt.task.run(['validate']);
+        }
+        grunt.task.run([
+            'clean:js',
+            'requirejs:compile',
+            'requirejs:compileTools',
+            'requirejs:compileAdmin',
+            'copy:polyfills',
+            'copy:curl',
+            'copy:zxcvbn',
+            'copy:omniture'
+        ]);
+    });
     grunt.registerTask('compile', function(){
         grunt.task.run([
             'clean:public',
@@ -383,32 +422,6 @@ module.exports = function (grunt) {
                 'clean:public:prod'
             ]);
         }
-    });
-    grunt.registerTask('compile:css', function() {
-        grunt.task.run([
-            'clean:css',
-            'clean:images',
-            'svgSprite',
-            'copy:images',
-            'imagemin',
-            'sass',
-            'postcss'
-        ]);
-    });
-    grunt.registerTask('compile:js', function() {
-        if (!isDev) {
-            grunt.task.run(['validate']);
-        }
-        grunt.task.run([
-            'clean:js',
-            'requirejs:compile',
-            'requirejs:compileTools',
-            'requirejs:compileAdmin',
-            'copy:polyfills',
-            'copy:curl',
-            'copy:zxcvbn',
-            'copy:omniture'
-        ]);
     });
 
     /***********************************************************************

--- a/frontend/assets/stylesheets/_mixins.scss
+++ b/frontend/assets/stylesheets/_mixins.scss
@@ -7,6 +7,8 @@
 // Guss - https://github.com/guardian/guss
 // =============================================================================
 
+$guss-rem-baseline: 16px;
+
 @import 'components/bower-components/guss-rem/rem';
 @import 'components/bower-components/guss-typography/typography';
 @import 'components/bower-components/guss-layout/columns';

--- a/frontend/assets/stylesheets/base/_base.scss
+++ b/frontend/assets/stylesheets/base/_base.scss
@@ -28,12 +28,11 @@ body:after {
 html {
     overflow-y: scroll;
     font-family: $f-serif-text;
-    font-size: 10px;
+    font-size: 100%;
 }
 
 body {
     color: $c-body;
-    font-size: 1.6em; // Bump font-size back up to 16px
     line-height: 1.4;
 }
 
@@ -43,7 +42,7 @@ h1, h2, h3, h4, h5, h6 {
 
 p {
     margin-top: 0;
-    margin-bottom: rem($gs-baseline * 1.3333);
+    margin-bottom: $gs-baseline * 1.3333;
 }
 
 table {
@@ -59,7 +58,7 @@ blockquote,
     font-style: italic;
     font-weight: 300;
     margin: 0;
-    margin-bottom: rem($gs-baseline);
+    margin-bottom: $gs-baseline;
 
     &:before {
         content: '';
@@ -68,13 +67,13 @@ blockquote,
         background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzNCIgaGVpZ2h0PSIyMCI+PHBhdGggZmlsbD0iIzRCQzZERiIgZD0iTTI2LjU1OCA1Ljk5OGMtMi4wMjMgMC0zLjg0NS44Ni01LjEyNCAyLjIzMi0uMDc3LS40Ny0uMTE4LS45NTctLjExOC0xLjQ2IDAtMy41MDYgMi40NS02LjM1IDYuMDU1LTYuMzUgMS42MTYgMCAzLjEzLjU4OCA0LjI2OCAxLjUzMmguNTEyYy0xLjYyMS0xLjM0NC0yLjcyNC0xLjg2NS01LjIwMy0xLjk0Ny01LjY3LS4xODctOS41OTUgNC40NzYtOS41OTUgOS45OTdzMy4zNzcgOS45OTggOS4wNSA5Ljk5OHYtLjAwNGwuMTU1LjAwNGMzLjg2NyAwIDctMy4xMzUgNy03IC4wMDItMy44NjgtMy4xMzMtNy4wMDItNy03LjAwMnptLTE3LjM1NCAwYy0yLjAyMyAwLTMuODQ1Ljg2LTUuMTIzIDIuMjMyLS4wNzctLjQ3LS4xMTctLjk1Ny0uMTE3LTEuNDYgMC0zLjUwNiAyLjQ1LTYuMzUgNi4wNTYtNi4zNSAxLjYxNCAwIDMuMTI2LjU4OCA0LjI2NiAxLjUzMmguNTEyYy0xLjYyLTEuMzQ0LTIuNzIyLTEuODY1LTUuMi0xLjk0Ny01LjY3My0uMTg3LTkuNTk4IDQuNDc1LTkuNTk4IDkuOTk3czMuMzc2IDkuOTk4IDkuMDUgOS45OTh2LS4wMDRsLjE1NC4wMDRjMy44NjcgMCA3LjAwMi0zLjEzNSA3LjAwMi03IDAtMy44NjgtMy4xMzUtNy4wMDItNy4wMDItNy4wMDJ6Ii8+PC9zdmc+);
         background-repeat: no-repeat;
         width: 34px; height: 20px;
-        margin-right: rem($gs-baseline / 2);
+        margin-right: $gs-baseline / 2;
     }
 }
 .blockquote__citation {
     @include fs-data(4);
     font-style: normal;
-    margin-top: rem($gs-baseline / 2);
+    margin-top: $gs-baseline / 2;
     display: block;
 }
 
@@ -95,5 +94,5 @@ blockquote,
 
 address {
     font-style: normal;
-    margin-bottom: rem($gs-baseline / 2);
+    margin-bottom: $gs-baseline / 2;
 }

--- a/frontend/assets/stylesheets/base/_helpers.scss
+++ b/frontend/assets/stylesheets/base/_helpers.scss
@@ -50,21 +50,21 @@
 .u-anchor {
     @include mq($until: mem-full) {
         position: absolute;
-        right: rem($gs-gutter / 2);
-        top: rem($gs-gutter / 2);
+        right: $gs-gutter / 2;
+        top: $gs-gutter / 2;
     }
 }
 
 .u-divider {
-    padding-top: rem($gs-baseline / 2);
+    padding-top: $gs-baseline / 2;
     border-top: 1px solid $c-border-brand;
 }
 .u-divider-neutral {
-    padding-top: rem($gs-baseline / 2);
+    padding-top: $gs-baseline / 2;
     border-top: 1px solid $c-border-neutral;
 }
 .u-divider-dotted {
-    padding-top: rem($gs-baseline / 2);
+    padding-top: $gs-baseline / 2;
     border-top: 1px dotted $c-neutral3;
 }
 

--- a/frontend/assets/stylesheets/tools/layout/_page.scss
+++ b/frontend/assets/stylesheets/tools/layout/_page.scss
@@ -2,7 +2,7 @@
    Utils page layout
    ========================================================================== */
 .utils-page-section {
-    padding: rem(10px);
+    padding: 10px;
 }
 
 .utils-page-section-header {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "grunt-eslint": "^15.0.0",
     "grunt-karma": "~0.11.0",
     "grunt-postcss": "^0.5.1",
+    "grunt-px-to-rem": "^0.4.0",
     "grunt-sass": "^1.0.0",
     "grunt-shell": "~1.1.2",
     "grunt-svgmin": "^2.0.1",


### PR DESCRIPTION
This PR switches from `guss-rem` to a grunt task for converting px values to `rem` units. Means we no longer have to wrap everything in `rem()`. Removes a few instances of `rem()`, another PR will follow removing the rest if this goes well.

Frontend have already made this move and as `guss-rem` is unlikely to get much love in future it makes sense to move to this as well.

Tested a key pages across a few browsers and all looks good:

![screen shot 2015-06-25 at 14 18 31](https://cloud.githubusercontent.com/assets/123386/8355324/89b5ec04-1b46-11e5-9ab0-ffe6cf296965.png)

![screen shot 2015-06-25 at 14 23 18](https://cloud.githubusercontent.com/assets/123386/8355323/89b5387c-1b46-11e5-8476-66a26bb8af84.png)

![screen shot 2015-06-25 at 14 18 46](https://cloud.githubusercontent.com/assets/123386/8355325/89b60572-1b46-11e5-8f06-f6d6247665e3.png)


cc/ @sndrs In the absence of another client-side developer on this project, mind giving this the once over?

@TesterSpike It would be great if you're able to give this a run through as well. Expectation is that everything renders the same as PROD.