### PR TITLE
Separate the product rate configs from ZuoraAPIConfig

### DIFF
--- a/frontend/test/services/zuora/ZuoraActionTest.scala
+++ b/frontend/test/services/zuora/ZuoraActionTest.scala
@@ -49,7 +49,7 @@ class ZuoraActionTest extends Specification {
     }
 
     "not reveal login details in sanitized output" in {
-      val action = Login(ZuoraApiConfig("TEST", "http://example.com" / "test", "secret", "secret", Map.empty))
+      val action = Login(ZuoraApiConfig("TEST", "http://example.com" / "test", "secret", "secret"))
       action.sanitized must not contain "secret"
     }
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "0.4"
   val identityTestUsers = "com.gu" %% "identity-test-users" % "0.5"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.67"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.70-SNAPSHOT"
   val playGoogleAuth = "com.gu" %% "play-googleauth" % "0.3.0"
   val contentAPI = "com.gu" %% "content-api-client" % "6.4"
   val playWS = PlayImport.ws

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "0.4"
   val identityTestUsers = "com.gu" %% "identity-test-users" % "0.5"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.70-SNAPSHOT"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.70"
   val playGoogleAuth = "com.gu" %% "play-googleauth" % "0.3.0"
   val contentAPI = "com.gu" %% "content-api-client" % "6.4"
   val playWS = PlayImport.ws


### PR DESCRIPTION
Based on https://github.com/guardian/membership-common/pull/72 separate the product rate configs from ZuoraAPIConfig

This will allow Subscriptions to set up a different rate plan structure

cc/ @rtyley 