### PR TITLE
Fix SVG image scaling issues in IE

### DIFF
--- a/frontend/app/model/ResponsiveImage.scala
+++ b/frontend/app/model/ResponsiveImage.scala
@@ -1,6 +1,7 @@
 package model
 
 import com.gu.contentapi.client.model.Content
+import views.support.Asset
 import model.RichEvent.GridImage
 
 object ResponsiveImageGenerator {
@@ -51,7 +52,16 @@ case class ResponsiveImageGroup(
   val defaultImage = sortedImages.find(_.width > 300).map(_.path).getOrElse(smallestImage)
 
   val srcset = sortedImages.map { img =>
-    img.path + " " + img.width.toString() + "w"
+    img.path + " " + img.width.toString + "w"
   }.mkString(", ")
 
+}
+
+case class SVGImage(
+  label: String,
+  path: String,
+  width: Int,
+  height: Int
+) {
+  val src = Asset.at(path)
 }

--- a/frontend/app/views/event/guardianLive.scala.html
+++ b/frontend/app/views/event/guardianLive.scala.html
@@ -1,11 +1,17 @@
 @(eventPortfolio: model.EventPortfolio, pageInfo: model.PageInfo)
 
+@import model.SVGImage
+
 @main("Events", pageInfo=pageInfo) {
     <main role="main" class="l-constrained">
         @fragments.event.headerBar(
             title="Events, discussions, debates, interviews, keynote speeches and festivals exclusively for Guardian Members",
-            toneClassOpt=Some("tone-trans-guardian-live"),
-            logoOpt=Some("images/logos/guardian-live.svg")
+            logo=SVGImage(
+                "Guardian Live",
+                "images/logos/guardian-live.svg",
+                width=62, height=90
+            ),
+            classes=List("tone-trans-guardian-live")
         )
         @fragments.event.listing(eventPortfolio, "Sorry, no matching events were found.", showPastEvents=true)
         @fragments.tier.joinListing()

--- a/frontend/app/views/event/masterclass.scala.html
+++ b/frontend/app/views/event/masterclass.scala.html
@@ -5,6 +5,7 @@
     selectedSubTag: String = ""
 )
 
+@import model.SVGImage
 @import model.RichEvent.MasterclassEvent
 
 @main("Masterclasses", pageInfo=pageInfo) {
@@ -13,8 +14,12 @@
 
         @fragments.event.headerBar(
             title="Courses and workshops taught by award-winning professionals, with discounts for Partners and Patrons",
-            toneClassOpt=Some("tone-trans-masterclasses"),
-            logoOpt=Some("images/logos/guardian-masterclasses.svg")
+            logo=SVGImage(
+                "Guardian Masterclasses",
+                "images/logos/guardian-masterclasses.svg",
+                width=242, height=88
+            ),
+            classes=List("tone-trans-masterclasses")
         )
 
         <div class="event-filters">

--- a/frontend/app/views/fragments/common/inlineSvgImage.scala.html
+++ b/frontend/app/views/fragments/common/inlineSvgImage.scala.html
@@ -1,0 +1,7 @@
+@(svg: model.SVGImage, classes: Seq[String])
+
+@* http://nicolasgallagher.com/canvas-fix-svg-scaling-in-internet-explorer/ *@
+<div class="inline-svg @classes.mkString(" ")" role="img">
+    <canvas class="inline-svg__canvas" height="@svg.height" width="@svg.width" aria-hidden="true"></canvas>
+    <img class="inline-svg__image" src="@svg.src" alt="@svg.label">
+</div>

--- a/frontend/app/views/fragments/event/headerBar.scala.html
+++ b/frontend/app/views/fragments/event/headerBar.scala.html
@@ -1,16 +1,12 @@
 @(
     title: String,
-    toneClassOpt: Option[String] = None,
-    logoOpt: Option[String] = None
+    logo: model.SVGImage,
+    classes: Seq[String]
 )
 
-@import views.support.Asset
-
-<section class="header-bar @toneClassOpt.mkString("")">
+<section class="header-bar @classes.mkString("")">
     <h1 class="header-bar__title">@title</h1>
-    @for(logo <- logoOpt) {
-        <i class="header-bar__logo">
-            <img class="header-bar__logo__img" src="@Asset.at(logo)">
-        </i>
-    }
+    <div class="header-bar__logo">
+        @fragments.common.inlineSvgImage(logo, List("header-bar__logo__image"))
+    </div>
 </section>

--- a/frontend/app/views/patterns/patterns.scala.html
+++ b/frontend/app/views/patterns/patterns.scala.html
@@ -1,8 +1,8 @@
 @(eventPortfolio: model.EventPortfolio, pageImages: Seq[model.ResponsiveImageGroup])(implicit token: play.filters.csrf.CSRF.Token)
 
 @import com.gu.membership.salesforce.Tier
-@import configuration.{Config, Videos}
-@import model.{Benefits, FlashMessage}
+@import model.{SVGImage, Benefits, FlashMessage}
+@import configuration.Videos
 
 @pattern(title: String, description: String = "", removeClearFix: Boolean = false)(content: Html) = {
     <div class="pattern js-pattern-item@if(!removeClearFix){ u-cf}" data-pattern-label="@title">
@@ -262,16 +262,24 @@
     @pattern("Header Bar - Guardian Live", "Header bar with guardian live tone applied") {
         @fragments.event.headerBar(
             title="Events, discussions, debates, interviews, keynote speeches and festivals exclusively for Guardian Members",
-            toneClassOpt=Some("tone-trans-guardian-live"),
-            logoOpt=Some("images/logos/guardian-live.svg")
+            logo=SVGImage(
+                "Guardian Live",
+                "images/logos/guardian-live.svg",
+                width=62, height=90
+            ),
+            classes=List("tone-trans-guardian-live")
         )
     }
 
     @pattern("Header Bar - Masterclasses", "Header bar with masterclasses tone applied") {
         @fragments.event.headerBar(
             title="Courses and workshops taught by award-winning professionals, with discounts for Partners and Patrons",
-            toneClassOpt=Some("tone-trans-masterclasses"),
-            logoOpt=Some("images/logos/guardian-masterclasses.svg")
+            logo=SVGImage(
+                "Guardian Masterclasses",
+                "images/logos/guardian-masterclasses.svg",
+                width=242, height=88
+            ),
+            classes=List("tone-trans-masterclasses")
         )
     }
 

--- a/frontend/assets/stylesheets/base/_images.scss
+++ b/frontend/assets/stylesheets/base/_images.scss
@@ -1,3 +1,7 @@
+/* ==========================================================================
+   Images
+   ========================================================================== */
+
 img {
     background-color: transparent;
 }
@@ -21,4 +25,26 @@ img {
 }
 .stamped-image__stamp {
     height: rem($gs-gutter * 2);
+}
+
+/* Inline SVGs
+   http://nicolasgallagher.com/canvas-fix-svg-scaling-in-internet-explorer/
+   ========================================================================== */
+
+.inline-svg {
+    display: inline-block;
+    position: relative;
+    user-select: none;
+}
+.inline-svg__canvas {
+    display: block;
+    height: 100% !important; /* 1 */
+    visibility: hidden;
+}
+.inline-svg__image {
+    height: 100%;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
 }

--- a/frontend/assets/stylesheets/components/_header-bar.scss
+++ b/frontend/assets/stylesheets/components/_header-bar.scss
@@ -5,46 +5,51 @@
 .header-bar {
     @include clearfix;
     position: relative;
-    padding-left: rem($gs-gutter / 2);
-    padding-right: rem($gs-gutter / 2);
+    padding-left: ($gs-gutter / 2);
+    padding-right: ($gs-gutter / 2);
 
     @include mq(tablet) {
-        padding-left: rem($gs-gutter);
+        padding-left: $gs-gutter;
     }
 
     @include mq(mem-full) {
-        padding-left: rem(gs-span(2) + $gs-gutter * 2);
+        padding-left: (gs-span(2) + $gs-gutter * 2);
     }
 }
-    .header-bar__title {
-        @include fs-headline(4);
-        padding: rem($gs-gutter / 2) 0 0;
+.header-bar__title {
+    @include fs-headline(4);
+    padding: ($gs-gutter / 2) 0 0;
 
-        @include mq(tablet) {
-            @include fs-headline(6);
-            max-width: rem(gs-span(8));
-            padding-bottom: rem($gs-baseline);
-        }
-
-        @include mq(mem-full) {
-            @include fs-headline(7);
-        }
+    @include mq(tablet) {
+        @include fs-headline(6, true);
+        max-width: gs-span(8);
+        padding-bottom: $gs-baseline;
     }
-    .header-bar__logo {
-        float: right;
-        margin-bottom: rem($gs-gutter / 2);
 
-        @include mq(tablet) {
-            position: absolute;
-            right: rem($gs-gutter);
-            bottom: rem($gs-baseline);
-            margin-bottom: 0;
-        }
+    @include mq(mem-full) {
+        @include fs-headline(7, true);
     }
-    .header-bar__logo__img {
-        height: rem(44px);
+}
+.header-bar__logo {
+    float: right;
+    margin-bottom: ($gs-gutter / 2);
 
-        @include mq(tablet) {
-            height: rem(87px);
-        }
+    @include mq(tablet) {
+        position: absolute;
+        right: $gs-gutter;
+        bottom: $gs-baseline;
+        margin-bottom: 0;
     }
+}
+/**
+ * Note:
+ * Image heights are
+ * magic numbers.
+ */
+.header-bar__logo__image {
+    height: 44px;
+
+    @include mq(tablet) {
+        height: 87px;
+    }
+}


### PR DESCRIPTION
> Internet Explorer 9–11 suffer from various bugs that prevent proper scaling of inline SVG’s.
> [http://nicolasgallagher.com/canvas-fix-svg-scaling-in-internet-explorer/]()

As spotted by @TesterSpike there are some scaling/aspect-ratio issues with SVGs as images in IE (all versions 9-11), thankfully there's an approach for fixing it. 

This PR models SVG images to encapsulate Nicolas Gallagher's SVG scaling fix. Only being used on the event listing headers for now as this is the most prominent place there's an issue, but will also be used on other provider logos in future (we're currently doing some manual massaging on provider logos so the issues aren't as noticeable there but this will still improve things).

![screen shot 2015-07-02 at 10 54 05](https://cloud.githubusercontent.com/assets/123386/8474663/8ca73c52-20a9-11e5-9588-69f2a3f6c5d3.png)
![screen shot 2015-07-02 at 10 53 39](https://cloud.githubusercontent.com/assets/123386/8474662/8ca5381c-20a9-11e5-80fa-9065b3f18056.png)
![screen shot 2015-07-02 at 11 00 18](https://cloud.githubusercontent.com/assets/123386/8474661/8ca39192-20a9-11e5-9d1f-44cc5efe10dc.png)
![screen shot 2015-07-02 at 11 00 01](https://cloud.githubusercontent.com/assets/123386/8474664/8ca74382-20a9-11e5-9ac2-134bb242ad58.png)


*Masterclasses is particularly noticeable*

@TesterSpike Mind giving this the once over?

