### PR TITLE
Prevent dual sentry logging

### DIFF
--- a/frontend/assets/javascripts/src/modules/analytics/krux.js
+++ b/frontend/assets/javascripts/src/modules/analytics/krux.js
@@ -6,7 +6,6 @@ define(function() {
     function load() {
         require(['js!https://cdn.krxd.net/controltag?confid=' + KRUX_ID]).then(null, function(err) {
             Raven.captureException(err);
-            Raven.captureMessage('Krux failed to load');
         });
     }
 

--- a/frontend/assets/javascripts/src/modules/analytics/omniture.js
+++ b/frontend/assets/javascripts/src/modules/analytics/omniture.js
@@ -10,7 +10,6 @@ define([
     function init() {
         require('js!omniture').then(onSuccess, function(err) {
             Raven.captureException(err);
-            Raven.captureMessage('Omniture failed to load');
         });
     }
 

--- a/frontend/assets/javascripts/src/modules/analytics/ophan.js
+++ b/frontend/assets/javascripts/src/modules/analytics/ophan.js
@@ -5,7 +5,6 @@ define(function() {
         var ophanUrl = '//j.ophan.co.uk/ophan.membership.js';
         require('js!' + ophanUrl).then(null, function(err) {
             Raven.captureException(err);
-            Raven.captureMessage('Ophan failed to load');
         });
     }
 


### PR DESCRIPTION
Remove `Raven.captureMessage` for third-party JS as `Raven.captureException(err);` is enough. The former just gives an unnecessary line of logging without any context.