### PR TITLE
Update highlights link

### DIFF
--- a/frontend/app/model/RichEvent.scala
+++ b/frontend/app/model/RichEvent.scala
@@ -99,8 +99,8 @@ object RichEvent {
     val schema = EventSchema.from(this)
     val socialHashTag = Some("#GuardianLive")
     val tags = Nil
-    val fallbackHighlightsMetadata = HighlightsMetadata("Watch highlights of past events",
-      Links.membershipFront + "#video")
+    val fallbackHighlightsMetadata = HighlightsMetadata("View highlights of past events",
+      Links.membershipFront + "#recent-events")
     val highlight = contentOpt.map(c => HighlightsMetadata("Read more about this event", c.webUrl))
       .orElse(Some(fallbackHighlightsMetadata))
     val pastImageOpt = contentOpt.flatMap(ResponsiveImageGroup(_))


### PR DESCRIPTION
[theguardian.com/membership#video](http://www.theguardian.com/membership#video) container no longer exists but [theguardian.com/membership#recent-events](http://www.theguardian.com/membership#recent-events) does. This Updates higlights link to point to recent events container.

<img width="1335" alt="screen shot 2015-07-06 at 16 18 26" src="https://cloud.githubusercontent.com/assets/123386/8525843/00e1adb0-23fb-11e5-8027-8482e29ea785.png">
