### PR TITLE
Improve handling of long running events

### DIFF
--- a/frontend/app/model/Eventbrite.scala
+++ b/frontend/app/model/Eventbrite.scala
@@ -151,7 +151,7 @@ object Eventbrite {
 
     val salesDates = TicketSaleDates.datesFor(eventTimes, primaryTicket)
 
-    val salesEnd = primaryTicket.sales_end
+    val salesEnd = allTickets.map(_.sales_end).sorted.last
 
     val isCurrentlyAvailableToPaidMembersOnly =
       generalReleaseTicketOpt.map(!TicketSaleDates.datesFor(eventTimes, _).tierCanBuyTicket(Tier.Friend)).getOrElse(true)
@@ -208,13 +208,15 @@ object Eventbrite {
       ticket <- ticketing.generalReleaseTicketOpt
     } yield ticket
 
+    val hasBookableTicketClasses = ticket_classes.filter(_.sales_end < DateTime.now).nonEmpty
+
     val limitedAvailabilityText = "Last tickets remaining"
     val isLimitedAvailability = internalTicketing.exists(event => event.ticketsNotSold <= Config.eventbriteLimitedAvailabilityCutoff && !event.isSoldOut)
     val ticketsNotSold = internalTicketing.map(_.ticketsNotSold)
-
     val isSoldOut = internalTicketing.exists(_.isSoldOut)
-    val isBookable = status == "live" && !isSoldOut
-    val isPastEvent = status != "live" && status != "draft"
+
+    val isBookable = !isSoldOut && (status == "live" || hasBookableTicketClasses)
+    val isPastEvent = status == "completed"
 
     val statusSchema: Option[String] = {
       if (isPastEvent) None

--- a/frontend/app/model/Eventbrite.scala
+++ b/frontend/app/model/Eventbrite.scala
@@ -151,7 +151,7 @@ object Eventbrite {
 
     val salesDates = TicketSaleDates.datesFor(eventTimes, primaryTicket)
 
-    val salesEnd = allTickets.map(_.sales_end).sorted.last
+    val salesEnd = allTickets.map(_.sales_end).max
 
     val isCurrentlyAvailableToPaidMembersOnly =
       generalReleaseTicketOpt.map(!TicketSaleDates.datesFor(eventTimes, _).tierCanBuyTicket(Tier.Friend)).getOrElse(true)
@@ -208,15 +208,20 @@ object Eventbrite {
       ticket <- ticketing.generalReleaseTicketOpt
     } yield ticket
 
-    val hasBookableTicketClasses = ticket_classes.filter(_.sales_end < DateTime.now).nonEmpty
-
     val limitedAvailabilityText = "Last tickets remaining"
     val isLimitedAvailability = internalTicketing.exists(event => event.ticketsNotSold <= Config.eventbriteLimitedAvailabilityCutoff && !event.isSoldOut)
     val ticketsNotSold = internalTicketing.map(_.ticketsNotSold)
     val isSoldOut = internalTicketing.exists(_.isSoldOut)
 
-    val isBookable = !isSoldOut && (status == "live" || hasBookableTicketClasses)
-    val isPastEvent = status == "completed"
+    val isBookable = {
+      val isStartedAndHasBookableTicketClasses = status == "started" && ticket_classes.exists(_.sales_end < DateTime.now)
+      (status == "live" || isStartedAndHasBookableTicketClasses) && !isSoldOut
+    }
+
+    val isPastEvent = {
+      val conditions = Set("ended", "completed")
+      conditions.contains(status)
+    }
 
     val statusSchema: Option[String] = {
       if (isPastEvent) None

--- a/frontend/test/model/EBEventTest.scala
+++ b/frontend/test/model/EBEventTest.scala
@@ -20,6 +20,7 @@ class EBEventTest extends PlaySpecification {
   val nonTicketedEvent = ebResponse.data.find(_.id == "13602460325").get
   val soldOutEvent = ebResponse.data.find(_.id == "12238163677").get
   val startedEvent = ebResponse.data.find(_.id == "12972720757").get
+  val completedEvent = ebResponse.data.find(_.id == "13024577863").get
   val limitedAvailabilityEvent = ebResponse.data.find(_.id == "12718560557").get
 
   val ticketedEvent = ebLiveEvent;
@@ -56,7 +57,9 @@ class EBEventTest extends PlaySpecification {
       ebLiveEvent.statusText mustEqual None
     }
     "not be bookable when it has started" in {
-      startedEvent.isBookable mustEqual(false)
+      ebLiveEvent.isBookable mustEqual(true)
+      startedEvent.isBookable mustEqual(true)
+      completedEvent.isBookable mustEqual(false)
     }
     "should display past event text" in {
       startedEvent.statusText mustEqual Some("Past event")

--- a/frontend/test/model/EBEventTest.scala
+++ b/frontend/test/model/EBEventTest.scala
@@ -62,8 +62,14 @@ class EBEventTest extends PlaySpecification {
       completedEvent.isBookable mustEqual(false)
     }
     "should display past event text" in {
-      startedEvent.statusText mustEqual Some("Past event")
+      ebLiveEvent.statusText mustEqual None
+      startedEvent.statusText mustEqual None
       ebCompletedEvent.statusText mustEqual Some("Past event")
+    }
+    "should handle multi-day events" in{
+      val multiDayEvent = Resource.getJson("model/eventbrite/event-started-multi-day.json").as[EBEvent]
+      multiDayEvent.statusText mustEqual None
+      multiDayEvent.isBookable mustEqual(true)
     }
     "not be bookable when it is in draft mode" in {
       ebDraftEvent.isBookable mustEqual(false)

--- a/frontend/test/resources/model/eventbrite/event-started-multi-day.json
+++ b/frontend/test/resources/model/eventbrite/event-started-multi-day.json
@@ -1,0 +1,2059 @@
+{
+    "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/",
+    "name": {
+        "text": "Shubbak: A Window on Contemporary Arab Culture",
+        "html": "Shubbak: A Window on Contemporary Arab Culture"
+    },
+    "description": {
+        "text": "Taking place across London from 11-26 July, Shubbak 2015 features 16 full days of concerts, performances, screenings, debates, exhibitions and installations, and over 100 international artists as well as over 30 artists based in the UK. Their voices may be personal and reflective, or loud and provocative, celebratory or inquisitive, but what unites them is that they make us think afresh and see the world differently. \nNever before has the Arab world been more reported on in the media. Now is the time to hear from Arab artists who speak powerfully about what matters to them. Most of the works have never been seen in London before, so join us and dare to discover the new and unpredictable. \nIn partnership with the Guardian there are a number of events available as part of the festival \u2013 full details of which are detailed below: \nBurda - Karima Skalli & Asil Ensemble \nBarbican, 11 July 2015, 7pm \nLegendary Moroccan singer Karima Skalli and the Asil Ensemble perform three Burdas \u2013 song cycles combining poetry and music, which have inspired the greatest Arab composers and poets across the centuries, including the famous Nahj El Burda of Umm Kulthum. \nVisions of Palestine \nICA, 12 July 2015, 2-5.30pm \nA triple bill of seminal documentaries focusing on Palestine followed by a panel discussion featuring Tariq Ali, Michel Khleifi, Peter Kosminsky (The Promise) and Ilan Papp\u00e9 \nDisappearing Cities of the Arab World \nBritish Museum,12 July 2015, 11am-5pm \nDisappearing Cities of the Arab World explores issues of architecture, post-colonialism, globalisation and psycho-geography. It brings together writers, artists, historians, architects and urbanists to explore the complex space that is the contemporary Arab city. \nSOLD OUT: Raed Yassin in Concert \nLeighton House Museum, 13 July 2015, 8.30pm \nLebanese artist, turntablist and all-round musician Raed Yassin creates a special electronic and turntabling set for the unique surroundings of Leighton House Museum and his exhibition. \nThe Tree Climber: A Play by Tawfik Al-Hakeem \nCockpit 14-18 July 2015 \nLondon-based El-Alfy Theatre Company presents a classic of modern Egyptian theatre in a new English translation, adapted by Perdita Stott and directed by Ahmed El-Alfy. \nSOLD OUT: Queens of Syria \nBarbican Cinema, 15 July 2015, 6.30pm \nYasmin Fedda\u2019s documentary film Queens of Syria tells the story of fifty Syrian women living in exile in Jordan as they prepare to perform Euripides\u2019 tragedy, The Trojan Women. \nWhen The Arabs Used To Dance \nThe Place, 15 July 2015, 8pm \nTunisian choreographer Radhouane El Meddeb harks back in a bittersweet production to the 60s and 70s, the golden age of popular Arab cinema, when dancing and smoking divas filled the screens. \nSOLD OUT: Nahda \nBush Theatre, 15-18 July 2015 \nPresented in a diwaniya setting, Sevan K. Greene\u2019s Nahda: four visions from an Arab awakening looks at contemporary Arab identity. \nZahed Sultan \nBarbican, 16 July 2015, 7.30pm \nMultimedia artist Zahed Sultan performs a live set, especially created for the Barbican Art Gallery as part of Doug Aitken\u2019s Station to Station: A 30 Day Happening (27 June \u2013 26 July). \nRazor Sharp\u00a0 \nRich Mix, 17 July 2015, 4pm & 7.30pm \nRazor Sharp brings together three of London\u2019s foremost Arab women writing for the stage today: Hannah Khalil, Yamina Bakiri and Malu Halasa. \nD-Sysiphe \nRich Mix, 18 & 19 July 2015, 7.30pm \nAward-winning Tunisian actor and director Meher Awachri performs a night in the life of Khmais, a Tunisian construction worker in the midst of an existential crisis.\u00a0 \nInto The Night: Three Works by Nacera Belaza \nSadler\u2019s Wells, 23 & 24 July 2015, 8pm \nImmerse yourself in the evocative world of Algerian choreographer Nacera Belaza. Composed of three recent works, Les Oiseaux, La Nuit and La Travers\u00e9e, this programme offers a chance to witness physical ideas unfold over a longer encounter. \nThe Mix \nRich Mix, 25 July 2015, 8pm \nThe Mix unites international Arab music talent in a rousing festival music finale. Acclaimed Egyptian jazz-rock fusion band Massar Egbari share the main stage with Palestinian electro-dabke band 47SOUL. The floor is then given over to some of the most innovative audio-visual artists and DJs to dance the night away, including the first UK appearance of Hello Psychaleppo. \nShubbak Literature Festival \nBritish Library (Weekend passes), 25 & 26 July, 11am-6pm \nA packed weekend of literature and storytelling with some of the finest writers from across the Arab world, including Elias Khoury, Mourid Barghouti and many more. \n\n\u00a0 \n",
+        "html": "<P>Taking place across London from 11-26 July, <A HREF=\"http://www.shubbak.co.uk/\" TARGET=\"_blank\" REL=\"nofollow\">Shubbak 2015<\/A> features 16 full days of concerts, performances, screenings, debates, exhibitions and installations, and over 100 international artists as well as over 30 artists based in the UK. Their voices may be personal and reflective, or loud and provocative, celebratory or inquisitive, but what unites them is that they make us think afresh and see the world differently.<\/P>\r\n<P>Never before has the Arab world been more reported on in the media. Now is the time to hear from Arab artists who speak powerfully about what matters to them. Most of the works have never been seen in London before, so join us and dare to discover the new and unpredictable.<\/P>\r\n<P>In partnership with the Guardian there are a number of events available as part of the festival \u2013 full details of which are detailed below:<\/P>\r\n<P><STRONG>Burda - Karima Skalli &amp; Asil Ensemble<\/STRONG><\/P>\r\n<P><STRONG><\/STRONG><EM>Barbican, 11 July 2015, 7pm<\/EM><\/P>\r\n<P><EM><\/EM>Legendary Moroccan singer Karima Skalli and the Asil Ensemble perform three Burdas \u2013 song cycles combining poetry and music, which have inspired the greatest Arab composers and poets across the centuries, including the famous Nahj El Burda of Umm Kulthum.<\/P>\r\n<P><STRONG>Visions of Palestine<\/STRONG><\/P>\r\n<P><STRONG><\/STRONG><EM>ICA, 12 July 2015, 2-5.30pm<\/EM><\/P>\r\n<P>A triple bill of seminal documentaries focusing on Palestine followed by a panel discussion featuring Tariq Ali, Michel Khleifi, Peter Kosminsky (The Promise) and Ilan Papp\u00e9<\/P>\r\n<P><STRONG>Disappearing Cities of the Arab World<\/STRONG><\/P>\r\n<P><STRONG><\/STRONG><EM>British Museum,12 July 2015, 11am-5pm<\/EM><\/P>\r\n<P>Disappearing Cities of the Arab World explores issues of architecture, post-colonialism, globalisation and psycho-geography. It brings together writers, artists, historians, architects and urbanists to explore the complex space that is the contemporary Arab city.<\/P>\r\n<P><STRONG>SOLD OUT: Raed Yassin in Concert<\/STRONG><\/P>\r\n<P><STRONG><\/STRONG><EM>Leighton House Museum, 13 July 2015, 8.30pm<\/EM><\/P>\r\n<P>Lebanese artist, turntablist and all-round musician Raed Yassin creates a special electronic and turntabling set for the unique surroundings of Leighton House Museum and his exhibition.<\/P>\r\n<P><STRONG>The Tree Climber: A Play by Tawfik Al-Hakeem<\/STRONG><\/P>\r\n<P><STRONG><\/STRONG><EM>Cockpit 14-18 July 2015<\/EM><\/P>\r\n<P><EM><\/EM>London-based El-Alfy Theatre Company presents a classic of modern Egyptian theatre in a new English translation, adapted by Perdita Stott and directed by Ahmed El-Alfy.<\/P>\r\n<P><STRONG><STRONG>SOLD OUT: <\/STRONG>Queens of Syria<\/STRONG><\/P>\r\n<P><STRONG><\/STRONG><EM>Barbican Cinema, 15 July 2015, 6.30pm<\/EM><\/P>\r\n<P>Yasmin Fedda\u2019s documentary film Queens of Syria tells the story of fifty Syrian women living in exile in Jordan as they prepare to perform Euripides\u2019 tragedy, The Trojan Women.<\/P>\r\n<P><STRONG>When The Arabs Used To Dance<\/STRONG><\/P>\r\n<P><STRONG><\/STRONG><EM>The Place, 15 July 2015, 8pm<\/EM><\/P>\r\n<P><EM><\/EM>Tunisian choreographer Radhouane El Meddeb harks back in a bittersweet production to the 60s and 70s, the golden age of popular Arab cinema, when dancing and smoking divas filled the screens.<\/P>\r\n<P><STRONG>SOLD OUT: Nahda<\/STRONG><\/P>\r\n<P><STRONG><\/STRONG><EM>Bush Theatre, 15-18 July 2015<\/EM><\/P>\r\n<P><EM><\/EM>Presented in a diwaniya setting, Sevan K. Greene\u2019s Nahda: four visions from an Arab awakening looks at contemporary Arab identity.<\/P>\r\n<P><STRONG>Zahed Sultan<\/STRONG><\/P>\r\n<P><STRONG><\/STRONG><EM>Barbican, 16 July 2015, 7.30pm<\/EM><\/P>\r\n<P>Multimedia artist Zahed Sultan performs a live set, especially created for the Barbican Art Gallery as part of Doug Aitken\u2019s Station to Station: A 30 Day Happening (27 June \u2013 26 July).<\/P>\r\n<P><STRONG>Razor Sharp<\/STRONG>\u00a0<\/P>\r\n<P><EM>Rich Mix, 17 July 2015, 4pm &amp; 7.30pm<\/EM><\/P>\r\n<P>Razor Sharp brings together three of London\u2019s foremost Arab women writing for the stage today: Hannah Khalil, Yamina Bakiri and Malu Halasa.<\/P>\r\n<P><STRONG>D-Sysiphe<\/STRONG><\/P>\r\n<P><EM>Rich Mix, 18 &amp; 19 July 2015, 7.30pm<\/EM><\/P>\r\n<P>Award-winning Tunisian actor and director Meher Awachri performs a night in the life of Khmais, a Tunisian construction worker in the midst of an existential crisis.\u00a0<\/P>\r\n<P><STRONG>Into The Night: Three Works by Nacera Belaza<\/STRONG><\/P>\r\n<P><STRONG><\/STRONG><EM>Sadler\u2019s Wells, 23 &amp; 24 July 2015, 8pm<\/EM><\/P>\r\n<P>Immerse yourself in the evocative world of Algerian choreographer Nacera Belaza. Composed of three recent works, Les Oiseaux, La Nuit and La Travers\u00e9e, this programme offers a chance to witness physical ideas unfold over a longer encounter.<\/P>\r\n<P><STRONG>The Mix<\/STRONG><\/P>\r\n<P><EM>Rich Mix, 25 July 2015, 8pm<\/EM><\/P>\r\n<P>The Mix unites international Arab music talent in a rousing festival music finale. Acclaimed Egyptian jazz-rock fusion band Massar Egbari share the main stage with Palestinian electro-dabke band 47SOUL. The floor is then given over to some of the most innovative audio-visual artists and DJs to dance the night away, including the first UK appearance of Hello Psychaleppo.<\/P>\r\n<P><STRONG>Shubbak Literature Festival<\/STRONG><\/P>\r\n<P><STRONG><\/STRONG><EM>British Library (Weekend passes), 25 &amp; 26 July, 11am-6pm<\/EM><\/P>\r\n<P>A packed weekend of literature and storytelling with some of the finest writers from across the Arab world, including Elias Khoury, Mourid Barghouti and many more.<\/P>\r\n<!-- provider: shubbak -->\r\n<P>\u00a0<\/P>\r\n<!-- main-image: https://media.gutools.co.uk/images/3503a80a1255b5cd9a7453edcd09ead2490cd2b3?crop=0_0_1920_1151 -->"
+    },
+    "id": "17514481285",
+    "url": "http://www.eventbrite.co.uk/e/shubbak-a-window-on-contemporary-arab-culture-tickets-17514481285",
+    "start": {
+        "timezone": "Europe/London",
+        "local": "2015-07-11T19:00:00",
+        "utc": "2015-07-11T18:00:00Z"
+    },
+    "end": {
+        "timezone": "Europe/London",
+        "local": "2015-07-26T21:00:00",
+        "utc": "2015-07-26T20:00:00Z"
+    },
+    "created": "2015-06-24T15:46:01Z",
+    "changed": "2015-07-13T17:15:36Z",
+    "capacity": 70,
+    "status": "started",
+    "currency": "GBP",
+    "listed": false,
+    "shareable": false,
+    "invite_only": false,
+    "online_event": false,
+    "show_remaining": false,
+    "tx_time_limit": 900,
+    "logo_id": null,
+    "organizer_id": "6693856275",
+    "venue_id": "10949658",
+    "category_id": null,
+    "subcategory_id": null,
+    "format_id": null,
+    "category": null,
+    "subcategory": null,
+    "format": null,
+    "logo": null,
+    "venue": {
+        "address": {
+            "address_1": "Address 1",
+            "address_2": null,
+            "city": "London",
+            "region": null,
+            "postal_code": null,
+            "country": "GB",
+            "latitude": 51.5427084,
+            "longitude": -0.19933370000001105
+        },
+        "resource_uri": "https://www.eventbriteapi.com/v3/venues/10949658/",
+        "id": "10949658",
+        "name": "Various Locations",
+        "latitude": "51.5427084",
+        "longitude": "-0.19933370000001105"
+    },
+    "ticket_classes": [
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37040650/",
+            "id": "37040650",
+            "name": ".",
+            "description": " <div class=\"panel_head2 break_header\" style=\"margin-top: -30px;\"><h3>Tickets for 12th July 2015<\/h3><\/div>",
+            "donation": false,
+            "free": true,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 1,
+            "on_sale_status": "AVAILABLE",
+            "quantity_total": 1,
+            "quantity_sold": 0,
+            "sales_start": "2015-05-01T02:35:00Z",
+            "sales_end": "2015-07-26T16:30:00Z",
+            "hidden": false,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37040731/",
+            "id": "37040731",
+            "name": "Burda - Karima Skalli & Asil Ensemble",
+            "description": "This ticket gives you access to the performance at the Barbican on 11th July 2015",
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a335.00",
+                "value": 3500
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a32.75",
+                "value": 275
+            },
+            "tax": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a335.00",
+                "value": 3500
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a32.75",
+                "value": 275
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 10,
+            "on_sale_status": "UNAVAILABLE",
+            "quantity_total": 50,
+            "quantity_sold": 0,
+            "sales_start": "2015-04-01T05:25:00Z",
+            "sales_end": "2015-07-11T19:00:00Z",
+            "hidden": false,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37040732/",
+            "id": "37040732",
+            "name": "Burda - Karima Skalli & Asil Ensemble (Member Ticket)",
+            "description": "This ticket gives you access to the performance at the Barbican on 11th July 2015",
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a328.00",
+                "value": 2800
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a32.33",
+                "value": 233
+            },
+            "tax": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a328.00",
+                "value": 2800
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a32.33",
+                "value": 233
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 10,
+            "on_sale_status": "UNAVAILABLE",
+            "quantity_total": 50,
+            "quantity_sold": 0,
+            "sales_start": "2015-04-01T05:25:00Z",
+            "sales_end": "2015-07-11T19:00:00Z",
+            "hidden": true,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37040864/",
+            "id": "37040864",
+            "name": "Visions of Palestine",
+            "description": "This ticket gives you access to the event at the ICA on 12th July from 2-5.30pm",
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a311.00",
+                "value": 1100
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a31.31",
+                "value": 131
+            },
+            "tax": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a311.00",
+                "value": 1100
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a31.31",
+                "value": 131
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 10,
+            "on_sale_status": "UNAVAILABLE",
+            "quantity_total": 20,
+            "quantity_sold": 1,
+            "sales_start": "2015-04-01T05:30:00Z",
+            "sales_end": "2015-07-12T16:30:00Z",
+            "hidden": false,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37040865/",
+            "id": "37040865",
+            "name": "Visions of Palestine (Member Ticket)",
+            "description": "This ticket gives you access to the event at the ICA on 12th July from 2-5.30pm",
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a38.80",
+                "value": 880
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a31.18",
+                "value": 118
+            },
+            "tax": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a38.80",
+                "value": 880
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a31.18",
+                "value": 118
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 10,
+            "on_sale_status": "UNAVAILABLE",
+            "quantity_total": 20,
+            "quantity_sold": 0,
+            "sales_start": "2015-04-01T05:30:00Z",
+            "sales_end": "2015-07-12T16:30:00Z",
+            "hidden": true,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37040882/",
+            "id": "37040882",
+            "name": ".",
+            "description": " <div class=\"panel_head2 break_header\" style=\"margin-top: -30px;\"><h3>Tickets for 13th July 2015<\/h3><\/div>",
+            "donation": false,
+            "free": true,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 1,
+            "on_sale_status": "AVAILABLE",
+            "quantity_total": 1,
+            "quantity_sold": 0,
+            "sales_start": "2015-04-01T05:35:00Z",
+            "sales_end": "2015-07-26T16:30:00Z",
+            "hidden": false,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37040946/",
+            "id": "37040946",
+            "name": "Disappearing Cities of the Arab World",
+            "description": "This ticket gives you access to the event at the British Museum on 12th July from 11am to 5pm",
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a320.00",
+                "value": 2000
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a31.85",
+                "value": 185
+            },
+            "tax": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a320.00",
+                "value": 2000
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a31.85",
+                "value": 185
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 10,
+            "on_sale_status": "UNAVAILABLE",
+            "quantity_total": 20,
+            "quantity_sold": 0,
+            "sales_start": "2015-04-01T05:40:00Z",
+            "sales_end": "2015-07-12T16:30:00Z",
+            "hidden": false,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37040947/",
+            "id": "37040947",
+            "name": "Disappearing Cities of the Arab World (Member Ticket)",
+            "description": "This ticket gives you access to the event at the British Museum on 12th July from 11am to 5pm",
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a316.00",
+                "value": 1600
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a31.61",
+                "value": 161
+            },
+            "tax": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a316.00",
+                "value": 1600
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a31.61",
+                "value": 161
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 10,
+            "on_sale_status": "UNAVAILABLE",
+            "quantity_total": 20,
+            "quantity_sold": 0,
+            "sales_start": "2015-04-01T05:40:00Z",
+            "sales_end": "2015-07-12T16:30:00Z",
+            "hidden": true,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37052769/",
+            "id": "37052769",
+            "name": ".",
+            "description": " <div class=\"panel_head2 break_header\" style=\"margin-top: -30px;\"><h3>Tickets for 14th July 2015<\/h3><\/div>",
+            "donation": false,
+            "free": true,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 1,
+            "on_sale_status": "AVAILABLE",
+            "quantity_total": 1,
+            "quantity_sold": 0,
+            "sales_start": "2015-04-01T07:15:00Z",
+            "sales_end": "2015-07-14T17:00:00Z",
+            "hidden": false,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37052850/",
+            "id": "37052850",
+            "name": "The Tree Climber: A Play by Tawfik Al-Hakeem",
+            "description": "This ticket gives you access to the performance on 14th July at 7.30pm at Cockpit",
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a322.00",
+                "value": 2200
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a31.97",
+                "value": 197
+            },
+            "tax": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a322.00",
+                "value": 2200
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a31.97",
+                "value": 197
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 10,
+            "on_sale_status": "AVAILABLE",
+            "quantity_total": 20,
+            "quantity_sold": 0,
+            "sales_start": "2015-06-25T11:55:00Z",
+            "sales_end": "2015-07-14T18:30:00Z",
+            "hidden": false,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37052868/",
+            "id": "37052868",
+            "name": "The Tree Climber: A Play by Tawfik Al-Hakeem (Member Ticket)",
+            "description": "This ticket gives you access to the performance on 14th July at 7.30pm at Cockpit",
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a317.60",
+                "value": 1760
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a31.71",
+                "value": 171
+            },
+            "tax": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a317.60",
+                "value": 1760
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a31.71",
+                "value": 171
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 10,
+            "on_sale_status": "AVAILABLE",
+            "quantity_total": 20,
+            "quantity_sold": 0,
+            "sales_start": "2015-06-25T12:00:00Z",
+            "sales_end": "2015-07-14T19:00:00Z",
+            "hidden": true,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37053214/",
+            "id": "37053214",
+            "name": ".",
+            "description": " <div class=\"panel_head2 break_header\" style=\"margin-top: -30px;\"><h3>Tickets for 15th July 2015<\/h3><\/div>",
+            "donation": false,
+            "free": true,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 1,
+            "on_sale_status": "UNAVAILABLE",
+            "quantity_total": 1,
+            "quantity_sold": 0,
+            "sales_start": "2015-06-25T12:15:00Z",
+            "sales_end": "2015-06-30T16:30:00Z",
+            "hidden": false,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37053283/",
+            "id": "37053283",
+            "name": "When The Arabs Used To Dance",
+            "description": "This ticket gives you access to the performance on 15th July at 8pm at the Place ",
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a315.00",
+                "value": 1500
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a31.55",
+                "value": 155
+            },
+            "tax": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a315.00",
+                "value": 1500
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a31.55",
+                "value": 155
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 5,
+            "on_sale_status": "AVAILABLE",
+            "quantity_total": 5,
+            "quantity_sold": 0,
+            "sales_start": "2015-06-25T12:20:00Z",
+            "sales_end": "2015-07-15T19:00:00Z",
+            "hidden": false,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37053284/",
+            "id": "37053284",
+            "name": "When The Arabs Used To Dance (Member Ticket)",
+            "description": "This ticket gives you access to the performance on 15th July at 8pm at the Place ",
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a312.00",
+                "value": 1200
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a31.37",
+                "value": 137
+            },
+            "tax": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a312.00",
+                "value": 1200
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a31.37",
+                "value": 137
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 5,
+            "on_sale_status": "AVAILABLE",
+            "quantity_total": 5,
+            "quantity_sold": 0,
+            "sales_start": "2015-06-25T12:20:00Z",
+            "sales_end": "2015-07-15T19:00:00Z",
+            "hidden": true,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37053727/",
+            "id": "37053727",
+            "name": "The Tree Climber: A Play by Tawfik Al-Hakeem",
+            "description": "This ticket gives you access to the performance on 15th July at 7.30pm at Cockpit",
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a322.00",
+                "value": 2200
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a31.97",
+                "value": 197
+            },
+            "tax": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a322.00",
+                "value": 2200
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a31.97",
+                "value": 197
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 10,
+            "on_sale_status": "AVAILABLE",
+            "quantity_total": 20,
+            "quantity_sold": 0,
+            "sales_start": "2015-06-25T12:30:00Z",
+            "sales_end": "2015-07-15T18:00:00Z",
+            "hidden": false,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37053728/",
+            "id": "37053728",
+            "name": "The Tree Climber: A Play by Tawfik Al-Hakeem (Member Ticket)",
+            "description": "This ticket gives you access to the performance on 15th July at 7.30pm at Cockpit",
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a317.60",
+                "value": 1760
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a31.71",
+                "value": 171
+            },
+            "tax": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a317.60",
+                "value": 1760
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a31.71",
+                "value": 171
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 10,
+            "on_sale_status": "AVAILABLE",
+            "quantity_total": 20,
+            "quantity_sold": 0,
+            "sales_start": "2015-06-25T12:30:00Z",
+            "sales_end": "2015-07-15T18:00:00Z",
+            "hidden": true,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37053852/",
+            "id": "37053852",
+            "name": ".",
+            "description": " <div class=\"panel_head2 break_header\" style=\"margin-top: -30px;\"><h3>Tickets for 16th July 2015<\/h3><\/div>",
+            "donation": false,
+            "free": true,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 1,
+            "on_sale_status": "UNAVAILABLE",
+            "quantity_total": 1,
+            "quantity_sold": 0,
+            "sales_start": "2015-06-25T12:35:00Z",
+            "sales_end": "2015-07-11T17:00:00Z",
+            "hidden": false,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37053853/",
+            "id": "37053853",
+            "name": "Zahed Sultan",
+            "description": "This ticket gives you access to the performance at the Barbican on 16th July at 7.30pm",
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a310.00",
+                "value": 1000
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a31.25",
+                "value": 125
+            },
+            "tax": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a310.00",
+                "value": 1000
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a31.25",
+                "value": 125
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 10,
+            "on_sale_status": "AVAILABLE",
+            "quantity_total": 20,
+            "quantity_sold": 0,
+            "sales_start": "2015-06-25T12:35:00Z",
+            "sales_end": "2015-07-16T18:30:00Z",
+            "hidden": false,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37053854/",
+            "id": "37053854",
+            "name": "Zahed Sultan (Member Ticket)",
+            "description": "This ticket gives you access to the performance at the Barbican on 16th July at 7.30pm",
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a38.00",
+                "value": 800
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a31.13",
+                "value": 113
+            },
+            "tax": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a38.00",
+                "value": 800
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a31.13",
+                "value": 113
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 10,
+            "on_sale_status": "AVAILABLE",
+            "quantity_total": 20,
+            "quantity_sold": 0,
+            "sales_start": "2015-06-25T12:35:00Z",
+            "sales_end": "2015-07-16T18:30:00Z",
+            "hidden": true,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37053855/",
+            "id": "37053855",
+            "name": "The Tree Climber: A Play by Tawfik Al-Hakeem",
+            "description": "This ticket gives you access to the performance on 16th July at 7.30pm at Cockpit",
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a322.00",
+                "value": 2200
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a31.97",
+                "value": 197
+            },
+            "tax": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a322.00",
+                "value": 2200
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a31.97",
+                "value": 197
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 10,
+            "on_sale_status": "AVAILABLE",
+            "quantity_total": 20,
+            "quantity_sold": 0,
+            "sales_start": "2015-06-25T12:35:00Z",
+            "sales_end": "2015-07-16T18:30:00Z",
+            "hidden": false,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37053856/",
+            "id": "37053856",
+            "name": "The Tree Climber: A Play by Tawfik Al-Hakeem (Member Ticket)",
+            "description": "This ticket gives you access to the performance on 16th July at 7.30pm at Cockpit",
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a317.60",
+                "value": 1760
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a31.71",
+                "value": 171
+            },
+            "tax": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a317.60",
+                "value": 1760
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a31.71",
+                "value": 171
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 10,
+            "on_sale_status": "AVAILABLE",
+            "quantity_total": 20,
+            "quantity_sold": 0,
+            "sales_start": "2015-06-25T12:35:00Z",
+            "sales_end": "2015-07-16T18:30:00Z",
+            "hidden": true,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37054386/",
+            "id": "37054386",
+            "name": ".",
+            "description": " <div class=\"panel_head2 break_header\" style=\"margin-top: -30px;\"><h3>Tickets for 17th July 2015<\/h3><\/div>",
+            "donation": false,
+            "free": true,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 1,
+            "on_sale_status": "UNAVAILABLE",
+            "quantity_total": 1,
+            "quantity_sold": 0,
+            "sales_start": "2015-06-25T13:00:00Z",
+            "sales_end": "2015-07-11T17:00:00Z",
+            "hidden": false,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37064407/",
+            "id": "37064407",
+            "name": "Razor Sharp - 4pm",
+            "description": "This ticket gives you access to the 4pm showing of Razor Sharp at Rich Mix",
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a310.00",
+                "value": 1000
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a31.25",
+                "value": 125
+            },
+            "tax": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a310.00",
+                "value": 1000
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a31.25",
+                "value": 125
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 10,
+            "on_sale_status": "AVAILABLE",
+            "quantity_total": 20,
+            "quantity_sold": 0,
+            "sales_start": "2015-06-25T13:10:00Z",
+            "sales_end": "2015-07-17T15:30:00Z",
+            "hidden": false,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37064408/",
+            "id": "37064408",
+            "name": "Razor Sharp - 4pm (Member Ticket)",
+            "description": "This ticket gives you access to the 4pm showing of Razor Sharp at Rich Mix",
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a38.00",
+                "value": 800
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a31.13",
+                "value": 113
+            },
+            "tax": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a38.00",
+                "value": 800
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a31.13",
+                "value": 113
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 10,
+            "on_sale_status": "AVAILABLE",
+            "quantity_total": 20,
+            "quantity_sold": 0,
+            "sales_start": "2015-06-25T13:10:00Z",
+            "sales_end": "2015-07-17T15:30:00Z",
+            "hidden": true,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37064409/",
+            "id": "37064409",
+            "name": "Razor Sharp - 7.30pm",
+            "description": "This ticket gives you access to the 7.30pm showing of Razor Sharp at Rich Mix",
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a310.00",
+                "value": 1000
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a31.25",
+                "value": 125
+            },
+            "tax": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a310.00",
+                "value": 1000
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a31.25",
+                "value": 125
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 10,
+            "on_sale_status": "AVAILABLE",
+            "quantity_total": 20,
+            "quantity_sold": 0,
+            "sales_start": "2015-06-25T13:10:00Z",
+            "sales_end": "2015-07-17T18:30:00Z",
+            "hidden": false,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37064410/",
+            "id": "37064410",
+            "name": "Razor Sharp - 7.30pm (Member Ticket)",
+            "description": "This ticket gives you access to the 7.30pm showing of Razor Sharp at Rich Mix",
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a38.00",
+                "value": 800
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a31.13",
+                "value": 113
+            },
+            "tax": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a38.00",
+                "value": 800
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a31.13",
+                "value": 113
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 10,
+            "on_sale_status": "AVAILABLE",
+            "quantity_total": 20,
+            "quantity_sold": 0,
+            "sales_start": "2015-06-25T13:10:00Z",
+            "sales_end": "2015-07-17T18:30:00Z",
+            "hidden": true,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37064427/",
+            "id": "37064427",
+            "name": "The Tree Climber: A Play by Tawfik Al-Hakeem",
+            "description": "This ticket gives you access to the performance on 17th July at 7.30pm at Cockpit",
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a322.00",
+                "value": 2200
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a31.97",
+                "value": 197
+            },
+            "tax": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a322.00",
+                "value": 2200
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a31.97",
+                "value": 197
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 10,
+            "on_sale_status": "AVAILABLE",
+            "quantity_total": 20,
+            "quantity_sold": 0,
+            "sales_start": "2015-06-25T23:20:00Z",
+            "sales_end": "2015-07-17T18:30:00Z",
+            "hidden": false,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37064428/",
+            "id": "37064428",
+            "name": "The Tree Climber: A Play by Tawfik Al-Hakeem (Member Ticket)",
+            "description": "This ticket gives you access to the performance on 17th July at 7.30pm at Cockpit",
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a317.60",
+                "value": 1760
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a31.71",
+                "value": 171
+            },
+            "tax": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a317.60",
+                "value": 1760
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a31.71",
+                "value": 171
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 10,
+            "on_sale_status": "AVAILABLE",
+            "quantity_total": 20,
+            "quantity_sold": 0,
+            "sales_start": "2015-06-25T23:20:00Z",
+            "sales_end": "2015-07-17T18:30:00Z",
+            "hidden": true,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37064438/",
+            "id": "37064438",
+            "name": ".",
+            "description": " <div class=\"panel_head2 break_header\" style=\"margin-top: -30px;\"><h3>Tickets for 18th July 2015<\/h3><\/div>",
+            "donation": false,
+            "free": true,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 1,
+            "on_sale_status": "UNAVAILABLE",
+            "quantity_total": 1,
+            "quantity_sold": 0,
+            "sales_start": "2015-06-25T23:25:00Z",
+            "sales_end": "2015-07-11T17:00:00Z",
+            "hidden": false,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37064439/",
+            "id": "37064439",
+            "name": "The Tree Climber: A Play by Tawfik Al-Hakeem",
+            "description": "This ticket gives you access to the performance on 18th July at 7.30pm at Cockpit",
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a322.00",
+                "value": 2200
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a31.97",
+                "value": 197
+            },
+            "tax": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a322.00",
+                "value": 2200
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a31.97",
+                "value": 197
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 10,
+            "on_sale_status": "AVAILABLE",
+            "quantity_total": 20,
+            "quantity_sold": 0,
+            "sales_start": "2015-06-25T23:25:00Z",
+            "sales_end": "2015-07-18T18:30:00Z",
+            "hidden": false,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37064440/",
+            "id": "37064440",
+            "name": "The Tree Climber: A Play by Tawfik Al-Hakeem (Member Ticket)",
+            "description": "This ticket gives you access to the performance on 18th July at 7.30pm at Cockpit",
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a317.60",
+                "value": 1760
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a31.71",
+                "value": 171
+            },
+            "tax": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a317.60",
+                "value": 1760
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a31.71",
+                "value": 171
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 10,
+            "on_sale_status": "AVAILABLE",
+            "quantity_total": 20,
+            "quantity_sold": 0,
+            "sales_start": "2015-06-25T23:25:00Z",
+            "sales_end": "2015-07-18T17:00:00Z",
+            "hidden": true,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37064656/",
+            "id": "37064656",
+            "name": ".",
+            "description": " <div class=\"panel_head2 break_header\" style=\"margin-top: -30px;\"><h3>Tickets for 23rd July 2015<\/h3><\/div>",
+            "donation": false,
+            "free": true,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 1,
+            "on_sale_status": "UNAVAILABLE",
+            "quantity_total": 1,
+            "quantity_sold": 0,
+            "sales_start": "2015-06-25T23:55:00Z",
+            "sales_end": "2015-07-11T17:00:00Z",
+            "hidden": false,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37064657/",
+            "id": "37064657",
+            "name": "Into The Night: Three Works by Nacera Belaza",
+            "description": "This ticket gives you access to the show at Sadler's Wells on 23rd July at 8pm",
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a317.00",
+                "value": 1700
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a31.67",
+                "value": 167
+            },
+            "tax": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a317.00",
+                "value": 1700
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a31.67",
+                "value": 167
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 10,
+            "on_sale_status": "AVAILABLE",
+            "quantity_total": 10,
+            "quantity_sold": 0,
+            "sales_start": "2015-06-25T23:55:00Z",
+            "sales_end": "2015-07-23T19:00:00Z",
+            "hidden": false,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37064658/",
+            "id": "37064658",
+            "name": "Into The Night: Three Works by Nacera Belaza (Member Ticket)",
+            "description": "This ticket gives you access to the show at Sadler's Wells on 23rd July at 8pm",
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a313.60",
+                "value": 1360
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a31.47",
+                "value": 147
+            },
+            "tax": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a313.60",
+                "value": 1360
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a31.47",
+                "value": 147
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 10,
+            "on_sale_status": "AVAILABLE",
+            "quantity_total": 10,
+            "quantity_sold": 0,
+            "sales_start": "2015-06-25T23:55:00Z",
+            "sales_end": "2015-07-23T19:00:00Z",
+            "hidden": true,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37064676/",
+            "id": "37064676",
+            "name": ".",
+            "description": " <div class=\"panel_head2 break_header\" style=\"margin-top: -30px;\"><h3>Tickets for 24th July 2015<\/h3><\/div>",
+            "donation": false,
+            "free": true,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 1,
+            "on_sale_status": "UNAVAILABLE",
+            "quantity_total": 1,
+            "quantity_sold": 0,
+            "sales_start": "2015-06-26T00:00:00Z",
+            "sales_end": "2015-07-11T17:00:00Z",
+            "hidden": false,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37064677/",
+            "id": "37064677",
+            "name": "Into The Night: Three Works by Nacera Belaza",
+            "description": "This ticket gives you access to the show at Sadler's Wells on 24th July at 8pm",
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a317.00",
+                "value": 1700
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a31.67",
+                "value": 167
+            },
+            "tax": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a317.00",
+                "value": 1700
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a31.67",
+                "value": 167
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 10,
+            "on_sale_status": "AVAILABLE",
+            "quantity_total": 10,
+            "quantity_sold": 0,
+            "sales_start": "2015-06-26T00:00:00Z",
+            "sales_end": "2015-07-24T19:00:00Z",
+            "hidden": false,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37064678/",
+            "id": "37064678",
+            "name": "Into The Night: Three Works by Nacera Belaza (Member Ticket)",
+            "description": "This ticket gives you access to the show at Sadler's Wells on 24th July at 8pm",
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a313.60",
+                "value": 1360
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a31.47",
+                "value": 147
+            },
+            "tax": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a313.60",
+                "value": 1360
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a31.47",
+                "value": 147
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 10,
+            "on_sale_status": "AVAILABLE",
+            "quantity_total": 10,
+            "quantity_sold": 0,
+            "sales_start": "2015-06-26T00:00:00Z",
+            "sales_end": "2015-07-24T19:00:00Z",
+            "hidden": true,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37064693/",
+            "id": "37064693",
+            "name": ".",
+            "description": " <div class=\"panel_head2 break_header\" style=\"margin-top: -30px;\"><h3>Tickets for 25th and 26th July 2015<\/h3><\/div>",
+            "donation": false,
+            "free": true,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 1,
+            "on_sale_status": "UNAVAILABLE",
+            "quantity_total": 1,
+            "quantity_sold": 0,
+            "sales_start": "2015-06-26T00:05:00Z",
+            "sales_end": "2015-07-11T17:00:00Z",
+            "hidden": false,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37064694/",
+            "id": "37064694",
+            "name": "Shubbak Literature Festival",
+            "description": "This ticket gives you weekend access to the Shubbak Literature Festival for 25th and 26th July",
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a326.00",
+                "value": 2600
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a32.21",
+                "value": 221
+            },
+            "tax": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a326.00",
+                "value": 2600
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a32.21",
+                "value": 221
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 10,
+            "on_sale_status": "AVAILABLE",
+            "quantity_total": 25,
+            "quantity_sold": 0,
+            "sales_start": "2015-06-26T00:05:00Z",
+            "sales_end": "2015-07-26T17:00:00Z",
+            "hidden": false,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37064695/",
+            "id": "37064695",
+            "name": "Shubbak Literature Festival",
+            "description": "This ticket gives you weekend access to the Shubbak Literature Festival for 25th and 26th July",
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a320.80",
+                "value": 2080
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a31.90",
+                "value": 190
+            },
+            "tax": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a320.80",
+                "value": 2080
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a31.90",
+                "value": 190
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 10,
+            "on_sale_status": "AVAILABLE",
+            "quantity_total": 25,
+            "quantity_sold": 0,
+            "sales_start": "2015-06-26T00:05:00Z",
+            "sales_end": "2015-07-26T17:00:00Z",
+            "hidden": true,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37191245/",
+            "id": "37191245",
+            "name": "D-Sysiphe",
+            "description": "This ticket gives you access to the performance of D-Sysiphe at Rich Mix on 18th July at 7.30pm",
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a310.00",
+                "value": 1000
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a31.25",
+                "value": 125
+            },
+            "tax": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a310.00",
+                "value": 1000
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a31.25",
+                "value": 125
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 10,
+            "on_sale_status": "AVAILABLE",
+            "quantity_total": 10,
+            "quantity_sold": 0,
+            "sales_start": "2015-07-01T01:15:00Z",
+            "sales_end": "2015-07-18T18:30:00Z",
+            "hidden": false,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37191246/",
+            "id": "37191246",
+            "name": "D-Sysiphe (Member Ticket)",
+            "description": "This ticket gives you access to the performance of D-Sysiphe at Rich Mix on 18th July at 7.30pm",
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a38.00",
+                "value": 800
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a31.13",
+                "value": 113
+            },
+            "tax": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a38.00",
+                "value": 800
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a31.13",
+                "value": 113
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 10,
+            "on_sale_status": "AVAILABLE",
+            "quantity_total": 10,
+            "quantity_sold": 0,
+            "sales_start": "2015-07-01T01:15:00Z",
+            "sales_end": "2015-07-18T18:30:00Z",
+            "hidden": true,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37191277/",
+            "id": "37191277",
+            "name": "The Mix",
+            "description": "This ticket gives you access to the performance of the Mix on 25th July at 8pm",
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a312.00",
+                "value": 1200
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a31.37",
+                "value": 137
+            },
+            "tax": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a312.00",
+                "value": 1200
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a31.37",
+                "value": 137
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 10,
+            "on_sale_status": "AVAILABLE",
+            "quantity_total": 10,
+            "quantity_sold": 0,
+            "sales_start": "2015-07-01T01:20:00Z",
+            "sales_end": "2015-07-25T19:00:00Z",
+            "hidden": false,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37191278/",
+            "id": "37191278",
+            "name": "The Mix (Member Ticket)",
+            "description": "This ticket gives you access to the performance of the Mix on 25th July at 8pm",
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a39.60",
+                "value": 960
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a31.23",
+                "value": 123
+            },
+            "tax": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a39.60",
+                "value": 960
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a31.23",
+                "value": 123
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 10,
+            "on_sale_status": "AVAILABLE",
+            "quantity_total": 10,
+            "quantity_sold": 0,
+            "sales_start": "2015-07-01T01:20:00Z",
+            "sales_end": "2015-07-25T19:00:00Z",
+            "hidden": true,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37191329/",
+            "id": "37191329",
+            "name": ".",
+            "description": " <div class=\"panel_head2 break_header\" style=\"margin-top: -30px;\"><h3>Tickets for 19th July 2015<\/h3><\/div>",
+            "donation": false,
+            "free": true,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 1,
+            "on_sale_status": "UNAVAILABLE",
+            "quantity_total": 1,
+            "quantity_sold": 0,
+            "sales_start": "2015-07-01T01:20:00Z",
+            "sales_end": "2015-07-11T17:00:00Z",
+            "hidden": false,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37191330/",
+            "id": "37191330",
+            "name": "D-Sysiphe",
+            "description": "This ticket gives you access to the performance of D-Sysiphe on 19th July at Rich Mix at 7.30pm",
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a310.00",
+                "value": 1000
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a31.25",
+                "value": 125
+            },
+            "tax": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a310.00",
+                "value": 1000
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a31.25",
+                "value": 125
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 10,
+            "on_sale_status": "AVAILABLE",
+            "quantity_total": 10,
+            "quantity_sold": 0,
+            "sales_start": "2015-07-01T01:20:00Z",
+            "sales_end": "2015-07-19T18:30:00Z",
+            "hidden": false,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        },
+        {
+            "resource_uri": "https://www.eventbriteapi.com/v3/events/17514481285/ticket_classes/37191331/",
+            "id": "37191331",
+            "name": "D-Sysiphe (Member Ticket)",
+            "description": "This ticket gives you access to the performance of D-Sysiphe on 19th July at Rich Mix at 7.30pm",
+            "cost": {
+                "currency": "GBP",
+                "display": "\u00a38.00",
+                "value": 800
+            },
+            "fee": {
+                "currency": "GBP",
+                "display": "\u00a31.13",
+                "value": 113
+            },
+            "tax": {
+                "currency": "GBP",
+                "display": "\u00a30.00",
+                "value": 0
+            },
+            "actual_cost": {
+                "currency": "GBP",
+                "display": "\u00a38.00",
+                "value": 800
+            },
+            "actual_fee": {
+                "currency": "GBP",
+                "display": "\u00a31.13",
+                "value": 113
+            },
+            "donation": false,
+            "free": false,
+            "minimum_quantity": 1,
+            "maximum_quantity": null,
+            "maximum_quantity_per_order": 10,
+            "on_sale_status": "AVAILABLE",
+            "quantity_total": 10,
+            "quantity_sold": 0,
+            "sales_start": "2015-07-01T01:20:00Z",
+            "sales_end": "2015-07-19T18:30:00Z",
+            "hidden": true,
+            "include_fee": false,
+            "split_fee": false,
+            "hide_description": false,
+            "auto_hide": false,
+            "variants": [],
+            "event_id": "17514481285"
+        }
+    ],
+    "organizer": {
+        "description": null,
+        "logo": {
+            "id": "8559825",
+            "url": "http://cdn.evbuc.com/images/8559825/104062388105/2/logo.jpg",
+            "aspect_ratio": null,
+            "edge_color": null
+        },
+        "resource_uri": "https://www.eventbriteapi.com/v3/organizers/6693856275/",
+        "id": "6693856275",
+        "name": "Guardian Live events",
+        "url": "http://www.eventbrite.co.uk/o/guardian-live-events-6693856275",
+        "num_past_events": 11,
+        "num_future_events": 0
+    }
+}


### PR DESCRIPTION
**Revised version of https://github.com/guardian/membership-frontend/pull/563 now we have  a live example of this** 

I've added a JSON mock of that event and added some test cases around it. Will compare against [this production](https://membership.theguardian.com/event/shubbak-a-window-on-contemporary-arab-culture-17514481285) with @TesterSpike and then we can release this.

---

Improves handling of multi-day events. Previously events were only sellable when the eventbrite status was `live`. This causes issues with pseudo multi-day events where an event may be classed as `started` but there are still some ticket types available to buy (due to them being used to model future dates).

Having spoken to @rtyley a suitable fix for this is to use the `sales_end` dates from the events `ticket_classes`. If a ticket type is still for sale then it's OK to show the booking button.

**Before:**

![screen shot 2015-07-14 at 13 08 29](https://cloud.githubusercontent.com/assets/123386/8672784/713cd678-2a29-11e5-9b1b-321e39f7caec.png)

**After**

![screen shot 2015-07-14 at 13 10 42](https://cloud.githubusercontent.com/assets/123386/8672825/c131445c-2a29-11e5-8c26-5c8f8136bb92.png)

---

This also updates the sales end date to work with multi-day events. Previously this would show the sales end of the first ticket type.

![screen shot 2015-06-02 at 15 48 37](https://cloud.githubusercontent.com/assets/123386/7938731/f9788fac-093e-11e5-8e17-2d6db2934d1a.png)

@jennysivapalan @TesterSpike 