### PR TITLE
Fix zxcvbn version

### DIFF
--- a/frontend/assets/javascripts/bower.json
+++ b/frontend/assets/javascripts/bower.json
@@ -6,7 +6,7 @@
     "bean": "~1.0.6",
     "domready": "~1.0.5",
     "reqwest": "~1.1.0",
-    "zxcvbn": "*",
+    "zxcvbn": "90b7d2908d1305e0ab9f0fe0d983041e546af760",
     "curl": "~0.8.10",
     "raven-js": "~1.1.16",
     "lodash-amd": "~3.10.0",


### PR DESCRIPTION
zxcvbn, the password strength component we use has released a [number of broken versions](https://github.com/dropbox/zxcvbn/releases) which change the way it works with AMD. This PR locks down the version to an explicit hash for the version prior to the recent releases. Not ideal, but OK for now until I can update properly to the latest version.

See also https://github.com/guardian/subscriptions-frontend/pull/111

@afiore 