### PR TITLE
Simplify priority booking to 48 hours for partners and patrons

### DIFF
--- a/frontend/app/model/Benefits.scala
+++ b/frontend/app/model/Benefits.scala
@@ -27,13 +27,12 @@ object Benefits {
     BenefitItem("book_tickets", "Book tickets", "Book tickets to Guardian Live events", "benefit-booking"),
     BenefitItem("digital_digest", "Membership email updates", "Receive regular updates from the membership community", "benefit-digest"),
     BenefitItem("video_highlights", "Video highlights", "Watch highlights of selected Guardian Live events", "benefit-video"),
-    BenefitItem("early_booking", "Early booking", "Early ticket booking on Guardian Live Events (before Friends and Supporters)", "benefit-priority-booking"),
+    BenefitItem("priority_booking", "Priority booking", "Priority booking on Guardian Live Events (before Friends and Supporters)", "benefit-priority-booking"),
     BenefitItem("discount", "20% off live events", "20% discount on Guardian Live tickets", "benefit-live-discount"),
     BenefitItem("discount_masterclasses", "20% off masterclasses", "20% discount on Guardian Masterclasses", "benefit-masterclasses-discount"),
     BenefitItem("membership_card", "Membership card", "Membership card and annual gift", "benefit-card"),
     BenefitItem("plus_1_guest", "+1 guest", "Bring a guest to Guardian Live with the same discount and priority booking advantages", "benefit-plus1"),
     BenefitItem("live_stream", "Live stream events", "Watch live streams of flagship Guardian Live Membership events", "benefit-stream"),
-    BenefitItem("priority_booking", "Priority booking", "Additional priority ticket booking on Guardian Live Events (before Partners)", "benefit-priority-booking"),
     BenefitItem("complim_items", "Special thank-yous", "The occasional unique gift to thank you for your support", "benefit-gifts"),
     BenefitItem("unique_experiences", "Unique experiences", "Get behind the scenes of our journalism", "benefit-experiences")
   )
@@ -70,28 +69,19 @@ object Benefits {
     "book_tickets"
   )
   val partnerBenefitsList = benefitsFilter(
-    "early_booking",
-    "plus_1_guest",
-    "live_stream",
-    "discount",
-    "discount_masterclasses",
-    "membership_card",
-    "digital_digest",
-    "video_highlights",
-    "book_tickets"
-  )
-  val patronBenefitsList = benefitsFilter(
-    "discount",
-    "discount_masterclasses",
     "priority_booking",
-    "complim_items",
-    "unique_experiences",
     "plus_1_guest",
-    "membership_card",
     "live_stream",
+    "discount",
+    "discount_masterclasses",
+    "membership_card",
     "digital_digest",
     "video_highlights"
   )
+  val patronBenefitsList = benefitsFilter(
+    "complim_items",
+    "unique_experiences"
+  ) ++ partnerBenefitsList
 
   val friendBenefits = Benefits("Benefits",
     friendBenefitsList,
@@ -111,7 +101,7 @@ object Benefits {
     partnerBenefitsList,
     Some(Pricing(135, 15, Some("1 year membership, 3 months free"))),
     "Become a Partner",
-    "Support the Guardian and experience it brought to life, with early booking and discounted tickets"
+    "Support the Guardian and experience it brought to life, with priority booking and discounted tickets"
   )
   val patronBenefits = Benefits(
     "Partner benefits, plus…",

--- a/frontend/app/model/Faq.scala
+++ b/frontend/app/model/Faq.scala
@@ -49,7 +49,7 @@ object Faq {
       "difference-between-tiers"
     ),
     Item("Why do I have to sign in to the Guardian to become a member?",
-      Html("We ask you to sign in so we know who you are and ensure that we apply the correct discounts and privileges when you buy tickets to an event - Partners and Patrons get early booking and 20% discount on tickets to all Guardian Live events."),
+      Html("We ask you to sign in so we know who you are and ensure that we apply the correct discounts and privileges when you buy tickets to an event - Partners and Patrons get priority booking and 20% discount on tickets to all Guardian Live events."),
       "why-sign-in-to-become-a-member"
     ),
     Item("What is Guardian Live?",

--- a/frontend/app/model/TicketSaleDates.scala
+++ b/frontend/app/model/TicketSaleDates.scala
@@ -22,19 +22,13 @@ object TicketSaleDates {
   implicit val periodOrdering = Ordering.by[Period, Duration](_.toStandardDuration)
 
   /**
-   * Lead times each tier gets on ticket sales
-   * ticket start time in EB --------------- general release time (MEM) ----------------- Event start date
-   *  ------------(Patron lead time)-------------||---------------------------------------->
-   *                      ----(Partner lead time)||---------------------------------------->
-   *                                      Friend ||---------------------------------------->
+   * All tiers with event benefits get a 48 hour lead-time
+   * aside from cases where an event has been released with < 48 hours notice
    */
-
   val memberLeadTimeOverGeneralRelease = SortedMap[Duration, Map[Tier, Period]](
-    4.hours.standardDuration -> Map(Patron -> 30.minutes, Partner -> 20.minutes),
-    48.hours.standardDuration -> Map(Patron -> 4.hours, Partner -> 2.hours),
-    7.days.standardDuration -> Map(Patron -> 2.days, Partner -> 1.day),
-    2.weeks.standardDuration -> Map(Patron -> 5.days, Partner -> 3.days),
-    6.weeks.standardDuration -> Map(Patron -> 2.weeks, Partner -> 1.week)
+    4.hours.standardDuration -> Map(Patron -> 30.minutes, Partner -> 30.minutes),
+    48.hours.standardDuration -> Map(Patron -> 4.hours, Partner -> 4.hours),
+    7.days.standardDuration -> Map(Patron -> 48.hours, Partner -> 48.hours)
   )
 
   def datesFor(eventTimes: EventTimes, tickets: EBTicketClass): TicketSaleDates = {
@@ -65,8 +59,9 @@ object TicketSaleDates {
   }
 
 
-  private def maxStartSaleTime(effectiveSaleStart: Instant, tierSaleDate:Instant) =
+  private def maxStartSaleTime(effectiveSaleStart: Instant, tierSaleDate:Instant) = {
     Seq(effectiveSaleStart, toStartOfDay(tierSaleDate)).max
+  }
 
   private def toStartOfDay(instant: Instant) = instant.toDateTime(UTC).withTimeAtStartOfDay().toInstant
 

--- a/frontend/app/model/TicketSaleDates.scala
+++ b/frontend/app/model/TicketSaleDates.scala
@@ -22,13 +22,16 @@ object TicketSaleDates {
   implicit val periodOrdering = Ordering.by[Period, Duration](_.toStandardDuration)
 
   /**
-   * All tiers with event benefits get a 48 hour lead-time
-   * aside from cases where an event has been released with < 48 hours notice
+   * Lead times each tier gets on ticket sales
+   * Partners & Patrons get 48 hours priority booking, all other tiers are general release
+   * only if the event has been releasd with at least 4 days notice.
+   *
+   * Ticket start time in EB --------------------|| general release time ------------------> Event start date
+   * ----- Priority booking ---------------------||---------------------------------------->
+   *                             General Release ||---------------------------------------->
    */
   val memberLeadTimeOverGeneralRelease = SortedMap[Duration, Map[Tier, Period]](
-    4.hours.standardDuration -> Map(Patron -> 30.minutes, Partner -> 30.minutes),
-    48.hours.standardDuration -> Map(Patron -> 4.hours, Partner -> 4.hours),
-    7.days.standardDuration -> Map(Patron -> 48.hours, Partner -> 48.hours)
+    4.days.standardDuration -> Map(Patron -> 48.hours, Partner -> 48.hours)
   )
 
   def datesFor(eventTimes: EventTimes, tickets: EBTicketClass): TicketSaleDates = {

--- a/frontend/app/views/event/page.scala.html
+++ b/frontend/app/views/event/page.scala.html
@@ -8,7 +8,6 @@
 
 @main(event.name.text, pageInfo=pageInfo) {
 
-
     @* Event Name *@
     <div class="event-header tone-@event.metadata.identifier">
         <div class="event-header__container">

--- a/frontend/app/views/event/page.scala.html
+++ b/frontend/app/views/event/page.scala.html
@@ -8,6 +8,7 @@
 
 @main(event.name.text, pageInfo=pageInfo) {
 
+
     @* Event Name *@
     <div class="event-header tone-@event.metadata.identifier">
         <div class="event-header__container">

--- a/frontend/app/views/fragments/event/stats.scala.html
+++ b/frontend/app/views/fragments/event/stats.scala.html
@@ -1,6 +1,6 @@
 @(event: model.RichEvent.RichEvent, showTicketSales: Boolean = false)
 
-@import views.support.Dates._
+@import views.support.Dates.dateTimeRange
 
 @* Event start time *@
 <div class="stat-item">

--- a/frontend/app/views/fragments/event/ticketSales.scala.html
+++ b/frontend/app/views/fragments/event/ticketSales.scala.html
@@ -31,14 +31,18 @@
         id="js-event-ticket-dates-@event.id"
         @if(ticketing.salesDates.anyoneCanBuyTicket) { data-toggle-hidden}
     >
-        @for(tier <- Seq(Tier.Patron, Tier.Partner, Tier.Friend)) {
-            <li class="ticket-sales__item">
-                <span class="ticket-sales__item__label">@(tier + "s")</span>
-                <span class="ticket-sales__item__date">
-                    @ticketDateForTier(tier, ticketing.salesDates.datesByTier(tier), ticketing.salesDates.needToDistinguishTimes)
-                </span>
-            </li>
-        }
+        <li class="ticket-sales__item">
+            <span class="ticket-sales__item__label">Priority booking</span>
+            <span class="ticket-sales__item__date">
+            @ticketDateForTier(Tier.Patron, ticketing.salesDates .datesByTier(Tier.Patron), ticketing.salesDates.needToDistinguishTimes)
+            </span>
+        </li>
+        <li class="ticket-sales__item">
+            <span class="ticket-sales__item__label">General release</span>
+            <span class="ticket-sales__item__date">
+            @ticketDateForTier(Tier.Friend, ticketing.salesDates .datesByTier(Tier.Friend), ticketing.salesDates.needToDistinguishTimes)
+            </span>
+        </li>
     </ul>
     <ul class="ticket-sales__list u-unstyled">
         <li class="ticket-sales__item">

--- a/frontend/app/views/fragments/event/ticketSales.scala.html
+++ b/frontend/app/views/fragments/event/ticketSales.scala.html
@@ -1,20 +1,21 @@
 @(event: model.RichEvent.RichEvent, ticketing: model.Eventbrite.InternalTicketing)
 
+@import org.joda.time.Instant
 @import com.gu.membership.salesforce.Tier
 @import model.RichEvent._
-@import org.joda.time.Instant
 @import views.support.Dates._
 
-@ticketDateForTier(tier: Tier, salesDate: Instant, needToDisplayTimes: Boolean) = @{
-    Html(s"<time class='js-ticket-sale-start-${tier.slug}' datetime='$salesDate'>${salesDate.pretty(needToDisplayTimes)}</time>")
-}
+@salesDatesHidden = @{ if(ticketing.salesDates.anyoneCanBuyTicket) "data-toggle-hidden" else "" }
 
-@ticketEndSaleDate(endSalesDate: Instant, needToDisplayTimes: Boolean) = @{
-    Html(s"<time class='qa-event-detail-sales-end' datetime='$endSalesDate'>${endSalesDate.pretty(needToDisplayTimes || endSalesDate.isContemporary())}</time>")
+@ticketDateForTier(tier: Tier, salesDate: Instant, needToDisplayTimes: Boolean) = {
+    <time class="js-ticket-sale-start-@tier.slug" datetime="@salesDate">
+        @salesDate.prettyWithoutYear(needToDisplayTimes)
+    </time>
 }
 
 <div class="ticket-sales">
     <span class="ticket-sales__header">@if(ticketing.salesDates.anyoneCanBuyTicket) {Tickets on sale now} else {Ticket release dates}</span>
+
     @if(ticketing.salesDates.anyoneCanBuyTicket) {
         <button class="ticket-sales__toggle u-button-reset js-toggle"
                 data-toggle-label="Hide"
@@ -27,28 +28,29 @@
             Release dates
         </button>
     }
-    <ul class="ticket-sales__list u-unstyled"
-        id="js-event-ticket-dates-@event.id"
-        @if(ticketing.salesDates.anyoneCanBuyTicket) { data-toggle-hidden}
-    >
+
+    <ul class="ticket-sales__list u-unstyled" id="js-event-ticket-dates-@event.id" @salesDatesHidden>
         <li class="ticket-sales__item">
-            <span class="ticket-sales__item__label">Priority booking</span>
+            <span class="ticket-sales__item__label">Partners & Patrons</span>
             <span class="ticket-sales__item__date">
-            @ticketDateForTier(Tier.Patron, ticketing.salesDates .datesByTier(Tier.Patron), ticketing.salesDates.needToDistinguishTimes)
+                @ticketDateForTier(Tier.Patron, ticketing.salesDates.datesByTier(Tier.Patron), ticketing.salesDates.needToDistinguishTimes)
             </span>
         </li>
         <li class="ticket-sales__item">
             <span class="ticket-sales__item__label">General release</span>
             <span class="ticket-sales__item__date">
-            @ticketDateForTier(Tier.Friend, ticketing.salesDates .datesByTier(Tier.Friend), ticketing.salesDates.needToDistinguishTimes)
+                @ticketDateForTier(Tier.Friend, ticketing.salesDates.datesByTier(Tier.Friend), ticketing.salesDates.needToDistinguishTimes)
             </span>
         </li>
     </ul>
+
     <ul class="ticket-sales__list u-unstyled">
         <li class="ticket-sales__item">
             <span class="ticket-sales__item__label">Sale ends</span>
             <span class="ticket-sales__item__date">
-                @ticketEndSaleDate(ticketing.salesEnd, ticketing.salesDates.needToDistinguishTimes)
+                <time class='qa-event-detail-sales-end' datetime="@ticketing.salesEnd">
+                    @ticketing.salesEnd.prettyWithoutYear(ticketing.salesDates.needToDistinguishTimes || ticketing.salesEnd.isContemporary())
+                </time>
             </span>
         </li>
     </ul>

--- a/frontend/app/views/support/Dates.scala
+++ b/frontend/app/views/support/Dates.scala
@@ -21,8 +21,11 @@ object Dates {
 
   implicit class RichInstant(dt: Instant) {
     lazy val pretty = prettyDate(new DateTime(dt))
+    lazy val prettyWithoutYear = prettyDateNoYear(new DateTime(dt))
     lazy val prettyWithTime = prettyDateWithTime(new DateTime(dt))
+    lazy val prettyNoYearWithTime = prettyDateNoYearTime(new DateTime(dt))
     def pretty(includeTime: Boolean): String = if (includeTime) prettyWithTime else pretty
+    def prettyWithoutYear(includeTime: Boolean): String = if (includeTime) prettyNoYearWithTime else prettyWithoutYear
     def isContemporary(threshold: Duration = 24.hours) = new Interval(dt - threshold, dt + threshold).contains(DateTime.now)
   }
 
@@ -31,9 +34,11 @@ object Dates {
   }
 
   def prettyDate(dt: DateTime): String = dt.toString("d MMMMM YYYY")
+  def prettyDateNoYear(dt: DateTime): String = dt.toString("d MMMMM")
   def prettyTime(dt: DateTime): String = dt.toString(if (dt.getMinuteOfHour==0) "h" else "h.mm") + dt.toString("a").toLowerCase
 
   def prettyDateWithTime(dt: DateTime): String = prettyDate(dt) + ", " + prettyTime(dt)
+  def prettyDateNoYearTime(dt: DateTime): String = prettyDateNoYear(dt) + ", " + prettyTime(dt)
 
   def prettyDateWithTimeAndDayName(dt: DateTime): String =
     dt.toString("EEEE ") + prettyDateWithTime(dt)

--- a/frontend/test/model/TicketSaleDatesTest.scala
+++ b/frontend/test/model/TicketSaleDatesTest.scala
@@ -32,9 +32,10 @@ class TicketSaleDatesTest extends Specification {
       val datesByTier = TicketSaleDates.datesFor(testEventTimes, eventTicketClass.copy(sales_start = Some(saleStart))).datesByTier
 
       datesByTier(Patron) must be_==(saleStart)
-      datesByTier(Patron) must be_<=(datesByTier(Partner))
+      datesByTier(Patron) must be_==(datesByTier(Partner))
       datesByTier(Partner) must be_<=(datesByTier(Friend))
       datesByTier(Friend) must be_<=(testEventTimes.start)
+
       (datesByTier(Patron) to datesByTier(Friend)).duration must be_>=(7.days.standardDuration)
     }
 
@@ -44,9 +45,7 @@ class TicketSaleDatesTest extends Specification {
       val datesByTier = TicketSaleDates.datesFor(testEventTimes, eventTicketClass.copy(sales_start = Some(saleStart))).datesByTier
 
       datesByTier(Patron) must be_==(saleStart)
-
-      val partnerTicketSale = datesByTier(Partner).toDateTime(UTC)
-      dateMustBeToStartOfDay(partnerTicketSale) must be_==(true)
+      datesByTier(Partner) must be_==(saleStart)
 
       val friendTicketSale = datesByTier(Friend).toDateTime(UTC)
       dateMustBeToStartOfDay(friendTicketSale) must be_==(true)
@@ -58,9 +57,7 @@ class TicketSaleDatesTest extends Specification {
       val datesByTier = TicketSaleDates.datesFor(testEventTimes, eventTicketClass.copy(sales_start = Some(saleStart))).datesByTier
 
       datesByTier(Patron) must be_==(saleStart)
-
-      val partnerTicketSale = datesByTier(Partner).toDateTime
-      dateMustBeToStartOfDay(partnerTicketSale) must be_==(false)
+      datesByTier(Partner) must be_==(saleStart)
 
       val friendTicketSale = datesByTier(Friend).toDateTime
       dateMustBeToStartOfDay(friendTicketSale) must be_==(false)
@@ -84,12 +81,15 @@ class TicketSaleDatesTest extends Specification {
         val datesByTier = ticketSaleDates.datesByTier
 
         datesByTier(Patron) must be_==(effectiveStartDate)
-        datesByTier(Patron) must be_<=(datesByTier(Partner))
-        datesByTier(Partner) must be_<=(datesByTier(Friend))
+        datesByTier(Partner) must be_==(effectiveStartDate)
         datesByTier(Friend) must be_<=(event.start)
       }
     }
+
   }
-  private def dateMustBeToStartOfDay(dateTime: DateTime): Boolean =
-    dateTime.getHourOfDay() == 0 && dateTime.getMinuteOfHour() == 0 && dateTime.getSecondOfMinute() == 0
+
+  private def dateMustBeToStartOfDay(dateTime: DateTime): Boolean = {
+    dateTime.getHourOfDay == 0 && dateTime.getMinuteOfHour == 0 && dateTime.getSecondOfMinute == 0
+  }
+
 }


### PR DESCRIPTION
Simplifies priority booking to 48 hours for partners and patrons:

- If the event has been announced with at least 4 days lead-time partners and patrons get 48 hours priority booking
- Simplify ticket sales panels to show only Priority Booking (Partners & Patrons) and General Release rather than per tier dates
- Updates release dates in panel to not show year

![screen shot 2015-07-17 at 16 13 58](https://cloud.githubusercontent.com/assets/123386/8750420/1f01f1e0-2c9f-11e5-965f-94f1d4318656.png)

![screen shot 2015-07-17 at 15 13 16](https://cloud.githubusercontent.com/assets/123386/8750641/8036a4aa-2ca0-11e5-8d31-1bf3c2ab11a7.png)

@rtyley 