### PR TITLE
Simplify ticket sales dates. Remove toggle

### DIFF
--- a/frontend/app/views/fragments/event/stats.scala.html
+++ b/frontend/app/views/fragments/event/stats.scala.html
@@ -40,7 +40,7 @@
                 @fragments.inlineIcon("tickets", List("icon-inline--medium", "icon-inline--top", "icon-inline--neutral"))
             </div>
             <div class="stat-item__second">
-                @fragments.event.ticketSales(event, ticketing)
+                @fragments.event.ticketSales(ticketing)
             </div>
         </div>
     }

--- a/frontend/app/views/fragments/event/ticketSales.scala.html
+++ b/frontend/app/views/fragments/event/ticketSales.scala.html
@@ -1,11 +1,17 @@
-@(event: model.RichEvent.RichEvent, ticketing: model.Eventbrite.InternalTicketing)
+@(ticketing: model.Eventbrite.InternalTicketing)
 
 @import org.joda.time.Instant
 @import com.gu.membership.salesforce.Tier
-@import model.RichEvent._
 @import views.support.Dates._
 
-@salesDatesHidden = @{ if(ticketing.salesDates.anyoneCanBuyTicket) "data-toggle-hidden" else "" }
+@ticketSalesItem(label: String)(content: Html) = {
+    <li class="ticket-sales__item">
+        <span class="ticket-sales__item__label">@label</span>
+        <span class="ticket-sales__item__date">
+            @content
+        </span>
+    </li>
+}
 
 @ticketDateForTier(tier: Tier, salesDate: Instant, needToDisplayTimes: Boolean) = {
     <time class="js-ticket-sale-start-@tier.slug" datetime="@salesDate">
@@ -14,44 +20,19 @@
 }
 
 <div class="ticket-sales">
-    <span class="ticket-sales__header">@if(ticketing.salesDates.anyoneCanBuyTicket) {Tickets on sale now} else {Ticket release dates}</span>
-
-    @if(ticketing.salesDates.anyoneCanBuyTicket) {
-        <button class="ticket-sales__toggle u-button-reset js-toggle"
-                data-toggle-label="Hide"
-                data-toggle="js-event-ticket-dates-@event.id"
-                data-metric-trigger="click"
-                data-metric-category="events"
-                data-metric-action="toggle-release-dates"
-                data-toggle-icon="triangle-up">
-            @fragments.inlineIcon("triangle-down", Seq("u-align-right"))
-            Release dates
-        </button>
-    }
-
-    <ul class="ticket-sales__list u-unstyled" id="js-event-ticket-dates-@event.id" @salesDatesHidden>
-        <li class="ticket-sales__item">
-            <span class="ticket-sales__item__label">Partners & Patrons</span>
-            <span class="ticket-sales__item__date">
-                @ticketDateForTier(Tier.Patron, ticketing.salesDates.datesByTier(Tier.Patron), ticketing.salesDates.needToDistinguishTimes)
-            </span>
-        </li>
-        <li class="ticket-sales__item">
-            <span class="ticket-sales__item__label">General release</span>
-            <span class="ticket-sales__item__date">
-                @ticketDateForTier(Tier.Friend, ticketing.salesDates.datesByTier(Tier.Friend), ticketing.salesDates.needToDistinguishTimes)
-            </span>
-        </li>
-    </ul>
-
+    <span class="ticket-sales__header">Tickets</span>
     <ul class="ticket-sales__list u-unstyled">
-        <li class="ticket-sales__item">
-            <span class="ticket-sales__item__label">Sale ends</span>
-            <span class="ticket-sales__item__date">
-                <time class='qa-event-detail-sales-end' datetime="@ticketing.salesEnd">
-                    @ticketing.salesEnd.prettyWithoutYear(ticketing.salesDates.needToDistinguishTimes || ticketing.salesEnd.isContemporary())
-                </time>
-            </span>
-        </li>
+        @ticketSalesItem("Partners & Patrons") {
+            @ticketDateForTier(Tier.Patron, ticketing.salesDates.datesByTier(Tier.Patron), ticketing.salesDates.needToDistinguishTimes)
+        }
+        @ticketSalesItem("General release") {
+            @ticketDateForTier(Tier.Friend, ticketing.salesDates.datesByTier(Tier.Friend), ticketing.salesDates.needToDistinguishTimes)
+        }
+        @ticketSalesItem("Sale ends") {
+            <time class='qa-event-detail-sales-end' datetime="@ticketing.salesEnd">
+                @ticketing.salesEnd.prettyWithoutYear(ticketing.salesDates.needToDistinguishTimes || ticketing.salesEnd.isContemporary())
+            </time>
+        }
     </ul>
+
 </div>


### PR DESCRIPTION
As we have recently simplified out priority booking rules, this also means we can simplify how we display ticket dates on event detail pages. This PR removes the toggle and shows a consistent label for all cases. Less code, clearer UX, winner.

![screen shot 2015-07-20 at 16 54 33](https://cloud.githubusercontent.com/assets/123386/8780295/019f22d6-2f00-11e5-91bd-32b580a8333c.png)

**Before**

![screen shot 2015-07-20 at 16 52 35](https://cloud.githubusercontent.com/assets/123386/8780288/f4e5e854-2eff-11e5-88b6-94fd2b2bb157.png)

**After**

![screen shot 2015-07-20 at 16 52 23](https://cloud.githubusercontent.com/assets/123386/8780292/f88b9f8a-2eff-11e5-83c9-7225a1fb1b97.png)

@afiore @tudorraul 