### PR TITLE
Use thumbnail image, not main

### DIFF
--- a/frontend/app/model/ResponsiveImage.scala
+++ b/frontend/app/model/ResponsiveImage.scala
@@ -15,7 +15,7 @@ object ResponsiveImageGenerator {
 object ResponsiveImageGroup {
   def apply(content: Content): Option[ResponsiveImageGroup] = for {
     elements <- content.elements
-    element <- elements.find(_.relation == "main")
+    element <- elements.find(_.relation == "thumbnail")
   } yield ResponsiveImageGroup(
     altText = element.assets.headOption.flatMap(_.typeData.get("altText")),
     metadata = None,


### PR DESCRIPTION
We should be using the thumbnail crop for offers/masterclass images, not main. Solves this problem:

**Before**

![screen shot 2015-07-21 at 11 50 57](https://cloud.githubusercontent.com/assets/123386/8799056/2200e20e-2f9f-11e5-9e7b-8f43ece1e85e.png)

**After**

![screen shot 2015-07-21 at 11 53 57](https://cloud.githubusercontent.com/assets/123386/8799066/2f637b00-2f9f-11e5-92ea-5370350484a3.png)

Still looks correct on Masterclasses

![screen shot 2015-07-21 at 11 53 13](https://cloud.githubusercontent.com/assets/123386/8799076/4abe6e78-2f9f-11e5-92ad-d36f35a77af6.png)
![screen shot 2015-07-21 at 11 53 18](https://cloud.githubusercontent.com/assets/123386/8799077/4abf20a2-2f9f-11e5-9558-d8c9ff6ad9ca.png)

@afiore @TesterSpike  