### PR TITLE
De-remify base and layout styles

### DIFF
--- a/frontend/assets/stylesheets/base/_form.scss
+++ b/frontend/assets/stylesheets/base/_form.scss
@@ -36,7 +36,7 @@ form {
     border-bottom: 0;
 
     .fieldset__fields {
-        padding-top: rem($gs-gutter / 2);
+        padding-top: ($gs-gutter / 2);
     }
 }
 
@@ -46,11 +46,11 @@ form {
 
 .fieldset__heading {
     vertical-align: top;
-    padding: rem($gs-baseline / 2) rem($gs-baseline) rem($gs-baseline * 2) rem($gs-gutter / 2);
+    padding: ($gs-baseline / 2) $gs-baseline ($gs-baseline * 2) ($gs-gutter / 2);
 
     @include mq(tablet) {
         display: table-cell;
-        padding-right: rem($gs-gutter * 2);
+        padding-right: ($gs-gutter * 2);
         width: gs-span(4) + $gs-gutter;
     }
 }
@@ -64,7 +64,7 @@ form {
 .fieldset__note {
     @include fs-textSans(2);
     color: $c-neutral2;
-    margin-top: rem($gs-baseline / 2);
+    margin-top: ($gs-baseline / 2);
 
     p {
         margin-bottom: 0;
@@ -73,7 +73,7 @@ form {
 
 .fieldset__fields {
     vertical-align: top;
-    padding: rem($gs-gutter / 2) rem($gs-gutter / 2) rem($gs-baseline * 2);
+    padding: ($gs-gutter / 2) ($gs-gutter / 2) ($gs-baseline * 2);
 
     @include mq(tablet) {
         display: table-cell;
@@ -87,7 +87,7 @@ form {
    Form field
    ========================================================================== */
 .form-field {
-    margin-bottom: rem($gs-baseline);
+    margin-bottom: $gs-baseline;
 }
 
 .form-field--no-margin {
@@ -110,15 +110,15 @@ form {
 .form-field__error-message {
     @include fs-data(3);
     color: $c-error;
-    margin-top: rem(2px);
-    margin-bottom: rem($gs-baseline / 2);
+    margin-top: 2px;
+    margin-bottom: ($gs-baseline / 2);
 }
 
 .form-note {
     @include fs-textSans(1);
     color: $c-neutral2;
-    padding-top: rem($gs-baseline / 2);
-    margin-bottom: rem(8px);
+    padding-top: ($gs-baseline / 2);
+    margin-bottom: 8px;
 }
 
 .form-note--left {
@@ -130,12 +130,12 @@ form {
 .form-note--right {
     @include mq(mobileLandscape) {
         text-align: right;
-        margin-left: rem($gs-gutter);
+        margin-left: $gs-gutter;
     }
 }
 
 .form-note--underneath {
-    margin-top: rem($gs-baseline / 2);
+    margin-top: ($gs-baseline / 2);
 }
 
 /* ==========================================================================
@@ -157,7 +157,7 @@ form {
     color: $c-body;
     border: 1px solid $c-neutral4;
     @include fs-textSans(5);
-    padding: rem(8px) rem(8px) rem(7px);
+    padding: 8px 8px 7px;
     outline: none;
     width: 100%;
     -webkit-appearance: none;
@@ -167,7 +167,7 @@ form {
     }
 
     @include mq(tablet) {
-        font-size: rem(14px);
+        font-size: 14px;
     }
 }
 
@@ -180,7 +180,7 @@ form {
 }
 
 .input-textarea--long {
-    min-height: rem(($gs-baseline / 3) * 40);
+    min-height: (($gs-baseline / 3) * 40);
 }
 
 .optional-marker {
@@ -189,7 +189,7 @@ form {
         content: '(optional)';
         color: $c-neutral2;
         @include fs-textSans(1);
-        margin-left: rem(4px);
+        margin-left: 4px;
     }
 }
 
@@ -217,7 +217,7 @@ form {
 .pseudo-radio {
     width: 100%;
     border: 1px solid transparent;
-    padding: rem($gs-gutter) rem($gs-gutter) rem($gs-gutter) rem(36px);
+    padding: $gs-gutter $gs-gutter $gs-gutter 36px;
     position: relative;
 
     &:hover {
@@ -241,7 +241,7 @@ input[type=radio]:checked + .pseudo-radio {
 .pseudo-radio__header {
     @include fs-bodyHeading(2);
     line-height: 1.2;
-    margin-bottom: rem($gs-baseline / 2);
+    margin-bottom: ($gs-baseline / 2);
 }
 .pseudo-radio__note {
     @include fs-textSans(3);
@@ -261,14 +261,14 @@ $card-icon-offset: 1px;
 }
 
 .credit-card {
-    width: rem(54px);
+    width: 54px;
     height: $large-card;
 }
 
 .credit-card--input-visualisation {
     position: absolute;
-    right: rem($card-icon-offset);
-    top: rem($card-icon-offset);
+    right: $card-icon-offset;
+    top: $card-icon-offset;
 }
 
 
@@ -287,7 +287,7 @@ $card-icon-offset: 1px;
 
 .credit-card-input {
     // bit messy but needs to account for outline plus icon offset
-    height: rem($large-card + $card-icon-offset + 2px);
+    height: ($large-card + $card-icon-offset + 2px);
 }
 
 /* ==========================================================================
@@ -302,9 +302,9 @@ $password-strength-score-4: #33a22b;
 
 .password-strength-indicator {
     background-color: $c-neutral5;
-    height: rem(8px);
-    margin-top: rem(4px);
-    margin-bottom: rem($gs-baseline * 2);
+    height: 8px;
+    margin-top: 4px;
+    margin-bottom: ($gs-baseline * 2);
     position: relative;
 
     &:after {
@@ -328,15 +328,15 @@ $password-strength-score-4: #33a22b;
    ========================================================================== */
 .cvc-cta {
     font-family: $f-sans-serif-text;
-    font-size: rem(13px);
-    line-height: rem(16px);
+    font-size: 13px;
+    line-height: 16px;
 }
 
 .cvc {
     font-family: $f-sans-serif-text;
-    padding: rem($gs-baseline / 2) rem($gs-baseline / 2) rem($gs-baseline / 2) 0;
-    font-size: rem(13px);
-    line-height: rem(16px);
+    padding: ($gs-baseline / 2) ($gs-baseline / 2) ($gs-baseline / 2) 0;
+    font-size: 13px;
+    line-height: 16px;
 }
 
 .cvc__image {
@@ -344,12 +344,12 @@ $password-strength-score-4: #33a22b;
 }
 
 .cvc__detail {
-    margin-left: rem(70px);
+    margin-left: 70px;
 }
 
 .cvc__heading {
     font-weight: bold;
     font-family: $f-sans-serif-text;
-    font-size: rem(13px);
-    line-height: rem(16px);
+    font-size: 13px;
+    line-height: 16px;
 }

--- a/frontend/assets/stylesheets/base/_images.scss
+++ b/frontend/assets/stylesheets/base/_images.scss
@@ -19,12 +19,12 @@ img {
     position: absolute;
     top: 0; right: 0;
     height: 100%;
-    padding: rem($gs-gutter) rem($gs-gutter / 2);
+    padding: $gs-gutter ($gs-gutter / 2);
     background-image: -webkit-linear-gradient(0deg, transparent 0%, rgba(0, 0, 0, .6) 100%);
     background-image: linear-gradient(90deg, transparent 0%, rgba(0, 0, 0, .6) 100%);
 }
 .stamped-image__stamp {
-    height: rem($gs-gutter * 2);
+    height: ($gs-gutter * 2);
 }
 
 /* Inline SVGs

--- a/frontend/assets/stylesheets/base/_links.scss
+++ b/frontend/assets/stylesheets/base/_links.scss
@@ -102,7 +102,7 @@ a,
     position: static !important;
     width: 100% !important;
     height: auto !important;
-    padding: rem($gs-gutter/2) 0 !important;
+    padding: ($gs-gutter / 2) 0 !important;
     text-align: center;
     outline: none;
 }

--- a/frontend/assets/stylesheets/base/_lists.scss
+++ b/frontend/assets/stylesheets/base/_lists.scss
@@ -34,19 +34,19 @@ ul {
     }
 }
 .inline-list--bordered {
-    margin-top: rem($gs-baseline * 2);
-    padding-top: rem($gs-baseline / 2);
+    margin-top: ($gs-baseline * 2);
+    padding-top: ($gs-baseline / 2);
     border-top: 1px solid $c-border-brand;
 }
 
 .list-stack {
-    margin: 0 0 rem($gs-baseline);
+    margin: 0 0 $gs-baseline;
     list-style: none;
 
     li {
         border-bottom: 1px dotted $c-border-neutral;
-        padding-bottom: rem($gs-baseline / 2);
-        margin-bottom: rem($gs-baseline / 2);
+        padding-bottom: ($gs-baseline / 2);
+        margin-bottom: ($gs-baseline / 2);
     }
     li:last-child {
         border-bottom: 0 none;
@@ -56,12 +56,12 @@ ul {
 .list-stack__title {
     @include fs-bodyCopy(2);
     font-weight: bold;
-    margin-top: rem($gs-baseline);
-    padding: rem($gs-baseline / 2) 0;
+    margin-top: $gs-baseline;
+    padding: ($gs-baseline / 2) 0;
     border-top: dotted $c-border-neutral;
     border-width: 1px 0;
 }
 .list-stack--bordered {
     border-top: 1px dotted $c-border-neutral;
-    padding-top: rem($gs-baseline / 2);
+    padding-top: ($gs-baseline / 2);
 }

--- a/frontend/assets/stylesheets/base/_tables.scss
+++ b/frontend/assets/stylesheets/base/_tables.scss
@@ -5,12 +5,12 @@
 .table {
     color: $c-neutral1;
     background-color: $c-neutral8;
-    margin-bottom: rem($gs-baseline);
+    margin-bottom: $gs-baseline;
 
     th,
     td {
         @include fs-data(3);
-        padding: rem($gs-baseline * 1.3) rem($gs-gutter / 2);
+        padding: ($gs-baseline * 1.3) ($gs-gutter / 2);
         vertical-align: top;
     }
 
@@ -22,7 +22,7 @@
 
     tbody th {
         @include mq($from: tablet) {
-            width: rem(gs-span(3));
+            width: gs-span(3);
         }
     }
 
@@ -39,7 +39,7 @@
         td,
         thead td {
             @include fs-textSans(4);
-            padding: rem($gs-baseline);
+            padding: $gs-baseline;
         }
     }
 }

--- a/frontend/assets/stylesheets/layout/_footer.scss
+++ b/frontend/assets/stylesheets/layout/_footer.scss
@@ -17,11 +17,11 @@
 .global-footer__brand {
     @include clearfix;
     background-color: $mem-brandBlue;
-    padding: rem($gs-baseline / 2) rem($gs-gutter / 4);
+    padding: ($gs-baseline / 2) ($gs-gutter / 4);
 
     @include mq(mobileLandscape) {
-        padding-left: rem($gs-gutter / 2);
-        padding-right: rem($gs-gutter / 2);
+        padding-left: ($gs-gutter / 2);
+        padding-right: ($gs-gutter / 2);
     }
 }
 .global-footer__logo {
@@ -33,21 +33,21 @@
     @include font($f-sans-serif-text, normal, 13, 19);
     color: $c-neutral1;
     box-sizing: border-box;
-    padding-right: rem($gs-gutter / 2);
-    padding-left: rem($gs-gutter / 2);
+    padding-right: ($gs-gutter / 2);
+    padding-left: ($gs-gutter / 2);
 
     a {
         color: $c-neutral1;
     }
 
     @include mq(tablet) {
-        padding-right: rem($gs-gutter);
-        padding-left: rem($gs-gutter);
+        padding-right: $gs-gutter;
+        padding-left: $gs-gutter;
     }
 }
 .global-footer__misc {
-    padding-top: rem($gs-baseline / 2);
-    padding-bottom: rem($gs-baseline * 1.5);
+    padding-top: ($gs-baseline / 2);
+    padding-bottom: ($gs-baseline * 1.5);
     border-top: 1px solid $c-neutral4;
 }
 
@@ -64,7 +64,7 @@
 .to-top__label {
     @include fs-bodyHeading(1);
     color: $black;
-    padding-left: rem($gs-gutter / 4);
+    padding-left: ($gs-gutter / 4);
     text-transform: lowercase;
 }
 
@@ -76,8 +76,8 @@
     @include fs-bodyHeading(1);
     list-style: none;
     margin: 0;
-    padding-top: rem($gs-baseline * 2);
-    padding-bottom: rem($gs-baseline / 2);
+    padding-top: ($gs-baseline * 2);
+    padding-bottom: ($gs-baseline / 2);
 
     @include mq(desktop) {
         max-width: 75%;
@@ -85,7 +85,7 @@
 
     a {
         display: inline-block;
-        padding-bottom: rem($gs-baseline / 2);
+        padding-bottom: ($gs-baseline / 2);
     }
 }
 .colophon__item {
@@ -100,5 +100,5 @@
 }
 
 .really-serious-copyright {
-    margin-bottom: rem($gs-baseline / 3);
+    margin-bottom: ($gs-baseline / 3);
 }

--- a/frontend/assets/stylesheets/layout/_header.scss
+++ b/frontend/assets/stylesheets/layout/_header.scss
@@ -9,9 +9,9 @@
 
     .header__branding {
         @include clearfix();
-        padding-top: rem($gs-gutter / 4);
-        padding-bottom: rem($gs-gutter / 4);
-        height: rem(48px);
+        padding-top: ($gs-gutter / 4);
+        padding-bottom: ($gs-gutter / 4);
+        height: 48px;
 
         @include mq(tablet) {
             height: auto;
@@ -19,31 +19,31 @@
     }
     .header__primary {
         float: left;
-        padding-left: rem($gs-gutter / 2);
+        padding-left: ($gs-gutter / 2);
         padding-right: 0;
         @include mq(mobileLandscape) {
-            padding-right: rem($gs-gutter / 2);
+            padding-right: ($gs-gutter / 2);
         }
     }
 
     .header__secondary {
         float: right;
         width: auto;
-        margin-right: rem($gs-gutter / 2);
+        margin-right: ($gs-gutter / 2);
 
         @include mq(mobile) {
-            margin-right: rem($gs-gutter / 2);
+            margin-right: ($gs-gutter / 2);
         }
     }
     .header__logo {
         clear: right;
         text-align: right;
-        padding-right: rem($gs-gutter / 2);
+        padding-right: ($gs-gutter / 2);
 
         @include mq(tablet) {
             width: 100%;
-            margin-top: -(rem($gs-gutter / 2));
-            margin-bottom: rem($gs-gutter / 4);
+            margin-top: -($gs-gutter / 2);
+            margin-bottom: ($gs-gutter / 4);
         }
     }
     .header__logo__image {
@@ -59,8 +59,8 @@
     }
     @include mq(tablet) {
         .i-logo {
-            margin-top: rem($gs-gutter / 2);
-            margin-bottom: rem($gs-gutter / 2);
+            margin-top: ($gs-gutter / 2);
+            margin-bottom: ($gs-gutter / 2);
         }
     }
 }

--- a/frontend/assets/stylesheets/layout/_layout.scss
+++ b/frontend/assets/stylesheets/layout/_layout.scss
@@ -44,35 +44,35 @@ body {
 }
 
 .l-inset {
-    padding: rem($gs-baseline) rem($gs-gutter / 2) rem($gs-baseline * 2);
+    padding: $gs-baseline ($gs-gutter / 2) ($gs-baseline * 2);
 
     @include mq(tablet) {
-        padding-left: rem($gs-gutter);
-        padding-right: rem($gs-gutter);
+        padding-left: ($gs-gutter);
+        padding-right: ($gs-gutter);
     }
 }
 
 .l-pad-vertical {
-    margin-top: rem($gs-baseline);
-    margin-bottom: rem($gs-baseline);
+    margin-top: $gs-baseline;
+    margin-bottom: $gs-baseline;
 }
 
 .l-pad-top {
-    margin-top: rem($gs-baseline / 2);
+    margin-top: ($gs-baseline / 2);
 }
 .l-pad-bottom {
-    margin-bottom: rem($gs-baseline / 2);
+    margin-bottom: ($gs-baseline / 2);
 }
 
 .l-pad-left {
     @include mq(tablet) {
-        padding-left: rem(gs-span(1) + $gs-gutter);
+        padding-left: (gs-span(1) + $gs-gutter);
     }
 }
 
 .l-pad-right {
     @include mq(tablet) {
-        padding-right: rem(gs-span(1) + $gs-gutter);
+        padding-right: (gs-span(1) + $gs-gutter);
     }
 }
 
@@ -112,15 +112,15 @@ body {
 .page-content {
     @include clearfix;
     background-color: $c-background;
-    padding: 0 rem($gs-gutter / 2);
+    padding: 0 ($gs-gutter / 2);
     position: relative;
 
     @include mq(mobileLandscape) {
-        padding: 0 rem($gs-gutter);
+        padding: 0 ($gs-gutter);
     }
 }
 .page-content--padded {
     @include mq(tablet) {
-        padding: 0 rem($gs-gutter * 4) rem($gs-gutter * 8);
+        padding: 0 ($gs-gutter * 4) ($gs-gutter * 8);
     }
 }


### PR DESCRIPTION
As we now [use a postprocessor](https://github.com/guardian/membership-frontend/blob/master/frontend/Gruntfile.js#L72) to handle converting all px values to rem, we can remove the direct use of `rem()` This PR cleans up base and layout styles. Another PR to follow which cleans up components.

@afiore @tudorraul 