### PR TITLE
Implement Content Security Policy

### DIFF
--- a/frontend/app/Global.scala
+++ b/frontend/app/Global.scala
@@ -1,11 +1,11 @@
-import filters.{AddEC2InstanceHeader, CheckCacheHeadersFilter, Gzipper}
+import filters.{AddCSPHeader, AddEC2InstanceHeader, CheckCacheHeadersFilter, Gzipper}
 import monitoring.SentryLogging
 import play.api.Application
 import play.api.mvc.WithFilters
 import play.filters.csrf._
 import services._
 
-object Global extends WithFilters(CheckCacheHeadersFilter, CSRFFilter(), Gzipper, AddEC2InstanceHeader) {
+object Global extends WithFilters(CheckCacheHeadersFilter, CSRFFilter(), Gzipper, AddCSPHeader, AddEC2InstanceHeader) {
   override def onStart(app: Application) {
     SentryLogging.init()
 

--- a/frontend/app/controllers/Security.scala
+++ b/frontend/app/controllers/Security.scala
@@ -1,0 +1,25 @@
+package controllers
+
+import com.typesafe.scalalogging.LazyLogging
+import monitoring.SentryLogging
+import play.api.libs.json.Json
+import play.api.mvc.Controller
+
+import scala.concurrent.Future
+
+object Security extends Controller with LazyLogging {
+
+  def cspReport = NoCacheAction.async(parse.tolerantJson(maxLength = 4096)) { implicit request =>
+
+    val message = s"CSP warning ${Json.prettyPrint(request.body)}"
+
+    SentryLogging.ravenOpt.fold {
+      logger.error(message)
+    } {
+      _.sendMessage(message)
+    }
+
+    Future.successful(Ok)
+  }
+
+}

--- a/frontend/app/filters/AddCSPHeader.scala
+++ b/frontend/app/filters/AddCSPHeader.scala
@@ -10,13 +10,18 @@ object AddCSPHeader extends Filter {
   private val scriptWhitelist = Seq(
     "js.stripe.com",
     "*.ophan.co.uk",
+    "*.twitter.com",
+    "*.ytimg.com",
+    "*.youtube.com",
     "*.google-analytics.com",
     "*.krxd.net",
+    "secure.adnxs.com",
     "script.crazyegg.com"
   ).mkString(" ")
 
   private val frameWhitelist = Seq(
-    "js.stripe.com"
+    "js.stripe.com",
+    "*.youtube.com"
   ).mkString(" ")
 
   private val imageWhitelist = Seq(
@@ -24,6 +29,9 @@ object AddCSPHeader extends Filter {
     "*.theguardian.com",
     "*.krxd.net",
     "*.google-analytics.com",
+    "*.ytimg.com",
+    "t.co",
+    "*.twitter.com",
     "sb.scorecardresearch.com"
   ).mkString(" ")
 

--- a/frontend/app/filters/AddCSPHeader.scala
+++ b/frontend/app/filters/AddCSPHeader.scala
@@ -1,0 +1,50 @@
+package filters
+
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import play.api.mvc._
+
+import scala.concurrent.Future
+
+object AddCSPHeader extends Filter {
+
+  private val scriptWhitelist = Seq(
+    "js.stripe.com",
+    "*.ophan.co.uk",
+    "*.google-analytics.com",
+    "*.krxd.net",
+    "script.crazyegg.com"
+  ).mkString(" ")
+
+  private val frameWhitelist = Seq(
+    "js.stripe.com"
+  ).mkString(" ")
+
+  private val imageWhitelist = Seq(
+    "*.guim.co.uk",
+    "*.theguardian.com",
+    "*.krxd.net",
+    "*.google-analytics.com",
+    "sb.scorecardresearch.com"
+  ).mkString(" ")
+
+  private val fontWhitelist = Seq(
+    "pasteup.guim.co.uk"
+  ).mkString(" ")
+
+  val cspHeaders = "Content-Security-Policy-Report-Only" -> Seq(
+    "default-src 'self'",
+    "style-src 'self' 'unsafe-inline'",
+    "script-src 'self' 'unsafe-inline' 'unsafe-eval' " + scriptWhitelist,
+    "frame-src 'self' " + frameWhitelist,
+    "img-src 'self' data: " + imageWhitelist,
+    "font-src 'self' " + fontWhitelist,
+    "report-uri /csp-report"
+  ).mkString("; ")
+
+  def apply(nextFilter: RequestHeader => Future[Result])(requestHeader: RequestHeader): Future[Result] = for {
+    result <- nextFilter(requestHeader)
+  } yield {
+      val isHtml = result.header.headers.get("Content-Type").exists(_.contains("text/html"))
+      if (isHtml) result.withHeaders(cspHeaders) else result
+    }
+}

--- a/frontend/assets/javascripts/src/modules/analytics/setup.js
+++ b/frontend/assets/javascripts/src/modules/analytics/setup.js
@@ -21,6 +21,12 @@ define([
     optimizely
 ) {
 
+    var analyticsEnabled = (
+        guardian.analyticsEnabled &&
+        !navigator.doNotTrack &&
+        !cookie.getCookie('ANALYTICS_OFF_KEY')
+    );
+
     function setupAnalytics() {
         ophan.init();
         omniture.init();
@@ -36,15 +42,12 @@ define([
     }
 
     function init() {
-        if (cookie.getCookie('ANALYTICS_OFF_KEY')) {
-            guardian.analyticsEnabled = false;
-        }
 
-        if (guardian.analyticsEnabled) {
+        if (analyticsEnabled) {
             setupAnalytics();
         }
 
-        if(guardian.analyticsEnabled && !guardian.isDev) {
+        if(analyticsEnabled && !guardian.isDev) {
             setupThirdParties();
         }
     }

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -121,3 +121,5 @@ GET            /patterns                          controllers.PatternLibrary.pat
 
 # Offers and Competitions
 GET            /offers-competitions               controllers.OffersAndCompetitions.list
+
+POST           /csp-report                        controllers.Security.cspReport


### PR DESCRIPTION
This PR implements a [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/Security/CSP)

Known third-party sources have been white-listed in the policy. We are running this in report only mode for now, which means that no content will be blocked but any violations will be reported to and endpoint and logged to Sentry. 

The reporting should help us audit for any third-parties we don't know about as well as reporting any malicious third-party scripts. Testing:

- [x] Check functional tests pass
- [x] Check membership tab on Profile

@rtyley @afiore 