### PR TITLE
Priority booking: No longer need start of day logic

### DIFF
--- a/frontend/app/model/TicketSaleDates.scala
+++ b/frontend/app/model/TicketSaleDates.scala
@@ -52,7 +52,7 @@ object TicketSaleDates {
 
           val memberAdvanceTicketSales = memberTicketAvailabilityTimes.mapValues(maxStartSaleTime(effectiveSaleStart, _))
 
-          TicketSaleDates(toStartOfDay(generalRelease), Some(memberAdvanceTicketSales), needToDistinguishTicketTimes)
+          TicketSaleDates(generalRelease, Some(memberAdvanceTicketSales), needToDistinguishTicketTimes)
 
         }
         else TicketSaleDates(generalRelease, Some(memberTicketAvailabilityTimes), needToDistinguishTicketTimes)
@@ -60,7 +60,6 @@ object TicketSaleDates {
       case None => TicketSaleDates(effectiveSaleStart)
     }
   }
-
 
   private def maxStartSaleTime(effectiveSaleStart: Instant, tierSaleDate:Instant) = {
     Seq(effectiveSaleStart, toStartOfDay(tierSaleDate)).max

--- a/frontend/test/model/TicketSaleDatesTest.scala
+++ b/frontend/test/model/TicketSaleDatesTest.scala
@@ -41,30 +41,6 @@ class TicketSaleDatesTest extends Specification {
 
     }
 
-    "give set advance tickets to be available to start of the day if sale dates between tiers is more than a day" in {
-      val saleStart = (testEventTimes.start - 10.days).toInstant
-
-      val datesByTier = TicketSaleDates.datesFor(testEventTimes, eventTicketClass.copy(sales_start = Some(saleStart))).datesByTier
-
-      datesByTier(Patron) must be_==(saleStart)
-      datesByTier(Partner) must be_==(saleStart)
-
-      val friendTicketSale = datesByTier(Friend).toDateTime(UTC)
-      dateMustBeToStartOfDay(friendTicketSale) must be_==(true)
-    }
-
-    "give set advance tickets to be available a specific time if sale dates between tiers is less than a day" in {
-      val saleStart = (testEventTimes.start - 36.hours).toInstant
-
-      val datesByTier = TicketSaleDates.datesFor(testEventTimes, eventTicketClass.copy(sales_start = Some(saleStart))).datesByTier
-
-      datesByTier(Patron) must be_==(saleStart)
-      datesByTier(Partner) must be_==(saleStart)
-
-      val friendTicketSale = datesByTier(Friend).toDateTime
-      dateMustBeToStartOfDay(friendTicketSale) must be_==(false)
-    }
-
     "not die if sales_start is missing" in {
       val event = Resource.getJson("model/eventbrite/event.long-lead-time.missing-sales-start.json").as[EBEvent]
 
@@ -92,10 +68,6 @@ class TicketSaleDatesTest extends Specification {
 
   private def toStartOfDay(instant: Instant) = {
     instant.toDateTime(UTC).withTimeAtStartOfDay().toInstant
-  }
-
-  private def dateMustBeToStartOfDay(dateTime: DateTime): Boolean = {
-    dateTime.getHourOfDay == 0 && dateTime.getMinuteOfHour == 0 && dateTime.getSecondOfMinute == 0
   }
 
 }


### PR DESCRIPTION
General release for Alex Ferguson event was set to midnight, instead of specified time of 9am. This was due to some holdover logic from the previous priority booking rules. We no longer need to adjust the times to the start of the day in any case.

@rtyley 