### PR TITLE
[Redesign prep] Simplify Masterclasses event listings logic

### DIFF
--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -120,7 +120,7 @@ trait Event extends Controller with ActivityTracking {
       request.path,
       Some(CopyConfig.copyDescriptionMasterclasses)
     )
-    Ok(views.html.event.masterclass(EventPortfolio(Nil, masterclassEvents.events, None, None), pageInfo))
+    Ok(views.html.event.masterclass(pageInfo, masterclassEvents.events))
   }
 
   def masterclassesByTag(rawTag: String, rawSubTag: String = "") = CachedAction { implicit request =>
@@ -131,8 +131,8 @@ trait Event extends Controller with ActivityTracking {
       Some(CopyConfig.copyDescriptionMasterclasses)
     )
     Ok(views.html.event.masterclass(
-      EventPortfolio(Nil, masterclassEvents.getTaggedEvents(tag), None, None),
       pageInfo,
+      masterclassEvents.getTaggedEvents(tag),
       MasterclassEvent.decodeTag(rawTag),
       MasterclassEvent.decodeTag(rawSubTag)
     ))

--- a/frontend/app/views/event/masterclass.scala.html
+++ b/frontend/app/views/event/masterclass.scala.html
@@ -1,6 +1,6 @@
 @(
-    eventPortfolio: model.EventPortfolio,
     pageInfo: model.PageInfo,
+    events: Seq[model.RichEvent.RichEvent],
     selectedTag: String = "",
     selectedSubTag: String = ""
 )
@@ -51,7 +51,7 @@
                     }
 
                     <span class="event-filters__count">
-                        <span class="js-filter-count">@eventPortfolio.normal.length</span> masterclasses
+                        <span class="js-filter-count">@events.length</span> masterclasses
                         @if(selectedTag.isEmpty) {
                             <span class="hidden-mobile">in @MasterclassEvent.tags.length categories</span>
                         }
@@ -78,7 +78,7 @@
             </div>
         </div>
 
-        @fragments.event.listing(eventPortfolio, "Sorry, no matching Masterclasses were found.", isFilterable=true)
+        @fragments.eventListings.listing(events,  "Sorry, no matching Masterclasses were found.", true)
         @fragments.tier.joinListing()
     </main>
 

--- a/frontend/app/views/fragments/eventListings/listing.scala.html
+++ b/frontend/app/views/fragments/eventListings/listing.scala.html
@@ -1,0 +1,27 @@
+@(
+    events: Seq[model.RichEvent.RichEvent],
+    noResultsMessage: String,
+    isFilterable: Boolean
+)
+
+<section class="listing">
+    <div class="listing__lead-in">
+        <h3 class="listing__title h-intro">What's on</h3>
+    </div>
+    <div class="listing__content">
+        @if(events.isEmpty) {
+            <div class="listing__empty">@noResultsMessage</div>
+        } else {
+            @if(isFilterable) {
+                <div class="listing__no-results js-filter-empty">@noResultsMessage</div>
+            }
+            <ul class="grid grid--bordered grid--3up"@if(isFilterable){ id="js-filter-container"}>
+                @for(event <- events) {
+                    <li class="grid__item@if(isFilterable){ js-filter-item}">
+                        @fragments.event.item(event)
+                    </li>
+                }
+            </ul>
+        }
+    </div>
+</section>


### PR DESCRIPTION
This has come out of the work on the rebrand https://github.com/guardian/membership-frontend/pull/636. Simplifies how Masterclass event listings are handled, no need to use an empty `EventPortfolio` here. The goal is to use the new fragment to simplify the main events page too.

@afiore @rtyley 