### PR TITLE
[Redesign prep] Extract SVGImage out from ResponsiveImage model

### DIFF
--- a/frontend/app/model/ResponsiveImage.scala
+++ b/frontend/app/model/ResponsiveImage.scala
@@ -56,12 +56,3 @@ case class ResponsiveImageGroup(
   }.mkString(", ")
 
 }
-
-case class SVGImage(
-  label: String,
-  path: String,
-  width: Int,
-  height: Int
-) {
-  val src = Asset.at(path)
-}

--- a/frontend/app/model/SVG.scala
+++ b/frontend/app/model/SVG.scala
@@ -1,0 +1,16 @@
+package model
+
+import views.support.Asset
+
+object SVG {
+
+  case class SVGImage(
+    label: String,
+    path: String,
+    width: Int,
+    height: Int
+  ) {
+    val src = Asset.at(path)
+  }
+
+}

--- a/frontend/app/views/event/guardianLive.scala.html
+++ b/frontend/app/views/event/guardianLive.scala.html
@@ -1,6 +1,6 @@
 @(eventPortfolio: model.EventPortfolio, pageInfo: model.PageInfo)
 
-@import model.SVGImage
+@import model.SVG.SVGImage
 
 @main("Events", pageInfo=pageInfo) {
     <main role="main" class="l-constrained">

--- a/frontend/app/views/event/masterclass.scala.html
+++ b/frontend/app/views/event/masterclass.scala.html
@@ -5,7 +5,7 @@
     selectedSubTag: String = ""
 )
 
-@import model.SVGImage
+@import model.SVG.SVGImage
 @import model.RichEvent.MasterclassEvent
 
 @main("Masterclasses", pageInfo=pageInfo) {

--- a/frontend/app/views/fragments/common/inlineSvgImage.scala.html
+++ b/frontend/app/views/fragments/common/inlineSvgImage.scala.html
@@ -1,4 +1,4 @@
-@(svg: model.SVGImage, classes: Seq[String])
+@(svg: model.SVG.SVGImage, classes: Seq[String])
 
 @* http://nicolasgallagher.com/canvas-fix-svg-scaling-in-internet-explorer/ *@
 <div class="inline-svg @classes.mkString(" ")" role="img">

--- a/frontend/app/views/fragments/event/headerBar.scala.html
+++ b/frontend/app/views/fragments/event/headerBar.scala.html
@@ -1,6 +1,6 @@
 @(
     title: String,
-    logo: model.SVGImage,
+    logo: model.SVG.SVGImage,
     classes: Seq[String]
 )
 

--- a/frontend/app/views/patterns/patterns.scala.html
+++ b/frontend/app/views/patterns/patterns.scala.html
@@ -1,7 +1,8 @@
 @(eventPortfolio: model.EventPortfolio, pageImages: Seq[model.ResponsiveImageGroup])(implicit token: play.filters.csrf.CSRF.Token)
 
 @import com.gu.membership.salesforce.Tier
-@import model.{SVGImage, Benefits, FlashMessage}
+@import model.{Benefits, FlashMessage}
+@import model.SVG.SVGImage
 @import configuration.Videos
 
 @pattern(title: String, description: String = "", removeClearFix: Boolean = false)(content: Html) = {


### PR DESCRIPTION
This is an effort to remove any non-visual changes from https://github.com/guardian/membership-frontend/pull/636.

This extracts SVGImage out from ResponsiveImage model, as this model is likely to get larger as part of the redesign; and it was a bit lazy of me to dump it here in the first place.

@rtyley @afiore 