### PR TITLE
Allow partners to select free books or events as a membership perk

### DIFF
--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -164,6 +164,4 @@ object Config {
   val bcryptPepper = config.getString("activity.tracking.bcrypt.pepper")
 
   val casServiceConfig = config.getString("cas.url")
-
-  val tierFeatures = config.getStringList("tierFeatures").toList
 }

--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -5,7 +5,6 @@ import com.amazonaws.auth.{AWSCredentialsProviderChain, InstanceProfileCredentia
 import com.gu.googleauth.{GoogleAuthConfig, GoogleServiceAccount}
 import com.gu.identity.cookie.{PreProductionKeys, ProductionKeys}
 import com.gu.membership.salesforce.Tier
-import com.gu.membership.touchpoint.TouchpointBackendConfig
 import com.netaporter.uri.dsl._
 import com.typesafe.config.ConfigFactory
 import model.Eventbrite.EBEvent
@@ -13,8 +12,8 @@ import net.kencochrane.raven.dsn.Dsn
 import play.api.Logger
 import services._
 
+import scala.collection.JavaConversions._
 import scala.util.Try
-import java.net.URLEncoder
 
 object Config {
   val logger = Logger(this.getClass())
@@ -166,4 +165,5 @@ object Config {
 
   val casServiceConfig = config.getString("cas.url")
 
+  val tierFeatures = config.getStringList("tierFeatures").toList
 }

--- a/frontend/app/controllers/FrontPage.scala
+++ b/frontend/app/controllers/FrontPage.scala
@@ -1,21 +1,9 @@
 package controllers
 
-import model.Zuora.Feature
-import model.{ResponsiveImageGenerator, ResponsiveImage, ResponsiveImageGroup, Zuora}
-import model.ZuoraDeserializer._
+import model.{ResponsiveImageGenerator, ResponsiveImageGroup}
 import play.api.mvc.Controller
-import services.zuora.AddSubscriptionProductFeature
-import scala.concurrent.ExecutionContext.Implicits.global
 
 trait FrontPage extends Controller {
-
-  def _index = NoCacheAction.async { implicit req =>
-    val touchPoint = services.TouchpointBackend.TestUser
-    val service = touchPoint.zuoraService
-    for {
-      features <- service.query[Feature]("FeatureCode = 'Events' or FeatureCode = 'Books'")
-    } yield Ok(s"out: $features")
-  }
 
   def index = CachedAction { implicit request =>
 

--- a/frontend/app/controllers/FrontPage.scala
+++ b/frontend/app/controllers/FrontPage.scala
@@ -1,9 +1,21 @@
 package controllers
 
-import model.{ResponsiveImageGenerator, ResponsiveImage, ResponsiveImageGroup}
+import model.Zuora.Feature
+import model.{ResponsiveImageGenerator, ResponsiveImage, ResponsiveImageGroup, Zuora}
+import model.ZuoraDeserializer._
 import play.api.mvc.Controller
+import services.zuora.AddSubscriptionProductFeature
+import scala.concurrent.ExecutionContext.Implicits.global
 
 trait FrontPage extends Controller {
+
+  def _index = NoCacheAction.async { implicit req =>
+    val touchPoint = services.TouchpointBackend.TestUser
+    val service = touchPoint.zuoraService
+    for {
+      features <- service.query[Feature]("FeatureCode = 'Events' or FeatureCode = 'Books'")
+    } yield Ok(s"out: $features")
+  }
 
   def index = CachedAction { implicit request =>
 

--- a/frontend/app/controllers/Healthcheck.scala
+++ b/frontend/app/controllers/Healthcheck.scala
@@ -1,39 +1,33 @@
 package controllers
 
+import com.github.nscala_time.time.Imports._
+import com.gu.monitoring.CloudWatchHealth
 import play.api.Logger
 import play.api.mvc.{Action, Controller}
-import services.{TouchpointBackend, GuardianLiveEventService}
-import com.gu.monitoring.CloudWatchHealth
-import com.github.nscala_time.time.Imports._
-import play.api.libs.concurrent.Execution.Implicits._
+import services.{GuardianLiveEventService, TouchpointBackend}
 
-import scala.concurrent.Future
-
-case class Test(name: String, result: () => Future[Boolean])
+case class Test(name: String, ok: () => Boolean)
 
 object Healthcheck extends Controller {
   val zuoraService = TouchpointBackend.Normal.zuoraService
 
   val tests = Seq(
-    Test("Events", () => Future { GuardianLiveEventService.events.nonEmpty }),
-    Test("CloudWatch", () => Future { CloudWatchHealth.hasPushedMetricSuccessfully }),
-    Test("Zuora", () => zuoraService.pingSupplier.get().map(t => t > DateTime.now - 2.minutes))
+    Test("Events", () => GuardianLiveEventService.events.nonEmpty),
+    Test("CloudWatch", () => CloudWatchHealth.hasPushedMetricSuccessfully),
+    Test("Zuora", () => zuoraService.lastPingTimeWithin(2.minutes))
   )
 
-  def healthcheck() = Action.async { req =>
-    Future.sequence(tests.map(_.result())).map { results =>
-      val failedTests =
-        results.zip(tests.map(_.name)).filterNot { case (ok, _) => ok }
+  def healthcheck() = Action { req =>
+    val failedTests = tests.filterNot(_.ok())
 
-      Cached(1) {
-        if (failedTests.nonEmpty) {
-          failedTests.foreach { case (_, test) =>
-            Logger.warn(s"Test $test failed, health check will fail")
-          }
-          ServiceUnavailable("Service Unavailable")
-        } else {
-          Ok("OK")
+    Cached(1) {
+      if (failedTests.nonEmpty) {
+        failedTests.foreach { test =>
+          Logger.warn(s"Test ${test.name} failed, health check will fail")
         }
+        ServiceUnavailable("Service Unavailable")
+      } else {
+        Ok("OK")
       }
     }
   }

--- a/frontend/app/forms/MemberForm.scala
+++ b/frontend/app/forms/MemberForm.scala
@@ -56,11 +56,11 @@ object MemberForm {
   implicit val productFeaturesFormatter: Formatter[Set[FeatureChoice]] = new Formatter[Set[FeatureChoice]] {
     override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], Set[FeatureChoice]] = {
       val inputVal = data.getOrElse(key, "")
-      Right(FeatureChoice.fromString(inputVal))
+      Right(FeatureChoice.setFromString(inputVal))
     }
 
     override def unbind(key: String, choices: Set[FeatureChoice]): Map[String, String] =
-      Map(key -> choices.mkString(""))
+      Map(key -> FeatureChoice.setToString(choices))
   }
 
   private val productFeature = of[Set[FeatureChoice]] as productFeaturesFormatter

--- a/frontend/app/forms/MemberForm.scala
+++ b/frontend/app/forms/MemberForm.scala
@@ -136,7 +136,7 @@ object MemberForm {
     )(StaffJoinForm.apply)(StaffJoinForm.unapply)
   )
 
-  def paidMemberJoinForm: Form[PaidMemberJoinForm] = Form(
+  val paidMemberJoinForm: Form[PaidMemberJoinForm] = Form(
     mapping(
       "tier" -> nonEmptyText.transform[Tier](Tier.slugMap, _.slug),
       "name" -> nameMapping,

--- a/frontend/app/forms/MemberForm.scala
+++ b/frontend/app/forms/MemberForm.scala
@@ -53,7 +53,6 @@ object MemberForm {
 
   case class FeedbackForm(category: String, page: String, feedback: String, name: String, email: String)
 
-
   implicit val productFeaturesFormatter: Formatter[FeatureChoice] = new Formatter[FeatureChoice] {
     override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], FeatureChoice] = {
       val inputVal = data.get(key)

--- a/frontend/app/forms/MemberForm.scala
+++ b/frontend/app/forms/MemberForm.scala
@@ -56,13 +56,14 @@ object MemberForm {
 
   implicit val productFeaturesFormatter: Formatter[FeatureChoice] = new Formatter[FeatureChoice] {
     override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], FeatureChoice] = {
-      val inputVal = data.get(key).flatMap(FeatureChoice.fromString)
+      val inputVal = data.get(key)
 
       lazy val errorMsg =
         inputVal.fold("FeatureChoice id not supplied")(id =>
           s"Unknown feature choice id $id")
 
-      inputVal.map(Right(_))
+      inputVal.flatMap(FeatureChoice.fromString)
+        .map(Right(_))
         .getOrElse(Left(Seq(FormError(key, errorMsg))))
     }
 

--- a/frontend/app/forms/MemberForm.scala
+++ b/frontend/app/forms/MemberForm.scala
@@ -3,8 +3,10 @@ package forms
 import com.gu.membership.model._
 import com.gu.membership.salesforce.Tier
 import com.gu.membership.zuora.{Address, Countries, Country}
+import model.FeatureChoice
 import play.api.data.Forms._
-import play.api.data.{Form, Mapping}
+import play.api.data.format.Formatter
+import play.api.data.{Form, FormError, Mapping}
 
 object MemberForm {
   case class NameForm(first: String, last: String)
@@ -19,22 +21,26 @@ object MemberForm {
     val marketingChoices: MarketingChoicesForm
     val password: Option[String]
     val plan: ProductRatePlan
+    val featureChoice: Option[FeatureChoice]
   }
 
   case class FriendJoinForm(name: NameForm, deliveryAddress: Address, marketingChoices: MarketingChoicesForm,
-                            password: Option[String] ) extends JoinForm {
-    val plan = FriendTierPlan
+                            password: Option[String]) extends JoinForm {
+    override val plan = FriendTierPlan
+    override val featureChoice = None
   }
 
   case class StaffJoinForm(name: NameForm, deliveryAddress: Address, marketingChoices: MarketingChoicesForm,
-                            password: Option[String] ) extends JoinForm {
-    val plan = StaffPlan
+                            password: Option[String]) extends JoinForm {
+    override val plan = StaffPlan
+    override val featureChoice = None
   }
 
   case class PaidMemberJoinForm(tier: Tier, name: NameForm, payment: PaymentForm, deliveryAddress: Address,
                                 billingAddress: Option[Address], marketingChoices: MarketingChoicesForm,
-                                password: Option[String], casId: Option[String], subscriberOffer: Boolean) extends JoinForm {
-    val plan = PaidTierPlan(tier, payment.annual)
+                                password: Option[String], casId: Option[String], subscriberOffer: Boolean,
+                                featureChoice: Option[FeatureChoice]) extends JoinForm {
+    override val plan = PaidTierPlan(tier, payment.annual)
   }
 
   trait MemberChangeForm {
@@ -46,6 +52,25 @@ object MemberForm {
   case class FreeMemberChangeForm(payment: PaymentForm, deliveryAddress: Address, billingAddress: Option[Address]) extends MemberChangeForm
 
   case class FeedbackForm(category: String, page: String, feedback: String, name: String, email: String)
+
+
+  implicit val productFeaturesFormatter: Formatter[FeatureChoice] = new Formatter[FeatureChoice] {
+    override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], FeatureChoice] = {
+      val inputVal = data.get(key).flatMap(FeatureChoice.fromString)
+
+      lazy val errorMsg =
+        inputVal.fold("FeatureChoice id not supplied")(id =>
+          s"Unknown feature choice id $id")
+
+      inputVal.map(Right(_))
+        .getOrElse(Left(Seq(FormError(key, errorMsg))))
+    }
+
+    override def unbind(key: String, feature: FeatureChoice): Map[String, String] =
+      Map(key -> feature.id)
+  }
+
+  private val productFeature = of[FeatureChoice] as productFeaturesFormatter
 
   val countryText = nonEmptyText.verifying(Countries.allCodes.contains _)
     .transform[Country](Countries.allCodes.apply, _.alpha2)
@@ -79,7 +104,8 @@ object MemberForm {
   )(MarketingChoicesForm.apply)(MarketingChoicesForm.unapply)
 
   val paymentMapping: Mapping[PaymentForm] = mapping(
-    "type" -> nonEmptyText.transform[Boolean]((b => b == "annual" || b == "subscriberOfferAnnual"), x => if (x) "annual" else "month"),
+    "type" -> nonEmptyText.transform[Boolean](b =>
+      Seq("annual","subscriberOfferAnnual").contains(b), x => if (x) "annual" else "month"),
     "token" -> nonEmptyText
   )(PaymentForm.apply)(PaymentForm.unapply)
 
@@ -109,7 +135,7 @@ object MemberForm {
     )(StaffJoinForm.apply)(StaffJoinForm.unapply)
   )
 
-  val paidMemberJoinForm: Form[PaidMemberJoinForm] = Form(
+  def paidMemberJoinForm: Form[PaidMemberJoinForm] = Form(
     mapping(
       "tier" -> nonEmptyText.transform[Tier](Tier.slugMap, _.slug),
       "name" -> nameMapping,
@@ -119,7 +145,8 @@ object MemberForm {
       "marketingChoices" -> marketingChoicesMapping,
       "password" -> optional(nonEmptyText),
       "casId" -> optional(nonEmptyText),
-      "subscriberOffer" -> default(boolean, false)
+      "subscriberOffer" -> default(boolean, false),
+      "featureChoice" -> optional(productFeature)
     )(PaidMemberJoinForm.apply)(PaidMemberJoinForm.unapply)
   )
 

--- a/frontend/app/model/FeatureChoice.scala
+++ b/frontend/app/model/FeatureChoice.scala
@@ -3,14 +3,18 @@ package model
 trait FeatureChoice {
   val id: String
   val label: String
-  val codes: Seq[String]
+  val codes: Set[String]
 }
 
 object FeatureChoice {
-  val partners: Seq[FeatureChoice] = Seq(
+  val all: Seq[FeatureChoice] = Seq(
     Events,
     Books
   )
+
+  val codes = all.foldLeft(Set.empty[String]) {
+    case (_codes, choice) => _codes ++ choice.codes
+  }
 
   def fromString(id: String): Option[FeatureChoice] = id match {
     case Books.id => Some(Books)
@@ -23,16 +27,16 @@ object FeatureChoice {
 case object Books extends FeatureChoice {
   override val id    = "Books"
   override val label = "4 free books"
-  override val codes = Seq("Books")
+  override val codes = Set(id)
 }
 case object Events extends FeatureChoice {
   override val id    = "Events"
   override val label = "6 free events"
-  override val codes = Seq("Events")
+  override val codes = Set(id)
 }
 
 case object BooksAndEvents extends FeatureChoice {
-  override val id = "Both"
+  override val id = "BooksAndEvents"
   override val label = "Patron memberships are entitled to both"
   override val codes = Books.codes ++ Events.codes
 }

--- a/frontend/app/model/FeatureChoice.scala
+++ b/frontend/app/model/FeatureChoice.scala
@@ -1,32 +1,35 @@
 package model
 
 trait FeatureChoice {
-  val id: String
+  val zuoraCode: String
   val label: String
 }
 
 object FeatureChoice {
+  val separator = ':'
+
   val all: Set[FeatureChoice] = Set(
-    Events,
+    FreeEventTickets,
     Books
   )
+  val byId = all.map(fc => fc.zuoraCode -> fc).toMap
+  val codes = byId.keySet
 
-  val codes = all.map(_.id)
+  def setToString(choices: Set[FeatureChoice]): String =
+    choices.map(_.zuoraCode).mkString(separator.toString)
 
-  def fromString(id: String): Set[FeatureChoice] = id match {
-    case Books.id => Set(Books)
-    case Events.id => Set(Events)
-    case _ =>
-      if (id == Events.id + Books.id || id == Books.id + Events.id) Set(Books, Events)
-      else Set.empty
+  def setFromString(ids: String): Set[FeatureChoice] = {
+    ids.split(separator)
+      .flatMap(byId.get)
+      .toSet
   }
 }
 
 case object Books extends FeatureChoice {
-  override val id    = "Books"
+  override val zuoraCode = "Books"
   override val label = "4 free books"
 }
-case object Events extends FeatureChoice {
-  override val id    = "Events"
+case object FreeEventTickets extends FeatureChoice {
+  override val zuoraCode = "Events"
   override val label = "6 free events"
 }

--- a/frontend/app/model/FeatureChoice.scala
+++ b/frontend/app/model/FeatureChoice.scala
@@ -3,40 +3,30 @@ package model
 trait FeatureChoice {
   val id: String
   val label: String
-  val codes: Set[String]
 }
 
 object FeatureChoice {
-  val all: Seq[FeatureChoice] = Seq(
+  val all: Set[FeatureChoice] = Set(
     Events,
     Books
   )
 
-  val codes = all.foldLeft(Set.empty[String]) {
-    case (_codes, choice) => _codes ++ choice.codes
-  }
+  val codes = all.map(_.id)
 
-  def fromString(id: String): Option[FeatureChoice] = id match {
-    case Books.id => Some(Books)
-    case Events.id => Some(Events)
-    case BooksAndEvents.id => Some(BooksAndEvents)
-    case _ => None
+  def fromString(id: String): Set[FeatureChoice] = id match {
+    case Books.id => Set(Books)
+    case Events.id => Set(Events)
+    case _ =>
+      if (id == Events.id + Books.id || id == Books.id + Events.id) Set(Books, Events)
+      else Set.empty
   }
 }
 
 case object Books extends FeatureChoice {
   override val id    = "Books"
   override val label = "4 free books"
-  override val codes = Set(id)
 }
 case object Events extends FeatureChoice {
   override val id    = "Events"
   override val label = "6 free events"
-  override val codes = Set(id)
-}
-
-case object BooksAndEvents extends FeatureChoice {
-  override val id = "BooksAndEvents"
-  override val label = "Patron memberships are entitled to both"
-  override val codes = Books.codes ++ Events.codes
 }

--- a/frontend/app/model/FeatureChoice.scala
+++ b/frontend/app/model/FeatureChoice.scala
@@ -1,0 +1,38 @@
+package model
+
+trait FeatureChoice {
+  val id: String
+  val label: String
+  val codes: Seq[String]
+}
+
+object FeatureChoice {
+  val partners: Seq[FeatureChoice] = Seq(
+    Events,
+    Books
+  )
+
+  def fromString(id: String): Option[FeatureChoice] = id match {
+    case Books.id => Some(Books)
+    case Events.id => Some(Events)
+    case BooksAndEvents.id => Some(BooksAndEvents)
+    case _ => None
+  }
+}
+
+case object Books extends FeatureChoice {
+  override val id    = "Books"
+  override val label = "4 free books"
+  override val codes = Seq("Books")
+}
+case object Events extends FeatureChoice {
+  override val id    = "Events"
+  override val label = "6 free events"
+  override val codes = Seq("Events")
+}
+
+case object BooksAndEvents extends FeatureChoice {
+  override val id = "Both"
+  override val label = "Patron memberships are entitled to both"
+  override val codes = Books.codes ++ Events.codes
+}

--- a/frontend/app/model/Zuora.scala
+++ b/frontend/app/model/Zuora.scala
@@ -32,6 +32,7 @@ object Zuora {
   case class RatePlanCharge(id: String, chargedThroughDate: Option[DateTime], effectiveStartDate: DateTime,
                             price: Float) extends ZuoraQuery
   case class Subscription(id: String, version: Int, termStartDate: DateTime, contractAcceptanceDate: DateTime) extends ZuoraQuery
+  case class Feature(id: String, code: String) extends ZuoraQuery
 
   trait Error extends Throwable {
     val code: String
@@ -222,6 +223,10 @@ object ZuoraDeserializer {
     } else {
       Left(InternalError("QUERY_ERROR", "The query was not complete (we don't support iterating query results)"))
     }
+  }
+
+  implicit val FeatureReader = ZuoraQueryReader("Feature", Seq("Id", "FeatureCode")) { result =>
+    Feature(result("Id"), result("FeatureCode"))
   }
 
   implicit val subscribeResultReader = ZuoraResultReader("subscribeResponse") { result =>

--- a/frontend/app/services/SubscriptionService.scala
+++ b/frontend/app/services/SubscriptionService.scala
@@ -87,7 +87,7 @@ object SubscriptionService {
 
   def featuresPerTier(zuoraFeatures: Seq[Feature])(tier: ProductRatePlan, choice: Set[FeatureChoice]): Seq[Feature] = {
     def byChoice(choice: Set[FeatureChoice]) =
-      zuoraFeatures.filter(f => choice.map(_.id).contains(f.code))
+      zuoraFeatures.filter(f => choice.map(_.zuoraCode).contains(f.code))
 
     tier match {
       case PaidTierPlan(Patron, _) => byChoice(FeatureChoice.all)

--- a/frontend/app/services/SubscriptionService.scala
+++ b/frontend/app/services/SubscriptionService.scala
@@ -7,7 +7,7 @@ import com.gu.membership.salesforce.Tier.{Partner, Patron}
 import com.gu.membership.stripe.Stripe
 import com.typesafe.scalalogging.LazyLogging
 import forms.MemberForm.JoinForm
-import model.{FeatureChoice, MembershipSummary}
+import model.{BooksAndEvents, FeatureChoice, MembershipSummary}
 import model.Zuora._
 import model.ZuoraDeserializer._
 import org.joda.time.DateTime
@@ -85,12 +85,12 @@ object SubscriptionService {
 
   def sortAccounts(accounts: Seq[Account]) = accounts.sortBy(_.createdDate)
 
-  def featuresPerTier(features: Seq[Feature])(tier: ProductRatePlan, choiceOpt: Option[FeatureChoice]): Seq[Feature] = {
+  def featuresPerTier(zuoraFeatures: Seq[Feature])(tier: ProductRatePlan, choiceOpt: Option[FeatureChoice]): Seq[Feature] = {
     def byChoice(choice: FeatureChoice) =
-      features.filter(f => choice.codes.contains(f.code))
+      zuoraFeatures.filter(f => choice.codes.contains(f.code))
 
     (tier, choiceOpt) match {
-      case (PaidTierPlan(Patron, _), Some(choice)) => byChoice(choice)
+      case (PaidTierPlan(Patron, _), _) => byChoice(BooksAndEvents)
       case (PaidTierPlan(Partner, _), Some(choice)) => byChoice(choice).take(1)
       case _ => Seq[Feature]()
     }

--- a/frontend/app/services/TouchpointBackend.scala
+++ b/frontend/app/services/TouchpointBackend.scala
@@ -30,7 +30,7 @@ object TouchpointBackend {
       val service = "Stripe"
     })
 
-    val zuoraService = new ZuoraService(touchpointBackendConfig.zuora)
+    val zuoraService = new ZuoraService(touchpointBackendConfig.zuora, Config.tierFeatures)
 
     val memberRepository = new FrontendMemberRepository(touchpointBackendConfig.salesforce)
 

--- a/frontend/app/services/TouchpointBackend.scala
+++ b/frontend/app/services/TouchpointBackend.scala
@@ -30,7 +30,7 @@ object TouchpointBackend {
       val service = "Stripe"
     })
 
-    val zuoraService = new ZuoraService(touchpointBackendConfig.zuora, Config.tierFeatures)
+    val zuoraService = new ZuoraService(touchpointBackendConfig.zuora)
 
     val memberRepository = new FrontendMemberRepository(touchpointBackendConfig.salesforce)
 

--- a/frontend/app/services/zuora/ZuoraActions.scala
+++ b/frontend/app/services/zuora/ZuoraActions.scala
@@ -115,19 +115,6 @@ case class Subscribe(memberId: MemberId,
       </ns1:PaymentMethod>
     }.getOrElse(Null)
 
-    val addFeatures = if(features.nonEmpty){
-        <ns1:SubscriptionProductFeatureList>
-          {features.map(f =>
-          <ns1:SubscriptionProductFeature xsi:type="ns2:SubscriptionProductFeature">
-            <ns2:FeatureId>
-              {f.id}
-            </ns2:FeatureId>
-          </ns1:SubscriptionProductFeature>
-        )}
-        </ns1:SubscriptionProductFeatureList>
-      } else Null
-
-
     // NOTE: This appears to be white-space senstive in some way. Zuora rejected
     // the XML after Intellij auto-reformatted the code.
     <ns1:subscribe>
@@ -178,7 +165,13 @@ case class Subscribe(memberId: MemberId,
             <ns1:RatePlan xsi:type="ns2:RatePlan">
               <ns2:ProductRatePlanId>{ratePlanId}</ns2:ProductRatePlanId>
             </ns1:RatePlan>
-            {addFeatures}
+            <ns1:SubscriptionProductFeatureList>
+            {features.map(f =>
+            <ns1:SubscriptionProductFeature xsi:type="ns2:SubscriptionProductFeature">
+              <ns2:FeatureId>{f.id}</ns2:FeatureId>
+            </ns1:SubscriptionProductFeature>
+            )}
+            </ns1:SubscriptionProductFeatureList>
           </ns1:RatePlanData>
         </ns1:SubscriptionData>
       </ns1:subscribes>

--- a/frontend/app/services/zuora/ZuoraActions.scala
+++ b/frontend/app/services/zuora/ZuoraActions.scala
@@ -89,8 +89,17 @@ case class Query(query: String) extends ZuoraAction[QueryResult] {
     </ns1:query>
 }
 
-case class Subscribe(memberId: MemberId, customerOpt: Option[Stripe.Customer], ratePlanId: String, name: NameForm,
-                     address: Address, paymentDelay: Option[Period], casIdOpt: Option[String]) extends ZuoraAction[SubscribeResult] {
+case class Subscribe(memberId: MemberId,
+                     customerOpt: Option[Stripe.Customer],
+                     ratePlanId: String,
+                     name: NameForm,
+                     address: Address,
+                     paymentDelay: Option[Period],
+                     casIdOpt: Option[String],
+                     features: Set[Feature] = Set(
+                       Feature("2c92c0f84e4d2bc3014e4f3d5d237211","Events"),
+                       Feature("2c92c0f94e4d3a3d014e4f3d1b301071","Books")
+                     )) extends ZuoraAction[SubscribeResult] {
 
   val body = {
     val now = DateTime.now
@@ -159,6 +168,13 @@ case class Subscribe(memberId: MemberId, customerOpt: Option[Stripe.Customer], r
             <ns1:RatePlan xsi:type="ns2:RatePlan">
               <ns2:ProductRatePlanId>{ratePlanId}</ns2:ProductRatePlanId>
             </ns1:RatePlan>
+            <ns1:SubscriptionProductFeatureList>
+              {features.map(f =>
+                <ns1:SubscriptionProductFeature xsi:type="ns2:SubscriptionProductFeature">
+                  <ns2:FeatureId>{f.id}</ns2:FeatureId>
+                </ns1:SubscriptionProductFeature>
+              )}
+            </ns1:SubscriptionProductFeatureList>
           </ns1:RatePlanData>
         </ns1:SubscriptionData>
       </ns1:subscribes>

--- a/frontend/app/services/zuora/ZuoraActions.scala
+++ b/frontend/app/services/zuora/ZuoraActions.scala
@@ -96,10 +96,7 @@ case class Subscribe(memberId: MemberId,
                      address: Address,
                      paymentDelay: Option[Period],
                      casIdOpt: Option[String],
-                     features: Set[Feature] = Set(
-                       Feature("2c92c0f84e4d2bc3014e4f3d5d237211","Events"),
-                       Feature("2c92c0f94e4d3a3d014e4f3d1b301071","Books")
-                     )) extends ZuoraAction[SubscribeResult] {
+                     features: Set[Feature]) extends ZuoraAction[SubscribeResult] {
 
   val body = {
     val now = DateTime.now

--- a/frontend/app/services/zuora/ZuoraActions.scala
+++ b/frontend/app/services/zuora/ZuoraActions.scala
@@ -118,6 +118,19 @@ case class Subscribe(memberId: MemberId,
       </ns1:PaymentMethod>
     }.getOrElse(Null)
 
+    val addFeatures = if(features.nonEmpty){
+        <ns1:SubscriptionProductFeatureList>
+          {features.map(f =>
+          <ns1:SubscriptionProductFeature xsi:type="ns2:SubscriptionProductFeature">
+            <ns2:FeatureId>
+              {f.id}
+            </ns2:FeatureId>
+          </ns1:SubscriptionProductFeature>
+        )}
+        </ns1:SubscriptionProductFeatureList>
+      } else Null
+
+
     // NOTE: This appears to be white-space senstive in some way. Zuora rejected
     // the XML after Intellij auto-reformatted the code.
     <ns1:subscribe>
@@ -168,13 +181,7 @@ case class Subscribe(memberId: MemberId,
             <ns1:RatePlan xsi:type="ns2:RatePlan">
               <ns2:ProductRatePlanId>{ratePlanId}</ns2:ProductRatePlanId>
             </ns1:RatePlan>
-            <ns1:SubscriptionProductFeatureList>
-              {features.map(f =>
-                <ns1:SubscriptionProductFeature xsi:type="ns2:SubscriptionProductFeature">
-                  <ns2:FeatureId>{f.id}</ns2:FeatureId>
-                </ns1:SubscriptionProductFeature>
-              )}
-            </ns1:SubscriptionProductFeatureList>
+            {addFeatures}
           </ns1:RatePlanData>
         </ns1:SubscriptionData>
       </ns1:subscribes>

--- a/frontend/app/services/zuora/ZuoraActions.scala
+++ b/frontend/app/services/zuora/ZuoraActions.scala
@@ -96,7 +96,7 @@ case class Subscribe(memberId: MemberId,
                      address: Address,
                      paymentDelay: Option[Period],
                      casIdOpt: Option[String],
-                     features: Set[Feature]) extends ZuoraAction[SubscribeResult] {
+                     features: Seq[Feature]) extends ZuoraAction[SubscribeResult] {
 
   val body = {
     val now = DateTime.now

--- a/frontend/app/services/zuora/ZuoraService.scala
+++ b/frontend/app/services/zuora/ZuoraService.scala
@@ -1,6 +1,5 @@
 package services.zuora
 
-import com.github.nscala_time.time.DurationBuilder
 import com.gu.membership.util.Timing
 import com.gu.membership.zuora.ZuoraApiConfig
 import com.gu.monitoring.{AuthenticationMetrics, StatusMetrics}
@@ -11,7 +10,7 @@ import model.ZuoraDeserializer._
 import model.ZuoraReaders._
 import monitoring.TouchpointBackendMetrics
 import org.joda.time.format.ISODateTimeFormat
-import org.joda.time.{DateTime, DateTimeZone}
+import org.joda.time.{ReadableDuration, DateTime, DateTimeZone}
 import play.api.Logger
 import play.api.Play.current
 import play.api.libs.concurrent.Akka
@@ -60,8 +59,8 @@ class ZuoraService(val apiConfig: ZuoraApiConfig) extends LazyLogging {
     authenticatedRequest(Query("SELECT Id FROM Product")).map { _ => Some(new DateTime) }
   )
 
-  def lastPingTimeWithin(duration: DurationBuilder): Boolean =
-    lastPingTime.get().exists { t => t > new DateTime() - duration}
+  def lastPingTimeWithin(duration: ReadableDuration): Boolean =
+    lastPingTime.get().exists { t => t > DateTime.now - duration}
 
   private val scheduler = Akka.system.scheduler
 

--- a/frontend/app/services/zuora/ZuoraService.scala
+++ b/frontend/app/services/zuora/ZuoraService.scala
@@ -48,11 +48,11 @@ class ZuoraService(val apiConfig: ZuoraApiConfig) extends LazyLogging {
     }
   }
 
-  val featuresTask = ScheduledTask(s"Zuora ${apiConfig.envName} retrieve features of membership tiers", Set[Feature](), 0.seconds, 1.day) {
-    val featuresF = query[Feature]("Status = 'Active'").map(_.toSet)
+  val featuresTask = ScheduledTask(s"Zuora ${apiConfig.envName} retrieve features of membership tiers", Seq[Feature](), 0.seconds, 1.day) {
+    val featuresF = query[Feature]("Status = 'Active'")
 
     featuresF.foreach { features =>
-      val diff = FeatureChoice.codes &~ features.map(_.code)
+      val diff = FeatureChoice.codes &~ features.map(_.code).toSet
       lazy val msg =
         s"""
            |Zuora ${apiConfig.envName} is missing the following product features:

--- a/frontend/app/services/zuora/ZuoraService.scala
+++ b/frontend/app/services/zuora/ZuoraService.scala
@@ -33,7 +33,7 @@ object ZuoraServiceHelpers {
     s"SELECT ${reader.fields.mkString(",")} FROM ${reader.table} WHERE $where"
 }
 
-class ZuoraService(val apiConfig: ZuoraApiConfig, productFeatures: List[String]) {
+class ZuoraService(val apiConfig: ZuoraApiConfig) {
   import services.zuora.ZuoraServiceHelpers._
 
   val metrics = new TouchpointBackendMetrics with StatusMetrics with AuthenticationMetrics {
@@ -47,8 +47,7 @@ class ZuoraService(val apiConfig: ZuoraApiConfig, productFeatures: List[String])
   }
 
   val featuresTask = ScheduledTask(s"Zuora ${apiConfig.envName} retrieve features of membership tiers", Set[Feature](), 0.seconds, 1.day) {
-    val whereStatement = productFeatures.map(f => s"FeatureCode = '$f'").mkString(" or ")
-    query[Feature](whereStatement).map(_.toSet)
+    query[Feature]("Status = 'Active'").map(_.toSet)
   }
 
   lazy val featuresSchedule = featuresTask.start()

--- a/frontend/app/views/fragments/form/featureChoice.scala.html
+++ b/frontend/app/views/fragments/form/featureChoice.scala.html
@@ -2,7 +2,7 @@
 @import Tier.Patron
 @import Tier.Partner
 @import model.FeatureChoice
-@import model.Events
+@import model.FreeEventTickets
 @import model.Books
 @import configuration.Config
 
@@ -24,13 +24,13 @@
           <div class="fieldset__fields">
           @for(choice <- FeatureChoice.all) {
                   <div class="form-field">
-                      <label class="label" for="@choice.id">
+                      <label class="label" for="@choice.zuoraCode">
                           <input type="radio"
                           class="is-hidden"
                           name="featureChoice"
-                          id="@choice.id"
-                          @if(choice == Events) { checked="checked" }
-                          value="@choice.id"
+                          id="@choice.zuoraCode"
+                          @if(choice == FreeEventTickets) { checked="checked" }
+                          value="@choice.zuoraCode"
                           />
 
                           <div class="pseudo-radio">
@@ -45,7 +45,7 @@
       case Patron => {
           @heading("Select your perks", Some("As a patron member you are entitled to both Books and Events"))
           <div class="fieldset__fields">
-              <input type="hidden" name="featureChoice" value="@Books.id@Events.id" />
+              <input type="hidden" name="featureChoice" value="@FeatureChoice.setToString(FeatureChoice.all)" />
           </div>
       }
 

--- a/frontend/app/views/fragments/form/featureChoice.scala.html
+++ b/frontend/app/views/fragments/form/featureChoice.scala.html
@@ -47,6 +47,8 @@
               <input type="hidden" name="featureChoice" value="@BooksAndEvents.id" />
           </div>
       }
+
+      case _ =>  {}
   }
 }
 

--- a/frontend/app/views/fragments/form/featureChoice.scala.html
+++ b/frontend/app/views/fragments/form/featureChoice.scala.html
@@ -4,6 +4,7 @@
 @import model.FeatureChoice
 @import model.Events
 @import model.BooksAndEvents
+@import configuration.Config
 
 @(tier: Tier)
 
@@ -51,9 +52,10 @@
       case _ =>  {}
   }
 }
-
-@if(Seq(Patron, Partner).contains(tier)) {
-    <fieldset class="fieldset js-feature-choice-container">
+@if(!Config.stageProd) {
+    @if(Seq(Patron, Partner).contains(tier)) {
+        <fieldset class="fieldset js-feature-choice-container">
         @fieldset(tier)
-    </fieldset>
+        </fieldset>
+    }
 }

--- a/frontend/app/views/fragments/form/featureChoice.scala.html
+++ b/frontend/app/views/fragments/form/featureChoice.scala.html
@@ -1,0 +1,57 @@
+@import com.gu.membership.salesforce.Tier
+@import Tier.Patron
+@import Tier.Partner
+@import model.FeatureChoice
+@import model.Events
+@import model.BooksAndEvents
+
+@(tier: Tier)
+
+
+@heading(headline: String, note: Option[String] = None) = {
+  <div class="fieldset__heading">
+      <h2 class="fieldset__headline">@headline</h2>
+      @note.map { n => <div class="fieldset__note">@n</div> }
+  </div>
+}
+
+@fieldset(tier: Tier)= {
+  @tier match {
+      case Partner => {
+          @heading("Select your perks", Some("You can change your mind later on"))
+
+          <div class="fieldset__fields">
+          @for(choice <- FeatureChoice.partners) {
+                  <div class="form-field">
+                      <label class="label" for="@choice.id">
+                          <input type="radio"
+                          class="is-hidden"
+                          name="featureChoice"
+                          id="@choice.id"
+                          @if(choice == Events) { checked="checked" }
+                          value="@choice.id"
+                          />
+
+                          <div class="pseudo-radio">
+                              <div class="pseudo-radio__header">@choice.label</div>
+                              <p class="pseudo-radio__note">Longer description here </p>
+                          </div>
+                      </label>
+                  </div>
+          }
+          </div>
+      }
+      case Patron => {
+          @heading("Select your perks", Some("As a patron member you are entitled to both Books and Events"))
+          <div class="fieldset__fields">
+              <input type="hidden" name="featureChoice" value="@BooksAndEvents.id" />
+          </div>
+      }
+  }
+}
+
+@if(Seq(Patron, Partner).contains(tier)) {
+    <fieldset class="fieldset js-feature-choice-container">
+        @fieldset(tier)
+    </fieldset>
+}

--- a/frontend/app/views/fragments/form/featureChoice.scala.html
+++ b/frontend/app/views/fragments/form/featureChoice.scala.html
@@ -3,7 +3,7 @@
 @import Tier.Partner
 @import model.FeatureChoice
 @import model.Events
-@import model.BooksAndEvents
+@import model.Books
 @import configuration.Config
 
 @(tier: Tier)
@@ -45,7 +45,7 @@
       case Patron => {
           @heading("Select your perks", Some("As a patron member you are entitled to both Books and Events"))
           <div class="fieldset__fields">
-              <input type="hidden" name="featureChoice" value="@BooksAndEvents.id" />
+              <input type="hidden" name="featureChoice" value="@Books.id@Events.id" />
           </div>
       }
 

--- a/frontend/app/views/fragments/form/featureChoice.scala.html
+++ b/frontend/app/views/fragments/form/featureChoice.scala.html
@@ -21,7 +21,7 @@
           @heading("Select your perks", Some("You can change your mind later on"))
 
           <div class="fieldset__fields">
-          @for(choice <- FeatureChoice.partners) {
+          @for(choice <- FeatureChoice.all) {
                   <div class="form-field">
                       <label class="label" for="@choice.id">
                           <input type="radio"

--- a/frontend/app/views/joiner/form/payment.scala.html
+++ b/frontend/app/views/joiner/form/payment.scala.html
@@ -56,9 +56,11 @@
                     @if(showSubscriberFields) {
                         @fragments.form.subscriberNumber()
                      }
-                    
+
+                    @fragments.form.featureChoice(tier)
+
                     @fragments.form.paymentOptions(tier)
-                    
+
                      @if(showSubscriberFields) {
                          @fragments.form.paymentOptionsForSubscribers()
                      }

--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -54,6 +54,8 @@ include "touchpoint.DEV.conf"
 include "touchpoint.UAT.conf"
 include "touchpoint.PROD.conf"
 
+tierFeatures = ["Books", "Events"]
+
 google.oauth {
   // https://console.developers.google.com/project/guardian-membership/apiui/credential?authuser=1
   client.id=""

--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -54,8 +54,6 @@ include "touchpoint.DEV.conf"
 include "touchpoint.UAT.conf"
 include "touchpoint.PROD.conf"
 
-tierFeatures = ["Books", "Events"]
-
 google.oauth {
   // https://console.developers.google.com/project/guardian-membership/apiui/credential?authuser=1
   client.id=""

--- a/frontend/conf/dev.conf
+++ b/frontend/conf/dev.conf
@@ -18,7 +18,7 @@ include "PROD"
 
 identity.webapp.url="https://profile.thegulocal.com"
 identity.production.keys=false
-identity.api.url="https://idapi.thegulocal.com"
+identity.api.url="https://idapi.code.dev-theguardian.com"
 identity.api.client.token="membership-dev-client-token"
 ws.acceptAnyCertificate=true
 

--- a/frontend/test/forms/MemberFormTest.scala
+++ b/frontend/test/forms/MemberFormTest.scala
@@ -96,7 +96,7 @@ class MemberFormTest extends Specification {
       BooksAndEvents
     )
 
-    "fails when the supplied id does not match" in {
+    "fails when the supplied id does not match any known FeatureChoice id" in {
       productFeaturesFormatter
         .bind(key, Map(key -> "wrong-id")) must beLeft.like {
           case Seq(FormError(_, List(msg), _)) => msg.contains("wrong-id")

--- a/frontend/test/forms/MemberFormTest.scala
+++ b/frontend/test/forms/MemberFormTest.scala
@@ -1,6 +1,6 @@
 package forms
 
-import model.{Books, Events}
+import model.{FeatureChoice, Books, FreeEventTickets}
 import org.specs2.mutable.Specification
 
 import play.api.data.Form
@@ -90,17 +90,20 @@ class MemberFormTest extends Specification {
 
   "ProductFeatureFormatter" should {
     val key = "key"
-    val featureChoices = List(Events, Books)
 
     "returns an empty set the supplied id does not match any known FeatureChoice id" in {
       productFeaturesFormatter.bind(key, Map(key -> "wrong-id")) mustEqual Right(Set.empty)
     }
 
+    "unbinds a set of choices into form data" in {
+      productFeaturesFormatter.unbind(key, FeatureChoice.all) mustEqual Map(key -> "Events:Books")
+      productFeaturesFormatter.unbind(key, Set(Books)) mustEqual Map(key -> "Books")
+    }
+
     "bind featureChoices from form data" in {
-      productFeaturesFormatter.bind(key, Map(key -> Books.id)) mustEqual Right(Set(Books))
-      productFeaturesFormatter.bind(key, Map(key -> Events.id)) mustEqual Right(Set(Events))
-      productFeaturesFormatter.bind(key, Map(key -> (Events.id + Books.id))) mustEqual Right(Set(Events, Books))
-      productFeaturesFormatter.bind(key, Map(key -> (Books.id + Events.id))) mustEqual Right(Set(Events, Books))
+      productFeaturesFormatter.bind(key, Map(key -> Books.zuoraCode)) mustEqual Right(Set(Books))
+      productFeaturesFormatter.bind(key, Map(key -> FreeEventTickets.zuoraCode)) mustEqual Right(Set(FreeEventTickets))
+      productFeaturesFormatter.bind(key, Map(key -> FeatureChoice.setToString(Set(Books, FreeEventTickets)))) mustEqual Right(Set(FreeEventTickets, Books))
     }
   }
 }

--- a/frontend/test/forms/MemberFormTest.scala
+++ b/frontend/test/forms/MemberFormTest.scala
@@ -1,9 +1,9 @@
 package forms
 
-import model.{Books, BooksAndEvents, FeatureChoice, Events}
+import model.{Books, Events}
 import org.specs2.mutable.Specification
 
-import play.api.data.{FormError, Form}
+import play.api.data.Form
 
 import MemberForm._
 
@@ -90,26 +90,17 @@ class MemberFormTest extends Specification {
 
   "ProductFeatureFormatter" should {
     val key = "key"
-    val featureChoices: List[FeatureChoice] = List(
-      Events,
-      Books,
-      BooksAndEvents
-    )
+    val featureChoices = List(Events, Books)
 
-    "fails when the supplied id does not match any known FeatureChoice id" in {
-      productFeaturesFormatter
-        .bind(key, Map(key -> "wrong-id")) must beLeft.like {
-          case Seq(FormError(_, List(msg), _)) => msg.contains("wrong-id")
-      }
+    "returns an empty set the supplied id does not match any known FeatureChoice id" in {
+      productFeaturesFormatter.bind(key, Map(key -> "wrong-id")) mustEqual Right(Set.empty)
     }
 
     "bind featureChoices from form data" in {
-      val results = featureChoices.map { choice =>
-        productFeaturesFormatter.bind(key, Map(key -> choice.id))
-      }
-
-      results mustEqual featureChoices.map(Right(_))
+      productFeaturesFormatter.bind(key, Map(key -> Books.id)) mustEqual Right(Set(Books))
+      productFeaturesFormatter.bind(key, Map(key -> Events.id)) mustEqual Right(Set(Events))
+      productFeaturesFormatter.bind(key, Map(key -> (Events.id + Books.id))) mustEqual Right(Set(Events, Books))
+      productFeaturesFormatter.bind(key, Map(key -> (Books.id + Events.id))) mustEqual Right(Set(Events, Books))
     }
   }
-
 }

--- a/frontend/test/forms/MemberFormTest.scala
+++ b/frontend/test/forms/MemberFormTest.scala
@@ -1,8 +1,9 @@
 package forms
 
+import model.{Books, BooksAndEvents, FeatureChoice, Events}
 import org.specs2.mutable.Specification
 
-import play.api.data.Form
+import play.api.data.{FormError, Form}
 
 import MemberForm._
 
@@ -86,4 +87,29 @@ class MemberFormTest extends Specification {
       badCountryFriend.hasErrors must beTrue
     }
   }
+
+  "ProductFeatureFormatter" should {
+    val key = "key"
+    val featureChoices: List[FeatureChoice] = List(
+      Events,
+      Books,
+      BooksAndEvents
+    )
+
+    "fails when the supplied id does not match" in {
+      productFeaturesFormatter
+        .bind(key, Map(key -> "wrong-id")) must beLeft.like {
+          case Seq(FormError(_, List(msg), _)) => msg.contains("wrong-id")
+      }
+    }
+
+    "bind featureChoices from form data" in {
+      val results = featureChoices.map { choice =>
+        productFeaturesFormatter.bind(key, Map(key -> choice.id))
+      }
+
+      results mustEqual featureChoices.map(Right(_))
+    }
+  }
+
 }

--- a/frontend/test/model/PaymentSummaryTest.scala
+++ b/frontend/test/model/PaymentSummaryTest.scala
@@ -3,7 +3,7 @@ package model
 import model.Zuora.PaymentSummary
 import model.ZuoraDeserializer._
 import org.specs2.mutable.Specification
-import services.SubscriptionServiceHelpers
+import services.SubscriptionService
 import utils.Resource
 
 class PaymentSummaryTest extends Specification {

--- a/frontend/test/services/IdentityServiceTest.scala
+++ b/frontend/test/services/IdentityServiceTest.scala
@@ -54,13 +54,14 @@ class IdentityServiceTest extends Specification with Mockito {
       val paidForm = PaidMemberJoinForm(
         Tier.Partner,
         NameForm("Joe", "Bloggs"),
-        PaymentForm(true, "token"),
+        PaymentForm(annual = true, "token"),
         Address("line one", "line 2", "town", "country", "postcode", Countries.UK),
         Some(Address("line one", "line 2", "town", "country", "postcode", Countries.UK)),
         MarketingChoicesForm(Some(false), Some(false)),
         None,
         None,
-        false
+        subscriberOffer = false,
+        None
       )
 
       identityService.updateUserFieldsBasedOnJoining(user, paidForm, identityRequest)

--- a/frontend/test/services/IdentityServiceTest.scala
+++ b/frontend/test/services/IdentityServiceTest.scala
@@ -61,7 +61,7 @@ class IdentityServiceTest extends Specification with Mockito {
         None,
         None,
         subscriberOffer = false,
-        None
+        Set.empty
       )
 
       identityService.updateUserFieldsBasedOnJoining(user, paidForm, identityRequest)

--- a/frontend/test/services/SubscriptionServiceHelpersTest.scala
+++ b/frontend/test/services/SubscriptionServiceHelpersTest.scala
@@ -13,7 +13,7 @@ class SubscriptionServiceHelpersTest extends Specification {
       val subscriptions = subscriptionReader.read(query("model/zuora/subscriptions.xml"))
       val amendments = amendmentReader.read(query("model/zuora/amendments.xml"))
 
-      val sortedAmendments = SubscriptionServiceHelpers.sortAmendments(subscriptions, amendments)
+      val sortedAmendments = SubscriptionService.sortAmendments(subscriptions, amendments)
 
       sortedAmendments(0).id mustEqual "2c92c0f847cdc31e0147cf24390d6ad7"
       sortedAmendments(1).id mustEqual "2c92c0f847cdc31e0147cf2439b76ae6"
@@ -22,7 +22,7 @@ class SubscriptionServiceHelpersTest extends Specification {
     "sort subscriptions by version" in {
       val subscriptions = subscriptionReader.read(query("model/zuora/subscriptions.xml"))
 
-      val sortedSubscriptions = SubscriptionServiceHelpers.sortSubscriptions(subscriptions)
+      val sortedSubscriptions = SubscriptionService.sortSubscriptions(subscriptions)
 
       sortedSubscriptions(0).id mustEqual "2c92c0f847cdc31e0147cf2111ba6173"
       sortedSubscriptions(1).id mustEqual "2c92c0f847cdc31e0147cf24396f6ae1"
@@ -32,7 +32,7 @@ class SubscriptionServiceHelpersTest extends Specification {
     "sort accounts by created date" in {
       val accounts = accountReader.read(query("model/zuora/accounts.xml"))
 
-      val sortedAccounts = SubscriptionServiceHelpers.sortAccounts(accounts)
+      val sortedAccounts = SubscriptionService.sortAccounts(accounts)
 
       sortedAccounts(0).id mustEqual "2c92c0f9483f301e01485efe9af6743e"
       sortedAccounts(1).id mustEqual "2c92c0f8483f1ca401485f0168f1614c"
@@ -41,7 +41,7 @@ class SubscriptionServiceHelpersTest extends Specification {
     "sort invoice items by charge number ascending" in {
       val invoiceItems = invoiceItemReader.read(query("model/zuora/invoice-result.xml"))
 
-      val sortedInvoiceItems = SubscriptionServiceHelpers.sortInvoiceItems(invoiceItems)
+      val sortedInvoiceItems = SubscriptionService.sortInvoiceItems(invoiceItems)
 
       sortedInvoiceItems(0).id mustEqual "2c92c0f94b34f993014b4a1c3b0104b7"
       sortedInvoiceItems(1).id mustEqual "2c92c0f94b34f993014b4a1c3b0004b6"
@@ -50,7 +50,7 @@ class SubscriptionServiceHelpersTest extends Specification {
     "sort preview invoice items by price ascending" in {
       val amendResult = amendResultReader.read(Resource.get("model/zuora/amend-result-preview.xml")).right.get
 
-      val sortedInvoiceItems = SubscriptionServiceHelpers.sortPreviewInvoiceItems(amendResult.invoiceItems)
+      val sortedInvoiceItems = SubscriptionService.sortPreviewInvoiceItems(amendResult.invoiceItems)
 
       sortedInvoiceItems(0).price mustEqual -135f
       sortedInvoiceItems(1).price mustEqual 540f

--- a/frontend/test/services/SubscriptionServiceTest.scala
+++ b/frontend/test/services/SubscriptionServiceTest.scala
@@ -1,5 +1,9 @@
 package services
 
+import com.gu.membership.model.{FriendTierPlan, PaidTierPlan}
+import com.gu.membership.salesforce.Tier
+import com.gu.membership.salesforce.Tier.{Friend, Supporter, Partner, Patron}
+import model.{Events, Books, BooksAndEvents}
 import org.specs2.mutable.Specification
 import model.Zuora.{Subscription, RatePlanCharge, RatePlan, SubscriptionDetails}
 import org.joda.time.DateTime
@@ -18,6 +22,38 @@ class SubscriptionServiceTest extends Specification {
 
       subscriptionDetails mustEqual SubscriptionDetails("Product name", 12.0f, startDate, startDate, Some(endDate), "RatePlanId")
       subscriptionDetails.annual mustEqual false
+    }
+  }
+
+  "featuresPerTier" should {
+    import SubscriptionService.featuresPerTier
+    import model.Zuora.{Feature => ZuoraFeature}
+
+    val feature1 = ZuoraFeature(id="1", code="Books")
+    val feature2 = ZuoraFeature(id="2", code="Events")
+    val feature3 = ZuoraFeature(id="3", code="OtherFeature")
+
+
+    val features = featuresPerTier(Seq(feature1, feature2, feature3)) _
+
+    def plan(t: Tier) = PaidTierPlan(t, annual = true)
+
+    "return both books and events for patrons" in {
+      features(plan(Patron), Some(BooksAndEvents)) mustEqual List(
+        feature1,
+        feature2
+      )
+    }
+
+    "return only one book or event for partner" in {
+      features(plan(Partner), Some(Books)) mustEqual List(feature1)
+      features(plan(Partner), Some(Events)) mustEqual List(feature2)
+      features(plan(Partner), Some(BooksAndEvents)).size mustEqual 1
+    }
+
+    "return no features for supporters or friends" in {
+      features(plan(Supporter), Some(Books)) mustEqual List.empty
+      features(FriendTierPlan, Some(Events)) mustEqual List.empty
     }
   }
 }

--- a/frontend/test/services/SubscriptionServiceTest.scala
+++ b/frontend/test/services/SubscriptionServiceTest.scala
@@ -3,7 +3,7 @@ package services
 import com.gu.membership.model.{FriendTierPlan, PaidTierPlan}
 import com.gu.membership.salesforce.Tier
 import com.gu.membership.salesforce.Tier.{Friend, Supporter, Partner, Patron}
-import model.{Events, Books}
+import model.{FreeEventTickets, Books}
 import org.specs2.mutable.Specification
 import model.Zuora.{Subscription, RatePlanCharge, RatePlan, SubscriptionDetails}
 import org.joda.time.DateTime
@@ -38,19 +38,19 @@ class SubscriptionServiceTest extends Specification {
     def plan(t: Tier) = PaidTierPlan(t, annual = true)
 
     "return both books and events for patrons" in {
-      features(plan(Patron), Set(Books, Events)) mustEqual List(feature1, feature2)
+      features(plan(Patron), Set(Books, FreeEventTickets)) mustEqual List(feature1, feature2)
       features(plan(Patron), Set()) mustEqual List(feature1, feature2)
     }
 
     "return only one book or event for partner" in {
       features(plan(Partner), Set(Books)) mustEqual List(feature1)
-      features(plan(Partner), Set(Events)) mustEqual List(feature2)
-      features(plan(Partner), Set(Books, Events)).size mustEqual 1
+      features(plan(Partner), Set(FreeEventTickets)) mustEqual List(feature2)
+      features(plan(Partner), Set(Books, FreeEventTickets)).size mustEqual 1
     }
 
     "return no features for supporters or friends" in {
       features(plan(Supporter), Set(Books)) mustEqual List.empty
-      features(FriendTierPlan, Set(Events)) mustEqual List.empty
+      features(FriendTierPlan, Set(FreeEventTickets)) mustEqual List.empty
     }
   }
 }

--- a/frontend/test/services/SubscriptionServiceTest.scala
+++ b/frontend/test/services/SubscriptionServiceTest.scala
@@ -3,7 +3,7 @@ package services
 import com.gu.membership.model.{FriendTierPlan, PaidTierPlan}
 import com.gu.membership.salesforce.Tier
 import com.gu.membership.salesforce.Tier.{Friend, Supporter, Partner, Patron}
-import model.{Events, Books, BooksAndEvents}
+import model.{Events, Books}
 import org.specs2.mutable.Specification
 import model.Zuora.{Subscription, RatePlanCharge, RatePlan, SubscriptionDetails}
 import org.joda.time.DateTime
@@ -33,27 +33,24 @@ class SubscriptionServiceTest extends Specification {
     val feature2 = ZuoraFeature(id="2", code="Events")
     val feature3 = ZuoraFeature(id="3", code="OtherFeature")
 
-
     val features = featuresPerTier(Seq(feature1, feature2, feature3)) _
 
     def plan(t: Tier) = PaidTierPlan(t, annual = true)
 
     "return both books and events for patrons" in {
-      features(plan(Patron), Some(BooksAndEvents)) mustEqual List(
-        feature1,
-        feature2
-      )
+      features(plan(Patron), Set(Books, Events)) mustEqual List(feature1, feature2)
+      features(plan(Patron), Set()) mustEqual List(feature1, feature2)
     }
 
     "return only one book or event for partner" in {
-      features(plan(Partner), Some(Books)) mustEqual List(feature1)
-      features(plan(Partner), Some(Events)) mustEqual List(feature2)
-      features(plan(Partner), Some(BooksAndEvents)).size mustEqual 1
+      features(plan(Partner), Set(Books)) mustEqual List(feature1)
+      features(plan(Partner), Set(Events)) mustEqual List(feature2)
+      features(plan(Partner), Set(Books, Events)).size mustEqual 1
     }
 
     "return no features for supporters or friends" in {
-      features(plan(Supporter), Some(Books)) mustEqual List.empty
-      features(FriendTierPlan, Some(Events)) mustEqual List.empty
+      features(plan(Supporter), Set(Books)) mustEqual List.empty
+      features(FriendTierPlan, Set(Events)) mustEqual List.empty
     }
   }
 }


### PR DESCRIPTION
Benefit selection

- Allows new partners to chose between books or events
- Automatically setup patrons with both perks

This implementation relies on `model.FeatureChoice.id` in order for the code to synchronise with Zuora product features. We are disabling this functionality on production, but it will still be accessible in development mode.

*Coding todo*
- [  ] ~~Add appropriate copy for form dialogs~~
- [x] Produce an error when the expected product features cannot be found in Zuora 

**Config todo**  
- [x] Add `Events` and `Books` product features to Zuora Dev
- [x] Make sure that the *patron* and *partner* product have the allow *Allow Feature Changes in Subscriptions*  option set to `yes` 
- [x] repeat steps above for UAT
- [x] repeat steps above for PROD

@rtyley @davidrapson @TesterSpike 