### PR TITLE
Update external actions to use inline svg icons

### DIFF
--- a/frontend/app/views/event/page.scala.html
+++ b/frontend/app/views/event/page.scala.html
@@ -77,7 +77,11 @@
                                href="@highlight.url"
                                data-metric-trigger="click"
                                data-metric-category="events"
-                               data-metric-action="highlights">@highlight.title</a>
+                               data-metric-action="highlights"
+                            >
+                                @highlight.title
+                                @fragments.actionIcon("arrow-right")
+                            </a>
                         }
                     } else {
                         @if(event.isSoldOut) {

--- a/frontend/app/views/fragments/event/infoPanel.scala.html
+++ b/frontend/app/views/fragments/event/infoPanel.scala.html
@@ -9,7 +9,7 @@
             </div>
             @if(!event.isPastEvent) {
                 <div class="status-panel__content">
-                    @fragments.event.waitlist(event, List("u-no-margin"))
+                    @fragments.event.waitlist(event)
                 </div>
             }
         </div>

--- a/frontend/app/views/fragments/event/waitlist.scala.html
+++ b/frontend/app/views/fragments/event/waitlist.scala.html
@@ -1,12 +1,13 @@
-@(event: model.RichEvent.RichEvent, extraClasses: Seq[String] = Nil)
+@(event: model.RichEvent.RichEvent)
 
 @import configuration.Config
 
-<a class="action action--external @extraClasses.mkString(" ")"
+<a class="action action--external"
    href="@Config.eventbriteWaitlistUrl(event)"
    data-metric-trigger="click"
    data-metric-category="events"
    data-metric-action="waitlist"
 >
     Add me to the waitlist
+    @fragments.actionIcon("arrow-right")
 </a>

--- a/frontend/app/views/fragments/promos/promoTertiary.scala.html
+++ b/frontend/app/views/fragments/promos/promoTertiary.scala.html
@@ -17,7 +17,7 @@
             @description
         </div>
         <div class="promo-tertiary__action">
-            <a class="action action--external action--no-icon" href="@linkHref">
+            <a class="action action--external" href="@linkHref">
                 @linkText
                 @fragments.actionIcon("arrow-right")
             </a>

--- a/frontend/app/views/patterns/patterns.scala.html
+++ b/frontend/app/views/patterns/patterns.scala.html
@@ -161,7 +161,10 @@
         </button></p>
         <p><button class="action action--booking">Booking Action</button></p>
         <div class="l-inset tone-guardian-live">
-            <button class="action action--external u-no-margin">External Action</button>
+            <button class="action action--external">
+                External Action
+                @fragments.actionIcon("arrow-right")
+            </button>
         </div>
     }
 

--- a/frontend/assets/stylesheets/components/_action.scss
+++ b/frontend/assets/stylesheets/components/_action.scss
@@ -156,6 +156,10 @@
        background-color: transparent;
    }
 
+   &:after {
+       display: none;
+   }
+
    @include mq(tablet) {
        width: auto;
    }


### PR DESCRIPTION
Update external actions to use the preferred new inline SVG icons instead of background images. No visual changes; just cleanup.

![screen shot 2015-07-29 at 14 26 31](https://cloud.githubusercontent.com/assets/123386/8958633/ed1149fc-35fd-11e5-855f-0e0d20335cc6.png)

@afiore 