### PR TITLE
Use strict for all JS modules; generally tighten up validation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,17 +15,12 @@
 
   "rules": {
     "camelcase": 0,
-    "strict": 0,
     "curly": [2, "all"],
-    "comma-spacing": 0,
-    "eqeqeq": 0,
     "new-cap": 2,
     "no-caller": 2,
     "no-empty": 0,
     "no-new": 0,
-    "eol-last": 0,
     "no-trailing-spaces": 2,
-    "no-multi-spaces": 0,
     "no-use-before-define": 0,
     "no-unused-vars": 2,
     "quotes": [2, "single"],

--- a/frontend/assets/javascripts/config/paymentErrorMessages.js
+++ b/frontend/assets/javascripts/config/paymentErrorMessages.js
@@ -1,4 +1,5 @@
 define(function () {
+    'use strict';
 
     var paymentErrMsgs = {
         invalid_request_error: {},

--- a/frontend/assets/javascripts/src/modules/analytics/appnexus.js
+++ b/frontend/assets/javascripts/src/modules/analytics/appnexus.js
@@ -1,5 +1,6 @@
 /*global Raven */
 define(function() {
+    'use strict';
 
     var tierMapping = {
         '/join/supporter/thankyou': 568467,

--- a/frontend/assets/javascripts/src/modules/analytics/crazyegg.js
+++ b/frontend/assets/javascripts/src/modules/analytics/crazyegg.js
@@ -1,4 +1,5 @@
 define(function() {
+    'use strict';
 
     function load() {
         require(['js!//script.crazyegg.com/pages/scripts/0030/6248.js?' + Math.floor(new Date().getTime() / 3600000)]);

--- a/frontend/assets/javascripts/src/modules/analytics/ga.js
+++ b/frontend/assets/javascripts/src/modules/analytics/ga.js
@@ -1,4 +1,6 @@
 define(function() {
+    'use strict';
+
     return {
         init: function() {
             /* Google analytics snippet */

--- a/frontend/assets/javascripts/src/modules/analytics/krux.js
+++ b/frontend/assets/javascripts/src/modules/analytics/krux.js
@@ -1,5 +1,6 @@
 /*global Raven */
 define(function() {
+    'use strict';
 
     var KRUX_ID = 'JglooLwn';
 

--- a/frontend/assets/javascripts/src/modules/analytics/omniture.js
+++ b/frontend/assets/javascripts/src/modules/analytics/omniture.js
@@ -2,6 +2,7 @@
 define([
     'src/utils/user'
 ], function (user) {
+    'use strict';
 
     var GU_ID_STRING = 'GUID';
     var NONE_STRING = 'none';

--- a/frontend/assets/javascripts/src/modules/analytics/ophan.js
+++ b/frontend/assets/javascripts/src/modules/analytics/ophan.js
@@ -1,5 +1,6 @@
 /*global Raven */
 define(function() {
+    'use strict';
 
     function init() {
         var ophanUrl = '//j.ophan.co.uk/ophan.membership.js';

--- a/frontend/assets/javascripts/src/modules/analytics/optimizely.js
+++ b/frontend/assets/javascripts/src/modules/analytics/optimizely.js
@@ -1,4 +1,5 @@
 define(function() {
+    'use strict';
 
     var EXPERIMENT_ID = 3267360204;
     var VARIATION_INDEX = 1;

--- a/frontend/assets/javascripts/src/modules/analytics/setup.js
+++ b/frontend/assets/javascripts/src/modules/analytics/setup.js
@@ -20,6 +20,7 @@ define([
     crazyegg,
     optimizely
 ) {
+    'use strict';
 
     var analyticsEnabled = (
         guardian.analyticsEnabled &&

--- a/frontend/assets/javascripts/src/modules/analytics/twitter.js
+++ b/frontend/assets/javascripts/src/modules/analytics/twitter.js
@@ -1,5 +1,6 @@
 /*global Raven, twttr */
 define(function() {
+    'use strict';
 
     var tierMapping = {
         '/join/friend/thankyou': 'l6gt9',

--- a/frontend/assets/javascripts/src/modules/events/cta.js
+++ b/frontend/assets/javascripts/src/modules/events/cta.js
@@ -2,6 +2,7 @@ define([
     '$',
     'src/utils/user'
 ], function($, userUtil) {
+    'use strict';
 
     var CTA_ELEM = '.js-ticket-cta';
     var CTA_ACTIONS = {

--- a/frontend/assets/javascripts/src/modules/events/eventPriceEnhance.js
+++ b/frontend/assets/javascripts/src/modules/events/eventPriceEnhance.js
@@ -1,4 +1,5 @@
 define(['$', 'bonzo', 'src/utils/user'], function ($, bonzo, userUtil) {
+    'use strict';
 
     var selectors = {
         EVENT_CONTAINER: '.js-event-price',

--- a/frontend/assets/javascripts/src/modules/events/filter.js
+++ b/frontend/assets/javascripts/src/modules/events/filter.js
@@ -1,15 +1,16 @@
 define(['$'], function ($) {
+    'use strict';
 
-    var FILTER_INPUT    = document.getElementById('js-filter');
-    var FILTER_PARENT   = document.getElementById('js-filter-container');
+    var FILTER_INPUT = document.getElementById('js-filter');
+    var FILTER_PARENT = document.getElementById('js-filter-container');
     var FILTER_CATEGORY = $('.js-filter-category');
-    var FILTER_ITEMS    = $('.js-filter-item');
-    var FILTER_CLEAR    = $('.js-filter-clear');
-    var FILTER_COUNT    = $('.js-filter-count');
-    var FILTER_EMPTY    = $('.js-filter-empty');
-    var THROTTLE        = 300;
-    var HIDDEN_CLASS    = 'is-hidden';
-    var SHOWN_CLASS     = 'is-shown';
+    var FILTER_ITEMS = $('.js-filter-item');
+    var FILTER_CLEAR = $('.js-filter-clear');
+    var FILTER_COUNT = $('.js-filter-count');
+    var FILTER_EMPTY = $('.js-filter-empty');
+    var THROTTLE = 300;
+    var HIDDEN_CLASS = 'is-hidden';
+    var SHOWN_CLASS = 'is-shown';
 
     var currentTimeout;
 

--- a/frontend/assets/javascripts/src/modules/form/address/subdivision.js
+++ b/frontend/assets/javascripts/src/modules/form/address/subdivision.js
@@ -5,7 +5,7 @@ define(['$'], function ($) {
     var UNITED_STATES_STRING = 'united states';
     var CANADA_STRING = 'canada';
     var ZIP_CODE_STRING = 'Zip code';
-    var POST_CODE_STRING  = 'Post code';
+    var POST_CODE_STRING = 'Post code';
     var COUNTY_CONTAINER_SELECTOR = '.js-county-container';
     var POSTCODE_LABEL_SELECTOR = '.js-postcode-label';
 

--- a/frontend/assets/javascripts/src/modules/form/helper/formUtil.js
+++ b/frontend/assets/javascripts/src/modules/form/helper/formUtil.js
@@ -1,6 +1,7 @@
 define([
     'src/utils/helper'
 ], function (utilsHelper) {
+    'use strict';
 
     /**
      * Filter only the elements that require validation, 'input', 'textarea', 'select' input elements that are

--- a/frontend/assets/javascripts/src/modules/form/helper/serializer.js
+++ b/frontend/assets/javascripts/src/modules/form/helper/serializer.js
@@ -1,4 +1,5 @@
 define(['lodash/object/extend'], function (extend) {
+    'use strict';
 
     /**
      * serialize form elements

--- a/frontend/assets/javascripts/src/modules/form/payment.js
+++ b/frontend/assets/javascripts/src/modules/form/payment.js
@@ -2,6 +2,7 @@ define([
     'src/modules/form/payment/listeners',
     'src/modules/form/payment/options'
 ], function (listeners, options) {
+    'use strict';
 
     /**
      * Initialise payment

--- a/frontend/assets/javascripts/src/modules/form/payment/displayCardImg.js
+++ b/frontend/assets/javascripts/src/modules/form/payment/displayCardImg.js
@@ -1,4 +1,5 @@
 define(function () {
+    'use strict';
 
     var CARD_SPRITE_ICON_PREFIX = 'sprite-card--';
     var CREDIT_CARD_IMG_ELEM = document.querySelector('.js-credit-card-image');

--- a/frontend/assets/javascripts/src/modules/form/payment/listeners.js
+++ b/frontend/assets/javascripts/src/modules/form/payment/listeners.js
@@ -3,6 +3,7 @@ define([
     'src/utils/masker',
     'src/modules/form/payment/displayCardImg'
 ], function (bean, masker, displayCardImg) {
+    'use strict';
 
     var CREDIT_CARD_NUMBER_ELEM = document.querySelector('.js-credit-card-number');
 

--- a/frontend/assets/javascripts/src/modules/form/processSubmit.js
+++ b/frontend/assets/javascripts/src/modules/form/processSubmit.js
@@ -7,16 +7,17 @@ define([
     'src/utils/helper',
     'src/modules/form/helper/loader'
 ], function (utilsHelper, loader) {
+    'use strict';
 
     var FORM_ELEMENT_SELECTOR = '.js-processing-form';
     var FORM_SUBMIT_ELEMENT_SELECTOR = '.js-processing-form-submit';
 
-    var init = function () {
+    var init = function() {
         var formElements = utilsHelper.toArray(document.querySelectorAll(FORM_ELEMENT_SELECTOR));
 
         if(formElements) {
-            formElements.map(function (formElem) {
-                formElem.addEventListener('submit', function () {
+            formElements.map(function(formElem) {
+                formElem.addEventListener('submit', function() {
                     loader.startLoader();
                     formElem.querySelector(FORM_SUBMIT_ELEMENT_SELECTOR).setAttribute('disabled', 'disabled');
                 }, false);
@@ -24,7 +25,7 @@ define([
         }
     };
 
-    return  {
+    return {
         init: init
     };
 });

--- a/frontend/assets/javascripts/src/modules/identityPopup.js
+++ b/frontend/assets/javascripts/src/modules/identityPopup.js
@@ -8,6 +8,7 @@ define([
     'bean',
     'src/utils/user'
 ], function (bean, userUtil) {
+    'use strict';
 
     var IS_HIDDEN = 'is-hidden';
     var IS_ACTIVE = 'is-active';

--- a/frontend/assets/javascripts/src/modules/identityPopupDetails.js
+++ b/frontend/assets/javascripts/src/modules/identityPopupDetails.js
@@ -6,6 +6,7 @@
  * Controls the "Join Us" cta visibility
  */
 define(['src/utils/user'], function (userUtil) {
+    'use strict';
 
     var IS_HIDDEN = 'is-hidden';
     var MENU_EDIT_PROFILE_ELEM = document.querySelector('.js-identity-menu-edit-profile');

--- a/frontend/assets/javascripts/src/modules/images.js
+++ b/frontend/assets/javascripts/src/modules/images.js
@@ -1,4 +1,5 @@
 define(['respimage', 'lazySizes'], function(respimage, lazySizes) {
+    'use strict';
 
     var LAZYLOAD_CLASS = 'js-lazyload';
 

--- a/frontend/assets/javascripts/src/modules/metrics.js
+++ b/frontend/assets/javascripts/src/modules/metrics.js
@@ -2,6 +2,8 @@ define([
     'src/modules/metrics/triggers',
     'src/modules/metrics/forms'
 ], function (metricsTriggers, metricsForms) {
+    'use strict';
+
     return {
         init: function() {
             metricsTriggers.init();

--- a/frontend/assets/javascripts/src/modules/metrics/forms.js
+++ b/frontend/assets/javascripts/src/modules/metrics/forms.js
@@ -3,6 +3,7 @@ define([
     'src/modules/metrics/logger',
     'src/modules/form/helper/formUtil'
 ], function (bean, logMetric, formUtil) {
+    'use strict';
 
     /**
      * Successful submission: Form was submitted without errors

--- a/frontend/assets/javascripts/src/modules/metrics/logger.js
+++ b/frontend/assets/javascripts/src/modules/metrics/logger.js
@@ -1,5 +1,7 @@
 /* global ga */
 define(['lodash/object/extend'], function (extend) {
+    'use strict';
+
     return function(options) {
         var metricData;
         if (window.ga) {

--- a/frontend/assets/javascripts/src/modules/metrics/triggers.js
+++ b/frontend/assets/javascripts/src/modules/metrics/triggers.js
@@ -2,6 +2,7 @@ define([
     'lodash/function/debounce',
     'src/modules/metrics/logger'
 ], function (debounce, logMetric) {
+    'use strict';
 
     var METRIC_ATTRS = {
         'trigger': 'data-metric-trigger',

--- a/frontend/assets/javascripts/src/modules/navigation.js
+++ b/frontend/assets/javascripts/src/modules/navigation.js
@@ -1,4 +1,5 @@
 define(['src/utils/user'], function (userUtil) {
+    'use strict';
 
     var MENU_TOGGLE_SELECTOR = '.js-menu-icon';
     var NAVIGATION_SELECTOR = '.js-global-nav';

--- a/frontend/assets/javascripts/src/modules/patterns.js
+++ b/frontend/assets/javascripts/src/modules/patterns.js
@@ -1,4 +1,5 @@
 define(function() {
+    'use strict';
 
     function buildItems(selector) {
         var items = [];

--- a/frontend/assets/javascripts/src/modules/sectionNav.js
+++ b/frontend/assets/javascripts/src/modules/sectionNav.js
@@ -3,6 +3,7 @@ define([
     'smoothScroll',
     'src/utils/helper'
 ], function (gumshoe, smoothScroll, helper) {
+    'use strict';
 
     var SELECTORS = {
         sectionNav: '.js-section-nav'

--- a/frontend/assets/javascripts/src/modules/slideshow.js
+++ b/frontend/assets/javascripts/src/modules/slideshow.js
@@ -1,4 +1,5 @@
 define(function() {
+    'use strict';
 
     var SLIDESHOW_CONTAINER = '.js-slideshow',
         SLIDESHOW_CHILDREN = '.js-slideshow-item',

--- a/frontend/assets/javascripts/src/modules/sticky.js
+++ b/frontend/assets/javascripts/src/modules/sticky.js
@@ -1,9 +1,9 @@
 define(['$', 'src/utils/helper'], function ($, helper) {
+    'use strict';
 
     var sticky = $('.js-sticky'),
         stickyLink = $(sticky.attr('data-sticky-sibling')),
         stickyTop;
-
 
     function checkSiblingHeight() {
         var run = true,
@@ -12,7 +12,7 @@ define(['$', 'src/utils/helper'], function ($, helper) {
         if (stickyLink.length) {
             heightEl = helper.getOuterHeight(sticky.get(0));
             heightSiblingEl = helper.getOuterHeight(stickyLink.get(0));
-            run = (heightSiblingEl >  heightEl) ? true : false;
+            run = (heightSiblingEl > heightEl) ? true : false;
         }
         return run;
     }

--- a/frontend/assets/javascripts/src/modules/toggle.js
+++ b/frontend/assets/javascripts/src/modules/toggle.js
@@ -13,7 +13,6 @@
  *     * data-toggle-hidden should be added to toggle elements which should be hidden on pageload
  */
 define(['$', 'bean'], function ($, bean) {
-
     'use strict';
 
     var TOGGLE_BTN_SELECTOR = '.js-toggle',

--- a/frontend/assets/javascripts/src/modules/tools/commentBuilder.js
+++ b/frontend/assets/javascripts/src/modules/tools/commentBuilder.js
@@ -1,4 +1,5 @@
 define(['src/utils/helper'], function (utilsHelper) {
+    'use strict';
 
     var COMMENT_START = '<!--';
     var COMMENT_END = '-->';

--- a/frontend/assets/javascripts/src/modules/userDetails.js
+++ b/frontend/assets/javascripts/src/modules/userDetails.js
@@ -2,6 +2,7 @@ define([
     '$',
     'src/utils/user'
 ], function ($, userUtil) {
+    'use strict';
 
     var AVAILABLE_DETAILS = ['displayname', 'firstName', 'tier'];
     var CLASS_NAMES = {

--- a/frontend/assets/javascripts/src/modules/videoOverlay.js
+++ b/frontend/assets/javascripts/src/modules/videoOverlay.js
@@ -3,6 +3,7 @@
  * Play video when clicking on a video overlay image
  */
 define(function() {
+    'use strict';
 
     var SELECTOR_PLAYER = '.js-video';
     var SELECTOR_PLAYER_IFRAME = '.js-video__iframe';

--- a/frontend/assets/javascripts/src/tools.js
+++ b/frontend/assets/javascripts/src/tools.js
@@ -1,3 +1,5 @@
 require(['src/modules/tools/commentBuilder'], function (commentBuilder) {
+    'use strict';
+
     commentBuilder.init();
 });

--- a/frontend/assets/javascripts/src/utils/$.js
+++ b/frontend/assets/javascripts/src/utils/$.js
@@ -2,6 +2,7 @@ define([
     'bonzo',
     'qwery'
 ], function(bonzo, qwery){
+    'use strict';
 
     function $(selector, context){
         return bonzo(qwery(selector, context));

--- a/frontend/assets/javascripts/src/utils/ajax.js
+++ b/frontend/assets/javascripts/src/utils/ajax.js
@@ -1,8 +1,5 @@
-define([
-    'reqwest'
-], function (
-    reqwest
-    ) {
+define(['reqwest'], function (reqwest) {
+    'use strict';
 
     var makeAbsolute = function () {
         throw new Error('AJAX has not been initialised yet');

--- a/frontend/assets/javascripts/src/utils/atob.js
+++ b/frontend/assets/javascripts/src/utils/atob.js
@@ -1,5 +1,7 @@
 /*eslint-disable */
 define(function () {
+    'use strict';
+
     return function AtoB(){
         return window.atob ? function(str){
             return window.atob(str);

--- a/frontend/assets/javascripts/src/utils/component.js
+++ b/frontend/assets/javascripts/src/utils/component.js
@@ -1,4 +1,5 @@
-define(['bean','qwery'], function(bean, qwery) {
+define(['bean', 'qwery'], function(bean, qwery) {
+    'use strict';
 
     var Component = function() {};
 

--- a/frontend/assets/javascripts/src/utils/cookie.js
+++ b/frontend/assets/javascripts/src/utils/cookie.js
@@ -1,4 +1,5 @@
 define(['src/utils/decodeBase64'], function (decodeBase64) {
+    'use strict';
 
     /*
      Cookie functions originally from http://www.quirksmode.org/js/cookies.html

--- a/frontend/assets/javascripts/src/utils/decodeBase64.js
+++ b/frontend/assets/javascripts/src/utils/decodeBase64.js
@@ -1,4 +1,5 @@
 define(['src/utils/atob'], function (AtoB) {
+    'use strict';
 
     return function(str) {
         /* global escape: true */

--- a/frontend/assets/javascripts/src/utils/helper.js
+++ b/frontend/assets/javascripts/src/utils/helper.js
@@ -1,4 +1,5 @@
 define(function () {
+    'use strict';
 
     /**
      * get parent by className

--- a/frontend/assets/javascripts/src/utils/masker.js
+++ b/frontend/assets/javascripts/src/utils/masker.js
@@ -5,6 +5,8 @@
 *   el.addEventListener('keyup', maskInput('', 4)) // cvc
 */
 define(function () {
+    'use strict';
+
     function maskInput(delim, len) {
         var tokRegex = new RegExp('\\d{1,' + len + '}', 'g');
         var validRegex = new RegExp('\\d|(' + delim + ')|^', 'g');

--- a/frontend/assets/javascripts/src/utils/text.js
+++ b/frontend/assets/javascripts/src/utils/text.js
@@ -1,7 +1,9 @@
 define(function() {
+    'use strict';
+
     return {
         trimWhitespace: function(str) {
-            return str.replace(/(^\s+|\s+$)/g,'');
+            return str.replace(/(^\s+|\s+$)/g, '');
         },
         removeWhitespace: function(str) {
             return str.replace(/\s+/g, '');

--- a/frontend/assets/javascripts/src/utils/url.js
+++ b/frontend/assets/javascripts/src/utils/url.js
@@ -1,7 +1,9 @@
 define(function() {
+    'use strict';
+
     return {
         isExternal: function(url) {
-            var external = url.replace('http://','').replace('https://','').split('/')[0];
+            var external = url.replace('http://', '').replace('https://', '').split('/')[0];
             return (external.length) ? true : false;
         }
     };

--- a/frontend/assets/javascripts/src/utils/user.js
+++ b/frontend/assets/javascripts/src/utils/user.js
@@ -4,6 +4,7 @@ define([
     'src/utils/cookie',
     'config/appCredentials'
 ], function(AtoB, ajax, cookie, appCredentials){
+    'use strict';
 
     var MEM_USER_COOKIE_KEY = appCredentials.membership.userCookieKey;
 


### PR DESCRIPTION
JS `strict` mode is generally worth defaulting to. We we're doing this in some modules, but as it wasn't enforced a lot were missing it. This PR adds `'use strict';` where needed; and generally tightens up our `eslint` config where possible.