### PR TITLE
Refactor zuora service implementation

### DIFF
--- a/frontend/app/controllers/Healthcheck.scala
+++ b/frontend/app/controllers/Healthcheck.scala
@@ -5,27 +5,36 @@ import play.api.mvc.{Action, Controller}
 import services.{TouchpointBackend, GuardianLiveEventService}
 import com.gu.monitoring.CloudWatchHealth
 import com.github.nscala_time.time.Imports._
+import play.api.libs.concurrent.Execution.Implicits._
 
-case class Test(name: String, result: () => Boolean)
+import scala.concurrent.Future
+
+case class Test(name: String, result: Future[Boolean])
 
 object Healthcheck extends Controller {
+  val zuoraService = TouchpointBackend.Normal.zuoraService
 
   val tests = Seq(
-    Test("Events", GuardianLiveEventService.events.nonEmpty _),
-    Test("CloudWatch", CloudWatchHealth.hasPushedMetricSuccessfully _),
-    Test("Zuora", () => TouchpointBackend.Normal.zuoraService.pingTask.get() > DateTime.now - 2.minutes)
+    Test("Events", Future { GuardianLiveEventService.events.nonEmpty }),
+    Test("CloudWatch", Future { CloudWatchHealth.hasPushedMetricSuccessfully }),
+    Test("Zuora", zuoraService.pingSupplier.get().map(t => t > DateTime.now - 2.minutes))
   )
 
-  def healthcheck() = Action {
-    Cached(1) {
-      val serviceOk = tests.forall { test =>
-        val result = test.result()
-        if (!result) Logger.warn(s"${test.name} test failed, health check will fail")
-        result
-      }
+  def healthcheck() = Action.async { req =>
+    Future.sequence(tests.map(_.result)).map { results =>
+      val failedTests =
+        results.zip(tests.map(_.name)).filterNot { case (ok, _) => ok }
 
-      if (serviceOk) Ok("OK") else ServiceUnavailable("Service Unavailable")
+      Cached(1) {
+        if (failedTests.nonEmpty) {
+          failedTests.foreach { case (_, test) =>
+            Logger.warn(s"Test $test failed, health check will fail")
+          }
+          ServiceUnavailable("Service Unavailable")
+        } else {
+          Ok("OK")
+        }
+      }
     }
   }
-
 }

--- a/frontend/app/model/Zuora.scala
+++ b/frontend/app/model/Zuora.scala
@@ -225,7 +225,7 @@ object ZuoraDeserializer {
     }
   }
 
-  implicit val FeatureReader = ZuoraQueryReader("Feature", Seq("Id", "FeatureCode")) { result =>
+  implicit val featureReader = ZuoraQueryReader("Feature", Seq("Id", "FeatureCode")) { result =>
     Feature(result("Id"), result("FeatureCode"))
   }
 

--- a/frontend/app/services/TouchpointBackend.scala
+++ b/frontend/app/services/TouchpointBackend.scala
@@ -53,7 +53,6 @@ case class TouchpointBackend(
 
   def start() = {
     memberRepository.salesforce.authTask.start()
-    zuoraService.start()
   }
 
   val subscriptionService = new SubscriptionService(products, zuoraService)

--- a/frontend/app/services/zuora/ZuoraService.scala
+++ b/frontend/app/services/zuora/ZuoraService.scala
@@ -13,12 +13,13 @@ import org.joda.time.format.ISODateTimeFormat
 import org.joda.time.{DateTime, DateTimeZone}
 import play.api.Logger
 import play.api.Play.current
+import play.api.libs.concurrent.Akka
 import play.api.libs.ws.WS
-import utils.ScheduledTask
-
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import utils.FutureSupplier
 import scala.concurrent.duration._
+
+import play.api.libs.concurrent.Execution.Implicits._
+import scala.concurrent.Future
 
 case class ZuoraServiceError(s: String) extends Throwable {
   override def getMessage: String = s
@@ -36,21 +37,82 @@ object ZuoraServiceHelpers {
 }
 
 class ZuoraService(val apiConfig: ZuoraApiConfig) extends LazyLogging {
-  import services.zuora.ZuoraServiceHelpers._
+  import ZuoraServiceHelpers._
 
   val metrics = new TouchpointBackendMetrics with StatusMetrics with AuthenticationMetrics {
     val backendEnv = apiConfig.envName
 
     val service = "Zuora"
 
-    def recordError {
+    def recordError() {
       put("error-count", 1)
     }
   }
 
-  val featuresTask = ScheduledTask(s"Zuora ${apiConfig.envName} retrieve features of membership tiers", Seq[Feature](), 0.seconds, 1.day) {
-    val featuresF = query[Feature]("Status = 'Active'")
+  private val authSupplier =
+    new FutureSupplier[Authentication](request(Login(apiConfig)))
 
+  val featuresSupplier =
+    new FutureSupplier[Seq[Feature]](getFeatures)
+
+  val pingSupplier =
+    new FutureSupplier[DateTime](authRequest(
+      Query("SELECT Id FROM Product")).map { _ => new DateTime })
+
+  private val scheduler = Akka.system.scheduler
+
+  List(
+    (30.minutes, authSupplier),
+    (30.seconds, pingSupplier),
+    (30.minutes, featuresSupplier)
+  ) foreach { case (duration, supplier) =>
+    scheduler.schedule(duration, duration) { supplier.refresh() }
+  }
+
+  def getAuth = authSupplier.get()
+
+  def authRequest[T <: ZuoraResult](action: => ZuoraAuthAction[T])(implicit reader: ZuoraReader[T]): Future[T] = {
+    getAuth.flatMap(auth => request(action, Some(auth)))
+  }
+
+  def query[T <: ZuoraQuery](where: String)(implicit reader: ZuoraQueryReader[T]): Future[Seq[T]] = {
+    authRequest(Query(formatQuery(reader, where))).map { case QueryResult(results) => reader.read(results) }
+  }
+
+  def queryOne[T <: ZuoraQuery](where: String)(implicit reader: ZuoraQueryReader[T]): Future[T] = {
+    query(where)(reader).map { results =>
+      if (results.length != 1) {
+        throw new ZuoraServiceError(s"Query '${reader.getClass.getSimpleName} $where' returned ${results.length} results, expected one")
+      }
+      results.head
+    }
+  }
+
+  private def request[T <: ZuoraResult](action: ZuoraAction[T], authOpt: Option[Authentication] = None)
+                                       (implicit reader: ZuoraReader[T]): Future[T] = {
+
+    val url = apiConfig.url.toString()
+
+    Timing.record(metrics, action.getClass.getSimpleName) {
+      WS.url(url.toString).post(action.xml(authOpt))
+    }.map { result =>
+      metrics.putResponseCode(result.status, "POST")
+      reader.read(result.body) match {
+        case Left(error) =>
+          if (error.fatal) {
+            metrics.recordError()
+            Logger.error(s"Zuora action error ${action.getClass.getSimpleName} with status ${result.status} and body ${action.sanitized}")
+            Logger.error(result.body)
+          }
+          throw error
+
+        case Right(obj) => obj
+      }
+    }
+  }
+
+  private def getFeatures: Future[Seq[Feature]] = {
+    val featuresF = query[Feature]("Status = 'Active'")
     featuresF.foreach { features =>
       val diff = FeatureChoice.codes &~ features.map(_.code).toSet
       lazy val msg =
@@ -63,69 +125,5 @@ class ZuoraService(val apiConfig: ZuoraApiConfig) extends LazyLogging {
     }
 
     featuresF
-  }
-
-  lazy val featuresSchedule = featuresTask.start()
-
-  def authTaskWithCallbacks(callbacks: Seq[() => Unit]) =
-    ScheduledTask(s"Zuora ${apiConfig.envName} auth", Authentication("", ""), 0.seconds, 30.minutes) {
-      val eventualAuthentication = request(Login(apiConfig))
-      eventualAuthentication.filter(_.token.nonEmpty).foreach(_ => callbacks.foreach(_()))
-      eventualAuthentication
-    }
-
-  val authTask = authTaskWithCallbacks(Seq(() => featuresSchedule))
-
-  val pingTask = ScheduledTask(s"Zuora ${apiConfig.envName} ping", DateTime.now, 30.seconds, 30.seconds) {
-    request(Query("SELECT Id FROM Product")).map { _ => new DateTime }
-  }
-
-  def start() {
-    authTask.start()
-    pingTask.start()
-  }
-
-  implicit def authentication: Authentication = authTask.get()
-
-  def request[T <: ZuoraResult](action: ZuoraAction[T])(implicit reader: ZuoraReader[T]): Future[T] = {
-    val url = if (action.authRequired) authentication.url else apiConfig.url
-
-    if (action.authRequired && authentication.url.length == 0) {
-      metrics.putAuthenticationError
-      throw ZuoraServiceError(s"Can't build authenticated request for ${action.getClass.getSimpleName}, no Zuora authentication")
-    }
-
-    Timing.record(metrics, action.getClass.getSimpleName) {
-      WS.url(url.toString).post(action.xml)
-    }.map { result =>
-      metrics.putResponseCode(result.status, "POST")
-
-      reader.read(result.body) match {
-        case Left(error) =>
-          if (error.fatal) {
-            metrics.recordError
-            Logger.error(s"Zuora action error ${action.getClass.getSimpleName} with status ${result.status} and body ${action.sanitized}")
-            Logger.error(result.body)
-          }
-
-          throw error
-
-        case Right(obj) => obj
-      }
-    }
-  }
-
-  def query[T <: ZuoraQuery](where: String)(implicit reader: ZuoraQueryReader[T]): Future[Seq[T]] = {
-    request(Query(formatQuery(reader, where))).map { case QueryResult(results) => reader.read(results) }
-  }
-
-  def queryOne[T <: ZuoraQuery](where: String)(implicit reader: ZuoraQueryReader[T]): Future[T] = {
-    query(where)(reader).map { results =>
-      if (results.length != 1) {
-        throw new ZuoraServiceError(s"Query '${reader.getClass.getSimpleName} $where' returned ${results.length} results, expected one")
-      }
-
-      results(0)
-    }
   }
 }

--- a/frontend/app/utils/FutureSupplier.scala
+++ b/frontend/app/utils/FutureSupplier.scala
@@ -12,8 +12,8 @@ class FutureSupplier[T](f: => Future[T]) {
     refreshAlteringFuture <- agent.alter { currentRefresh =>
       if (currentRefresh.isCompleted) f else currentRefresh
     }
-    refreshFuture <- refreshAlteringFuture
-  } yield refreshFuture
+    refreshed <- refreshAlteringFuture
+  } yield refreshed
 
   def get(): Future[T] = agent.get()
 }

--- a/frontend/app/utils/FutureSupplier.scala
+++ b/frontend/app/utils/FutureSupplier.scala
@@ -1,0 +1,19 @@
+package utils
+
+import akka.agent.Agent
+
+import scala.concurrent.Future
+import play.api.libs.concurrent.Execution.Implicits._
+
+class FutureSupplier[T](f: => Future[T]) {
+  private val agent = Agent(f)
+
+  def refresh(): Future[T] = for {
+    refreshAlteringFuture <- agent.alter { currentRefresh =>
+      if (currentRefresh.isCompleted) f else currentRefresh
+    }
+    refreshFuture <- refreshAlteringFuture
+  } yield refreshFuture
+
+  def get(): Future[T] = agent.get()
+}

--- a/frontend/test/services/zuora/ZuoraActionTest.scala
+++ b/frontend/test/services/zuora/ZuoraActionTest.scala
@@ -7,7 +7,7 @@ import org.specs2.mutable.Specification
 
 class ZuoraActionTest extends Specification {
 
-  val auth = Some(Authentication("token", "http://example.com/"))
+  implicit val auth = Some(Authentication("token", "http://example.com/"))
 
   "ZuoraAction" should {
     "create a standard action" in {
@@ -15,6 +15,13 @@ class ZuoraActionTest extends Specification {
       (xml \ "Body" \ "test").length mustEqual 1
       (xml \ "Header" \ "SessionHeader" \ "session").text.trim mustEqual "token"
       (xml \ "Header" \ "CallOptions" \ "useSingleTransaction").length mustEqual 0
+    }
+
+    "create an un-authenticated action" in {
+      val action = new TestAction {}
+
+      val xml = action.xml(None)
+      (xml \ "Header" \ "SessionHeader").length mustEqual 0
     }
 
     "create a single transaction action" in {
@@ -26,6 +33,16 @@ class ZuoraActionTest extends Specification {
       (xml \ "Header" \ "CallOptions" \ "useSingleTransaction").text mustEqual "true"
     }
 
+    "create an un-authenticated, single transaction action" in {
+      val action = new TestAction {
+        override val singleTransaction = true
+      }
+
+      val xml = action.xml(None)
+      (xml \ "Header" \ "SessionHeader").length mustEqual 0
+      (xml \ "Header" \ "CallOptions" \ "useSingleTransaction").text mustEqual "true"
+    }
+
     "not reveal login details in sanitized output" in {
       val action = Login(ZuoraApiConfig("TEST", "http://example.com" / "test", "secret", "secret"))
       action.sanitized must not contain "secret"
@@ -34,7 +51,7 @@ class ZuoraActionTest extends Specification {
 
   case class TestResult() extends ZuoraResult
 
-  case class TestAction() extends ZuoraAuthAction[TestResult] {
+  case class TestAction() extends ZuoraAction[TestResult] {
     val body = <test></test>
   }
 

--- a/frontend/test/services/zuora/ZuoraActionTest.scala
+++ b/frontend/test/services/zuora/ZuoraActionTest.scala
@@ -5,27 +5,16 @@ import com.netaporter.uri.dsl._
 import model.Zuora.{Authentication, ZuoraResult}
 import org.specs2.mutable.Specification
 
-import scala.xml.XML
-
 class ZuoraActionTest extends Specification {
 
-  implicit val auth = Authentication("token", "http://example.com/")
+  val auth = Some(Authentication("token", "http://example.com/"))
 
   "ZuoraAction" should {
     "create a standard action" in {
-      val xml = XML.loadString(TestAction().xml)
+      val xml = TestAction().xml(auth)
       (xml \ "Body" \ "test").length mustEqual 1
       (xml \ "Header" \ "SessionHeader" \ "session").text.trim mustEqual "token"
       (xml \ "Header" \ "CallOptions" \ "useSingleTransaction").length mustEqual 0
-    }
-
-    "create an un-authenticated action" in {
-      val action = new TestAction {
-        override val authRequired = false
-      }
-
-      val xml = XML.loadString(action.xml)
-      (xml \ "Header" \ "SessionHeader").length mustEqual 0
     }
 
     "create a single transaction action" in {
@@ -33,18 +22,7 @@ class ZuoraActionTest extends Specification {
         override val singleTransaction = true
       }
 
-      val xml = XML.loadString(action.xml)
-      (xml \ "Header" \ "CallOptions" \ "useSingleTransaction").text mustEqual "true"
-    }
-
-    "create an un-authenticated, single transaction action" in {
-      val action = new TestAction {
-        override val authRequired = false
-        override val singleTransaction = true
-      }
-
-      val xml = XML.loadString(action.xml)
-      (xml \ "Header" \ "SessionHeader").length mustEqual 0
+      val xml = action.xml(auth)
       (xml \ "Header" \ "CallOptions" \ "useSingleTransaction").text mustEqual "true"
     }
 
@@ -56,7 +34,7 @@ class ZuoraActionTest extends Specification {
 
   case class TestResult() extends ZuoraResult
 
-  case class TestAction() extends ZuoraAction[TestResult] {
+  case class TestAction() extends ZuoraAuthAction[TestResult] {
     val body = <test></test>
   }
 


### PR DESCRIPTION
The current implementation of `ZuoraService` initialises a number of `ScheduledTasks` with a "blank" authentication value. This is not ideal, as it means that for a small time window, the application is not capable to talk to Zuora. In this specific case `ScheduledTask` also makes composing async operations in the right order harder than necessary, forcing us to use fiddly callbacks to ensure that operations happen in the right order.

Following a suggestion from @rtyley, I have repurposed a pattern from [Prout](github.com/guardian/prout). This consists in wrapping a future value into an Akka agent, which in turn gets periodically refreshed by the Actor system's scheduler (see `utils.FutureSupplier`).

**Note**: This PR branches off #647

@tudorraul @rtyley 