### PR TITLE
Fix Local events not displaying in past events

### DIFF
--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -143,21 +143,19 @@ trait Event extends Controller with ActivityTracking {
   }
 
   def list = CachedAction { implicit request =>
-    val pageInfo = PageInfo(
-      CopyConfig.copyTitleEvents,
-      request.path,
-      Some(CopyConfig.copyDescriptionEvents)
-    )
-    val pastEvents = (guLiveEvents.getEventsArchive ++ localEvents.getEventsArchive).headOption
-      .map(chronologicalSort(_).reverse)
     Ok(views.html.event.guardianLive(
       EventPortfolio(
         guLiveEvents.getFeaturedEvents,
         chronologicalSort(guLiveEvents.getEvents ++ localEvents.getEvents),
-        pastEvents,
+        chronologicalSort(guLiveEvents.getEventsArchive.toList.flatten ++ localEvents.getEventsArchive.toList.flatten).reverse,
         guLiveEvents.getPartnerEvents
       ),
-      pageInfo))
+      PageInfo(
+        CopyConfig.copyTitleEvents,
+        request.path,
+        Some(CopyConfig.copyDescriptionEvents)
+      ))
+    )
   }
 
   def listFilteredBy(urlTagText: String) = CachedAction { implicit request =>
@@ -171,7 +169,7 @@ trait Event extends Controller with ActivityTracking {
       EventPortfolio(
         Seq.empty,
         chronologicalSort(guLiveEvents.getTaggedEvents(tag) ++ localEvents.getTaggedEvents(tag)),
-        None,
+        Seq.empty,
         None
       ),
       pageInfo))

--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -143,11 +143,15 @@ trait Event extends Controller with ActivityTracking {
   }
 
   def list = CachedAction { implicit request =>
+
+    val archivedEvents =
+      guLiveEvents.getEventsArchive.toList.flatten ++ localEvents.getEventsArchive.toList.flatten
+
     Ok(views.html.event.guardianLive(
       EventPortfolio(
         guLiveEvents.getFeaturedEvents,
         chronologicalSort(guLiveEvents.getEvents ++ localEvents.getEvents),
-        chronologicalSort(guLiveEvents.getEventsArchive.toList.flatten ++ localEvents.getEventsArchive.toList.flatten).reverse,
+        chronologicalSort(archivedEvents).reverse,
         guLiveEvents.getPartnerEvents
       ),
       PageInfo(

--- a/frontend/app/controllers/PatternLibrary.scala
+++ b/frontend/app/controllers/PatternLibrary.scala
@@ -28,12 +28,7 @@ trait PatternLibrary extends Controller {
 
   def patterns = NoCacheAction { implicit request =>
     Ok(views.html.patterns.patterns(
-      EventPortfolio(
-        guLiveEvents.getFeaturedEvents,
-        guLiveEvents.getEvents,
-        guLiveEvents.getEventsArchive,
-        guLiveEvents.getPartnerEvents
-      ),
+      guLiveEvents.getEvents,
       pageImages
     ))
   }

--- a/frontend/app/model/EventPortfolio.scala
+++ b/frontend/app/model/EventPortfolio.scala
@@ -8,7 +8,7 @@ case class EventGroup(sequenceTitle: String, events: Seq[RichEvent])
 case class EventPortfolio(
     orderedEvents: Seq[RichEvent],
     normal: Seq[RichEvent],
-    pastEvents: Option[Seq[RichEvent]],
+    pastEvents: Seq[RichEvent],
     otherEvents: Option[EventGroup]
   ) {
   lazy val heroOpt = orderedEvents.headOption

--- a/frontend/app/views/fragments/event/listing.scala.html
+++ b/frontend/app/views/fragments/event/listing.scala.html
@@ -75,7 +75,7 @@
             </div>
             <div class="listing__content">
                 <ul class="grid grid--bordered grid--4up">
-                    @for(event <- eventPortfolio.pastEvents.slice(0, 4)) {
+                    @for(event <- eventPortfolio.pastEvents.take(4)) {
                         <li class="grid__item">
                             @fragments.event.itemMinimal(event, isCard=false)
                         </li>

--- a/frontend/app/views/fragments/event/listing.scala.html
+++ b/frontend/app/views/fragments/event/listing.scala.html
@@ -68,34 +68,30 @@
         </section>
     }
 
-    @if(showPastEvents && eventPortfolio.pastEvents) {
+    @if(showPastEvents && eventPortfolio.pastEvents.nonEmpty) {
         <section class="listing">
             <div class="listing__lead-in">
                 <h3 class="listing__title h-intro">Past events</h3>
             </div>
             <div class="listing__content">
-                @if(eventPortfolio.normal.isEmpty) {
-                    <div class="listing__empty">@noResultsMessage</div>
-                } else {
-                    <ul class="grid grid--bordered grid--4up">
-                        @for(event <- eventPortfolio.pastEvents.get.slice(0, 4)) {
-                            <li class="grid__item">
-                                @fragments.event.itemMinimal(event)
-                            </li>
-                        }
-                    </ul>
-                    <ul class="grid grid--bordered grid--2up" id="js-toggle-past-events" data-toggle-hidden>
-                        @for(event <- eventPortfolio.pastEvents.get.slice(4, 26)) {
-                            <li class="grid__item">
-                                @fragments.event.itemMinimal(event, isCard=true)
-                            </li>
-                        }
-                    </ul>
-                    <button class="action action--secondary u-no-margin js-toggle" data-toggle="js-toggle-past-events" data-toggle-label="Less" data-toggle-icon="minus">
-                        @fragments.actionIcon("plus", leftIcon=true)
-                        <span class="action__label js-toggle-label">More past events</span>
-                    </button>
-                }
+                <ul class="grid grid--bordered grid--4up">
+                    @for(event <- eventPortfolio.pastEvents.slice(0, 4)) {
+                        <li class="grid__item">
+                            @fragments.event.itemMinimal(event, isCard=false)
+                        </li>
+                    }
+                </ul>
+                <ul class="grid grid--bordered grid--2up" id="js-toggle-past-events" data-toggle-hidden>
+                    @for(event <- eventPortfolio.pastEvents.slice(4, 36)) {
+                        <li class="grid__item">
+                            @fragments.event.itemMinimal(event, isCard=true)
+                        </li>
+                    }
+                </ul>
+                <button class="action action--secondary u-no-margin js-toggle" data-toggle="js-toggle-past-events" data-toggle-label="Less" data-toggle-icon="minus">
+                    @fragments.actionIcon("plus", leftIcon=true)
+                    <span class="action__label js-toggle-label">More past events</span>
+                </button>
             </div>
         </section>
     }

--- a/frontend/app/views/patterns/patterns.scala.html
+++ b/frontend/app/views/patterns/patterns.scala.html
@@ -1,4 +1,4 @@
-@(eventPortfolio: model.EventPortfolio, pageImages: Seq[model.ResponsiveImageGroup])(implicit token: play.filters.csrf.CSRF.Token)
+@(events: Seq[model.RichEvent.RichEvent], pageImages: Seq[model.ResponsiveImageGroup])(implicit token: play.filters.csrf.CSRF.Token)
 
 @import com.gu.membership.salesforce.Tier
 @import model.{Benefits, FlashMessage}
@@ -288,7 +288,7 @@
     }
 
     @pattern("Series Detail") {
-        @fragments.event.seriesDetails(eventPortfolio.orderedEvents.head)
+        @fragments.event.seriesDetails(events.head)
     }
 
     @for(img <- pageImages.find(_.name.contains("sample-1"))) {
@@ -327,12 +327,12 @@
     }
 
     @pattern("Event – Hero", "Used to highlight a single event at the top of the /events listing") {
-        @fragments.event.itemHero(eventPortfolio.orderedEvents.head)
+        @fragments.event.itemHero(events.head)
     }
 
     @pattern("Event – Full", "A standard event, used in a number of places") {
         <ul class="grid grid--3up">
-            @for(event <- eventPortfolio.normal.slice(0, 3)) {
+            @for(event <- events.slice(0, 3)) {
                 <li class="grid__item">
                     @fragments.event.item(event)
                 </li>
@@ -342,7 +342,7 @@
 
     @pattern("Event – Minimal", "Used currently to list recent past events, where pricing/dates info is redundant") {
         <ul class="grid grid--3up">
-            @for(event <- eventPortfolio.normal.slice(0, 3)) {
+            @for(event <- events.slice(0, 3)) {
                 <li class="grid__item">
                     @fragments.event.itemMinimal(event)
                 </li>
@@ -352,7 +352,7 @@
 
     @pattern("Event – Minimal & Card", "An even more minimal theme which splits the photo and event title") {
         <ul class="grid grid--2up">
-            @for(event <- eventPortfolio.normal.slice(0, 3)) {
+            @for(event <- events.slice(0, 3)) {
                 <li class="grid__item">
                     @fragments.event.itemMinimal(event, isCard=true)
                 </li>
@@ -361,15 +361,15 @@
     }
 
     @pattern("Event – Info Panel", "Panel shown in the sidebar on event detail pages") {
-        @fragments.event.infoPanel(eventPortfolio.orderedEvents.head)
+        @fragments.event.infoPanel(events.head)
     }
 
     @pattern("Event – Snapshot", "Simple snapshot of event information") {
-        @fragments.event.itemSnapshot(eventPortfolio.orderedEvents.head)
+        @fragments.event.itemSnapshot(events.head)
     }
 
     @pattern("Event – Stats", "Key stats for an event") {
-        @fragments.event.stats(eventPortfolio.orderedEvents.head)
+        @fragments.event.stats(events.head)
     }
 
     @pattern("Pricing Info", "Single pricing info item which flexes to fill available width (up to maximum)") {
@@ -381,7 +381,7 @@
     }
 
     @pattern("Pricing Info - Event", "Simple inline version of price info for events") {
-        @fragments.pricing.priceInfoEvent(eventPortfolio.normal.head)
+        @fragments.pricing.priceInfoEvent(events.head)
     }
 
     @pattern("Benefit Item", "Single benefit item") {


### PR DESCRIPTION
This PR fixes a bug with Local events not displaying in past events. It looked like they were being included, but they actually weren't.

- Fix issue with Local events not displaying in past events container
- Increase the number of past events we show
- Don't use EventPortfolio for patterns; overcomplicated, we only need a sample list of events

**Before**
![screen shot 2015-07-31 at 13 57 20](https://cloud.githubusercontent.com/assets/123386/9007783/ab15eb12-378c-11e5-8041-3b99c3a46136.png)

**After**
![screen shot 2015-07-31 at 13 56 59](https://cloud.githubusercontent.com/assets/123386/9007784/af4558c6-378c-11e5-870b-606864f9c9ee.png)

@rtyley 