### PR TITLE
Unset CSP header, logging too noisy in Sentry

### DIFF
--- a/frontend/app/Global.scala
+++ b/frontend/app/Global.scala
@@ -1,11 +1,11 @@
-import filters.{AddCSPHeader, AddEC2InstanceHeader, CheckCacheHeadersFilter, Gzipper}
+import filters.{AddEC2InstanceHeader, CheckCacheHeadersFilter, Gzipper}
 import monitoring.SentryLogging
 import play.api.Application
 import play.api.mvc.WithFilters
 import play.filters.csrf._
 import services._
 
-object Global extends WithFilters(CheckCacheHeadersFilter, CSRFFilter(), Gzipper, AddCSPHeader, AddEC2InstanceHeader) {
+object Global extends WithFilters(CheckCacheHeadersFilter, CSRFFilter(), Gzipper, AddEC2InstanceHeader) {
   override def onStart(app: Application) {
     SentryLogging.init()
 


### PR DESCRIPTION
CSP logging is currently very noisy in Sentry, messages seem to get truncated so we're missing context and where there is context there's a lot of noise from browser extensions (e.g., Safari Pinterest extension). Going to review this next week to see if there's a clearer way we can report this without overwhelming Sentry with more noise than signal. For now, let's unset the header.

@rtyley 