### PR TITLE
Re-model CSP message to send formatted version

### DIFF
--- a/frontend/app/Global.scala
+++ b/frontend/app/Global.scala
@@ -1,11 +1,11 @@
-import filters.{AddEC2InstanceHeader, CheckCacheHeadersFilter, Gzipper}
+import filters.{AddCSPHeader, AddEC2InstanceHeader, CheckCacheHeadersFilter, Gzipper}
 import monitoring.SentryLogging
 import play.api.Application
 import play.api.mvc.WithFilters
 import play.filters.csrf._
 import services._
 
-object Global extends WithFilters(CheckCacheHeadersFilter, CSRFFilter(), Gzipper, AddEC2InstanceHeader) {
+object Global extends WithFilters(CheckCacheHeadersFilter, CSRFFilter(), Gzipper, AddCSPHeader, AddEC2InstanceHeader) {
   override def onStart(app: Application) {
     SentryLogging.init()
 

--- a/frontend/app/controllers/Security.scala
+++ b/frontend/app/controllers/Security.scala
@@ -39,6 +39,8 @@ object Security extends Controller with LazyLogging {
       |Violated Directive: $violatedDirective
       |Referrer: $referrer
       |""".stripMargin
+
+    val directiveTag = violatedDirective.split(" ").head
   }
 
   implicit val reads: Reads[CSPReport] = (
@@ -57,10 +59,13 @@ object Security extends Controller with LazyLogging {
     } {
       _.sendEvent(new EventBuilder()
         .withMessage(report.message)
-        .withLevel(RavenEvent.Level.INFO).build())
+        .withLevel(RavenEvent.Level.INFO)
+        .withTag("CSP Directive", report.directiveTag)
+        .build()
+      )
     }
 
-    Future.successful(Ok)
+    Future.successful(NoContent)
   }
 
 }

--- a/frontend/app/controllers/Security.scala
+++ b/frontend/app/controllers/Security.scala
@@ -2,7 +2,10 @@ package controllers
 
 import com.typesafe.scalalogging.LazyLogging
 import monitoring.SentryLogging
-import play.api.libs.json.Json
+import net.kencochrane.raven.event.{Event => RavenEvent, EventBuilder}
+import play.api.libs.functional.syntax._
+import play.api.libs.json.Reads._
+import play.api.libs.json._
 import play.api.mvc.Controller
 
 import scala.concurrent.Future
@@ -11,12 +14,50 @@ object Security extends Controller with LazyLogging {
 
   def cspReport = NoCacheAction.async(parse.tolerantJson(maxLength = 4096)) { implicit request =>
 
-    val message = s"CSP warning ${Json.prettyPrint(request.body)}"
+    /**
+     * See: https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Using_CSP_violation_reports
+     * Report format:
+     *
+     *  {
+     *    "csp-report": {
+     *      "document-uri": "http://example.com/signup.html",
+     *      "referrer": "",
+     *      "blocked-uri": "http://example.com/css/style.css",
+     *      "violated-directive": "style-src cdn.example.com",
+     *      "original-policy": "default-src 'none'; style-src cdn.example.com; report-uri /_/csp-reports"
+     *    }
+     *  }
+     */
+    case class CSPReport(
+      documentUri: String,
+      blockedUri: String,
+      violatedDirective: String,
+      referrer: Option[String]
+    ) {
+      val message = s"""
+        |CSP warning:
+        |Document URI: $documentUri
+        |Blocked URI: $blockedUri
+        |Violated Directive: $violatedDirective
+        |Referrer: $referrer
+        |""".stripMargin
+    }
+
+    implicit val reads: Reads[CSPReport] = (
+      (JsPath \ "csp-report" \ "document-uri").read[String] and
+      (JsPath \ "csp-report" \ "blocked-uri").read[String] and
+      (JsPath \ "csp-report" \ "violated-directive").read[String] and
+      (JsPath \ "csp-report" \ "referrer").readNullable[String]
+    )(CSPReport.apply _)
+
+    val report = request.body.as[CSPReport]
 
     SentryLogging.ravenOpt.fold {
-      logger.error(message)
+      logger.error(report.message)
     } {
-      _.sendMessage(message)
+      _.sendEvent(new EventBuilder()
+        .withMessage(report.message)
+        .withLevel(RavenEvent.Level.INFO).build())
     }
 
     Future.successful(Ok)

--- a/frontend/app/controllers/Security.scala
+++ b/frontend/app/controllers/Security.scala
@@ -12,43 +12,43 @@ import scala.concurrent.Future
 
 object Security extends Controller with LazyLogging {
 
+  /**
+   * See: https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Using_CSP_violation_reports
+   * Report format:
+   *
+   *  {
+   *    "csp-report": {
+   *      "document-uri": "http://example.com/signup.html",
+   *      "referrer": "",
+   *      "blocked-uri": "http://example.com/css/style.css",
+   *      "violated-directive": "style-src cdn.example.com",
+   *      "original-policy": "default-src 'none'; style-src cdn.example.com; report-uri /_/csp-reports"
+   *    }
+   *  }
+   */
+  case class CSPReport(
+    documentUri: String,
+    blockedUri: String,
+    violatedDirective: String,
+    referrer: Option[String]
+  ) {
+    val message = s"""
+      |CSP warning:
+      |Document URI: $documentUri
+      |Blocked URI: $blockedUri
+      |Violated Directive: $violatedDirective
+      |Referrer: $referrer
+      |""".stripMargin
+  }
+
+  implicit val reads: Reads[CSPReport] = (
+    (JsPath \ "csp-report" \ "document-uri").read[String] and
+    (JsPath \ "csp-report" \ "blocked-uri").read[String] and
+    (JsPath \ "csp-report" \ "violated-directive").read[String] and
+    (JsPath \ "csp-report" \ "referrer").readNullable[String]
+  )(CSPReport.apply _)
+
   def cspReport = NoCacheAction.async(parse.tolerantJson(maxLength = 4096)) { implicit request =>
-
-    /**
-     * See: https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Using_CSP_violation_reports
-     * Report format:
-     *
-     *  {
-     *    "csp-report": {
-     *      "document-uri": "http://example.com/signup.html",
-     *      "referrer": "",
-     *      "blocked-uri": "http://example.com/css/style.css",
-     *      "violated-directive": "style-src cdn.example.com",
-     *      "original-policy": "default-src 'none'; style-src cdn.example.com; report-uri /_/csp-reports"
-     *    }
-     *  }
-     */
-    case class CSPReport(
-      documentUri: String,
-      blockedUri: String,
-      violatedDirective: String,
-      referrer: Option[String]
-    ) {
-      val message = s"""
-        |CSP warning:
-        |Document URI: $documentUri
-        |Blocked URI: $blockedUri
-        |Violated Directive: $violatedDirective
-        |Referrer: $referrer
-        |""".stripMargin
-    }
-
-    implicit val reads: Reads[CSPReport] = (
-      (JsPath \ "csp-report" \ "document-uri").read[String] and
-      (JsPath \ "csp-report" \ "blocked-uri").read[String] and
-      (JsPath \ "csp-report" \ "violated-directive").read[String] and
-      (JsPath \ "csp-report" \ "referrer").readNullable[String]
-    )(CSPReport.apply _)
 
     val report = request.body.as[CSPReport]
 


### PR DESCRIPTION
Messages were getting truncated in Sentry, this formats the CSP report into something more readable, and removes `original-policy` from the reported message.

@rtyley 