### PR TITLE
Update Optimizely experiment ID

### DIFF
--- a/frontend/assets/javascripts/src/modules/analytics/optimizely.js
+++ b/frontend/assets/javascripts/src/modules/analytics/optimizely.js
@@ -1,6 +1,6 @@
 define(function() {
 
-    var EXPERIMENT_ID = 3171000188;
+    var EXPERIMENT_ID = 3267360204;
     var VARIATION_INDEX = 1;
 
     function updateHomeLink() {


### PR DESCRIPTION
In order to push the winning Optimizely variant to 100% of users we need to restart the experiment (to reset old visitors that might already be bucketed). This means we need to update the experiment ID in our code.

@afiore @tudorraul 