### PR TITLE
Record free event ticket usage in Zuora

### DIFF
--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -204,6 +204,7 @@ trait Event extends Controller with ActivityTracking {
         val eventUrl = ebCode.fold(Uri.parse(event.url))(c => event.url ? ("discount" -> c.code))
         val memberData = MemberData(request.member.salesforceContactId, request.user.id, request.member.tier.name, campaignCode = extractCampaignCode(request))
         track(EventActivity("redirectToEventbrite", Some(memberData), EventData(event)))(request.user)
+
         Found(eventUrl)
           .withCookies(Cookie(eventCookie(event), "", Some(3600)))
       }

--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -222,7 +222,7 @@ trait Event extends Controller with ActivityTracking {
         event <- EventbriteService.getEvent(id)
       } yield {
         event.service.getOrder(oid).map { order =>
-          val count = memberService.complimentaryTicketsUsed(event, order)
+          val count = memberService.countComplimentaryTicketsUsed(event, order)
           if (count > 0) {
             memberService.recordFreeEventUsage(request.member, event, order, count)
           }

--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -21,6 +21,7 @@ import services.{EventbriteService, GuardianLiveEventService, LocalEventService,
 import services.EventbriteService._
 import tracking._
 import utils.CampaignCode.extractCampaignCode
+import utils.TestUsers.isTestUser
 
 import scala.concurrent.Future
 
@@ -224,7 +225,7 @@ trait Event extends Controller with ActivityTracking {
       } yield {
         event.service.getOrder(oid).map { order =>
           val count = memberService.countComplimentaryTicketsUsed(event, order)
-          if (count > 0) {
+          if (count > 0 && isTestUser(request.user)) {
             memberService.recordFreeEventUsage(request.member, event, order, count)
           }
 

--- a/frontend/app/model/Eventbrite.scala
+++ b/frontend/app/model/Eventbrite.scala
@@ -317,7 +317,7 @@ object Eventbrite {
 
   case class EBCost(value: Int) extends EBObject
 
-  case class EBAttendee(quantity: Int) extends EBObject
+  case class EBAttendee(quantity: Int, ticket_class_id: String) extends EBObject
 }
 
 object EventbriteDeserializer {

--- a/frontend/app/model/Eventbrite.scala
+++ b/frontend/app/model/Eventbrite.scala
@@ -317,7 +317,7 @@ object Eventbrite {
 
   case class EBCost(value: Int) extends EBObject
 
-  case class EBAttendee(quantity: Int, ticket_class_id: Int) extends EBObject
+  case class EBAttendee(quantity: Int, ticket_class_id: String) extends EBObject
 }
 
 object EventbriteDeserializer {

--- a/frontend/app/model/Eventbrite.scala
+++ b/frontend/app/model/Eventbrite.scala
@@ -317,7 +317,7 @@ object Eventbrite {
 
   case class EBCost(value: Int) extends EBObject
 
-  case class EBAttendee(quantity: Int, ticket_class_id: String) extends EBObject
+  case class EBAttendee(quantity: Int, ticket_class_id: Int) extends EBObject
 }
 
 object EventbriteDeserializer {

--- a/frontend/app/services/EventbriteService.scala
+++ b/frontend/app/services/EventbriteService.scala
@@ -2,7 +2,6 @@ package services
 
 import com.gu.membership.util.WebServiceHelper
 import configuration.Config
-import model.Zuora.CreateResult
 import model.{TicketSaleDates, EventGroup}
 import model.Eventbrite._
 import model.EventbriteDeserializer._

--- a/frontend/app/services/EventbriteService.scala
+++ b/frontend/app/services/EventbriteService.scala
@@ -2,6 +2,7 @@ package services
 
 import com.gu.membership.util.WebServiceHelper
 import configuration.Config
+import model.Zuora.CreateResult
 import model.{TicketSaleDates, EventGroup}
 import model.Eventbrite._
 import model.EventbriteDeserializer._

--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -137,7 +137,7 @@ trait MemberService extends LazyLogging with ActivityTracking {
       account <- tp.subscriptionService.getAccount(member)
       subscriptions <- tp.subscriptionService.getSubscriptions(member)
       description = s"event-id:${event.id};order-id:${order.id}"
-      action = CreateFreeEventUsage(account.id, description, quantity, subscriptions.headOption.map(_.id))
+      action = CreateFreeEventUsage(account.id, description, quantity, subscriptions.head.id)
       result <- tp.zuoraSoapService.authenticatedRequest(action)
     } yield result
   }

--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -128,9 +128,7 @@ trait MemberService extends LazyLogging with ActivityTracking {
 
   def countComplimentaryTicketsUsed(event: RichEvent, order: EBOrder): Int = {
     val ticketIds = event.internalTicketing.map(_.complimentaryTickets).getOrElse(Nil).map(_.id)
-    order.attendees.foldLeft(0) { (count, attendee) =>
-      if (ticketIds.contains(attendee.ticket_class_id)) attendee.quantity else 0
-    }
+    order.attendees.count(attendee => ticketIds.contains(attendee.ticket_class_id))
   }
 
   def recordFreeEventUsage(member: Member, event: RichEvent, order: EBOrder, quantity: Int): Future[CreateResult] = {

--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -126,10 +126,10 @@ trait MemberService extends LazyLogging with ActivityTracking {
     }
   }
 
-  def complimentaryTicketsUsed(event: RichEvent, order: EBOrder): Int = {
-    val complimentaryTicketIds = event.internalTicketing.map(_.complimentaryTickets).getOrElse(Nil).map(_.id)
+  def countComplimentaryTicketsUsed(event: RichEvent, order: EBOrder): Int = {
+    val ticketIds = event.internalTicketing.map(_.complimentaryTickets).getOrElse(Nil).map(_.id)
     order.attendees.foldLeft(0) { (count, attendee) =>
-      if (complimentaryTicketIds.contains(attendee.ticket_class_id)) attendee.quantity else 0
+      if (ticketIds.contains(attendee.ticket_class_id)) attendee.quantity else 0
     }
   }
 

--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -126,14 +126,20 @@ trait MemberService extends LazyLogging with ActivityTracking {
     }
   }
 
+  def complimentaryTicketsUsed(event: RichEvent, order: EBOrder): Int = {
+    val complimentaryTicketIds = event.internalTicketing.map(_.complimentaryTickets).getOrElse(Nil).map(_.id)
+    order.attendees.foldLeft(0) { (count, attendee) =>
+      if (complimentaryTicketIds.contains(attendee.ticket_class_id)) attendee.quantity else 0
+    }
+  }
 
-  def recordFreeEventUsage(member: Member, event: RichEvent, order: EBOrder): Future[CreateResult] = {
+  def recordFreeEventUsage(member: Member, event: RichEvent, order: EBOrder, quantity: Int): Future[CreateResult] = {
     val tp = TouchpointBackend.forUser(member)
     for {
       account <- tp.subscriptionService.getAccount(member)
       subscriptions <- tp.subscriptionService.getSubscriptions(member)
       description = s"event-id:${event.id};order-id:${order.id}"
-      action = CreateFreeEventUsage(account.id, description, subscriptions.headOption.map(_.id))
+      action = CreateFreeEventUsage(account.id, description, quantity, subscriptions.headOption.map(_.id))
       result <- tp.zuoraSoapService.authenticatedRequest(action)
     } yield result
   }

--- a/frontend/app/services/SubscriptionService.scala
+++ b/frontend/app/services/SubscriptionService.scala
@@ -102,7 +102,7 @@ class SubscriptionService(val tierPlanRateIds: Map[ProductRatePlan, String],
                           val zuoraRestService: ZuoraRestService) extends AmendSubscription with LazyLogging {
   import SubscriptionService._
 
-  private def getAccount(memberId: MemberId): Future[Account] =
+  def getAccount(memberId: MemberId): Future[Account] =
     zuoraSoapService.query[Account](s"crmId='${memberId.salesforceAccountId}'").map(sortAccounts(_).last)
 
   //TODO before we do subs we need to filter by rate plans membership knows about

--- a/frontend/app/services/zuora/ZuoraActions.scala
+++ b/frontend/app/services/zuora/ZuoraActions.scala
@@ -353,8 +353,8 @@ case class UpgradePlan(subscriptionId: String, subscriptionRatePlanId: String, n
   }
 }
 
-case class CreateFreeEventUsage(accountId: String, description: String, subscriptionId: Option[String]) extends ZuoraAction[CreateResult] {
-  val uom = "Each"
+case class CreateFreeEventUsage(accountId: String, description: String, quantity: Int, subscriptionId: Option[String]) extends ZuoraAction[CreateResult] {
+  val uom = "Events"
   val startDateTime = formatDateTime(DateTime.now)
   private val subscriptionEl: NodeSeq =
     subscriptionId.fold(NodeSeq.Empty){ id =>
@@ -366,10 +366,11 @@ case class CreateFreeEventUsage(accountId: String, description: String, subscrip
       <ns1:zObjects xsi:type="ns2:Usage">
         <ns2:AccountId>{accountId}</ns2:AccountId>
         {subscriptionEl}
-        <ns2:Quantity>1</ns2:Quantity>
+        <ns2:Quantity>{quantity}</ns2:Quantity>
         <ns2:StartDateTime>{startDateTime}</ns2:StartDateTime>
-        <ns2:Description>Events/{description}</ns2:Description>
+        <ns2:Description>{description}</ns2:Description>
         <ns2:UOM>{uom}</ns2:UOM>
       </ns1:zObjects>
     </ns1:create>
 }
+

--- a/frontend/app/services/zuora/ZuoraActions.scala
+++ b/frontend/app/services/zuora/ZuoraActions.scala
@@ -353,19 +353,14 @@ case class UpgradePlan(subscriptionId: String, subscriptionRatePlanId: String, n
   }
 }
 
-case class CreateFreeEventUsage(accountId: String, description: String, quantity: Int, subscriptionId: Option[String]) extends ZuoraAction[CreateResult] {
+case class CreateFreeEventUsage(accountId: String, description: String, quantity: Int, subscriptionId: String) extends ZuoraAction[CreateResult] {
   val uom = "Events"
   val startDateTime = formatDateTime(DateTime.now)
-  private val subscriptionEl: NodeSeq =
-    subscriptionId.fold(NodeSeq.Empty){ id =>
-      <ns2:SubscriptionId>{id}</ns2:SubscriptionId>
-    }
-
   override protected val body: Elem =
       <ns1:create>
       <ns1:zObjects xsi:type="ns2:Usage">
         <ns2:AccountId>{accountId}</ns2:AccountId>
-        {subscriptionEl}
+        <ns2:SubscriptionId>{subscriptionId}</ns2:SubscriptionId>
         <ns2:Quantity>{quantity}</ns2:Quantity>
         <ns2:StartDateTime>{startDateTime}</ns2:StartDateTime>
         <ns2:Description>{description}</ns2:Description>

--- a/frontend/app/services/zuora/ZuoraActions.scala
+++ b/frontend/app/services/zuora/ZuoraActions.scala
@@ -352,3 +352,24 @@ case class UpgradePlan(subscriptionId: String, subscriptionRatePlanId: String, n
     </ns1:amend>
   }
 }
+
+case class CreateFreeEventUsage(accountId: String, description: String, subscriptionId: Option[String]) extends ZuoraAction[CreateResult] {
+  val uom = "Each"
+  val startDateTime = formatDateTime(DateTime.now)
+  private val subscriptionEl: NodeSeq =
+    subscriptionId.fold(NodeSeq.Empty){ id =>
+      <ns2:SubscriptionId>{id}</ns2:SubscriptionId>
+    }
+
+  override protected val body: Elem =
+      <ns1:create>
+      <ns1:zObjects xsi:type="ns2:Usage">
+        <ns2:AccountId>{accountId}</ns2:AccountId>
+        {subscriptionEl}
+        <ns2:Quantity>1</ns2:Quantity>
+        <ns2:StartDateTime>{startDateTime}</ns2:StartDateTime>
+        <ns2:Description>Events/{description}</ns2:Description>
+        <ns2:UOM>{uom}</ns2:UOM>
+      </ns1:zObjects>
+    </ns1:create>
+}


### PR DESCRIPTION
After a quick investigation that ruled out the possibility of using EventBrite webhooks, @rtyley and I agreed on recording event usage within the thank you page the user lands on after buying an event.
Assuming that the user is signed into the app, we can link the newly created usage record in Zuora with the member `salesforceContactId` and its corresponding subscription id.

![screen shot 2015-08-10 at 18 04 37](https://cloud.githubusercontent.com/assets/63361/9177655/6025dac6-3f8a-11e5-9152-c3e4018134e2.png)

**Rollout plan**
- [x] Create a UOM in Zuora DEV and UAT for _Free event tickets_ and get rid of the 'events' prefix in the usage description.
- [x] Ensure the UOM configuration is reproduced to the other tiers
 
@rtyley @tudorraul 