### PR TITLE
Sentry doesn't like filtering on tags w/ spaces

### DIFF
--- a/frontend/app/controllers/Security.scala
+++ b/frontend/app/controllers/Security.scala
@@ -63,7 +63,7 @@ object Security extends Controller with LazyLogging {
         .withChecksumFor(report.blockedUri)
         .withMessage(report.message)
         .withLevel(RavenEvent.Level.INFO)
-        .withTag("CSP Directive", report.directiveTag)
+        .withTag("CSPDIRECTIVE", report.directiveTag)
 
       raven.sendEvent(eventBuilder.build())
     }


### PR DESCRIPTION
Looks like Sentry doesn't like filtering on tags w/ spaces @rtyley 