### PR TITLE
Remove unnecessary reference to ~/.aws/config

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,14 +80,6 @@ region = eu-west-1
 
 ```
 
-In `~/.aws/config` add the following:
-
-```
-[default]
-output = json
-region = eu-west-1
-```
-
 ### Ubuntu
 
 In an ideal world, your Ubuntu package install would be:


### PR DESCRIPTION
The AWS SDK for Java reads from only `~/.aws/credentials`, not  `~/.aws/config` so far as I can see (corrected thanks to @davidrapson !):

http://docs.aws.amazon.com/AWSSdkDocsJava/latest/DeveloperGuide/credentials.html

(introduced with https://github.com/guardian/membership-frontend/commit/7ccfe6df)

We use the credentials to download a key file from S3 to connect to the Google Directory API.

cc @davidrapson 