### PR TITLE
Remove 'Join' from homepage title

### DIFF
--- a/frontend/app/views/index.scala.html
+++ b/frontend/app/views/index.scala.html
@@ -8,7 +8,7 @@
 @import views.support.NavAnchor
 @import views.support.Asset
 
-@main("Join", pageInfo) {
+@main("", pageInfo) {
 
     @* ===== Intro ===== *@
     <div class="hero-banner" style="background-image: url(@Asset.at("images/join-challenger/event-grid.jpg"))">

--- a/frontend/app/views/main.scala.html
+++ b/frontend/app/views/main.scala.html
@@ -11,7 +11,7 @@
 <html class="js-off id--signed-out@if(!pageInfo.hasBackgroundImage){ no-background}">
     <head>
         <meta charset="utf-8">
-        <title>@(title + " | " + Config.siteTitle )</title>
+        <title>@if(title.isEmpty){ @Config.siteTitle } else { @(s"$title | ${Config.siteTitle}") }</title>
 
         @fragments.meta.mobile()
         <meta name="description" content="@pageInfo.description"/>


### PR DESCRIPTION
One minor detail missed when migrating join challenger page to home page. Removes 'Join' from the homepage title.

![screen shot 2015-08-20 at 12 27 52](https://cloud.githubusercontent.com/assets/123386/9382275/4161967a-4737-11e5-83cc-606e555e2498.png)
![screen shot 2015-08-20 at 12 28 00](https://cloud.githubusercontent.com/assets/123386/9382276/41770032-4737-11e5-9075-8ee7bde17451.png)

@afiore 