### PR TITLE
[Merge **before** redesign] Guardian Membership => Guardian Members

### DIFF
--- a/frontend/app/configuration/Videos.scala
+++ b/frontend/app/configuration/Videos.scala
@@ -23,7 +23,7 @@ object Videos {
     srcUrl="//www.youtube.com/embed/z_IFkfuEuz0?enablejsapi=1&wmode=transparent",
     posterImage=Some(
       ResponsiveImageGroup(
-        altText=Some("What is Guardian Membership?"),
+        altText=Some("What is Guardian Members?"),
         availableImages=videoPlaceholder
       )
     )

--- a/frontend/app/model/Faq.scala
+++ b/frontend/app/model/Faq.scala
@@ -15,7 +15,7 @@ object Faq {
     Item("Can I use social sign in/registration?",
       Html("No, you must have a Guardian account using your work email address.")
     ),
-    Item("I've already joined Guardian Membership as a friend, can I upgrade?",
+    Item("I've already joined Guardian Members as a friend, can I upgrade?",
       Html("No, sorry you can't upgrade, you need to cancel your friend membership first.")
     ),
     Item("How do I cancel my friend membership?",
@@ -33,16 +33,16 @@ object Faq {
   )
 
   val help = List(
-    Item("What is Guardian Membership?",
-      Html("Guardian Membership is for you if you share our belief that the open exchange of information, ideas and opinions can change the world for the better. By signing up and paying your subscription (at Partner and Patron level), you are helping bring these words to life by supporting open and independent journalism. In return, you get access to events and experiences that are only available to members."),
+    Item("What is Guardian Members?",
+      Html("Guardian Members is for you if you share our belief that the open exchange of information, ideas and opinions can change the world for the better. By signing up and paying your subscription (at Partner and Patron level), you are helping bring these words to life by supporting open and independent journalism. In return, you get access to events and experiences that are only available to members."),
       "what-is-membership"
     ),
     Item("Why should I join?",
-      Html("Membership has a lot to offer, and by joining in this beta phase, you can help build and shape Guardian Membership into one of the world’s largest communities of free thinkers. Benefits include access to the Guardian live events programme. Events range from lectures by the world’s foremost thinkers to exclusive screenings of the latest independent films; from sessions with senior journalists at our offices in Kings Place to more intimate, bespoke events. Tickets are only available to Guardian members. If you want to support the Guardian and its journalism, and keep our website open to all, then joining Guardian Membership and paying your subscription is a great way to do it."),
+      Html("Membership has a lot to offer, and by joining in this beta phase, you can help build and shape Guardian Members into one of the world’s largest communities of free thinkers. Benefits include access to the Guardian live events programme. Events range from lectures by the world’s foremost thinkers to exclusive screenings of the latest independent films; from sessions with senior journalists at our offices in Kings Place to more intimate, bespoke events. Tickets are only available to Guardian members. If you want to support the Guardian and its journalism, and keep our website open to all, then joining Guardian Members and paying your subscription is a great way to do it."),
       "why-join"
     ),
     Item("How much does membership cost?",
-      Html("The Friend tier of Guardian Membership is free. Partners pay £15 per month or £135 per year if you pay in one go. For Patrons, the cost is £60 per month or £540 per year. If you choose the annual payment you get 3 months free."),
+      Html("The Friend tier of Guardian Members is free. Partners pay £15 per month or £135 per year if you pay in one go. For Patrons, the cost is £60 per month or £540 per year. If you choose the annual payment you get 3 months free."),
       "how-much-does-it-cost"
     ),
     Item("What is the difference between a Friend, a Partner and a Patron?",
@@ -82,11 +82,11 @@ object Faq {
       "under-18"
     ),
     Item("I don’t live in London - can I still be a member?",
-      Html("Yes, Guardian Membership is open to everyone. Guardian Live events at launch will be taking place in London, Edinburgh, Manchester and Bristol, and we have plans to run future events across the UK."),
+      Html("Yes, Guardian Members is open to everyone. Guardian Live events at launch will be taking place in London, Edinburgh, Manchester and Bristol, and we have plans to run future events across the UK."),
       "do-not-live-in-london"
     ),
     Item("I don’t live in the UK - can I still be a member?",
-      Html("Yes, Guardian Membership is open to anyone living anywhere in the world. And although our home is London, we will be extending membership and staging events for members in the USA and Australia."),
+      Html("Yes, Guardian Members is open to anyone living anywhere in the world. And although our home is London, we will be extending membership and staging events for members in the USA and Australia."),
       "do-not-live-in-uk"
     ),
     Item("What happens if I want to change my membership tier?",
@@ -114,7 +114,7 @@ object Faq {
       "wheelchair-access-for-venue"
     ),
     Item("I've got a question",
-      Html(s"Please email <a href='mailto:${Email.membershipSupport}'>${Email.membershipSupport}</a> with your question. We will do our best to get back to you within 24 hours. Alternatively, you can call the Guardian Membership customer services team on 0330 333 6898 from 8am to 5.30pm Monday to Friday and 8.30am to 12.30pm at weekends."),
+      Html(s"Please email <a href='mailto:${Email.membershipSupport}'>${Email.membershipSupport}</a> with your question. We will do our best to get back to you within 24 hours. Alternatively, you can call the Guardian Members customer services team on 0330 333 6898 from 8am to 5.30pm Monday to Friday and 8.30am to 12.30pm at weekends."),
       "have-a-question"
     ),
     Item("What are Guardian Masterclasses?",
@@ -157,7 +157,7 @@ object Faq {
       "existing-subscriber-member"
     ),
     Item("How much does membership cost normally?",
-      Html("The Friend tier of Guardian Membership is free. Partners pay £15 per month or £135 per year if you pay in one go. For Patrons, the cost is £60 per month or £540 per year. If you choose the annual payment you get 3 months free when compared to the monthly price."),
+      Html("The Friend tier of Guardian Members is free. Partners pay £15 per month or £135 per year if you pay in one go. For Patrons, the cost is £60 per month or £540 per year. If you choose the annual payment you get 3 months free when compared to the monthly price."),
       "normal-cost"
     ),
     Item("I don’t have an email address, can I still join?",
@@ -177,11 +177,11 @@ object Faq {
       "pay-direct-debit"
     ),
     Item("I don’t live in London - can I still be a member?",
-      Html("Yes, Guardian Membership is open to everyone. Guardian Live events at launch will be taking place in London, Edinburgh, Manchester and Bristol, and we have plans to run future events across the UK."),
+      Html("Yes, Guardian Members is open to everyone. Guardian Live events at launch will be taking place in London, Edinburgh, Manchester and Bristol, and we have plans to run future events across the UK."),
       "outside-london"
     ),
     Item("I don’t live in the UK - can I still be a member?",
-      Html("Yes, Guardian Membership is open to anyone living anywhere in the world. And although our home is London, we will be extending membership and staging events for members in the USA and Australia."),
+      Html("Yes, Guardian Members is open to anyone living anywhere in the world. And although our home is London, we will be extending membership and staging events for members in the USA and Australia."),
       "outside-uk"
     ),
     Item("How do I know you are protecting my personal information?",
@@ -215,7 +215,7 @@ object Faq {
       "who-to-contact"
     ),
     Item("I have a question not answered above",
-      Html(s"Please email <a href='mailto:${Email.membershipSupport}'>${Email.membershipSupport}</a> with your question. We will do our best to get back to you within 24 hours. Alternatively, you can call the Guardian Membership customer services team on 0330 333 6898 from 8am to 5.30pm Monday to Friday and 8.30am to 12.30pm at weekends."),
+      Html(s"Please email <a href='mailto:${Email.membershipSupport}'>${Email.membershipSupport}</a> with your question. We will do our best to get back to you within 24 hours. Alternatively, you can call the Guardian Members customer services team on 0330 333 6898 from 8am to 5.30pm Monday to Friday and 8.30am to 12.30pm at weekends."),
       "questions"
     )
   )

--- a/frontend/app/views/fragments/analytics/videoCampaignPHD/aboutPage.scala.html
+++ b/frontend/app/views/fragments/analytics/videoCampaignPHD/aboutPage.scala.html
@@ -3,7 +3,7 @@
 @if(Config.stage == "PROD") {
     <!--
     Start of DoubleClick Floodlight Tag: Please do not remove
-    Activity name of this tag: Guardian Membership - About
+    Activity name of this tag: Guardian Members - About
     URL of the webpage where the tag is expected to be placed: https://membership.theguardian.com/about
     This tag must be placed between the <body> and </body> tags, as close as possible to the opening tag.
     Creation Date: 03/06/2015

--- a/frontend/app/views/fragments/analytics/videoCampaignPHD/thankyouPage.scala.html
+++ b/frontend/app/views/fragments/analytics/videoCampaignPHD/thankyouPage.scala.html
@@ -5,7 +5,7 @@
 @if(Config.stage == "PROD") {
     <!--
     Start of DoubleClick Floodlight Tag: Please do not remove
-    Activity name of this tag: Guardian Membership - Join Confirmation
+    Activity name of this tag: Guardian Members - Join Confirmation
     URL of the webpage where the tag is expected to be placed: http://www.tbc.com
     This tag must be placed between the <body> and </body> tags, as close as possible to the opening tag.
     Creation Date: 03/06/2015

--- a/frontend/app/views/fragments/form/submit.scala.html
+++ b/frontend/app/views/fragments/form/submit.scala.html
@@ -15,7 +15,7 @@
     <div class="fieldset__fields fieldset__fields--no-padding">
 
     @if(membershipTermsAndConditions){
-        <p class="ts-and-cs">By joining Guardian Membership, you are agreeing to our
+        <p class="ts-and-cs">By joining Guardian Members, you are agreeing to our
             <a href="@Links.membershipTerms" class="text-link" target="_blank">Terms and Conditions</a> and
             <a href="@Links.guardianPrivacyPolicy" class="text-link" target="_blank">Privacy Policy</a>.
         </p>

--- a/frontend/app/views/fragments/modal/staffChangeEmail.scala.html
+++ b/frontend/app/views/fragments/modal/staffChangeEmail.scala.html
@@ -2,7 +2,7 @@
 
 <div class="modal is-hidden js-modal js-change-email-modal" role="alertdialog" aria-describedby="dialog-description">
     <div id="dialog-description" class="modal-content">
-        <h2 class="modal-content__header">Allow Guardian Membership to change the email address on your profile</h2>
+        <h2 class="modal-content__header">Allow Guardian Members to change the email address on your profile</h2>
         <p>You will no longer be able to sign in to <strong>theguardian.com</strong> using <strong>@identityEmail</strong>.</p>
         <p>You must use <strong>@staffGoogleEmail</strong> to sign in from now.</p>
         <div class="modal-cta-container action-group">

--- a/frontend/app/views/index.scala.html
+++ b/frontend/app/views/index.scala.html
@@ -49,7 +49,7 @@
                 </p>
                 @fragments.media.videoPreview(
                     configuration.Videos.whatIsMembershipAlt,
-                    "Alan Rusbridger, Polly Toynbee, Jonathan Freedland, Owen Jones and Zoe Williams introduce Guardian Membership."
+                    "Alan Rusbridger, Polly Toynbee, Jonathan Freedland, Owen Jones and Zoe Williams introduce Guardian Members."
                 )
                 @fragments.common.jumpLink("Benefits of membership", "#why-join")
             </div>
@@ -91,7 +91,7 @@
                     @fragments.promos.panel("Exclusive content", pageImages.find(_.name.contains("exclusive"))) {
                         <p>
                             From live streams of Members’ events, member articles in our monthly Guardian supplement, to a range
-                            of offers, competitions and discounts at places we love there’s something for you in Guardian Membership.
+                            of offers, competitions and discounts at places we love there’s something for you in Guardian Members.
                         </p>
                     }
                     </li>
@@ -167,7 +167,7 @@
                                 will reopen to create a new kind of civic space.
                             </p>
                             <p>
-                                As well as being the home of Guardian Membership, the building will be a hub for
+                                As well as being the home of Guardian Members, the building will be a hub for
                                 big ideas and stimulating conversations. It will host events, activities and
                                 courses from Guardian Live and organisations we admire.
                             </p>

--- a/frontend/app/views/info/feedback.scala.html
+++ b/frontend/app/views/info/feedback.scala.html
@@ -22,7 +22,7 @@
         <section class="form-section form-section--no-padding">
             <div class="form-section__content copy">
                 <div class="form-detail">
-                    <p>Use the form below to send us your comments or suggestions on Guardian Membership. We'd like to hear it.</p>
+                    <p>Use the form below to send us your comments or suggestions on Guardian Members. We'd like to hear it.</p>
                     <p>We read all feedback carefully, but please note we cannot respond to all comments submitted.</p>
                     <p>If you’re having any problems please visit our <a href="@routes.Info.help">help section</a>.</p>
                 </div>

--- a/frontend/app/views/info/help.scala.html
+++ b/frontend/app/views/info/help.scala.html
@@ -3,7 +3,7 @@
 
 @main("Help") {
     <main role="main" class="page-content l-constrained">
-        @fragments.page.pageHeader("FAQ", Some("Common questions about Guardian Membership"))
+        @fragments.page.pageHeader("FAQ", Some("Common questions about Guardian Members"))
         <section class="page-section">
             <div class="page-section__content">
                 @fragments.faq.questions(Faq.help)

--- a/frontend/app/views/info/supporterUSA.scala.html
+++ b/frontend/app/views/info/supporterUSA.scala.html
@@ -54,7 +54,7 @@
             "Katharine Viner, editor-in-chief of the Guardian"
         ) {
             <blockquote class="blockquote blockquote--feature">
-                With Guardian Membership we have a profound opportunity to
+                With Guardian Members we have a profound opportunity to
                 defend the Guardian's independent journalism and collaborate
                 together on a better, more informed future.
                 <cite class="blockquote__citation">Katharine Viner, editor-in-chief of the Guardian</cite>

--- a/frontend/app/views/joiner/form/addressWithWelcomePack.scala.html
+++ b/frontend/app/views/joiner/form/addressWithWelcomePack.scala.html
@@ -38,7 +38,7 @@
                     @fragments.form.nameDetail(userFields.firstName, userFields.secondName)
                     @fragments.form.addressDetail(
                         heading = "Delivery address",
-                        note = "Once you've joined Guardian Membership we'll send you a welcome pack in the post.",
+                        note = "Once you've joined Guardian Members we'll send you a welcome pack in the post.",
                         formType = "deliveryAddress",
                         addressRequired = true,
                         address1 = userFields.address1,

--- a/frontend/app/views/joiner/form/payment.scala.html
+++ b/frontend/app/views/joiner/form/payment.scala.html
@@ -46,7 +46,7 @@
                         @fragments.form.nameDetail(userFields.firstName, userFields.secondName)
                         @fragments.form.addressDetail(
                             heading = "Delivery address",
-                            note = "Once you've joined Guardian Membership we'll send you a welcome pack in the post.",
+                            note = "Once you've joined Guardian Members we'll send you a welcome pack in the post.",
                             formType = "deliveryAddress",
                             addressRequired = true,
                             address1 = userFields.address1,

--- a/frontend/app/views/joiner/staff.scala.html
+++ b/frontend/app/views/joiner/staff.scala.html
@@ -36,7 +36,7 @@
         }
 
         @fragments.page.pageHeader("Guardian Staff Membership",
-            Some("All permanent Guardian staff can sign up to the Partner tier of Guardian Membership for free (equivalent to £15/month)"))
+            Some("All permanent Guardian staff can sign up to the Partner tier of Guardian Members for free (equivalent to £15/month)"))
 
         <section class="page-section page-section--bordered">
             <div class="page-section__lead-in">
@@ -92,7 +92,7 @@
                                 <li class="signpost-item">
                                     <h4 class="signpost-item__title">Option 1</h4>
                                     <p class="signpost-item__description">
-                                        Allow Guardian membership to change your Guardian Identity email address from <strong>@identityEmail</strong> to <strong>@staffEmail.googleEmail</strong
+                                        Allow Guardian Members to change your Guardian Identity email address from <strong>@identityEmail</strong> to <strong>@staffEmail.googleEmail</strong
                                     </p>
                                     <div class="signpost__cta">
                                         <form action="@routes.Joiner.updateEmailStaff" method="POST">

--- a/frontend/app/views/joiner/thankyou.scala.html
+++ b/frontend/app/views/joiner/thankyou.scala.html
@@ -28,7 +28,7 @@
         for(firstName <- member.firstName) {
             "Hello " + firstName + "<br/>"
         }
-        "Welcome to Guardian Membership"
+        "Welcome to Guardian Members"
     }
 }
 

--- a/frontend/app/views/joiner/unsupportedBrowser.scala.html
+++ b/frontend/app/views/joiner/unsupportedBrowser.scala.html
@@ -9,7 +9,7 @@
                 <div class="copy">
                     <div class="text-intro">
                         <p>
-                            To join Guardian Membership, you'll need a modern browser
+                            To join Guardian Members, you'll need a modern browser
                             that can run Javascript - without that we can't take your payment.
                             Unfortunately, it looks like you'll need to upgrade
                             your browser:

--- a/frontend/app/views/main.scala.html
+++ b/frontend/app/views/main.scala.html
@@ -37,7 +37,7 @@
             {
                 "@@context": "http://schema.org",
                 "@@type": "Organization",
-                "name": "Guardian Membership",
+                "name": "Guardian Members",
                 "url": "@(Config.membershipUrl)",
                 "logo": "@(Config.membershipUrl)@Asset.at("images/favicons/152x152.png")",
                 "sameAs" : [
@@ -80,7 +80,7 @@
         <a class="u-h skip" href="#container">Skip to main content</a>
         <noscript>
             <div class="warning-message copy hidden-print">
-                Please enable JavaScript &ndash; we use it to enhance behaviour for Guardian Membership.
+                Please enable JavaScript &ndash; we use it to enhance behaviour for Guardian Members.
                 <a href="http://www.enable-javascript.com/">Click here for instructions to do so in your browser</a>.
             </div>
         </noscript>

--- a/frontend/app/views/patterns/patterns.scala.html
+++ b/frontend/app/views/patterns/patterns.scala.html
@@ -329,7 +329,7 @@
             "Katharine Viner, editor-in-chief of the Guardian"
         ) {
             <blockquote class="blockquote blockquote--feature">
-                With Guardian Membership we have a profound opportunity to
+                With Guardian Members we have a profound opportunity to
                 defend the Guardian's independent journalism and collaborate
                 together on a better, more informed future.
                 <cite class="blockquote__citation">Katharine Viner, editor-in-chief of the Guardian</cite>

--- a/frontend/app/views/tier/cancel/confirm.scala.html
+++ b/frontend/app/views/tier/cancel/confirm.scala.html
@@ -37,7 +37,7 @@
     <main role="main" class="page-content l-constrained">
 
         @fragments.page.pageHeader("We don't like goodbyes…",
-            Some("So instead we're going to try and tempt you to stay by reminding you of all the good things you get from Guardian Membership"))
+            Some("So instead we're going to try and tempt you to stay by reminding you of all the good things you get from Guardian Members"))
 
         <div class="page-section">
             <div class="page-section__content">

--- a/frontend/app/views/tier/upgrade/freeToPaid.scala.html
+++ b/frontend/app/views/tier/upgrade/freeToPaid.scala.html
@@ -40,7 +40,7 @@
                         <h2 class="form-group__title">Address</h2>
                         @fragments.form.addressDetail(
                             "Delivery address",
-                            "Once you've joined Guardian Membership we'll send you a welcome pack in the post.",
+                            "Once you've joined Guardian Members we'll send you a welcome pack in the post.",
                             "deliveryAddress", true, userFields.address1, userFields.address2, userFields.address3,
                             userFields.postcode, userFields.address4, userFields.country
                         )

--- a/frontend/app/views/tier/upgrade/paidToPaid.scala.html
+++ b/frontend/app/views/tier/upgrade/paidToPaid.scala.html
@@ -136,7 +136,7 @@
                 @fragments.user.cardSummary(paidPreview.card)
                 <p class="text-note">
                     <strong>First payment:</strong> Your first payment of <strong>@paidPreview.totalPrice.pretty</strong>
-                    will be taken today under the name Guardian Membership.
+                    will be taken today under the name Guardian Members.
                 </p>
                 <p class="text-note">
                     <strong>Ongoing payments:</strong> Your card will be charged

--- a/frontend/app/views/welcome.scala.html
+++ b/frontend/app/views/welcome.scala.html
@@ -30,7 +30,7 @@
         @* ===== Introduction ===== *@
         <section class="block-description block-description--padded block-description--right block-description--pull">
             <p class="block-description__lead">Hello <span class="js-user-firstName"></span></p>
-            <p class="block-description__text">Welcome back to Guardian Membership</p>
+            <p class="block-description__text">Welcome back to Guardian Members</p>
         </section>
 
         @* ===== Feature panels ===== *@

--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -5,7 +5,7 @@ session.secure=true
 
 play.http.errorHandler = "monitoring.ErrorHandler"
 
-site.title="The Guardian Membership"
+site.title="The Guardian Members"
 index.title="Home Page"
 
 guardian.host="www.theguardian.com"

--- a/frontend/conf/copy.conf
+++ b/frontend/conf/copy.conf
@@ -1,11 +1,11 @@
-copy.default.title="Guardian Membership"
-copy.default.description="Guardian Membership feeds your curiosity and broadens your perspective. We introduce you to some of the world's most influential thinkers. Not only our speakers, but the community of members around you."
+copy.default.title="Guardian Members"
+copy.default.description="Guardian Members feeds your curiosity and broadens your perspective. We introduce you to some of the world's most influential thinkers. Not only our speakers, but the community of members around you."
 
-copy.join.title="Join Guardian Membership"
-copy.join.description="Guardian Membership is launching in beta. We have ambitious plans, and new features will be added regularly. Guardian Membership will grow into a vibrant, self-organising community of free-thinkers."
+copy.join.title="Join Guardian Members"
+copy.join.description="Guardian Members is launching in beta. We have ambitious plans, and new features will be added regularly. Guardian Members will grow into a vibrant, self-organising community of free-thinkers."
 
-copy.choosetier.title="Join Guardian Membership: choose your tier"
-copy.choosetier.description="Guardian Membership brings together diverse, progressive minds, journalistic skills and the best of what others create to give you a richer understanding of the world and the opportunity to shape it."
+copy.choosetier.title="Join Guardian Members: choose your tier"
+copy.choosetier.description="Guardian Members brings together diverse, progressive minds, journalistic skills and the best of what others create to give you a richer understanding of the world and the opportunity to shape it."
 
 copy.supporters.title="Supporters of the Guardian"
 copy.supporters.description="Supporters protect our editorial freedom and help us seek out those stories that people are determined to keep hidden."
@@ -19,5 +19,5 @@ copy.events.description="Guardian Live is a programme of discussions, debates, i
 copy.masterclasses.title="Guardian Masterclasses"
 copy.masterclasses.description="Guardian Masterclasses courses and workshops taught by award-winning professionals, with a 20% discount for partners and patrons."
 
-copy.about.title="About Guardian Membership"
-copy.about.description="Guardian Membership brings together diverse, progressive minds, journalistic skills and the best of what others create to give you a richer understanding of the world and the opportunity to shape it."
+copy.about.title="About Guardian Members"
+copy.about.description="Guardian Members brings together diverse, progressive minds, journalistic skills and the best of what others create to give you a richer understanding of the world and the opportunity to shape it."


### PR DESCRIPTION
As part of the redesign (see https://github.com/guardian/membership-frontend/pull/636) we are changing names. This PR replaces all instances of Guardian Membership with Guardian Members.

@afiore 