### PR TITLE
Disambiguating Zuora subscription data from Membership vs Subscriptions

### DIFF
--- a/frontend/app/controllers/TierController.scala
+++ b/frontend/app/controllers/TierController.scala
@@ -38,8 +38,8 @@ trait DowngradeTier extends ActivityTracking {
     val futureTierName = "Friend"
     for {
       subscriptionStatus <- subscriptionService.getSubscriptionStatus(request.member)
-      currentSubscription <- subscriptionService.getSubscriptionDetails(subscriptionStatus.current)
-      futureSubscription <- subscriptionService.getSubscriptionDetails(subscriptionStatus.future.get)
+      currentSubscription <- subscriptionService.getSubscriptionDetails(subscriptionStatus.currentVersion)
+      futureSubscription <- subscriptionService.getSubscriptionDetails(subscriptionStatus.futureVersionOpt.get)
     } yield Ok(views.html.tier.downgrade.summary(currentSubscription, futureSubscription, currentTier, futureTierName))
   }
 }
@@ -84,7 +84,7 @@ trait UpgradeTier {
       val subscriptionStatusFuture = subscriptionService.getSubscriptionStatus(memberRequest.member)
       for {
         subscriptionStatus <- subscriptionStatusFuture
-        currentSubscription <- subscriptionService.getSubscriptionDetails(subscriptionStatus.current)
+        currentSubscription <- subscriptionService.getSubscriptionDetails(subscriptionStatus.currentVersion)
       } yield currentSubscription
     }
 

--- a/frontend/app/controllers/User.scala
+++ b/frontend/app/controllers/User.scala
@@ -59,7 +59,7 @@ trait User extends Controller {
           "nextPaymentPrice" -> membershipSummary.nextPaymentPrice * 100,
           "nextPaymentDate" -> membershipSummary.nextPaymentDate,
           "renewalDate" -> membershipSummary.renewalDate,
-          "cancelledAt" -> subscriptionStatus.future.isDefined,
+          "cancelledAt" -> subscriptionStatus.futureIdOpt.isDefined,
           "plan" -> Json.obj(
             "name" -> subscriptionDetails.planName,
             "amount" -> subscriptionDetails.planAmount * 100,

--- a/frontend/app/controllers/User.scala
+++ b/frontend/app/controllers/User.scala
@@ -48,7 +48,7 @@ trait User extends Controller {
     val futurePaymentDetails = for {
       cardDetails <- futureCardDetails
       subscriptionStatus <- request.touchpointBackend.subscriptionService.getSubscriptionStatus(request.member)
-      subscriptionDetails <- request.touchpointBackend.subscriptionService.getSubscriptionDetails(subscriptionStatus.current)
+      subscriptionDetails <- request.touchpointBackend.subscriptionService.getSubscriptionDetails(subscriptionStatus.currentVersion)
       membershipSummary <- request.touchpointBackend.subscriptionService.getMembershipSubscriptionSummary(request.member)
     } yield
       Json.obj(
@@ -59,7 +59,7 @@ trait User extends Controller {
           "nextPaymentPrice" -> membershipSummary.nextPaymentPrice * 100,
           "nextPaymentDate" -> membershipSummary.nextPaymentDate,
           "renewalDate" -> membershipSummary.renewalDate,
-          "cancelledAt" -> subscriptionStatus.futureIdOpt.isDefined,
+          "cancelledAt" -> subscriptionStatus.futureVersionIdOpt.isDefined,
           "plan" -> Json.obj(
             "name" -> subscriptionDetails.planName,
             "amount" -> subscriptionDetails.planAmount * 100,

--- a/frontend/app/model/Zuora.scala
+++ b/frontend/app/model/Zuora.scala
@@ -55,9 +55,9 @@ object Zuora {
   }
   case class InternalError(code: String, message: String) extends Error
 
-  case class SubscriptionStatus(current: Subscription, future: Option[Subscription], amendType: Option[String]) {
-    val currentId = current.id
-    val futureIdOpt = future.map(_.id)
+  case class SubscriptionStatus(currentVersion: Subscription, futureVersionOpt: Option[Subscription], amendType: Option[String]) {
+    val currentVersionId = currentVersion.id
+    val futureVersionIdOpt = futureVersionOpt.map(_.id)
     val cancelled = amendType.contains("Cancellation")
   }
 

--- a/frontend/app/model/Zuora.scala
+++ b/frontend/app/model/Zuora.scala
@@ -55,8 +55,10 @@ object Zuora {
   }
   case class InternalError(code: String, message: String) extends Error
 
-  case class SubscriptionStatus(current: String, future: Option[String], amendType: Option[String]) {
-    val cancelled = amendType.exists(_ == "Cancellation")
+  case class SubscriptionStatus(current: Subscription, future: Option[Subscription], amendType: Option[String]) {
+    val currentId = current.id
+    val futureIdOpt = future.map(_.id)
+    val cancelled = amendType.contains("Cancellation")
   }
 
   case class SubscriptionDetails(planName: String, planAmount: Float, effectiveStartDate: DateTime,

--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -137,14 +137,12 @@ trait MemberService extends LazyLogging with ActivityTracking {
   def recordFreeEventUsage(member: Member, event: RichEvent, order: EBOrder, quantity: Int): Future[CreateResult] = {
     val tp = TouchpointBackend.forUser(member)
     for {
-      account <- tp.subscriptionService.getAccount(member)
-      subscriptions <- tp.subscriptionService.getSubscriptions(member)
+      (account, subscription) <- tp.subscriptionService.accountWithLatestMembershipSubscription(member)
       description = s"event-id:${event.id};order-id:${order.id}"
-      action = CreateFreeEventUsage(account.id, description, quantity, subscriptions.head.id)
+      action = CreateFreeEventUsage(account.id, description, quantity, subscription.id)
       result <- tp.zuoraSoapService.authenticatedRequest(action)
     } yield result
   }
-
 
   def retrieveComplimentaryTickets(member: Member, event: RichEvent): Future[Seq[EBTicketClass]] = {
     val tp = TouchpointBackend.forUser(member)

--- a/frontend/app/services/SubscriptionService.scala
+++ b/frontend/app/services/SubscriptionService.scala
@@ -24,10 +24,10 @@ case class SubscriptionServiceError(s: String) extends Throwable {
 trait AmendSubscription {
   self: SubscriptionService =>
 
-  private def checkForPendingAmendments(memberId: MemberId)(fn: String => Future[AmendResult]): Future[AmendResult] = {
+  private def checkForPendingAmendments(memberId: MemberId)(fn: SubscriptionStatus => Future[AmendResult]): Future[AmendResult] = {
     getSubscriptionStatus(memberId).flatMap { subscriptionStatus =>
-      if (subscriptionStatus.future.isEmpty) {
-        fn(subscriptionStatus.current)
+      if (subscriptionStatus.futureIdOpt.isEmpty) {
+        fn(subscriptionStatus)
       } else {
         throw SubscriptionServiceError("Cannot amend subscription, amendments are already pending")
       }
@@ -35,11 +35,12 @@ trait AmendSubscription {
   }
 
   def cancelSubscription(memberId: MemberId, instant: Boolean): Future[AmendResult] = {
-    checkForPendingAmendments(memberId) { subscriptionId =>
+    checkForPendingAmendments(memberId) { subscriptionStatus =>
+      val currentSubscriptionVersion = subscriptionStatus.current
       for {
-        subscriptionDetails <- getSubscriptionDetails(subscriptionId)
+        subscriptionDetails <- getSubscriptionDetails(currentSubscriptionVersion)
         cancelDate = if (instant) DateTime.now else subscriptionDetails.chargedThroughDate.getOrElse(DateTime.now())
-        result <- zuoraSoapService.authenticatedRequest(CancelPlan(subscriptionId, subscriptionDetails.ratePlanId, cancelDate))
+        result <- zuoraSoapService.authenticatedRequest(CancelPlan(currentSubscriptionVersion.id, subscriptionDetails.ratePlanId, cancelDate))
       } yield result
     }
   }
@@ -51,12 +52,13 @@ trait AmendSubscription {
     def effectiveFrom(subscriptionDetails: SubscriptionDetails) = subscriptionDetails.chargedThroughDate.getOrElse(subscriptionDetails.contractAcceptanceDate)
 
 
-    checkForPendingAmendments(memberId) { subscriptionId =>
+    checkForPendingAmendments(memberId) { subscriptionStatus =>
+      val currentSubscriptionVersion = subscriptionStatus.current
       for {
-        subscriptionDetails <- getSubscriptionDetails(subscriptionId)
+        subscriptionDetails <- getSubscriptionDetails(subscriptionStatus.current)
         dateToMakeDowngradeEffectiveFrom = effectiveFrom(subscriptionDetails)
 
-        result <- zuoraSoapService.authenticatedRequest(DowngradePlan(subscriptionId, subscriptionDetails.ratePlanId,
+        result <- zuoraSoapService.authenticatedRequest(DowngradePlan(currentSubscriptionVersion.id, subscriptionDetails.ratePlanId,
           tierPlanRateIds(newTierPlan), dateToMakeDowngradeEffectiveFrom))
       } yield result
     }
@@ -65,7 +67,8 @@ trait AmendSubscription {
   def upgradeSubscription(memberId: MemberId, newTierPlan: TierPlan, preview: Boolean, featureChoice: Set[FeatureChoice]): Future[AmendResult] = {
     import SubscriptionService._
 
-    checkForPendingAmendments(memberId) { subscriptionId =>
+    checkForPendingAmendments(memberId) { subscriptionStatus =>
+      val subscriptionId = subscriptionStatus.currentId
       for {
         zuoraFeatures <- zuoraSoapService.featuresSupplier.get()
         ratePlan <- zuoraSoapService.queryOne[RatePlan](s"SubscriptionId='$subscriptionId'")
@@ -88,8 +91,6 @@ object SubscriptionService {
 
   def sortSubscriptions(subscriptions: Seq[Subscription]) = subscriptions.sortBy(_.version)
 
-  def sortAccounts(accounts: Seq[Account]) = accounts.sortBy(_.createdDate)
-
   def featuresPerTier(zuoraFeatures: Seq[Feature])(tier: ProductRatePlan, choice: Set[FeatureChoice]): Seq[Feature] = {
     def byChoice(choice: Set[FeatureChoice]) =
       zuoraFeatures.filter(f => choice.map(_.zuoraCode).contains(f.code))
@@ -105,76 +106,74 @@ object SubscriptionService {
 class SubscriptionService(val tierPlanRateIds: Map[ProductRatePlan, String],
                           val zuoraSoapService: ZuoraSoapService,
                           val zuoraRestService: ZuoraRestService) extends AmendSubscription with LazyLogging {
+
   import SubscriptionService._
+  val MembershipProductType = "Membership"
 
-  def getAccount(memberId: MemberId): Future[Account] =
-    zuoraSoapService.query[Account](s"crmId='${memberId.salesforceAccountId}'").map(sortAccounts(_).last)
+  private def subscriptionVersions(subscriptionNumber: String): Future[Seq[Subscription]] = for {
+    subscriptions <- zuoraSoapService.query[Subscription](s"Name = '$subscriptionNumber'")
+  } yield subscriptions
 
-  //TODO before we do subs we need to filter by rate plans membership knows about
-  def getSubscriptions(memberId: MemberId): Future[Seq[Subscription]] = {
-    for {
-      account <- getAccount(memberId)
-      subscriptions <- zuoraSoapService.query[Subscription](s"AccountId='${account.id}'")
-    } yield subscriptions
-  }
-
-  def memberTierFeatures(memberId: MemberId): Future[Seq[Rest.Feature]] =
-    for {
-      account <- getAccount(memberId)
-      features <- zuoraRestService.productFeaturesByAccount(account.id)
-    } yield features
-
-  def getSubscription(subscriptionId: String): Future[Subscription] = zuoraSoapService.queryOne[Subscription](s"Id='$subscriptionId'")
-
-  def getSubscriptionStatus(memberId: MemberId): Future[SubscriptionStatus] = {
-    for {
-      subscriptions <- getSubscriptions(memberId)
-
-      if subscriptions.nonEmpty
-
-      where = subscriptions.map { sub => s"SubscriptionId='${sub.id}'" }.mkString(" OR ")
-      amendments <- zuoraSoapService.query[Amendment](where)
-    } yield {
-      val latestSubscriptionId = sortSubscriptions(subscriptions).last.id
-
-      sortAmendments(subscriptions, amendments)
-        .find(_.contractEffectiveDate.isAfterNow)
-        .fold(SubscriptionStatus(latestSubscriptionId, None, None)) { amendment =>
-          SubscriptionStatus(amendment.subscriptionId, Some(latestSubscriptionId), Some(amendment.amendType))
-        }
+  def accountWithLatestMembershipSubscription(member: MemberId): Future[(Account, Rest.Subscription)] = for {
+    accounts <- zuoraSoapService.query[Account](s"crmId='${member.salesforceAccountId}'")
+    accountAndSubscriptionOpts <- Future.traverse(accounts){ account =>
+      zuoraRestService.lastSubscriptionWithProductOfTypeOpt(MembershipProductType, Set(account.id)).map(account -> _)}
+  } yield {
+      accountAndSubscriptionOpts.collect { case (account, Some(subscription)) =>
+        account -> subscription
+      }.sortBy(_._2.termStartDate).lastOption.getOrElse(throw new SubscriptionServiceError(
+        s"Cannot find a membership subscription for account ids ${accounts.map(_.id)}"))
     }
-  }
 
-  def getSubscriptionDetails(subscriptionId: String): Future[SubscriptionDetails] = {
-    for {
-      subscription <- getSubscription(subscriptionId)
-      ratePlan <- zuoraSoapService.queryOne[RatePlan](s"SubscriptionId='$subscriptionId'")
-      ratePlanCharge <- zuoraSoapService.queryOne[RatePlanCharge](s"RatePlanId='${ratePlan.id}'")
-    } yield SubscriptionDetails(subscription, ratePlan, ratePlanCharge)
-  }
+  def memberTierFeatures(memberId: MemberId): Future[Seq[Rest.Feature]] = for {
+    (_, subscription) <- accountWithLatestMembershipSubscription(memberId)
+    catalog  <- zuoraRestService.productCatalogSupplier.get
+  } yield subscription
+      .latestWhiteListedRatePlan(catalog.productIdsOfType(MembershipProductType)).toSeq
+      .flatMap(_.subscriptionProductFeatures)
 
-  def getCurrentSubscriptionDetails(memberId: MemberId): Future[SubscriptionDetails] = {
-    for {
-      subscriptionStatus <- getSubscriptionStatus(memberId)
-      subscriptionDetails <- getSubscriptionDetails(subscriptionStatus.current)
-    } yield subscriptionDetails
-  }
+  /**
+   * @return the current subscription version of the user, and the future subscription version, if
+   *         they have a pending downgrade.
+   */
+  def getSubscriptionStatus(memberId: MemberId): Future[SubscriptionStatus] = for {
+    (_, subscription) <- accountWithLatestMembershipSubscription(memberId)
+    subscriptionVersions <- subscriptionVersions(subscription.subscriptionNumber)
+    where = subscriptionVersions.map { sub => s"SubscriptionId='${sub.id}'" }.mkString(" OR ")
+    amendments <- zuoraSoapService.query[Amendment](where)
+  } yield {
+      val latestSubscription = subscriptionVersions.maxBy(_.version)
+      sortAmendments(subscriptionVersions, amendments)
+        .find(_.contractEffectiveDate.isAfterNow)
+        .fold(SubscriptionStatus(latestSubscription, None, None)) { futureAmendment =>
+          logger.info(s"subscription = ${subscription.id}, latestSubscriptionId ${latestSubscription.id}")
+          val amendedSubscription = subscriptionVersions.find(_.id == futureAmendment.subscriptionId).get
+          SubscriptionStatus(amendedSubscription, Some(latestSubscription), Some(futureAmendment.amendType))
+      }
+    }
+
+  def getSubscriptionDetails(subscription: Subscription): Future[SubscriptionDetails] = for {
+    ratePlan <- zuoraSoapService.queryOne[RatePlan](s"SubscriptionId='${subscription.id}'")
+    ratePlanCharge <- zuoraSoapService.queryOne[RatePlanCharge](s"RatePlanId='${ratePlan.id}'")
+  } yield SubscriptionDetails(subscription, ratePlan, ratePlanCharge)
+
+  def getCurrentSubscriptionDetails(memberId: MemberId): Future[SubscriptionDetails] = for {
+    subscriptionStatus <- getSubscriptionStatus(memberId)
+    subscriptionDetails <- getSubscriptionDetails(subscriptionStatus.current)
+  } yield subscriptionDetails
 
   def getUsageCountWithinTerm(memberId: MemberId, unitOfMeasure: String): Future[Int] = for {
-    account <- getAccount(memberId)
-    subscription <- zuoraRestService.lastSubscriptionByAccount(account.id)
+    (_, subscription) <- accountWithLatestMembershipSubscription(memberId)
     startDate = formatDateTime(subscription.termStartDate)
     whereClause = s"StartDateTime >= '$startDate' AND SubscriptionID = '${subscription.id}' AND UOM = '$unitOfMeasure'"
     usages <- zuoraSoapService.query[Usage](whereClause)
   } yield usages.size
 
-  def createPaymentMethod(memberId: MemberId, customer: Stripe.Customer): Future[UpdateResult] = {
-    for {
-      account <- getAccount(memberId)
-      paymentMethod <- zuoraSoapService.authenticatedRequest(CreatePaymentMethod(account, customer))
-      result <- zuoraSoapService.authenticatedRequest(EnablePayment(account, paymentMethod))
-    } yield result
-  }
+  def createPaymentMethod(memberId: MemberId, customer: Stripe.Customer): Future[UpdateResult] = for {
+    (account, _) <- accountWithLatestMembershipSubscription(memberId)
+    paymentMethod <- zuoraSoapService.authenticatedRequest(CreatePaymentMethod(account, customer))
+    result <- zuoraSoapService.authenticatedRequest(EnablePayment(account, paymentMethod))
+  } yield result
 
   def createSubscription(memberId: MemberId,
                          joinData: JoinForm,
@@ -185,46 +184,44 @@ class SubscriptionService(val tierPlanRateIds: Map[ProductRatePlan, String],
       zuoraFeatures <- zuoraSoapService.featuresSupplier.get()
       features = featuresPerTier(zuoraFeatures)(joinData.plan, joinData.featureChoice)
       result <- zuoraSoapService.authenticatedRequest(Subscribe(memberId,
-                                            customerOpt,
-                                            tierPlanRateIds(joinData.plan),
-                                            joinData.name,
-                                            joinData.deliveryAddress,
-                                            paymentDelay,
-                                            casId,
-                                            features))
+                                                      customerOpt,
+                                                      tierPlanRateIds(joinData.plan),
+                                                      joinData.name,
+                                                      joinData.deliveryAddress,
+                                                      paymentDelay,
+                                                      casId,
+                                                      features))
     } yield result
 
   def getPaymentSummary(memberId: MemberId): Future[PaymentSummary] = {
     for {
       subscription <- getSubscriptionStatus(memberId)
-      invoiceItems <- zuoraSoapService.query[InvoiceItem](s"SubscriptionId='${subscription.current}'")
+      invoiceItems <- zuoraSoapService.query[InvoiceItem](s"SubscriptionId='${subscription.currentId}'")
     } yield PaymentSummary(invoiceItems)
   }
 
   def getMembershipSubscriptionSummary(memberId: MemberId): Future[MembershipSummary] = {
-
-    val latestSubF = {
-      for (subscriptions <- getSubscriptions(memberId))
-      yield sortSubscriptions(subscriptions).last
-    }
+    val latestSubF = for {
+      (_, subscription) <- accountWithLatestMembershipSubscription(memberId)
+      subscriptionVersions <- subscriptionVersions(subscription.subscriptionNumber)
+    } yield subscriptionVersions.maxBy(_.version)
 
     def hasUserBeenInvoiced(memberId: MemberId) =
       for (subscription <- latestSubF)
       yield subscription.contractAcceptanceDate.isBeforeNow
 
-    def getSummaryViaSubscriptionAmend(memberId: MemberId) = {
-      for {
-        latestSubscription <- latestSubF
-        subscriptionDetailsF = getSubscriptionDetails(latestSubscription.id)
-        result <- zuoraSoapService.authenticatedRequest(SubscriptionDetailsViaAmend(latestSubscription.id, latestSubscription.contractAcceptanceDate))
-        subscriptionDetails <- subscriptionDetailsF
-      } yield {
-        assert(result.invoiceItems.nonEmpty, "Subscription with delayed payment returning zero invoice items in SubscriptionDetailsViaAmend call")
-        val firstPreviewInvoice = result.invoiceItems.sortBy(_.serviceStartDate).head
+    def getSummaryViaSubscriptionAmend(memberId: MemberId) = for {
+      latestSubscription <- latestSubF
+      subscriptionDetailsF = getSubscriptionDetails(latestSubscription)
+      result <- zuoraSoapService.authenticatedRequest(SubscriptionDetailsViaAmend(latestSubscription.id, latestSubscription.contractAcceptanceDate))
+      subscriptionDetails <- subscriptionDetailsF
 
-        MembershipSummary(latestSubscription.termStartDate, firstPreviewInvoice.serviceEndDate, None,
-          subscriptionDetails.planAmount, firstPreviewInvoice.price, firstPreviewInvoice.serviceStartDate, firstPreviewInvoice.renewalDate )
-      }
+    } yield {
+      assert(result.invoiceItems.nonEmpty, "Subscription with delayed payment returning zero invoice items in SubscriptionDetailsViaAmend call")
+      val firstPreviewInvoice = result.invoiceItems.sortBy(_.serviceStartDate).head
+
+      MembershipSummary(latestSubscription.termStartDate, firstPreviewInvoice.serviceEndDate, None,
+        subscriptionDetails.planAmount, firstPreviewInvoice.price, firstPreviewInvoice.serviceStartDate, firstPreviewInvoice.renewalDate )
     }
 
     def getSummaryViaInvoice(memberId: MemberId) = for (paymentSummary <- getPaymentSummary(memberId)) yield {

--- a/frontend/app/services/SubscriptionService.scala
+++ b/frontend/app/services/SubscriptionService.scala
@@ -80,9 +80,36 @@ trait AmendSubscription {
 }
 
 object SubscriptionService {
+  /**
+   * A Zuora subscription may have many versions as it is amended, some of which can be in the future (ie. downgrading
+   * from a paid tier - because we don't refund that user, the downgrade is instead set to the point in the future when
+   * their paid period ends).
+   *
+   * The Zuora API does not explicitly tell you what the *current* subscription version is. You have to work it out,
+   * by looking at the 'amendments', finding the first amendment that has yet occurred. That amendment will give you the
+   * id of the subscription it modified - and THAT will be the *current* subscription version.
+   */
+  def findCurrentSubscriptionStatus(subscriptionVersions: Seq[Subscription], amendments: Seq[Amendment]): SubscriptionStatus = {
+    val firstAmendmentWhichHasNotYetOccurredOpt = // this amendment *will have modified the current subscription*
+      sortAmendments(subscriptionVersions, amendments).find(_.contractEffectiveDate.isAfterNow)
+
+    val latestSubVersion = subscriptionVersions.maxBy(_.version)
+
+    firstAmendmentWhichHasNotYetOccurredOpt.fold(SubscriptionStatus(latestSubVersion, None, None)) { amendmentOfCurrentSub =>
+      val currentSubId = amendmentOfCurrentSub.subscriptionId
+      val currentSubVersion = subscriptionVersions.find(_.id == currentSubId).get
+      SubscriptionStatus(currentSubVersion, Some(latestSubVersion), Some(amendmentOfCurrentSub.amendType))
+    }
+  }
+
+  /**
+   * @param subscriptions
+   * @param amendments which are returned by the Zurora API in an unpredictable order
+   * @return amendments which are sorted by the subscription version number they point to (the sub they amended)
+   */
   def sortAmendments(subscriptions: Seq[Subscription], amendments: Seq[Amendment]) = {
-    val versionsById = subscriptions.map { sub => (sub.id, sub.version) }.toMap
-    amendments.sortBy { amendment => versionsById(amendment.subscriptionId) }
+    val versionsNumberBySubVersionId = subscriptions.map { sub => (sub.id, sub.version) }.toMap
+    amendments.sortBy { amendment => versionsNumberBySubVersionId(amendment.subscriptionId) }
   }
 
   def sortInvoiceItems(items: Seq[InvoiceItem]) = items.sortBy(_.chargeNumber)
@@ -142,18 +169,7 @@ class SubscriptionService(val tierPlanRateIds: Map[ProductRatePlan, String],
     subscriptionVersions <- subscriptionVersions(subscription.subscriptionNumber)
     where = subscriptionVersions.map { sub => s"SubscriptionId='${sub.id}'" }.mkString(" OR ")
     amendments <- zuoraSoapService.query[Amendment](where)
-  } yield {
-      val latestSubscription = subscriptionVersions.maxBy(_.version)
-      sortAmendments(subscriptionVersions, amendments)
-        .find(_.contractEffectiveDate.isAfterNow)
-        .fold(SubscriptionStatus(latestSubscription, None, None)) { futureAmendment =>
-          if (subscription.id != latestSubscription.id) {
-            logger.error(s"current subscription id ${subscription.id} is different than latest subscription version ${latestSubscription.id}")
-          }
-          val amendedSubscription = subscriptionVersions.find(_.id == futureAmendment.subscriptionId).get
-          SubscriptionStatus(amendedSubscription, Some(latestSubscription), Some(futureAmendment.amendType))
-      }
-    }
+  } yield findCurrentSubscriptionStatus(subscriptionVersions, amendments)
 
   def getSubscriptionDetails(subscription: Subscription): Future[SubscriptionDetails] = for {
     ratePlan <- zuoraSoapService.queryOne[RatePlan](s"SubscriptionId='${subscription.id}'")

--- a/frontend/app/services/SubscriptionService.scala
+++ b/frontend/app/services/SubscriptionService.scala
@@ -133,8 +133,9 @@ class SubscriptionService(val tierPlanRateIds: Map[ProductRatePlan, String],
       .flatMap(_.subscriptionProductFeatures)
 
   /**
-   * @return the current subscription version of the user, and the future subscription version, if
-   *         they have a pending downgrade.
+   * @return the current and the future subscription version of the user if
+   *         they have a pending amendment (Currently this is the case only of downgrades, as upgrades
+   *         are effective immediately)
    */
   def getSubscriptionStatus(memberId: MemberId): Future[SubscriptionStatus] = for {
     (_, subscription) <- accountWithLatestMembershipSubscription(memberId)

--- a/frontend/app/services/zuora/Rest.scala
+++ b/frontend/app/services/zuora/Rest.scala
@@ -34,7 +34,7 @@ object Rest {
   /*
    * Zuora product catalogue entry: https://knowledgecenter.zuora.com/BC_Developers/REST_API/B_REST_API_reference/Catalog
    */
-  case class ProductCatalog(products: List[Product]) {
+  case class ProductCatalog(products: Seq[Product]) {
     def productsOfType(t: String): Seq[Product] = products.filter(_.`ProductType__c` == t)
     def productIdsOfType(t: String): Set[String] = productsOfType(t).map(_.id).toSet
   }

--- a/frontend/app/services/zuora/Rest.scala
+++ b/frontend/app/services/zuora/Rest.scala
@@ -31,6 +31,16 @@ object Rest {
   case object Cancelled extends SubscriptionStatus
   case object Expired extends SubscriptionStatus
 
+  /*
+   * Zuora product catalogue entry: https://knowledgecenter.zuora.com/BC_Developers/REST_API/B_REST_API_reference/Catalog
+   */
+  case class ProductCatalog(products: List[Product]) {
+    def productsOfType(t: String): Seq[Product] = products.filter(_.`ProductType__c` == t)
+    def productIdsOfType(t: String): Set[String] = productsOfType(t).map(_.id).toSet
+  }
+
+  case class Product(id: String, name: String, `ProductType__c`: String)
+
   case class Subscription(id: String,
                           subscriptionNumber: String,
                           accountId: String,
@@ -39,9 +49,20 @@ object Rest {
                           contractEffectiveDate: DateTime,
                           ratePlans: Seq[Rest.RatePlan],
                           status: SubscriptionStatus) {
+
     val isActive: Boolean = status == Active
+
+
+    def hasWhitelistedProduct(productIds: Set[String]): Boolean =
+      latestWhiteListedRatePlan(productIds).isDefined
+
+    def latestWhiteListedRatePlan(productIds: Set[String]): Option[RatePlan] =
+      ratePlans.find(_.isWhitelisted(productIds))
   }
 
   case class Feature(id: String, featureCode: String)
-  case class RatePlan(subscriptionProductFeatures: List[Rest.Feature])
+  case class RatePlan(id: String, productId: String, productName: String, subscriptionProductFeatures: List[Rest.Feature], ratePlanCharges: List[RatePlanCharge]) {
+    def isWhitelisted(productIds: Set[String]): Boolean = productIds.contains(productId)
+  }
+  case class RatePlanCharge(name: String, id: String)
 }

--- a/frontend/test/services/SubscriptionServiceHelpersTest.scala
+++ b/frontend/test/services/SubscriptionServiceHelpersTest.scala
@@ -19,25 +19,6 @@ class SubscriptionServiceHelpersTest extends Specification {
       sortedAmendments(1).id mustEqual "2c92c0f847cdc31e0147cf2439b76ae6"
     }
 
-    "sort subscriptions by version" in {
-      val subscriptions = subscriptionReader.read(query("model/zuora/subscriptions.xml"))
-
-      val sortedSubscriptions = SubscriptionService.sortSubscriptions(subscriptions)
-
-      sortedSubscriptions(0).id mustEqual "2c92c0f847cdc31e0147cf2111ba6173"
-      sortedSubscriptions(1).id mustEqual "2c92c0f847cdc31e0147cf24396f6ae1"
-      sortedSubscriptions(2).id mustEqual "2c92c0f847cdc31e0147cf243a166af0"
-    }
-
-    "sort accounts by created date" in {
-      val accounts = accountReader.read(query("model/zuora/accounts.xml"))
-
-      val sortedAccounts = SubscriptionService.sortAccounts(accounts)
-
-      sortedAccounts(0).id mustEqual "2c92c0f9483f301e01485efe9af6743e"
-      sortedAccounts(1).id mustEqual "2c92c0f8483f1ca401485f0168f1614c"
-    }
-
     "sort invoice items by charge number ascending" in {
       val invoiceItems = invoiceItemReader.read(query("model/zuora/invoice-result.xml"))
 

--- a/frontend/test/services/zuora/ZuoraRestResponseReadersTest.scala
+++ b/frontend/test/services/zuora/ZuoraRestResponseReadersTest.scala
@@ -19,6 +19,7 @@ class ZuoraRestResponseReadersTest extends Specification {
       }
     )
 
+
   def subscription(id: String, features: List[JsObject] = Nil): JsObject =
     Json.obj(
       "termStartDate" -> "2013-02-01",
@@ -30,7 +31,12 @@ class ZuoraRestResponseReadersTest extends Specification {
       "initialTerm" -> 12,
       "id" -> id,
       "ratePlans" -> JsArray(List(
-        Json.obj("subscriptionProductFeatures" -> features)
+        Json.obj(
+          "id" -> "Rate Plan Id",
+          "productId" -> "Product Id",
+          "productName" -> "Product Name",
+          "ratePlanCharges" -> JsArray(Nil),
+          "subscriptionProductFeatures" -> features)
       ))
     )
 
@@ -66,7 +72,7 @@ class ZuoraRestResponseReadersTest extends Specification {
                           DateTime.parse("2013-02-01"),
                           DateTime.parse("2014-02-01"),
                           DateTime.parse("2013-02-01"),
-                          Rest.RatePlan(Nil) :: Nil,
+                          Rest.RatePlan("Rate Plan Id", "Product Id", "Product Name", Nil, Nil) :: Nil,
                           Rest.Active))
     }
 


### PR DESCRIPTION
_PR description by @rtyley :_

These are some fairly intense changes to the `SubscriptionService` to ensure that it correctly disambiguates between Zuora data for Membership and for Subscriptions (now the Digital Pack 2.0 is soon to launch).

The key thing to know about Zuora data:

* **Zuora accounts** do **not** directly relate to Membership vs Subscriptions (you can not say 'this Zuora Account is a Membership Account'). A Zuora account only has to exist to provide a default payment method - so if a user is only paying with credit card, they should only have one account, but if they have both direct debit AND credit card, they will need _two_ Zuora accounts. PayPal, etc, would require a third.
* **Zuora Subscriptions** are only _loosely_ associated with Membership or Subscriptions. You could have a Zuora Subscription which had both membership.theguardian.com & subscribe.theguardian.com products on it - we don't currently create those, but there is no guarantee that they won't occur in future.
* **Zuora Products** _are_ associated with either Membership or Subscriptions. A Product might be 'Supporter' membership, or 'Digital Pack' for subscribe.theguardian.com.

So when it comes to working out which _Zuora Subscription_ you want to work with, you have to see which Products it has. If it has Membership Products, then it's a Membership subscription. The Zuora account that the subscription falls under could then be considered a 'Membership' account for some purposes - but might also include Zuora Subscriptions for subscribe.theguardian.com.

We are taking advantage of the Guardian custom field `ProductType` which already exists on Zuora Products. For Partner, Patron, Supporter, Staff Membership, this is correctly set to 'Membership'. For 'Digital Pack' the `ProductType` is 'Digital Pack' which I think may not be a good value for it - it should probably be 'Subscriptions'.

cc @tudorraul @vivekkr 

https://trello.com/c/ltEhCsjV/37-filter-non-membership-zoura-subscriptions-to-avoid-clash-with-subscribe-theguardian-com



