### PR TITLE
Post QA fixes

### DIFF
--- a/frontend/app/services/EventbriteService.scala
+++ b/frontend/app/services/EventbriteService.scala
@@ -143,7 +143,7 @@ object GuardianLiveEventService extends LiveService {
 
 object LocalEventService extends LiveService {
   val apiToken = Config.eventbriteLocalApiToken
-  val maxDiscountQuantityAvailable = 3
+  val maxDiscountQuantityAvailable = 2
   val wsMetrics = new EventbriteMetrics("Local")
 
   def mkRichEvent(event: EBEvent): Future[RichEvent] =  for { gridImageOpt <- gridImageFor(event) }

--- a/frontend/app/services/EventbriteService.scala
+++ b/frontend/app/services/EventbriteService.scala
@@ -143,7 +143,7 @@ object GuardianLiveEventService extends LiveService {
 
 object LocalEventService extends LiveService {
   val apiToken = Config.eventbriteLocalApiToken
-  val maxDiscountQuantityAvailable = 2 //TODO are these discounts correct for local?
+  val maxDiscountQuantityAvailable = 3
   val wsMetrics = new EventbriteMetrics("Local")
 
   def mkRichEvent(event: EBEvent): Future[RichEvent] =  for { gridImageOpt <- gridImageFor(event) }

--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -159,7 +159,7 @@ trait MemberService extends LazyLogging with ActivityTracking {
       usageCount <- ticketsUsed
     } yield {
       val hasComplimentaryTickets = features.map(_.featureCode).contains(FreeEventTickets.zuoraCode)
-      val allowanceNotExceeded = usageCount <= FreeEventTickets.allowance
+      val allowanceNotExceeded = usageCount < FreeEventTickets.allowance
 
       if (hasComplimentaryTickets && allowanceNotExceeded)
         event.internalTicketing.map(_.complimentaryTickets).getOrElse(Nil)


### PR DESCRIPTION
- Fixes an off-by-one error in the logic enforcing the free ticket allowance
- Sets `maxDiscountQuantityAvailable` also for local events

@rtyley is this setting appropriate for `LocalEventService`? We had to bump liveEventService to 3 in order to cater for the possibility of a user taking a combination of 2 discounted tickets and 1 free one. 
