### PR TITLE
Fix Play session-cookie config so that the cookie is marked Secure

### DIFF
--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -1,7 +1,7 @@
 # Config for the 'Vanilla' Membership site
 include "copy"
 
-session.secure=true
+play.http.session.secure=true
 
 play.http.errorHandler = "monitoring.ErrorHandler"
 


### PR DESCRIPTION
Play changed their config format with Play v2.4, and our old setting became deprecated:

https://github.com/playframework/playframework/blob/2.4.2/framework/src/play/src/main/scala/play/api/http/HttpConfiguration.scala#L128

https://www.playframework.com/documentation/2.4.x/Migration24#Configuration-changes

You can check the reference config here:

https://github.com/playframework/playframework/blob/2.4.2/framework/src/play/src/main/resources/reference.conf#L85-L91

See matching PR for Subs: https://github.com/guardian/subscriptions-frontend/pull/200
 