### PR TITLE
Fix the untruth of the `hasUserBeenInvoiced()` method

### DIFF
--- a/frontend/app/services/SubscriptionService.scala
+++ b/frontend/app/services/SubscriptionService.scala
@@ -206,7 +206,7 @@ class SubscriptionService(val tierPlanRateIds: Map[ProductRatePlan, String],
 
     def hasUserBeenInvoiced(memberId: MemberId) =
       for (subscription <- latestSubF)
-      yield subscription.contractAcceptanceDate.isAfterNow
+      yield subscription.contractAcceptanceDate.isBeforeNow
 
     def getSummaryViaSubscriptionAmend(memberId: MemberId) = {
       for {
@@ -230,7 +230,7 @@ class SubscriptionService(val tierPlanRateIds: Map[ProductRatePlan, String],
 
     for {
       userInvoiced <- hasUserBeenInvoiced(memberId)
-      summary <- if (userInvoiced) getSummaryViaSubscriptionAmend(memberId) else getSummaryViaInvoice(memberId)
+      summary <- if (userInvoiced) getSummaryViaInvoice(memberId) else getSummaryViaSubscriptionAmend(memberId)
     } yield summary
   }
 


### PR DESCRIPTION
We *want* to use a user's invoice to generate their MembershipSummary, but only if they've been invoiced (ie so long as they're not on a 6-month period offer, before 'contractAcceptance'). The `if` statement made it look like the logic was the other way around, but only because the method was misleading named with the inverse of what it actually did. The misleading naming was introduced during the free-offer-period work with commit 73d3b87e in https://github.com/guardian/membership-frontend/pull/454

We've double-checked with @jennysivapalan, who had to do all the awful 6-month-free-offer work, and we're confident that this is correct.

cc @afiore 