### PR TITLE
Redirect members to membership for SEO purposes

### DIFF
--- a/frontend/app/Global.scala
+++ b/frontend/app/Global.scala
@@ -1,11 +1,11 @@
-import filters.{AddCSPHeader, AddEC2InstanceHeader, CheckCacheHeadersFilter, Gzipper}
+import filters._
 import monitoring.SentryLogging
 import play.api.Application
 import play.api.mvc.WithFilters
 import play.filters.csrf._
 import services._
 
-object Global extends WithFilters(CheckCacheHeadersFilter, CSRFFilter(), Gzipper, AddCSPHeader, AddEC2InstanceHeader) {
+object Global extends WithFilters(RedirectMembersFilter, CheckCacheHeadersFilter, CSRFFilter(), Gzipper, AddCSPHeader, AddEC2InstanceHeader) {
   override def onStart(app: Application) {
     SentryLogging.init()
 

--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -5,6 +5,7 @@ import com.amazonaws.auth.{AWSCredentialsProviderChain, InstanceProfileCredentia
 import com.gu.googleauth.{GoogleAuthConfig, GoogleServiceAccount}
 import com.gu.identity.cookie.{PreProductionKeys, ProductionKeys}
 import com.gu.membership.salesforce.Tier
+import com.netaporter.uri.Uri
 import com.netaporter.uri.dsl._
 import com.typesafe.config.ConfigFactory
 import model.Eventbrite.EBEvent
@@ -30,6 +31,8 @@ object Config {
   val guardianHost = config.getString("guardian.host")
 
   val membershipUrl = config.getString("membership.url")
+  val membershipHost = Uri.parse(Config.membershipUrl).host.get
+
   val membershipFeedback = config.getString("membership.feedback")
 
   val idWebAppUrl = config.getString("identity.webapp.url")

--- a/frontend/app/filters/CheckCacheHeadersFilter.scala
+++ b/frontend/app/filters/CheckCacheHeadersFilter.scala
@@ -17,3 +17,7 @@ object CheckCacheHeadersFilter extends Filter {
     }
   }
 }
+
+
+
+

--- a/frontend/app/filters/RedirectMembersFilter.scala
+++ b/frontend/app/filters/RedirectMembersFilter.scala
@@ -1,7 +1,10 @@
 package filters
 
 
+import com.netaporter.uri.Uri
 import configuration.Config
+import play.api.http.Status.FOUND
+import play.api.mvc.Results.Redirect
 import play.api.mvc._
 
 import scala.concurrent.Future
@@ -9,12 +12,9 @@ import scala.concurrent.Future
 object RedirectMembersFilter extends Filter {
 
   def apply(nextFilter: RequestHeader => Future[Result])(requestHeader: RequestHeader): Future[Result] = {
-    val host: String = requestHeader.host.toLowerCase()
-    if (host.contains("members.")) {
-      Future.successful(Results.Redirect(s"${Config.membershipUrl}${requestHeader.uri}", 302));
-    }
-    else {
-      nextFilter(requestHeader);
-    }
+    if (requestHeader.host.toLowerCase.startsWith("members.")) {
+      val requestUri = Uri.parse(requestHeader.uri)
+      Future.successful(Redirect(requestUri.withScheme("https").withHost(Config.membershipHost).toString, FOUND))
+    } else nextFilter(requestHeader)
   }
 }

--- a/frontend/app/filters/RedirectMembersFilter.scala
+++ b/frontend/app/filters/RedirectMembersFilter.scala
@@ -1,0 +1,20 @@
+package filters
+
+
+import configuration.Config
+import play.api.mvc._
+
+import scala.concurrent.Future
+
+object RedirectMembersFilter extends Filter {
+
+  def apply(nextFilter: RequestHeader => Future[Result])(requestHeader: RequestHeader): Future[Result] = {
+    val host: String = requestHeader.host.toLowerCase()
+    if (host.contains("members.")) {
+      Future.successful(Results.Redirect(s"${Config.membershipUrl}${requestHeader.uri}", 302));
+    }
+    else {
+      nextFilter(requestHeader);
+    }
+  }
+}

--- a/nginx/membership.conf
+++ b/nginx/membership.conf
@@ -8,6 +8,15 @@ server {
 }
 
 server {
+    server_name members.thegulocal.com;
+
+    location / {
+        proxy_pass http://localhost:9100/;
+            proxy_set_header Host $http_host;
+    }
+}
+
+server {
     listen 443;
     server_name mem.thegulocal.com;
 
@@ -24,5 +33,25 @@ server {
     location / {
         proxy_pass http://localhost:9100/;
         proxy_set_header Host $http_host;
+    }
+}
+
+server {
+    listen 443;
+    server_name members.thegulocal.com;
+
+    ssl on;
+    ssl_certificate membership.crt;
+    ssl_certificate_key membership.key;
+
+    ssl_session_timeout 5m;
+
+    ssl_protocols SSLv2 SSLv3 TLSv1;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+    ssl_prefer_server_ciphers on;
+
+    location / {
+        proxy_pass http://localhost:9100/;
+            proxy_set_header Host $http_host;
     }
 }


### PR DESCRIPTION
As per this trello card:
https://trello.com/c/zF0Aj7Xt/61-redirect-members-theguardian-com-to-membership-theguardian-com

This is only one possible solution and if a fastly configuration change or other network level switch is preferred then happy to trash this pull request. 