### PR TITLE
Use subscription number

### DIFF
--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -139,10 +139,12 @@ trait MemberService extends LazyLogging with ActivityTracking {
     for {
       (account, subscription) <- tp.subscriptionService.accountWithLatestMembershipSubscription(member)
       description = s"event-id:${event.id};order-id:${order.id}"
-      _ = logger.info(s"Recording a complimentary event ticket usage for account ${account.id}, subscription: ${subscription.subscriptionNumber}, details: $description")
       action = CreateFreeEventUsage(account.id, description, quantity, subscription.subscriptionNumber)
       result <- tp.zuoraSoapService.authenticatedRequest(action)
-    } yield result
+    } yield {
+      logger.info(s"Recorded a complimentary event ticket usage for account ${account.id}, subscription: ${subscription.subscriptionNumber}, details: $description")
+      result
+    }
   }
 
   def retrieveComplimentaryTickets(member: Member, event: RichEvent): Future[Seq[EBTicketClass]] = {

--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -22,7 +22,7 @@ import org.joda.time.Period
 import play.api.Play.current
 import play.api.libs.concurrent.Akka
 import play.api.libs.json.Json
-import services.EventbriteService._
+import EventbriteService._
 import zuora.CreateFreeEventUsage
 import tracking._
 import utils.TestUsers.isTestUser
@@ -157,6 +157,9 @@ trait MemberService extends LazyLogging with ActivityTracking {
       } yield {
         val hasComplimentaryTickets = features.map(_.featureCode).contains(FreeEventTickets.zuoraCode)
         val allowanceNotExceeded = usageCount < FreeEventTickets.allowance
+        logger.info(
+          s"User ${member.identityId} has used $usageCount tickets" ++
+            s"(allowance not exceeded: $allowanceNotExceeded, is entitled: $hasComplimentaryTickets)")
 
         if (hasComplimentaryTickets && allowanceNotExceeded)
           event.internalTicketing.map(_.complimentaryTickets).getOrElse(Nil)

--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -23,7 +23,7 @@ import play.api.Play.current
 import play.api.libs.concurrent.Akka
 import play.api.libs.json.Json
 import services.EventbriteService._
-import _root_.services.zuora.CreateFreeEventUsage
+import zuora.CreateFreeEventUsage
 import tracking._
 import utils.TestUsers.isTestUser
 
@@ -139,7 +139,8 @@ trait MemberService extends LazyLogging with ActivityTracking {
     for {
       (account, subscription) <- tp.subscriptionService.accountWithLatestMembershipSubscription(member)
       description = s"event-id:${event.id};order-id:${order.id}"
-      action = CreateFreeEventUsage(account.id, description, quantity, subscription.id)
+      _ = logger.info(s"Recording a complimentary event ticket usage for account ${account.id}, subscription: ${subscription.subscriptionNumber}, details: $description")
+      action = CreateFreeEventUsage(account.id, description, quantity, subscription.subscriptionNumber)
       result <- tp.zuoraSoapService.authenticatedRequest(action)
     } yield result
   }

--- a/frontend/app/services/SubscriptionService.scala
+++ b/frontend/app/services/SubscriptionService.scala
@@ -184,7 +184,7 @@ class SubscriptionService(val tierPlanRateIds: Map[ProductRatePlan, String],
   def getUsageCountWithinTerm(memberId: MemberId, unitOfMeasure: String): Future[Int] = for {
     (_, subscription) <- accountWithLatestMembershipSubscription(memberId)
     startDate = formatDateTime(subscription.termStartDate)
-    whereClause = s"StartDateTime >= '$startDate' AND SubscriptionID = '${subscription.id}' AND UOM = '$unitOfMeasure'"
+    whereClause = s"StartDateTime >= '$startDate' AND SubscriptionNumber = '${subscription.subscriptionNumber}' AND UOM = '$unitOfMeasure'"
     usages <- zuoraSoapService.query[Usage](whereClause)
   } yield usages.size
 

--- a/frontend/app/services/zuora/ZuoraActions.scala
+++ b/frontend/app/services/zuora/ZuoraActions.scala
@@ -363,13 +363,13 @@ case class UpgradePlan(subscriptionId: String,
   }
 }
 
-case class CreateFreeEventUsage(accountId: String, description: String, quantity: Int, subscriptionId: String) extends ZuoraAction[CreateResult] {
+case class CreateFreeEventUsage(accountId: String, description: String, quantity: Int, subscriptionNumber: String) extends ZuoraAction[CreateResult] {
   val startDateTime = formatDateTime(DateTime.now)
   override protected val body: Elem =
       <ns1:create>
       <ns1:zObjects xsi:type="ns2:Usage">
         <ns2:AccountId>{accountId}</ns2:AccountId>
-        <ns2:SubscriptionId>{subscriptionId}</ns2:SubscriptionId>
+        <ns2:SubscriptionNumber>{subscriptionNumber}</ns2:SubscriptionNumber>
         <ns2:Quantity>{quantity}</ns2:Quantity>
         <ns2:StartDateTime>{startDateTime}</ns2:StartDateTime>
         <ns2:Description>{description}</ns2:Description>


### PR DESCRIPTION
Avoid using `SubscriptionId` in usage records. Use `SubscriptionNumber` instead.

**Note:** depends on #697 