### PR TITLE
Encode mailto links

### DIFF
--- a/frontend/app/views/fragments/social.scala.html
+++ b/frontend/app/views/fragments/social.scala.html
@@ -6,7 +6,7 @@
     <li class="social-list__item">
         <a class="social-action social-action--email"
            target="_blank"
-           href="mailto:?subject=@social.emailSubject&amp;body=@social.emailMessage"
+           href="mailto:?subject=@social.encodedEmailSubject&amp;body=@social.encodedEmailMessage"
            data-metric-trigger="click"
            data-metric-category="social"
            data-metric-action="email"

--- a/frontend/app/views/support/Social.scala
+++ b/frontend/app/views/support/Social.scala
@@ -6,6 +6,9 @@ import model.RichEvent.RichEvent
 
 case class Social(emailSubject: String, emailMessage: String, facebookUrl: String, twitterMessage: String) {
   def encode(str: String) = URLEncoder.encode(str, "UTF-8")
+  def encodeEmail(str: String) = URLEncoder.encode(str, "UTF-8").replaceAll("\\+", "%20")
+  val encodedEmailSubject = encodeEmail(emailSubject)
+  val encodedEmailMessage = encodeEmail(emailMessage)
   val encodedFacebookUrl = encode(facebookUrl)
   val encodedTwitterMessage = encode(twitterMessage)
 }


### PR DESCRIPTION
Fixes: https://trello.com/b/RmlFYzW5/membership

Mailto query parameters need to be url encoded and need to use `%20` for spaces instead of `+`

**Broken: Blank screen**
![broken-mailto](https://cloud.githubusercontent.com/assets/123386/9681746/5f570364-52f8-11e5-93e0-39ad59af9484.png)

**Fixed: Correct mailto link**
![screen shot 2015-09-04 at 11 29 09](https://cloud.githubusercontent.com/assets/123386/9681745/5f543332-52f8-11e5-9267-afcb62470a64.png)

On the back of this I've also raised a [new trello card](https://trello.com/c/0SfTvvXt/79-consider-removing-social-links-from-events-detail-pages) to consider removing social links completely as from our stats very few people actually use them to justify them.

@chrisjowen 
