### PR TITLE
npm shrinkwrap

### DIFF
--- a/frontend/npm-shrinkwrap.json
+++ b/frontend/npm-shrinkwrap.json
@@ -1,0 +1,16628 @@
+{
+  "name": "membership",
+  "dependencies": {
+    "autoprefixer-core": {
+      "version": "5.2.1",
+      "from": "autoprefixer-core@>=5.2.0 <6.0.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-5.2.1.tgz",
+      "dependencies": {
+        "browserslist": {
+          "version": "0.4.0",
+          "from": "browserslist@>=0.4.0 <0.5.0",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-0.4.0.tgz"
+        },
+        "num2fraction": {
+          "version": "1.1.0",
+          "from": "num2fraction@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.1.0.tgz"
+        },
+        "caniuse-db": {
+          "version": "1.0.30000276",
+          "from": "caniuse-db@>=1.0.30000214 <2.0.0",
+          "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000276.tgz"
+        },
+        "postcss": {
+          "version": "4.1.16",
+          "from": "postcss@>=4.1.12 <4.2.0",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.1.16.tgz",
+          "dependencies": {
+            "es6-promise": {
+              "version": "2.3.0",
+              "from": "es6-promise@>=2.3.0 <2.4.0",
+              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz"
+            },
+            "source-map": {
+              "version": "0.4.4",
+              "from": "source-map@>=0.4.2 <0.5.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                }
+              }
+            },
+            "js-base64": {
+              "version": "2.1.9",
+              "from": "js-base64@>=2.1.8 <2.2.0",
+              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
+            }
+          }
+        }
+      }
+    },
+    "bower": {
+      "version": "1.5.1",
+      "from": "bower@>=1.4.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/bower/-/bower-1.5.1.tgz",
+      "dependencies": {
+        "abbrev": {
+          "version": "1.0.7",
+          "from": "abbrev@>=1.0.5 <2.0.0",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+        },
+        "archy": {
+          "version": "1.0.0",
+          "from": "archy@1.0.0",
+          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
+        },
+        "bower-config": {
+          "version": "0.6.1",
+          "from": "bower-config@>=0.6.1 <0.7.0",
+          "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-0.6.1.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "2.0.3",
+              "from": "graceful-fs@>=2.0.0 <2.1.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+            },
+            "mout": {
+              "version": "0.9.1",
+              "from": "mout@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/mout/-/mout-0.9.1.tgz"
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "from": "optimist@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                },
+                "minimist": {
+                  "version": "0.0.10",
+                  "from": "minimist@>=0.0.1 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                }
+              }
+            },
+            "osenv": {
+              "version": "0.0.3",
+              "from": "osenv@0.0.3",
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz"
+            }
+          }
+        },
+        "bower-endpoint-parser": {
+          "version": "0.2.2",
+          "from": "bower-endpoint-parser@>=0.2.2 <0.3.0",
+          "resolved": "https://registry.npmjs.org/bower-endpoint-parser/-/bower-endpoint-parser-0.2.2.tgz"
+        },
+        "bower-json": {
+          "version": "0.4.0",
+          "from": "bower-json@>=0.4.0 <0.5.0",
+          "resolved": "https://registry.npmjs.org/bower-json/-/bower-json-0.4.0.tgz",
+          "dependencies": {
+            "deep-extend": {
+              "version": "0.2.11",
+              "from": "deep-extend@>=0.2.5 <0.3.0",
+              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+            },
+            "graceful-fs": {
+              "version": "2.0.3",
+              "from": "graceful-fs@>=2.0.0 <2.1.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+            },
+            "intersect": {
+              "version": "0.0.3",
+              "from": "intersect@>=0.0.3 <0.1.0",
+              "resolved": "https://registry.npmjs.org/intersect/-/intersect-0.0.3.tgz"
+            }
+          }
+        },
+        "bower-logger": {
+          "version": "0.2.2",
+          "from": "bower-logger@>=0.2.2 <0.3.0",
+          "resolved": "https://registry.npmjs.org/bower-logger/-/bower-logger-0.2.2.tgz"
+        },
+        "bower-registry-client": {
+          "version": "0.3.0",
+          "from": "bower-registry-client@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/bower-registry-client/-/bower-registry-client-0.3.0.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "from": "async@>=0.2.8 <0.3.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+            },
+            "graceful-fs": {
+              "version": "2.0.3",
+              "from": "graceful-fs@>=2.0.0 <2.1.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+            },
+            "lru-cache": {
+              "version": "2.3.1",
+              "from": "lru-cache@>=2.3.0 <2.4.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.3.1.tgz"
+            },
+            "request": {
+              "version": "2.51.0",
+              "from": "request@>=2.51.0 <2.52.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
+              "dependencies": {
+                "bl": {
+                  "version": "0.9.4",
+                  "from": "bl@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@>=1.0.26 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.8.0",
+                  "from": "caseless@>=0.8.0 <0.9.0",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
+                },
+                "forever-agent": {
+                  "version": "0.5.2",
+                  "from": "forever-agent@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                },
+                "form-data": {
+                  "version": "0.2.0",
+                  "from": "form-data@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.9.2",
+                      "from": "async@>=0.9.0 <0.10.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                    },
+                    "mime-types": {
+                      "version": "2.0.14",
+                      "from": "mime-types@>=2.0.3 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.12.0",
+                          "from": "mime-db@>=1.12.0 <1.13.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                },
+                "mime-types": {
+                  "version": "1.0.2",
+                  "from": "mime-types@>=1.0.1 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                },
+                "node-uuid": {
+                  "version": "1.4.3",
+                  "from": "node-uuid@>=1.4.0 <1.5.0",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                },
+                "qs": {
+                  "version": "2.3.3",
+                  "from": "qs@>=2.3.1 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.1",
+                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+                },
+                "tough-cookie": {
+                  "version": "2.0.0",
+                  "from": "tough-cookie@>=0.12.0",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
+                },
+                "http-signature": {
+                  "version": "0.10.1",
+                  "from": "http-signature@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "assert-plus@>=0.1.5 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "asn1@0.1.11",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "from": "ctype@0.5.3",
+                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.5.0",
+                  "from": "oauth-sign@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
+                },
+                "hawk": {
+                  "version": "1.1.1",
+                  "from": "hawk@1.1.1",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "0.9.1",
+                      "from": "hoek@>=0.9.0 <0.10.0",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                    },
+                    "boom": {
+                      "version": "0.4.2",
+                      "from": "boom@>=0.4.0 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "0.2.2",
+                      "from": "cryptiles@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                    },
+                    "sntp": {
+                      "version": "0.2.4",
+                      "from": "sntp@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                    }
+                  }
+                },
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "from": "aws-sign2@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                },
+                "stringstream": {
+                  "version": "0.0.4",
+                  "from": "stringstream@>=0.0.4 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                },
+                "combined-stream": {
+                  "version": "0.0.7",
+                  "from": "combined-stream@>=0.0.5 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "from": "delayed-stream@0.0.5",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "request-replay": {
+              "version": "0.2.0",
+              "from": "request-replay@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/request-replay/-/request-replay-0.2.0.tgz"
+            },
+            "rimraf": {
+              "version": "2.2.8",
+              "from": "rimraf@>=2.2.0 <2.3.0",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+            },
+            "mkdirp": {
+              "version": "0.3.5",
+              "from": "mkdirp@>=0.3.5 <0.4.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+            }
+          }
+        },
+        "cardinal": {
+          "version": "0.4.4",
+          "from": "cardinal@0.4.4",
+          "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.4.tgz",
+          "dependencies": {
+            "redeyed": {
+              "version": "0.4.4",
+              "from": "redeyed@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
+              "dependencies": {
+                "esprima": {
+                  "version": "1.0.4",
+                  "from": "esprima@>=1.0.4 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+                }
+              }
+            },
+            "ansicolors": {
+              "version": "0.2.1",
+              "from": "ansicolors@>=0.2.1 <0.3.0",
+              "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz"
+            }
+          }
+        },
+        "chalk": {
+          "version": "1.1.1",
+          "from": "chalk@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.1.0",
+              "from": "ansi-styles@>=2.1.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.0",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "from": "supports-color@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+            }
+          }
+        },
+        "chmodr": {
+          "version": "0.1.0",
+          "from": "chmodr@0.1.0",
+          "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-0.1.0.tgz"
+        },
+        "configstore": {
+          "version": "0.3.2",
+          "from": "configstore@>=0.3.2 <0.4.0",
+          "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
+          "dependencies": {
+            "js-yaml": {
+              "version": "3.4.0",
+              "from": "js-yaml@>=3.1.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.0.tgz",
+              "dependencies": {
+                "argparse": {
+                  "version": "1.0.2",
+                  "from": "argparse@>=1.0.2 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+                  "dependencies": {
+                    "lodash": {
+                      "version": "3.10.1",
+                      "from": "lodash@>=3.2.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                    },
+                    "sprintf-js": {
+                      "version": "1.0.3",
+                      "from": "sprintf-js@>=1.0.2 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                    }
+                  }
+                },
+                "esprima": {
+                  "version": "2.2.0",
+                  "from": "esprima@>=2.2.0 <2.3.0",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz"
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.1.1",
+              "from": "object-assign@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+            },
+            "osenv": {
+              "version": "0.1.3",
+              "from": "osenv@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+              "dependencies": {
+                "os-homedir": {
+                  "version": "1.0.1",
+                  "from": "os-homedir@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+                },
+                "os-tmpdir": {
+                  "version": "1.0.1",
+                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                }
+              }
+            },
+            "uuid": {
+              "version": "2.0.1",
+              "from": "uuid@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
+            },
+            "xdg-basedir": {
+              "version": "1.0.1",
+              "from": "xdg-basedir@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz"
+            }
+          }
+        },
+        "decompress-zip": {
+          "version": "0.1.0",
+          "from": "decompress-zip@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.1.0.tgz",
+          "dependencies": {
+            "binary": {
+              "version": "0.3.0",
+              "from": "binary@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+              "dependencies": {
+                "chainsaw": {
+                  "version": "0.1.0",
+                  "from": "chainsaw@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+                  "dependencies": {
+                    "traverse": {
+                      "version": "0.3.9",
+                      "from": "traverse@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz"
+                    }
+                  }
+                },
+                "buffers": {
+                  "version": "0.1.1",
+                  "from": "buffers@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
+                }
+              }
+            },
+            "mkpath": {
+              "version": "0.1.0",
+              "from": "mkpath@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz"
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "from": "readable-stream@>=1.1.8 <2.0.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "touch": {
+              "version": "0.0.3",
+              "from": "touch@0.0.3",
+              "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
+              "dependencies": {
+                "nopt": {
+                  "version": "1.0.10",
+                  "from": "nopt@>=1.0.10 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz"
+                }
+              }
+            }
+          }
+        },
+        "deep-sort-object": {
+          "version": "0.1.1",
+          "from": "deep-sort-object@>=0.1.1 <0.2.0",
+          "resolved": "https://registry.npmjs.org/deep-sort-object/-/deep-sort-object-0.1.1.tgz",
+          "dependencies": {
+            "mout": {
+              "version": "0.9.1",
+              "from": "mout@>=0.9.1 <0.10.0",
+              "resolved": "https://registry.npmjs.org/mout/-/mout-0.9.1.tgz"
+            }
+          }
+        },
+        "findup-sync": {
+          "version": "0.2.1",
+          "from": "findup-sync@>=0.2.1 <0.3.0",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "4.3.5",
+              "from": "glob@>=4.3.0 <4.4.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "2.0.10",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.2",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "fstream": {
+          "version": "1.0.7",
+          "from": "fstream@>=1.0.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.7.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <2.1.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            }
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.2",
+          "from": "fstream-ignore@>=1.0.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.2.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "minimatch": {
+              "version": "2.0.10",
+              "from": "minimatch@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.0",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "github": {
+          "version": "0.2.4",
+          "from": "github@>=0.2.3 <0.3.0",
+          "resolved": "https://registry.npmjs.org/github/-/github-0.2.4.tgz",
+          "dependencies": {
+            "mime": {
+              "version": "1.3.4",
+              "from": "mime@>=1.2.11 <2.0.0",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+            }
+          }
+        },
+        "glob": {
+          "version": "4.5.3",
+          "from": "glob@>=4.3.2 <5.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.4",
+              "from": "inflight@>=1.0.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "minimatch": {
+              "version": "2.0.10",
+              "from": "minimatch@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.0",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.2",
+              "from": "once@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "graceful-fs": {
+          "version": "3.0.8",
+          "from": "graceful-fs@>=3.0.5 <4.0.0",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+        },
+        "handlebars": {
+          "version": "2.0.0",
+          "from": "handlebars@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-2.0.0.tgz",
+          "dependencies": {
+            "optimist": {
+              "version": "0.3.7",
+              "from": "optimist@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                }
+              }
+            },
+            "uglify-js": {
+              "version": "2.3.6",
+              "from": "uglify-js@>=2.3.0 <2.4.0",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@>=0.2.6 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                },
+                "source-map": {
+                  "version": "0.1.43",
+                  "from": "source-map@>=0.1.7 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "inquirer": {
+          "version": "0.8.0",
+          "from": "inquirer@0.8.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.0.tgz",
+          "dependencies": {
+            "ansi-regex": {
+              "version": "1.1.1",
+              "from": "ansi-regex@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+            },
+            "chalk": {
+              "version": "0.5.1",
+              "from": "chalk@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "1.1.0",
+                  "from": "ansi-styles@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                },
+                "has-ansi": {
+                  "version": "0.1.0",
+                  "from": "has-ansi@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "0.2.1",
+                      "from": "ansi-regex@>=0.2.1 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "0.3.0",
+                  "from": "strip-ansi@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "0.2.1",
+                      "from": "ansi-regex@>=0.2.1 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "0.2.0",
+                  "from": "supports-color@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+                }
+              }
+            },
+            "cli-color": {
+              "version": "0.3.3",
+              "from": "cli-color@>=0.3.2 <0.4.0",
+              "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.3.tgz",
+              "dependencies": {
+                "d": {
+                  "version": "0.1.1",
+                  "from": "d@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                },
+                "es5-ext": {
+                  "version": "0.10.7",
+                  "from": "es5-ext@>=0.10.6 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
+                  "dependencies": {
+                    "es6-iterator": {
+                      "version": "0.1.3",
+                      "from": "es6-iterator@>=0.1.3 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
+                    },
+                    "es6-symbol": {
+                      "version": "2.0.1",
+                      "from": "es6-symbol@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                    }
+                  }
+                },
+                "memoizee": {
+                  "version": "0.3.9",
+                  "from": "memoizee@>=0.3.8 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.9.tgz",
+                  "dependencies": {
+                    "es6-weak-map": {
+                      "version": "0.1.4",
+                      "from": "es6-weak-map@>=0.1.4 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
+                      "dependencies": {
+                        "es6-iterator": {
+                          "version": "0.1.3",
+                          "from": "es6-iterator@>=0.1.3 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
+                        },
+                        "es6-symbol": {
+                          "version": "2.0.1",
+                          "from": "es6-symbol@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "event-emitter": {
+                      "version": "0.3.3",
+                      "from": "event-emitter@>=0.3.3 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
+                    },
+                    "lru-queue": {
+                      "version": "0.1.0",
+                      "from": "lru-queue@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz"
+                    },
+                    "next-tick": {
+                      "version": "0.2.2",
+                      "from": "next-tick@>=0.2.2 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
+                    }
+                  }
+                },
+                "timers-ext": {
+                  "version": "0.1.0",
+                  "from": "timers-ext@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
+                  "dependencies": {
+                    "next-tick": {
+                      "version": "0.2.2",
+                      "from": "next-tick@>=0.2.2 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "figures": {
+              "version": "1.3.5",
+              "from": "figures@>=1.3.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
+            },
+            "lodash": {
+              "version": "2.4.2",
+              "from": "lodash@>=2.4.1 <2.5.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+            },
+            "mute-stream": {
+              "version": "0.0.4",
+              "from": "mute-stream@0.0.4",
+              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
+            },
+            "readline2": {
+              "version": "0.1.1",
+              "from": "readline2@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+              "dependencies": {
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz"
+                }
+              }
+            },
+            "rx": {
+              "version": "2.5.3",
+              "from": "rx@>=2.2.27 <3.0.0",
+              "resolved": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz"
+            },
+            "through": {
+              "version": "2.3.8",
+              "from": "through@>=2.3.4 <2.4.0",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+            }
+          }
+        },
+        "insight": {
+          "version": "0.5.3",
+          "from": "insight@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/insight/-/insight-0.5.3.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.9.2",
+              "from": "async@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+            },
+            "lodash.debounce": {
+              "version": "3.1.1",
+              "from": "lodash.debounce@>=3.0.1 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-3.1.1.tgz",
+              "dependencies": {
+                "lodash._getnative": {
+                  "version": "3.9.1",
+                  "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.1.1",
+              "from": "object-assign@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+            },
+            "os-name": {
+              "version": "1.0.3",
+              "from": "os-name@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz",
+              "dependencies": {
+                "osx-release": {
+                  "version": "1.1.0",
+                  "from": "osx-release@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/osx-release/-/osx-release-1.1.0.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "1.2.0",
+                      "from": "minimist@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                    }
+                  }
+                },
+                "win-release": {
+                  "version": "1.0.1",
+                  "from": "win-release@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.0.1.tgz"
+                }
+              }
+            },
+            "tough-cookie": {
+              "version": "0.12.1",
+              "from": "tough-cookie@>=0.12.1 <0.13.0",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+              "dependencies": {
+                "punycode": {
+                  "version": "1.3.2",
+                  "from": "punycode@>=0.2.0",
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "is-root": {
+          "version": "1.0.0",
+          "from": "is-root@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz"
+        },
+        "junk": {
+          "version": "1.0.2",
+          "from": "junk@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/junk/-/junk-1.0.2.tgz"
+        },
+        "lockfile": {
+          "version": "1.0.1",
+          "from": "lockfile@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.1.tgz"
+        },
+        "lru-cache": {
+          "version": "2.6.5",
+          "from": "lru-cache@>=2.5.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "from": "mkdirp@0.5.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "mout": {
+          "version": "0.11.0",
+          "from": "mout@>=0.11.0 <0.12.0",
+          "resolved": "https://registry.npmjs.org/mout/-/mout-0.11.0.tgz"
+        },
+        "nopt": {
+          "version": "3.0.3",
+          "from": "nopt@>=3.0.1 <4.0.0",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz"
+        },
+        "opn": {
+          "version": "1.0.2",
+          "from": "opn@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/opn/-/opn-1.0.2.tgz"
+        },
+        "p-throttler": {
+          "version": "0.1.1",
+          "from": "p-throttler@0.1.1",
+          "resolved": "https://registry.npmjs.org/p-throttler/-/p-throttler-0.1.1.tgz",
+          "dependencies": {
+            "q": {
+              "version": "0.9.7",
+              "from": "q@>=0.9.2 <0.10.0",
+              "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
+            }
+          }
+        },
+        "promptly": {
+          "version": "0.2.0",
+          "from": "promptly@0.2.0",
+          "resolved": "https://registry.npmjs.org/promptly/-/promptly-0.2.0.tgz",
+          "dependencies": {
+            "read": {
+              "version": "1.0.6",
+              "from": "read@>=1.0.4 <1.1.0",
+              "resolved": "https://registry.npmjs.org/read/-/read-1.0.6.tgz",
+              "dependencies": {
+                "mute-stream": {
+                  "version": "0.0.5",
+                  "from": "mute-stream@>=0.0.4 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "q": {
+          "version": "1.4.1",
+          "from": "q@>=1.1.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
+        },
+        "request": {
+          "version": "2.53.0",
+          "from": "request@2.53.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
+          "dependencies": {
+            "bl": {
+              "version": "0.9.4",
+              "from": "bl@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.26 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "caseless": {
+              "version": "0.9.0",
+              "from": "caseless@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
+            },
+            "forever-agent": {
+              "version": "0.5.2",
+              "from": "forever-agent@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+            },
+            "form-data": {
+              "version": "0.2.0",
+              "from": "form-data@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.9.2",
+                  "from": "async@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                }
+              }
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+            },
+            "mime-types": {
+              "version": "2.0.14",
+              "from": "mime-types@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.12.0",
+                  "from": "mime-db@>=1.12.0 <1.13.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
+                }
+              }
+            },
+            "node-uuid": {
+              "version": "1.4.3",
+              "from": "node-uuid@>=1.4.0 <1.5.0",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+            },
+            "qs": {
+              "version": "2.3.3",
+              "from": "qs@>=2.3.1 <2.4.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+            },
+            "tunnel-agent": {
+              "version": "0.4.1",
+              "from": "tunnel-agent@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+            },
+            "tough-cookie": {
+              "version": "2.0.0",
+              "from": "tough-cookie@>=0.12.0",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
+            },
+            "http-signature": {
+              "version": "0.10.1",
+              "from": "http-signature@>=0.10.0 <0.11.0",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.1.5",
+                  "from": "assert-plus@>=0.1.5 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                },
+                "asn1": {
+                  "version": "0.1.11",
+                  "from": "asn1@0.1.11",
+                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                },
+                "ctype": {
+                  "version": "0.5.3",
+                  "from": "ctype@0.5.3",
+                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.6.0",
+              "from": "oauth-sign@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
+            },
+            "hawk": {
+              "version": "2.3.1",
+              "from": "hawk@>=2.3.0 <2.4.0",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+              "dependencies": {
+                "hoek": {
+                  "version": "2.14.0",
+                  "from": "hoek@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
+                },
+                "boom": {
+                  "version": "2.8.0",
+                  "from": "boom@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz"
+                },
+                "cryptiles": {
+                  "version": "2.0.4",
+                  "from": "cryptiles@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
+                },
+                "sntp": {
+                  "version": "1.0.9",
+                  "from": "sntp@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                }
+              }
+            },
+            "aws-sign2": {
+              "version": "0.5.0",
+              "from": "aws-sign2@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+            },
+            "stringstream": {
+              "version": "0.0.4",
+              "from": "stringstream@>=0.0.4 <0.1.0",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+            },
+            "combined-stream": {
+              "version": "0.0.7",
+              "from": "combined-stream@>=0.0.5 <0.1.0",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "0.0.5",
+                  "from": "delayed-stream@0.0.5",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                }
+              }
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "from": "isstream@>=0.1.1 <0.2.0",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+            }
+          }
+        },
+        "request-progress": {
+          "version": "0.3.1",
+          "from": "request-progress@0.3.1",
+          "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
+          "dependencies": {
+            "throttleit": {
+              "version": "0.0.2",
+              "from": "throttleit@>=0.0.2 <0.1.0",
+              "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
+            }
+          }
+        },
+        "retry": {
+          "version": "0.6.1",
+          "from": "retry@0.6.1",
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.1.tgz"
+        },
+        "rimraf": {
+          "version": "2.4.2",
+          "from": "rimraf@>=2.2.8 <3.0.0",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.2.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "5.0.14",
+              "from": "glob@>=5.0.14 <6.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "2.0.10",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.2",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "semver": {
+          "version": "5.0.1",
+          "from": "semver@>=5.0.1 <6.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.1.tgz"
+        },
+        "shell-quote": {
+          "version": "1.4.3",
+          "from": "shell-quote@>=1.4.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
+          "dependencies": {
+            "jsonify": {
+              "version": "0.0.0",
+              "from": "jsonify@>=0.0.0 <0.1.0",
+              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+            },
+            "array-filter": {
+              "version": "0.0.1",
+              "from": "array-filter@>=0.0.0 <0.1.0",
+              "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz"
+            },
+            "array-reduce": {
+              "version": "0.0.0",
+              "from": "array-reduce@>=0.0.0 <0.1.0",
+              "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz"
+            },
+            "array-map": {
+              "version": "0.0.0",
+              "from": "array-map@>=0.0.0 <0.1.0",
+              "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz"
+            }
+          }
+        },
+        "stringify-object": {
+          "version": "1.0.1",
+          "from": "stringify-object@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-1.0.1.tgz"
+        },
+        "tar-fs": {
+          "version": "1.8.1",
+          "from": "tar-fs@>=1.4.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.8.1.tgz",
+          "dependencies": {
+            "pump": {
+              "version": "1.0.0",
+              "from": "pump@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.0.tgz",
+              "dependencies": {
+                "end-of-stream": {
+                  "version": "1.1.0",
+                  "from": "end-of-stream@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz"
+                },
+                "once": {
+                  "version": "1.3.2",
+                  "from": "once@>=1.3.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "tar-stream": {
+              "version": "1.2.1",
+              "from": "tar-stream@>=1.1.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.2.1.tgz",
+              "dependencies": {
+                "bl": {
+                  "version": "1.0.0",
+                  "from": "bl@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
+                },
+                "end-of-stream": {
+                  "version": "1.1.0",
+                  "from": "end-of-stream@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                  "dependencies": {
+                    "once": {
+                      "version": "1.3.2",
+                      "from": "once@>=1.3.0 <1.4.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "2.0.2",
+                  "from": "readable-stream@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.2",
+                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.1",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.0",
+                  "from": "xtend@>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "tmp": {
+          "version": "0.0.24",
+          "from": "tmp@0.0.24",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz"
+        },
+        "update-notifier": {
+          "version": "0.3.2",
+          "from": "update-notifier@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.3.2.tgz",
+          "dependencies": {
+            "is-npm": {
+              "version": "1.0.0",
+              "from": "is-npm@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz"
+            },
+            "latest-version": {
+              "version": "1.0.1",
+              "from": "latest-version@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-1.0.1.tgz",
+              "dependencies": {
+                "package-json": {
+                  "version": "1.2.0",
+                  "from": "package-json@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/package-json/-/package-json-1.2.0.tgz",
+                  "dependencies": {
+                    "got": {
+                      "version": "3.3.1",
+                      "from": "got@>=3.2.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/got/-/got-3.3.1.tgz",
+                      "dependencies": {
+                        "duplexify": {
+                          "version": "3.4.2",
+                          "from": "duplexify@>=3.2.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
+                          "dependencies": {
+                            "end-of-stream": {
+                              "version": "1.0.0",
+                              "from": "end-of-stream@1.0.0",
+                              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                              "dependencies": {
+                                "once": {
+                                  "version": "1.3.2",
+                                  "from": "once@>=1.3.0 <1.4.0",
+                                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.1",
+                                      "from": "wrappy@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "readable-stream": {
+                              "version": "2.0.2",
+                              "from": "readable-stream@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.1",
+                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                },
+                                "isarray": {
+                                  "version": "0.0.1",
+                                  "from": "isarray@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                },
+                                "process-nextick-args": {
+                                  "version": "1.0.2",
+                                  "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                },
+                                "string_decoder": {
+                                  "version": "0.10.31",
+                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                },
+                                "util-deprecate": {
+                                  "version": "1.0.1",
+                                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "infinity-agent": {
+                          "version": "2.0.3",
+                          "from": "infinity-agent@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz"
+                        },
+                        "is-redirect": {
+                          "version": "1.0.0",
+                          "from": "is-redirect@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz"
+                        },
+                        "is-stream": {
+                          "version": "1.0.1",
+                          "from": "is-stream@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz"
+                        },
+                        "lowercase-keys": {
+                          "version": "1.0.0",
+                          "from": "lowercase-keys@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
+                        },
+                        "nested-error-stacks": {
+                          "version": "1.0.1",
+                          "from": "nested-error-stacks@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.1.tgz",
+                          "dependencies": {
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@>=2.0.1 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            }
+                          }
+                        },
+                        "object-assign": {
+                          "version": "3.0.0",
+                          "from": "object-assign@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                        },
+                        "prepend-http": {
+                          "version": "1.0.2",
+                          "from": "prepend-http@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.2.tgz"
+                        },
+                        "read-all-stream": {
+                          "version": "3.0.1",
+                          "from": "read-all-stream@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.0.1.tgz",
+                          "dependencies": {
+                            "pinkie-promise": {
+                              "version": "1.0.0",
+                              "from": "pinkie-promise@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+                              "dependencies": {
+                                "pinkie": {
+                                  "version": "1.0.0",
+                                  "from": "pinkie@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
+                                }
+                              }
+                            },
+                            "readable-stream": {
+                              "version": "2.0.2",
+                              "from": "readable-stream@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.1",
+                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                },
+                                "isarray": {
+                                  "version": "0.0.1",
+                                  "from": "isarray@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                },
+                                "process-nextick-args": {
+                                  "version": "1.0.2",
+                                  "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                },
+                                "string_decoder": {
+                                  "version": "0.10.31",
+                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                },
+                                "util-deprecate": {
+                                  "version": "1.0.1",
+                                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "timed-out": {
+                          "version": "2.0.0",
+                          "from": "timed-out@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "registry-url": {
+                      "version": "3.0.3",
+                      "from": "registry-url@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.0.3.tgz",
+                      "dependencies": {
+                        "rc": {
+                          "version": "1.1.0",
+                          "from": "rc@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.0.tgz",
+                          "dependencies": {
+                            "minimist": {
+                              "version": "1.2.0",
+                              "from": "minimist@>=1.1.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                            },
+                            "deep-extend": {
+                              "version": "0.2.11",
+                              "from": "deep-extend@>=0.2.5 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+                            },
+                            "strip-json-comments": {
+                              "version": "0.1.3",
+                              "from": "strip-json-comments@>=0.1.0 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+                            },
+                            "ini": {
+                              "version": "1.3.4",
+                              "from": "ini@>=1.3.0 <1.4.0",
+                              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "semver-diff": {
+              "version": "2.0.0",
+              "from": "semver-diff@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.0.0.tgz",
+              "dependencies": {
+                "semver": {
+                  "version": "4.3.6",
+                  "from": "semver@>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+                }
+              }
+            },
+            "string-length": {
+              "version": "1.0.1",
+              "from": "string-length@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
+              "dependencies": {
+                "strip-ansi": {
+                  "version": "3.0.0",
+                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "user-home": {
+          "version": "1.1.1",
+          "from": "user-home@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+        },
+        "which": {
+          "version": "1.1.1",
+          "from": "which@>=1.0.8 <2.0.0",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.1.1.tgz",
+          "dependencies": {
+            "is-absolute": {
+              "version": "0.1.7",
+              "from": "is-absolute@>=0.1.7 <0.2.0",
+              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+              "dependencies": {
+                "is-relative": {
+                  "version": "0.1.3",
+                  "from": "is-relative@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "grunt": {
+      "version": "0.4.5",
+      "from": "grunt@>=0.4.5 <0.5.0",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.1.22",
+          "from": "async@>=0.1.22 <0.2.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
+        },
+        "coffee-script": {
+          "version": "1.3.3",
+          "from": "coffee-script@>=1.3.3 <1.4.0",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
+        },
+        "colors": {
+          "version": "0.6.2",
+          "from": "colors@>=0.6.2 <0.7.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+        },
+        "dateformat": {
+          "version": "1.0.2-1.2.3",
+          "from": "dateformat@1.0.2-1.2.3",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz"
+        },
+        "eventemitter2": {
+          "version": "0.4.14",
+          "from": "eventemitter2@>=0.4.13 <0.5.0",
+          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
+        },
+        "findup-sync": {
+          "version": "0.1.3",
+          "from": "findup-sync@>=0.1.2 <0.2.0",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "3.2.11",
+              "from": "glob@>=3.2.9 <3.3.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "0.3.0",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.6.5",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash": {
+              "version": "2.4.2",
+              "from": "lodash@>=2.4.1 <2.5.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+            }
+          }
+        },
+        "glob": {
+          "version": "3.1.21",
+          "from": "glob@>=3.1.21 <3.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "1.2.3",
+              "from": "graceful-fs@>=1.2.0 <1.3.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+            },
+            "inherits": {
+              "version": "1.0.0",
+              "from": "inherits@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+            }
+          }
+        },
+        "hooker": {
+          "version": "0.2.3",
+          "from": "hooker@>=0.2.3 <0.3.0",
+          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
+        },
+        "iconv-lite": {
+          "version": "0.2.11",
+          "from": "iconv-lite@>=0.2.11 <0.3.0",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
+        },
+        "minimatch": {
+          "version": "0.2.14",
+          "from": "minimatch@>=0.2.12 <0.3.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.6.5",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+            },
+            "sigmund": {
+              "version": "1.0.1",
+              "from": "sigmund@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+            }
+          }
+        },
+        "nopt": {
+          "version": "1.0.10",
+          "from": "nopt@>=1.0.10 <1.1.0",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.7",
+              "from": "abbrev@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+            }
+          }
+        },
+        "rimraf": {
+          "version": "2.2.8",
+          "from": "rimraf@>=2.2.8 <2.3.0",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+        },
+        "lodash": {
+          "version": "0.9.2",
+          "from": "lodash@>=0.9.2 <0.10.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
+        },
+        "underscore.string": {
+          "version": "2.2.1",
+          "from": "underscore.string@>=2.2.1 <2.3.0",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
+        },
+        "which": {
+          "version": "1.0.9",
+          "from": "which@>=1.0.5 <1.1.0",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
+        },
+        "js-yaml": {
+          "version": "2.0.5",
+          "from": "js-yaml@>=2.0.5 <2.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+          "dependencies": {
+            "argparse": {
+              "version": "0.1.16",
+              "from": "argparse@>=0.1.11 <0.2.0",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+              "dependencies": {
+                "underscore": {
+                  "version": "1.7.0",
+                  "from": "underscore@>=1.7.0 <1.8.0",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
+                },
+                "underscore.string": {
+                  "version": "2.4.0",
+                  "from": "underscore.string@>=2.4.0 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
+                }
+              }
+            },
+            "esprima": {
+              "version": "1.0.4",
+              "from": "esprima@>=1.0.2 <1.1.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+            }
+          }
+        },
+        "exit": {
+          "version": "0.1.2",
+          "from": "exit@>=0.1.1 <0.2.0",
+          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+        },
+        "getobject": {
+          "version": "0.1.0",
+          "from": "getobject@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
+        },
+        "grunt-legacy-util": {
+          "version": "0.2.0",
+          "from": "grunt-legacy-util@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
+        },
+        "grunt-legacy-log": {
+          "version": "0.1.2",
+          "from": "grunt-legacy-log@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.2.tgz",
+          "dependencies": {
+            "grunt-legacy-log-utils": {
+              "version": "0.1.1",
+              "from": "grunt-legacy-log-utils@>=0.1.1 <0.2.0",
+              "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz"
+            },
+            "lodash": {
+              "version": "2.4.2",
+              "from": "lodash@>=2.4.1 <2.5.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+            },
+            "underscore.string": {
+              "version": "2.3.3",
+              "from": "underscore.string@>=2.3.3 <2.4.0",
+              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+            }
+          }
+        }
+      }
+    },
+    "grunt-asset-hash": {
+      "version": "0.1.6",
+      "from": "grunt-asset-hash@>=0.1.6 <0.2.0",
+      "resolved": "https://registry.npmjs.org/grunt-asset-hash/-/grunt-asset-hash-0.1.6.tgz"
+    },
+    "grunt-cli": {
+      "version": "0.1.13",
+      "from": "grunt-cli@>=0.1.13 <0.2.0",
+      "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-0.1.13.tgz",
+      "dependencies": {
+        "nopt": {
+          "version": "1.0.10",
+          "from": "nopt@>=1.0.10 <1.1.0",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.7",
+              "from": "abbrev@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+            }
+          }
+        },
+        "findup-sync": {
+          "version": "0.1.3",
+          "from": "findup-sync@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "3.2.11",
+              "from": "glob@>=3.2.9 <3.3.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "0.3.0",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.6.5",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash": {
+              "version": "2.4.2",
+              "from": "lodash@>=2.4.1 <2.5.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+            }
+          }
+        },
+        "resolve": {
+          "version": "0.3.1",
+          "from": "resolve@>=0.3.1 <0.4.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz"
+        }
+      }
+    },
+    "grunt-contrib-clean": {
+      "version": "0.6.0",
+      "from": "grunt-contrib-clean@>=0.6.0 <0.7.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-0.6.0.tgz",
+      "dependencies": {
+        "rimraf": {
+          "version": "2.2.8",
+          "from": "rimraf@>=2.2.1 <2.3.0",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+        }
+      }
+    },
+    "grunt-contrib-copy": {
+      "version": "0.8.1",
+      "from": "grunt-contrib-copy@>=0.8.0 <0.9.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-0.8.1.tgz",
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.1",
+          "from": "chalk@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.1.0",
+              "from": "ansi-styles@>=2.1.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.0",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "from": "supports-color@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+            }
+          }
+        },
+        "file-sync-cmp": {
+          "version": "0.1.1",
+          "from": "file-sync-cmp@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz"
+        }
+      }
+    },
+    "grunt-contrib-imagemin": {
+      "version": "0.9.4",
+      "from": "grunt-contrib-imagemin@>=0.9.4 <0.10.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-imagemin/-/grunt-contrib-imagemin-0.9.4.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "from": "async@>=0.9.0 <0.10.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+        },
+        "chalk": {
+          "version": "1.1.1",
+          "from": "chalk@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.1.0",
+              "from": "ansi-styles@>=2.1.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.0",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "from": "supports-color@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+            }
+          }
+        },
+        "gulp-rename": {
+          "version": "1.2.2",
+          "from": "gulp-rename@>=1.2.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz"
+        },
+        "imagemin": {
+          "version": "3.2.0",
+          "from": "imagemin@>=3.1.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/imagemin/-/imagemin-3.2.0.tgz",
+          "dependencies": {
+            "buffer-to-vinyl": {
+              "version": "1.0.1",
+              "from": "buffer-to-vinyl@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/buffer-to-vinyl/-/buffer-to-vinyl-1.0.1.tgz",
+              "dependencies": {
+                "file-type": {
+                  "version": "2.10.2",
+                  "from": "file-type@>=2.2.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/file-type/-/file-type-2.10.2.tgz",
+                  "dependencies": {
+                    "read-chunk": {
+                      "version": "1.0.1",
+                      "from": "read-chunk@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-1.0.1.tgz"
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "2.0.2",
+                  "from": "readable-stream@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.2",
+                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.1",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                    }
+                  }
+                },
+                "uuid": {
+                  "version": "2.0.1",
+                  "from": "uuid@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
+                },
+                "vinyl": {
+                  "version": "0.5.1",
+                  "from": "vinyl@>=0.5.1 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.1.tgz",
+                  "dependencies": {
+                    "clone": {
+                      "version": "1.0.2",
+                      "from": "clone@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+                    },
+                    "clone-stats": {
+                      "version": "0.0.1",
+                      "from": "clone-stats@>=0.0.1 <0.0.2",
+                      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                    },
+                    "replace-ext": {
+                      "version": "0.0.1",
+                      "from": "replace-ext@0.0.1",
+                      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "concat-stream": {
+              "version": "1.5.0",
+              "from": "concat-stream@>=1.4.6 <2.0.0",
+              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "typedarray": {
+                  "version": "0.0.6",
+                  "from": "typedarray@>=0.0.5 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                },
+                "readable-stream": {
+                  "version": "2.0.2",
+                  "from": "readable-stream@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.2",
+                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.1",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "get-stdin": {
+              "version": "4.0.1",
+              "from": "get-stdin@>=4.0.1 <5.0.0",
+              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+            },
+            "meow": {
+              "version": "3.3.0",
+              "from": "meow@>=3.1.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
+              "dependencies": {
+                "camelcase-keys": {
+                  "version": "1.0.0",
+                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.2.1",
+                      "from": "camelcase@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                    },
+                    "map-obj": {
+                      "version": "1.0.1",
+                      "from": "map-obj@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                    }
+                  }
+                },
+                "indent-string": {
+                  "version": "1.2.2",
+                  "from": "indent-string@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+                  "dependencies": {
+                    "repeating": {
+                      "version": "1.1.3",
+                      "from": "repeating@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.1",
+                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "minimist": {
+                  "version": "1.2.0",
+                  "from": "minimist@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                },
+                "object-assign": {
+                  "version": "3.0.0",
+                  "from": "object-assign@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                }
+              }
+            },
+            "optional": {
+              "version": "0.1.3",
+              "from": "optional@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/optional/-/optional-0.1.3.tgz"
+            },
+            "path-exists": {
+              "version": "1.0.0",
+              "from": "path-exists@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
+            },
+            "stream-combiner2": {
+              "version": "1.0.2",
+              "from": "stream-combiner2@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "duplexer2@>=0.0.2 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "from": "readable-stream@>=1.1.9 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "through2": {
+                  "version": "0.5.1",
+                  "from": "through2@>=0.5.1 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@>=1.0.17 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "xtend": {
+                      "version": "3.0.0",
+                      "from": "xtend@>=3.0.0 <3.1.0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "through2": {
+              "version": "0.6.5",
+              "from": "through2@>=0.6.1 <0.7.0",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.0",
+                  "from": "xtend@>=4.0.0 <4.1.0-0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                }
+              }
+            },
+            "vinyl-fs": {
+              "version": "1.0.0",
+              "from": "vinyl-fs@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-1.0.0.tgz",
+              "dependencies": {
+                "duplexify": {
+                  "version": "3.4.2",
+                  "from": "duplexify@>=3.2.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
+                  "dependencies": {
+                    "end-of-stream": {
+                      "version": "1.0.0",
+                      "from": "end-of-stream@1.0.0",
+                      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                      "dependencies": {
+                        "once": {
+                          "version": "1.3.2",
+                          "from": "once@>=1.3.0 <1.4.0",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "readable-stream": {
+                      "version": "2.0.2",
+                      "from": "readable-stream@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.2",
+                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.1",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "glob-stream": {
+                  "version": "4.1.1",
+                  "from": "glob-stream@>=4.0.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-4.1.1.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "4.5.3",
+                      "from": "glob@>=4.3.1 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "from": "inflight@>=1.0.4 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "once": {
+                          "version": "1.3.2",
+                          "from": "once@>=1.3.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "minimatch": {
+                      "version": "2.0.10",
+                      "from": "minimatch@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.0",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.2.0",
+                              "from": "balanced-match@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "ordered-read-streams": {
+                      "version": "0.1.0",
+                      "from": "ordered-read-streams@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
+                    },
+                    "glob2base": {
+                      "version": "0.0.12",
+                      "from": "glob2base@>=0.0.12 <0.0.13",
+                      "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+                      "dependencies": {
+                        "find-index": {
+                          "version": "0.1.1",
+                          "from": "find-index@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
+                        }
+                      }
+                    },
+                    "unique-stream": {
+                      "version": "2.2.0",
+                      "from": "unique-stream@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.0.tgz",
+                      "dependencies": {
+                        "through2-filter": {
+                          "version": "2.0.0",
+                          "from": "through2-filter@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
+                          "dependencies": {
+                            "through2": {
+                              "version": "2.0.0",
+                              "from": "through2@>=2.0.0 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
+                              "dependencies": {
+                                "readable-stream": {
+                                  "version": "2.0.2",
+                                  "from": "readable-stream@>=2.0.0 <2.1.0",
+                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                  "dependencies": {
+                                    "core-util-is": {
+                                      "version": "1.0.1",
+                                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@>=2.0.1 <2.1.0",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    },
+                                    "isarray": {
+                                      "version": "0.0.1",
+                                      "from": "isarray@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                    },
+                                    "process-nextick-args": {
+                                      "version": "1.0.2",
+                                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                    },
+                                    "string_decoder": {
+                                      "version": "0.10.31",
+                                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                    },
+                                    "util-deprecate": {
+                                      "version": "1.0.1",
+                                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "xtend": {
+                              "version": "4.0.0",
+                              "from": "xtend@>=4.0.0 <4.1.0",
+                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "glob-watcher": {
+                  "version": "0.0.8",
+                  "from": "glob-watcher@>=0.0.8 <0.0.9",
+                  "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.8.tgz",
+                  "dependencies": {
+                    "gaze": {
+                      "version": "0.5.1",
+                      "from": "gaze@>=0.5.1 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
+                      "dependencies": {
+                        "globule": {
+                          "version": "0.1.0",
+                          "from": "globule@>=0.1.0 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+                          "dependencies": {
+                            "lodash": {
+                              "version": "1.0.2",
+                              "from": "lodash@>=1.0.1 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
+                            },
+                            "glob": {
+                              "version": "3.1.21",
+                              "from": "glob@>=3.1.21 <3.2.0",
+                              "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                              "dependencies": {
+                                "graceful-fs": {
+                                  "version": "1.2.3",
+                                  "from": "graceful-fs@>=1.2.0 <1.3.0",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                                },
+                                "inherits": {
+                                  "version": "1.0.0",
+                                  "from": "inherits@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+                                }
+                              }
+                            },
+                            "minimatch": {
+                              "version": "0.2.14",
+                              "from": "minimatch@>=0.2.11 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                              "dependencies": {
+                                "lru-cache": {
+                                  "version": "2.6.5",
+                                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                                },
+                                "sigmund": {
+                                  "version": "1.0.1",
+                                  "from": "sigmund@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "graceful-fs": {
+                  "version": "3.0.8",
+                  "from": "graceful-fs@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+                },
+                "merge-stream": {
+                  "version": "0.1.8",
+                  "from": "merge-stream@>=0.1.7 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-0.1.8.tgz"
+                },
+                "object-assign": {
+                  "version": "2.1.1",
+                  "from": "object-assign@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+                },
+                "strip-bom": {
+                  "version": "1.0.0",
+                  "from": "strip-bom@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+                  "dependencies": {
+                    "first-chunk-stream": {
+                      "version": "1.0.0",
+                      "from": "first-chunk-stream@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
+                    },
+                    "is-utf8": {
+                      "version": "0.2.0",
+                      "from": "is-utf8@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
+                    }
+                  }
+                },
+                "vinyl": {
+                  "version": "0.4.6",
+                  "from": "vinyl@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+                  "dependencies": {
+                    "clone": {
+                      "version": "0.2.0",
+                      "from": "clone@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+                    },
+                    "clone-stats": {
+                      "version": "0.0.1",
+                      "from": "clone-stats@>=0.0.1 <0.0.2",
+                      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "imagemin-gifsicle": {
+              "version": "4.2.0",
+              "from": "imagemin-gifsicle@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/imagemin-gifsicle/-/imagemin-gifsicle-4.2.0.tgz",
+              "dependencies": {
+                "gifsicle": {
+                  "version": "3.0.1",
+                  "from": "gifsicle@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/gifsicle/-/gifsicle-3.0.1.tgz",
+                  "dependencies": {
+                    "bin-build": {
+                      "version": "2.1.2",
+                      "from": "bin-build@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/bin-build/-/bin-build-2.1.2.tgz",
+                      "dependencies": {
+                        "archive-type": {
+                          "version": "2.1.0",
+                          "from": "archive-type@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/archive-type/-/archive-type-2.1.0.tgz",
+                          "dependencies": {
+                            "file-type": {
+                              "version": "2.10.2",
+                              "from": "file-type@>=2.0.1 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/file-type/-/file-type-2.10.2.tgz"
+                            },
+                            "read-chunk": {
+                              "version": "1.0.1",
+                              "from": "read-chunk@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "decompress": {
+                          "version": "2.3.0",
+                          "from": "decompress@>=2.1.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/decompress/-/decompress-2.3.0.tgz",
+                          "dependencies": {
+                            "decompress-tar": {
+                              "version": "3.1.0",
+                              "from": "decompress-tar@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-3.1.0.tgz",
+                              "dependencies": {
+                                "is-tar": {
+                                  "version": "1.0.0",
+                                  "from": "is-tar@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-tar/-/is-tar-1.0.0.tgz"
+                                },
+                                "object-assign": {
+                                  "version": "2.1.1",
+                                  "from": "object-assign@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+                                },
+                                "strip-dirs": {
+                                  "version": "1.1.1",
+                                  "from": "strip-dirs@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                                  "dependencies": {
+                                    "is-absolute": {
+                                      "version": "0.1.7",
+                                      "from": "is-absolute@>=0.1.5 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                                      "dependencies": {
+                                        "is-relative": {
+                                          "version": "0.1.3",
+                                          "from": "is-relative@>=0.1.0 <0.2.0",
+                                          "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                                        }
+                                      }
+                                    },
+                                    "is-natural-number": {
+                                      "version": "2.0.0",
+                                      "from": "is-natural-number@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz"
+                                    },
+                                    "minimist": {
+                                      "version": "1.2.0",
+                                      "from": "minimist@>=1.1.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                                    },
+                                    "sum-up": {
+                                      "version": "1.0.2",
+                                      "from": "sum-up@>=1.0.1 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.2.tgz"
+                                    }
+                                  }
+                                },
+                                "tar-stream": {
+                                  "version": "1.2.1",
+                                  "from": "tar-stream@>=1.1.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.2.1.tgz",
+                                  "dependencies": {
+                                    "bl": {
+                                      "version": "1.0.0",
+                                      "from": "bl@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
+                                    },
+                                    "end-of-stream": {
+                                      "version": "1.1.0",
+                                      "from": "end-of-stream@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                                      "dependencies": {
+                                        "once": {
+                                          "version": "1.3.2",
+                                          "from": "once@>=1.3.0 <1.4.0",
+                                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                          "dependencies": {
+                                            "wrappy": {
+                                              "version": "1.0.1",
+                                              "from": "wrappy@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "readable-stream": {
+                                      "version": "2.0.2",
+                                      "from": "readable-stream@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                      "dependencies": {
+                                        "core-util-is": {
+                                          "version": "1.0.1",
+                                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                        },
+                                        "inherits": {
+                                          "version": "2.0.1",
+                                          "from": "inherits@>=2.0.1 <2.1.0",
+                                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        },
+                                        "isarray": {
+                                          "version": "0.0.1",
+                                          "from": "isarray@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        },
+                                        "process-nextick-args": {
+                                          "version": "1.0.2",
+                                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                        },
+                                        "string_decoder": {
+                                          "version": "0.10.31",
+                                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        },
+                                        "util-deprecate": {
+                                          "version": "1.0.1",
+                                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "xtend": {
+                                      "version": "4.0.0",
+                                      "from": "xtend@>=4.0.0 <4.1.0-0",
+                                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "vinyl": {
+                                  "version": "0.4.6",
+                                  "from": "vinyl@>=0.4.3 <0.5.0",
+                                  "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+                                  "dependencies": {
+                                    "clone": {
+                                      "version": "0.2.0",
+                                      "from": "clone@>=0.2.0 <0.3.0",
+                                      "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+                                    },
+                                    "clone-stats": {
+                                      "version": "0.0.1",
+                                      "from": "clone-stats@>=0.0.1 <0.0.2",
+                                      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "decompress-tarbz2": {
+                              "version": "3.1.0",
+                              "from": "decompress-tarbz2@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-3.1.0.tgz",
+                              "dependencies": {
+                                "is-bzip2": {
+                                  "version": "1.0.0",
+                                  "from": "is-bzip2@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-bzip2/-/is-bzip2-1.0.0.tgz"
+                                },
+                                "object-assign": {
+                                  "version": "2.1.1",
+                                  "from": "object-assign@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+                                },
+                                "seek-bzip": {
+                                  "version": "1.0.5",
+                                  "from": "seek-bzip@>=1.0.3 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
+                                  "dependencies": {
+                                    "commander": {
+                                      "version": "2.8.1",
+                                      "from": "commander@>=2.8.1 <2.9.0",
+                                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+                                      "dependencies": {
+                                        "graceful-readlink": {
+                                          "version": "1.0.1",
+                                          "from": "graceful-readlink@>=1.0.0",
+                                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "strip-dirs": {
+                                  "version": "1.1.1",
+                                  "from": "strip-dirs@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                                  "dependencies": {
+                                    "is-absolute": {
+                                      "version": "0.1.7",
+                                      "from": "is-absolute@>=0.1.5 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                                      "dependencies": {
+                                        "is-relative": {
+                                          "version": "0.1.3",
+                                          "from": "is-relative@>=0.1.0 <0.2.0",
+                                          "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                                        }
+                                      }
+                                    },
+                                    "is-natural-number": {
+                                      "version": "2.0.0",
+                                      "from": "is-natural-number@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz"
+                                    },
+                                    "minimist": {
+                                      "version": "1.2.0",
+                                      "from": "minimist@>=1.1.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                                    },
+                                    "sum-up": {
+                                      "version": "1.0.2",
+                                      "from": "sum-up@>=1.0.1 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.2.tgz"
+                                    }
+                                  }
+                                },
+                                "tar-stream": {
+                                  "version": "1.2.1",
+                                  "from": "tar-stream@>=1.1.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.2.1.tgz",
+                                  "dependencies": {
+                                    "bl": {
+                                      "version": "1.0.0",
+                                      "from": "bl@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
+                                    },
+                                    "end-of-stream": {
+                                      "version": "1.1.0",
+                                      "from": "end-of-stream@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                                      "dependencies": {
+                                        "once": {
+                                          "version": "1.3.2",
+                                          "from": "once@>=1.3.0 <1.4.0",
+                                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                          "dependencies": {
+                                            "wrappy": {
+                                              "version": "1.0.1",
+                                              "from": "wrappy@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "readable-stream": {
+                                      "version": "2.0.2",
+                                      "from": "readable-stream@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                      "dependencies": {
+                                        "core-util-is": {
+                                          "version": "1.0.1",
+                                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                        },
+                                        "inherits": {
+                                          "version": "2.0.1",
+                                          "from": "inherits@>=2.0.1 <2.1.0",
+                                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        },
+                                        "isarray": {
+                                          "version": "0.0.1",
+                                          "from": "isarray@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        },
+                                        "process-nextick-args": {
+                                          "version": "1.0.2",
+                                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                        },
+                                        "string_decoder": {
+                                          "version": "0.10.31",
+                                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        },
+                                        "util-deprecate": {
+                                          "version": "1.0.1",
+                                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "xtend": {
+                                      "version": "4.0.0",
+                                      "from": "xtend@>=4.0.0 <5.0.0",
+                                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "vinyl": {
+                                  "version": "0.4.6",
+                                  "from": "vinyl@>=0.4.3 <0.5.0",
+                                  "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+                                  "dependencies": {
+                                    "clone": {
+                                      "version": "0.2.0",
+                                      "from": "clone@>=0.2.0 <0.3.0",
+                                      "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+                                    },
+                                    "clone-stats": {
+                                      "version": "0.0.1",
+                                      "from": "clone-stats@>=0.0.1 <0.0.2",
+                                      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "decompress-targz": {
+                              "version": "3.1.0",
+                              "from": "decompress-targz@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-3.1.0.tgz",
+                              "dependencies": {
+                                "is-gzip": {
+                                  "version": "1.0.0",
+                                  "from": "is-gzip@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz"
+                                },
+                                "object-assign": {
+                                  "version": "2.1.1",
+                                  "from": "object-assign@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+                                },
+                                "strip-dirs": {
+                                  "version": "1.1.1",
+                                  "from": "strip-dirs@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                                  "dependencies": {
+                                    "is-absolute": {
+                                      "version": "0.1.7",
+                                      "from": "is-absolute@>=0.1.5 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                                      "dependencies": {
+                                        "is-relative": {
+                                          "version": "0.1.3",
+                                          "from": "is-relative@>=0.1.0 <0.2.0",
+                                          "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                                        }
+                                      }
+                                    },
+                                    "is-natural-number": {
+                                      "version": "2.0.0",
+                                      "from": "is-natural-number@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz"
+                                    },
+                                    "minimist": {
+                                      "version": "1.2.0",
+                                      "from": "minimist@>=1.1.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                                    },
+                                    "sum-up": {
+                                      "version": "1.0.2",
+                                      "from": "sum-up@>=1.0.1 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.2.tgz"
+                                    }
+                                  }
+                                },
+                                "tar-stream": {
+                                  "version": "1.2.1",
+                                  "from": "tar-stream@>=1.1.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.2.1.tgz",
+                                  "dependencies": {
+                                    "bl": {
+                                      "version": "1.0.0",
+                                      "from": "bl@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
+                                    },
+                                    "end-of-stream": {
+                                      "version": "1.1.0",
+                                      "from": "end-of-stream@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                                      "dependencies": {
+                                        "once": {
+                                          "version": "1.3.2",
+                                          "from": "once@>=1.3.0 <1.4.0",
+                                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                          "dependencies": {
+                                            "wrappy": {
+                                              "version": "1.0.1",
+                                              "from": "wrappy@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "readable-stream": {
+                                      "version": "2.0.2",
+                                      "from": "readable-stream@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                      "dependencies": {
+                                        "core-util-is": {
+                                          "version": "1.0.1",
+                                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                        },
+                                        "inherits": {
+                                          "version": "2.0.1",
+                                          "from": "inherits@>=2.0.1 <2.1.0",
+                                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        },
+                                        "isarray": {
+                                          "version": "0.0.1",
+                                          "from": "isarray@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        },
+                                        "process-nextick-args": {
+                                          "version": "1.0.2",
+                                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                        },
+                                        "string_decoder": {
+                                          "version": "0.10.31",
+                                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        },
+                                        "util-deprecate": {
+                                          "version": "1.0.1",
+                                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "xtend": {
+                                      "version": "4.0.0",
+                                      "from": "xtend@>=4.0.0 <4.1.0-0",
+                                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "vinyl": {
+                                  "version": "0.4.6",
+                                  "from": "vinyl@>=0.4.3 <0.5.0",
+                                  "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+                                  "dependencies": {
+                                    "clone": {
+                                      "version": "0.2.0",
+                                      "from": "clone@>=0.2.0 <0.3.0",
+                                      "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+                                    },
+                                    "clone-stats": {
+                                      "version": "0.0.1",
+                                      "from": "clone-stats@>=0.0.1 <0.0.2",
+                                      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "decompress-unzip": {
+                              "version": "3.3.0",
+                              "from": "decompress-unzip@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-3.3.0.tgz",
+                              "dependencies": {
+                                "is-zip": {
+                                  "version": "1.0.0",
+                                  "from": "is-zip@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-zip/-/is-zip-1.0.0.tgz"
+                                },
+                                "read-all-stream": {
+                                  "version": "3.0.1",
+                                  "from": "read-all-stream@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.0.1.tgz",
+                                  "dependencies": {
+                                    "pinkie-promise": {
+                                      "version": "1.0.0",
+                                      "from": "pinkie-promise@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+                                      "dependencies": {
+                                        "pinkie": {
+                                          "version": "1.0.0",
+                                          "from": "pinkie@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
+                                        }
+                                      }
+                                    },
+                                    "readable-stream": {
+                                      "version": "2.0.2",
+                                      "from": "readable-stream@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                      "dependencies": {
+                                        "core-util-is": {
+                                          "version": "1.0.1",
+                                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                        },
+                                        "inherits": {
+                                          "version": "2.0.1",
+                                          "from": "inherits@>=2.0.1 <2.1.0",
+                                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        },
+                                        "isarray": {
+                                          "version": "0.0.1",
+                                          "from": "isarray@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        },
+                                        "process-nextick-args": {
+                                          "version": "1.0.2",
+                                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                        },
+                                        "string_decoder": {
+                                          "version": "0.10.31",
+                                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        },
+                                        "util-deprecate": {
+                                          "version": "1.0.1",
+                                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "stat-mode": {
+                                  "version": "0.2.1",
+                                  "from": "stat-mode@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.1.tgz"
+                                },
+                                "strip-dirs": {
+                                  "version": "1.1.1",
+                                  "from": "strip-dirs@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                                  "dependencies": {
+                                    "is-absolute": {
+                                      "version": "0.1.7",
+                                      "from": "is-absolute@>=0.1.5 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                                      "dependencies": {
+                                        "is-relative": {
+                                          "version": "0.1.3",
+                                          "from": "is-relative@>=0.1.0 <0.2.0",
+                                          "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                                        }
+                                      }
+                                    },
+                                    "is-natural-number": {
+                                      "version": "2.0.0",
+                                      "from": "is-natural-number@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz"
+                                    },
+                                    "minimist": {
+                                      "version": "1.2.0",
+                                      "from": "minimist@>=1.1.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                                    },
+                                    "sum-up": {
+                                      "version": "1.0.2",
+                                      "from": "sum-up@>=1.0.1 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.2.tgz"
+                                    }
+                                  }
+                                },
+                                "through2": {
+                                  "version": "2.0.0",
+                                  "from": "through2@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
+                                  "dependencies": {
+                                    "readable-stream": {
+                                      "version": "2.0.2",
+                                      "from": "readable-stream@>=2.0.0 <2.1.0",
+                                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                      "dependencies": {
+                                        "core-util-is": {
+                                          "version": "1.0.1",
+                                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                        },
+                                        "inherits": {
+                                          "version": "2.0.1",
+                                          "from": "inherits@>=2.0.1 <2.1.0",
+                                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        },
+                                        "isarray": {
+                                          "version": "0.0.1",
+                                          "from": "isarray@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        },
+                                        "process-nextick-args": {
+                                          "version": "1.0.2",
+                                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                        },
+                                        "string_decoder": {
+                                          "version": "0.10.31",
+                                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        },
+                                        "util-deprecate": {
+                                          "version": "1.0.1",
+                                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "xtend": {
+                                      "version": "4.0.0",
+                                      "from": "xtend@>=4.0.0 <4.1.0-0",
+                                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "vinyl": {
+                                  "version": "0.5.1",
+                                  "from": "vinyl@>=0.5.0 <0.6.0",
+                                  "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.1.tgz",
+                                  "dependencies": {
+                                    "clone": {
+                                      "version": "1.0.2",
+                                      "from": "clone@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+                                    },
+                                    "clone-stats": {
+                                      "version": "0.0.1",
+                                      "from": "clone-stats@>=0.0.1 <0.0.2",
+                                      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                                    },
+                                    "replace-ext": {
+                                      "version": "0.0.1",
+                                      "from": "replace-ext@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "yauzl": {
+                                  "version": "2.3.1",
+                                  "from": "yauzl@>=2.2.1 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.3.1.tgz",
+                                  "dependencies": {
+                                    "fd-slicer": {
+                                      "version": "1.0.1",
+                                      "from": "fd-slicer@>=1.0.1 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz"
+                                    },
+                                    "pend": {
+                                      "version": "1.2.0",
+                                      "from": "pend@>=1.2.0 <1.3.0",
+                                      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "vinyl-assign": {
+                              "version": "1.2.0",
+                              "from": "vinyl-assign@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/vinyl-assign/-/vinyl-assign-1.2.0.tgz",
+                              "dependencies": {
+                                "object-assign": {
+                                  "version": "3.0.0",
+                                  "from": "object-assign@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                                },
+                                "readable-stream": {
+                                  "version": "2.0.2",
+                                  "from": "readable-stream@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                  "dependencies": {
+                                    "core-util-is": {
+                                      "version": "1.0.1",
+                                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@>=2.0.1 <2.1.0",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    },
+                                    "isarray": {
+                                      "version": "0.0.1",
+                                      "from": "isarray@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                    },
+                                    "process-nextick-args": {
+                                      "version": "1.0.2",
+                                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                    },
+                                    "string_decoder": {
+                                      "version": "0.10.31",
+                                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                    },
+                                    "util-deprecate": {
+                                      "version": "1.0.1",
+                                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "download": {
+                          "version": "4.2.0",
+                          "from": "download@>=4.0.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/download/-/download-4.2.0.tgz",
+                          "dependencies": {
+                            "caw": {
+                              "version": "1.1.0",
+                              "from": "caw@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/caw/-/caw-1.1.0.tgz",
+                              "dependencies": {
+                                "get-proxy": {
+                                  "version": "1.0.1",
+                                  "from": "get-proxy@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-1.0.1.tgz",
+                                  "dependencies": {
+                                    "rc": {
+                                      "version": "0.5.5",
+                                      "from": "rc@>=0.5.5 <0.6.0",
+                                      "resolved": "https://registry.npmjs.org/rc/-/rc-0.5.5.tgz",
+                                      "dependencies": {
+                                        "minimist": {
+                                          "version": "0.0.10",
+                                          "from": "minimist@>=0.0.7 <0.1.0",
+                                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                                        },
+                                        "deep-extend": {
+                                          "version": "0.2.11",
+                                          "from": "deep-extend@>=0.2.5 <0.3.0",
+                                          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+                                        },
+                                        "strip-json-comments": {
+                                          "version": "0.1.3",
+                                          "from": "strip-json-comments@>=0.1.0 <0.2.0",
+                                          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+                                        },
+                                        "ini": {
+                                          "version": "1.3.4",
+                                          "from": "ini@>=1.3.0 <1.4.0",
+                                          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "is-obj": {
+                                  "version": "1.0.0",
+                                  "from": "is-obj@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.0.tgz"
+                                },
+                                "object-assign": {
+                                  "version": "3.0.0",
+                                  "from": "object-assign@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                                },
+                                "tunnel-agent": {
+                                  "version": "0.4.1",
+                                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+                                }
+                              }
+                            },
+                            "each-async": {
+                              "version": "1.1.1",
+                              "from": "each-async@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
+                              "dependencies": {
+                                "onetime": {
+                                  "version": "1.0.0",
+                                  "from": "onetime@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz"
+                                },
+                                "set-immediate-shim": {
+                                  "version": "1.0.1",
+                                  "from": "set-immediate-shim@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "filenamify": {
+                              "version": "1.2.0",
+                              "from": "filenamify@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.0.tgz",
+                              "dependencies": {
+                                "filename-reserved-regex": {
+                                  "version": "1.0.0",
+                                  "from": "filename-reserved-regex@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz"
+                                },
+                                "strip-outer": {
+                                  "version": "1.0.0",
+                                  "from": "strip-outer@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.0.tgz",
+                                  "dependencies": {
+                                    "escape-string-regexp": {
+                                      "version": "1.0.3",
+                                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                    }
+                                  }
+                                },
+                                "trim-repeated": {
+                                  "version": "1.0.0",
+                                  "from": "trim-repeated@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+                                  "dependencies": {
+                                    "escape-string-regexp": {
+                                      "version": "1.0.3",
+                                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "got": {
+                              "version": "2.9.2",
+                              "from": "got@>=2.3.2 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/got/-/got-2.9.2.tgz",
+                              "dependencies": {
+                                "duplexify": {
+                                  "version": "3.4.2",
+                                  "from": "duplexify@>=3.2.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
+                                  "dependencies": {
+                                    "end-of-stream": {
+                                      "version": "1.0.0",
+                                      "from": "end-of-stream@1.0.0",
+                                      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                                      "dependencies": {
+                                        "once": {
+                                          "version": "1.3.2",
+                                          "from": "once@>=1.3.0 <1.4.0",
+                                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                          "dependencies": {
+                                            "wrappy": {
+                                              "version": "1.0.1",
+                                              "from": "wrappy@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "readable-stream": {
+                                      "version": "2.0.2",
+                                      "from": "readable-stream@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                      "dependencies": {
+                                        "core-util-is": {
+                                          "version": "1.0.1",
+                                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                        },
+                                        "inherits": {
+                                          "version": "2.0.1",
+                                          "from": "inherits@>=2.0.1 <2.1.0",
+                                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        },
+                                        "isarray": {
+                                          "version": "0.0.1",
+                                          "from": "isarray@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        },
+                                        "process-nextick-args": {
+                                          "version": "1.0.2",
+                                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                        },
+                                        "string_decoder": {
+                                          "version": "0.10.31",
+                                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        },
+                                        "util-deprecate": {
+                                          "version": "1.0.1",
+                                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "infinity-agent": {
+                                  "version": "2.0.3",
+                                  "from": "infinity-agent@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz"
+                                },
+                                "is-stream": {
+                                  "version": "1.0.1",
+                                  "from": "is-stream@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz"
+                                },
+                                "lowercase-keys": {
+                                  "version": "1.0.0",
+                                  "from": "lowercase-keys@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
+                                },
+                                "nested-error-stacks": {
+                                  "version": "1.0.1",
+                                  "from": "nested-error-stacks@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.1.tgz",
+                                  "dependencies": {
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "prepend-http": {
+                                  "version": "1.0.2",
+                                  "from": "prepend-http@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.2.tgz"
+                                },
+                                "read-all-stream": {
+                                  "version": "2.2.0",
+                                  "from": "read-all-stream@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-2.2.0.tgz",
+                                  "dependencies": {
+                                    "readable-stream": {
+                                      "version": "2.0.2",
+                                      "from": "readable-stream@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                      "dependencies": {
+                                        "core-util-is": {
+                                          "version": "1.0.1",
+                                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                        },
+                                        "inherits": {
+                                          "version": "2.0.1",
+                                          "from": "inherits@>=2.0.1 <2.1.0",
+                                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        },
+                                        "isarray": {
+                                          "version": "0.0.1",
+                                          "from": "isarray@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        },
+                                        "process-nextick-args": {
+                                          "version": "1.0.2",
+                                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                        },
+                                        "string_decoder": {
+                                          "version": "0.10.31",
+                                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        },
+                                        "util-deprecate": {
+                                          "version": "1.0.1",
+                                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "statuses": {
+                                  "version": "1.2.1",
+                                  "from": "statuses@>=1.2.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+                                },
+                                "timed-out": {
+                                  "version": "2.0.0",
+                                  "from": "timed-out@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "gulp-decompress": {
+                              "version": "1.1.0",
+                              "from": "gulp-decompress@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/gulp-decompress/-/gulp-decompress-1.1.0.tgz",
+                              "dependencies": {
+                                "archive-type": {
+                                  "version": "3.0.1",
+                                  "from": "archive-type@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/archive-type/-/archive-type-3.0.1.tgz",
+                                  "dependencies": {
+                                    "file-type": {
+                                      "version": "2.10.2",
+                                      "from": "file-type@>=2.0.1 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/file-type/-/file-type-2.10.2.tgz",
+                                      "dependencies": {
+                                        "read-chunk": {
+                                          "version": "1.0.1",
+                                          "from": "read-chunk@>=1.0.1 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-1.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "gulp-util": {
+                                  "version": "3.0.6",
+                                  "from": "gulp-util@>=3.0.1 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.6.tgz",
+                                  "dependencies": {
+                                    "array-differ": {
+                                      "version": "1.0.0",
+                                      "from": "array-differ@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
+                                    },
+                                    "array-uniq": {
+                                      "version": "1.0.2",
+                                      "from": "array-uniq@>=1.0.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+                                    },
+                                    "beeper": {
+                                      "version": "1.1.0",
+                                      "from": "beeper@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
+                                    },
+                                    "dateformat": {
+                                      "version": "1.0.11",
+                                      "from": "dateformat@>=1.0.11 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz"
+                                    },
+                                    "lodash._reescape": {
+                                      "version": "3.0.0",
+                                      "from": "lodash._reescape@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+                                    },
+                                    "lodash._reevaluate": {
+                                      "version": "3.0.0",
+                                      "from": "lodash._reevaluate@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+                                    },
+                                    "lodash._reinterpolate": {
+                                      "version": "3.0.0",
+                                      "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+                                    },
+                                    "lodash.template": {
+                                      "version": "3.6.2",
+                                      "from": "lodash.template@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+                                      "dependencies": {
+                                        "lodash._basecopy": {
+                                          "version": "3.0.1",
+                                          "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                                        },
+                                        "lodash._basetostring": {
+                                          "version": "3.0.1",
+                                          "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                                        },
+                                        "lodash._basevalues": {
+                                          "version": "3.0.0",
+                                          "from": "lodash._basevalues@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+                                        },
+                                        "lodash._isiterateecall": {
+                                          "version": "3.0.9",
+                                          "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                                        },
+                                        "lodash.escape": {
+                                          "version": "3.0.0",
+                                          "from": "lodash.escape@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+                                        },
+                                        "lodash.keys": {
+                                          "version": "3.1.2",
+                                          "from": "lodash.keys@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                                          "dependencies": {
+                                            "lodash._getnative": {
+                                              "version": "3.9.1",
+                                              "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                                              "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                                            },
+                                            "lodash.isarguments": {
+                                              "version": "3.0.4",
+                                              "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                                              "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                                            },
+                                            "lodash.isarray": {
+                                              "version": "3.0.4",
+                                              "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                                              "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                                            }
+                                          }
+                                        },
+                                        "lodash.restparam": {
+                                          "version": "3.6.1",
+                                          "from": "lodash.restparam@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                                        },
+                                        "lodash.templatesettings": {
+                                          "version": "3.1.0",
+                                          "from": "lodash.templatesettings@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+                                        }
+                                      }
+                                    },
+                                    "minimist": {
+                                      "version": "1.2.0",
+                                      "from": "minimist@>=1.1.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                                    },
+                                    "multipipe": {
+                                      "version": "0.1.2",
+                                      "from": "multipipe@>=0.1.2 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+                                      "dependencies": {
+                                        "duplexer2": {
+                                          "version": "0.0.2",
+                                          "from": "duplexer2@0.0.2",
+                                          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                                          "dependencies": {
+                                            "readable-stream": {
+                                              "version": "1.1.13",
+                                              "from": "readable-stream@>=1.1.9 <1.2.0",
+                                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                                              "dependencies": {
+                                                "core-util-is": {
+                                                  "version": "1.0.1",
+                                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                                },
+                                                "isarray": {
+                                                  "version": "0.0.1",
+                                                  "from": "isarray@0.0.1",
+                                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                                },
+                                                "string_decoder": {
+                                                  "version": "0.10.31",
+                                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                                },
+                                                "inherits": {
+                                                  "version": "2.0.1",
+                                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "object-assign": {
+                                      "version": "3.0.0",
+                                      "from": "object-assign@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                                    },
+                                    "replace-ext": {
+                                      "version": "0.0.1",
+                                      "from": "replace-ext@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+                                    },
+                                    "vinyl": {
+                                      "version": "0.5.1",
+                                      "from": "vinyl@>=0.5.0 <0.6.0",
+                                      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.1.tgz",
+                                      "dependencies": {
+                                        "clone": {
+                                          "version": "1.0.2",
+                                          "from": "clone@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+                                        },
+                                        "clone-stats": {
+                                          "version": "0.0.1",
+                                          "from": "clone-stats@>=0.0.1 <0.0.2",
+                                          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "is-url": {
+                              "version": "1.2.1",
+                              "from": "is-url@>=1.2.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.1.tgz"
+                            },
+                            "object-assign": {
+                              "version": "2.1.1",
+                              "from": "object-assign@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+                            },
+                            "read-all-stream": {
+                              "version": "3.0.1",
+                              "from": "read-all-stream@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.0.1.tgz",
+                              "dependencies": {
+                                "pinkie-promise": {
+                                  "version": "1.0.0",
+                                  "from": "pinkie-promise@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+                                  "dependencies": {
+                                    "pinkie": {
+                                      "version": "1.0.0",
+                                      "from": "pinkie@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "readable-stream": {
+                                  "version": "2.0.2",
+                                  "from": "readable-stream@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                  "dependencies": {
+                                    "core-util-is": {
+                                      "version": "1.0.1",
+                                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@>=2.0.1 <2.1.0",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    },
+                                    "isarray": {
+                                      "version": "0.0.1",
+                                      "from": "isarray@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                    },
+                                    "process-nextick-args": {
+                                      "version": "1.0.2",
+                                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                    },
+                                    "string_decoder": {
+                                      "version": "0.10.31",
+                                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                    },
+                                    "util-deprecate": {
+                                      "version": "1.0.1",
+                                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "through2": {
+                              "version": "2.0.0",
+                              "from": "through2@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
+                              "dependencies": {
+                                "readable-stream": {
+                                  "version": "2.0.2",
+                                  "from": "readable-stream@>=2.0.0 <2.1.0",
+                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                  "dependencies": {
+                                    "core-util-is": {
+                                      "version": "1.0.1",
+                                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@>=2.0.1 <2.1.0",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    },
+                                    "isarray": {
+                                      "version": "0.0.1",
+                                      "from": "isarray@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                    },
+                                    "process-nextick-args": {
+                                      "version": "1.0.2",
+                                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                    },
+                                    "string_decoder": {
+                                      "version": "0.10.31",
+                                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                    },
+                                    "util-deprecate": {
+                                      "version": "1.0.1",
+                                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "xtend": {
+                                  "version": "4.0.0",
+                                  "from": "xtend@>=4.0.0 <4.1.0",
+                                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                }
+                              }
+                            },
+                            "vinyl": {
+                              "version": "0.4.6",
+                              "from": "vinyl@>=0.4.3 <0.5.0",
+                              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+                              "dependencies": {
+                                "clone": {
+                                  "version": "0.2.0",
+                                  "from": "clone@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+                                },
+                                "clone-stats": {
+                                  "version": "0.0.1",
+                                  "from": "clone-stats@>=0.0.1 <0.0.2",
+                                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                                }
+                              }
+                            },
+                            "ware": {
+                              "version": "1.3.0",
+                              "from": "ware@>=1.2.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
+                              "dependencies": {
+                                "wrap-fn": {
+                                  "version": "0.1.4",
+                                  "from": "wrap-fn@>=0.1.0 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.4.tgz",
+                                  "dependencies": {
+                                    "co": {
+                                      "version": "3.1.0",
+                                      "from": "co@3.1.0",
+                                      "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "exec-series": {
+                          "version": "1.0.2",
+                          "from": "exec-series@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/exec-series/-/exec-series-1.0.2.tgz",
+                          "dependencies": {
+                            "async-each-series": {
+                              "version": "1.0.0",
+                              "from": "async-each-series@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "rimraf": {
+                          "version": "2.4.2",
+                          "from": "rimraf@>=2.2.6 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.2.tgz",
+                          "dependencies": {
+                            "glob": {
+                              "version": "5.0.14",
+                              "from": "glob@>=5.0.14 <6.0.0",
+                              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
+                              "dependencies": {
+                                "inflight": {
+                                  "version": "1.0.4",
+                                  "from": "inflight@>=1.0.4 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.1",
+                                      "from": "wrappy@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                },
+                                "minimatch": {
+                                  "version": "2.0.10",
+                                  "from": "minimatch@>=2.0.1 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                                  "dependencies": {
+                                    "brace-expansion": {
+                                      "version": "1.1.0",
+                                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                                      "dependencies": {
+                                        "balanced-match": {
+                                          "version": "0.2.0",
+                                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                                        },
+                                        "concat-map": {
+                                          "version": "0.0.1",
+                                          "from": "concat-map@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "once": {
+                                  "version": "1.3.2",
+                                  "from": "once@>=1.3.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.1",
+                                      "from": "wrappy@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "path-is-absolute": {
+                                  "version": "1.0.0",
+                                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "tempfile": {
+                          "version": "1.1.1",
+                          "from": "tempfile@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz",
+                          "dependencies": {
+                            "os-tmpdir": {
+                              "version": "1.0.1",
+                              "from": "os-tmpdir@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                            },
+                            "uuid": {
+                              "version": "2.0.1",
+                              "from": "uuid@>=2.0.1 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
+                            }
+                          }
+                        },
+                        "url-regex": {
+                          "version": "2.1.3",
+                          "from": "url-regex@>=2.0.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/url-regex/-/url-regex-2.1.3.tgz",
+                          "dependencies": {
+                            "ip-regex": {
+                              "version": "1.0.3",
+                              "from": "ip-regex@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-1.0.3.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "bin-wrapper": {
+                      "version": "3.0.2",
+                      "from": "bin-wrapper@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/bin-wrapper/-/bin-wrapper-3.0.2.tgz",
+                      "dependencies": {
+                        "bin-check": {
+                          "version": "2.0.0",
+                          "from": "bin-check@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/bin-check/-/bin-check-2.0.0.tgz",
+                          "dependencies": {
+                            "executable": {
+                              "version": "1.1.0",
+                              "from": "executable@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/executable/-/executable-1.1.0.tgz"
+                            }
+                          }
+                        },
+                        "bin-version-check": {
+                          "version": "2.1.0",
+                          "from": "bin-version-check@>=2.1.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-2.1.0.tgz",
+                          "dependencies": {
+                            "bin-version": {
+                              "version": "1.0.4",
+                              "from": "bin-version@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/bin-version/-/bin-version-1.0.4.tgz",
+                              "dependencies": {
+                                "find-versions": {
+                                  "version": "1.1.3",
+                                  "from": "find-versions@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-1.1.3.tgz",
+                                  "dependencies": {
+                                    "array-uniq": {
+                                      "version": "1.0.2",
+                                      "from": "array-uniq@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+                                    },
+                                    "semver-regex": {
+                                      "version": "1.0.0",
+                                      "from": "semver-regex@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-1.0.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "minimist": {
+                              "version": "1.2.0",
+                              "from": "minimist@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                            },
+                            "semver": {
+                              "version": "4.3.6",
+                              "from": "semver@>=4.0.3 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+                            },
+                            "semver-truncate": {
+                              "version": "1.0.0",
+                              "from": "semver-truncate@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "download": {
+                          "version": "4.2.0",
+                          "from": "download@>=4.0.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/download/-/download-4.2.0.tgz",
+                          "dependencies": {
+                            "caw": {
+                              "version": "1.1.0",
+                              "from": "caw@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/caw/-/caw-1.1.0.tgz",
+                              "dependencies": {
+                                "get-proxy": {
+                                  "version": "1.0.1",
+                                  "from": "get-proxy@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-1.0.1.tgz",
+                                  "dependencies": {
+                                    "rc": {
+                                      "version": "0.5.5",
+                                      "from": "rc@>=0.5.5 <0.6.0",
+                                      "resolved": "https://registry.npmjs.org/rc/-/rc-0.5.5.tgz",
+                                      "dependencies": {
+                                        "minimist": {
+                                          "version": "0.0.10",
+                                          "from": "minimist@>=0.0.7 <0.1.0",
+                                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                                        },
+                                        "deep-extend": {
+                                          "version": "0.2.11",
+                                          "from": "deep-extend@>=0.2.5 <0.3.0",
+                                          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+                                        },
+                                        "strip-json-comments": {
+                                          "version": "0.1.3",
+                                          "from": "strip-json-comments@>=0.1.0 <0.2.0",
+                                          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+                                        },
+                                        "ini": {
+                                          "version": "1.3.4",
+                                          "from": "ini@>=1.3.0 <1.4.0",
+                                          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "is-obj": {
+                                  "version": "1.0.0",
+                                  "from": "is-obj@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.0.tgz"
+                                },
+                                "object-assign": {
+                                  "version": "3.0.0",
+                                  "from": "object-assign@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                                },
+                                "tunnel-agent": {
+                                  "version": "0.4.1",
+                                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+                                }
+                              }
+                            },
+                            "filenamify": {
+                              "version": "1.2.0",
+                              "from": "filenamify@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.0.tgz",
+                              "dependencies": {
+                                "filename-reserved-regex": {
+                                  "version": "1.0.0",
+                                  "from": "filename-reserved-regex@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz"
+                                },
+                                "strip-outer": {
+                                  "version": "1.0.0",
+                                  "from": "strip-outer@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.0.tgz",
+                                  "dependencies": {
+                                    "escape-string-regexp": {
+                                      "version": "1.0.3",
+                                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                    }
+                                  }
+                                },
+                                "trim-repeated": {
+                                  "version": "1.0.0",
+                                  "from": "trim-repeated@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+                                  "dependencies": {
+                                    "escape-string-regexp": {
+                                      "version": "1.0.3",
+                                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "got": {
+                              "version": "2.9.2",
+                              "from": "got@>=2.3.2 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/got/-/got-2.9.2.tgz",
+                              "dependencies": {
+                                "duplexify": {
+                                  "version": "3.4.2",
+                                  "from": "duplexify@>=3.2.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
+                                  "dependencies": {
+                                    "end-of-stream": {
+                                      "version": "1.0.0",
+                                      "from": "end-of-stream@1.0.0",
+                                      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                                      "dependencies": {
+                                        "once": {
+                                          "version": "1.3.2",
+                                          "from": "once@>=1.3.0 <1.4.0",
+                                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                          "dependencies": {
+                                            "wrappy": {
+                                              "version": "1.0.1",
+                                              "from": "wrappy@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "readable-stream": {
+                                      "version": "2.0.2",
+                                      "from": "readable-stream@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                      "dependencies": {
+                                        "core-util-is": {
+                                          "version": "1.0.1",
+                                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                        },
+                                        "inherits": {
+                                          "version": "2.0.1",
+                                          "from": "inherits@>=2.0.1 <2.1.0",
+                                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        },
+                                        "isarray": {
+                                          "version": "0.0.1",
+                                          "from": "isarray@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        },
+                                        "process-nextick-args": {
+                                          "version": "1.0.2",
+                                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                        },
+                                        "string_decoder": {
+                                          "version": "0.10.31",
+                                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        },
+                                        "util-deprecate": {
+                                          "version": "1.0.1",
+                                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "infinity-agent": {
+                                  "version": "2.0.3",
+                                  "from": "infinity-agent@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz"
+                                },
+                                "is-stream": {
+                                  "version": "1.0.1",
+                                  "from": "is-stream@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz"
+                                },
+                                "lowercase-keys": {
+                                  "version": "1.0.0",
+                                  "from": "lowercase-keys@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
+                                },
+                                "nested-error-stacks": {
+                                  "version": "1.0.1",
+                                  "from": "nested-error-stacks@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.1.tgz",
+                                  "dependencies": {
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "prepend-http": {
+                                  "version": "1.0.2",
+                                  "from": "prepend-http@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.2.tgz"
+                                },
+                                "read-all-stream": {
+                                  "version": "2.2.0",
+                                  "from": "read-all-stream@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-2.2.0.tgz",
+                                  "dependencies": {
+                                    "readable-stream": {
+                                      "version": "2.0.2",
+                                      "from": "readable-stream@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                      "dependencies": {
+                                        "core-util-is": {
+                                          "version": "1.0.1",
+                                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                        },
+                                        "inherits": {
+                                          "version": "2.0.1",
+                                          "from": "inherits@>=2.0.1 <2.1.0",
+                                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        },
+                                        "isarray": {
+                                          "version": "0.0.1",
+                                          "from": "isarray@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        },
+                                        "process-nextick-args": {
+                                          "version": "1.0.2",
+                                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                        },
+                                        "string_decoder": {
+                                          "version": "0.10.31",
+                                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        },
+                                        "util-deprecate": {
+                                          "version": "1.0.1",
+                                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "statuses": {
+                                  "version": "1.2.1",
+                                  "from": "statuses@>=1.2.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+                                },
+                                "timed-out": {
+                                  "version": "2.0.0",
+                                  "from": "timed-out@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "gulp-decompress": {
+                              "version": "1.1.0",
+                              "from": "gulp-decompress@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/gulp-decompress/-/gulp-decompress-1.1.0.tgz",
+                              "dependencies": {
+                                "archive-type": {
+                                  "version": "3.0.1",
+                                  "from": "archive-type@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/archive-type/-/archive-type-3.0.1.tgz",
+                                  "dependencies": {
+                                    "file-type": {
+                                      "version": "2.10.2",
+                                      "from": "file-type@>=2.0.1 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/file-type/-/file-type-2.10.2.tgz",
+                                      "dependencies": {
+                                        "read-chunk": {
+                                          "version": "1.0.1",
+                                          "from": "read-chunk@>=1.0.1 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-1.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "decompress": {
+                                  "version": "2.3.0",
+                                  "from": "decompress@>=2.1.1 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/decompress/-/decompress-2.3.0.tgz",
+                                  "dependencies": {
+                                    "decompress-tar": {
+                                      "version": "3.1.0",
+                                      "from": "decompress-tar@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-3.1.0.tgz",
+                                      "dependencies": {
+                                        "is-tar": {
+                                          "version": "1.0.0",
+                                          "from": "is-tar@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/is-tar/-/is-tar-1.0.0.tgz"
+                                        },
+                                        "strip-dirs": {
+                                          "version": "1.1.1",
+                                          "from": "strip-dirs@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                                          "dependencies": {
+                                            "is-absolute": {
+                                              "version": "0.1.7",
+                                              "from": "is-absolute@>=0.1.5 <0.2.0",
+                                              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                                              "dependencies": {
+                                                "is-relative": {
+                                                  "version": "0.1.3",
+                                                  "from": "is-relative@>=0.1.0 <0.2.0",
+                                                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                                                }
+                                              }
+                                            },
+                                            "is-natural-number": {
+                                              "version": "2.0.0",
+                                              "from": "is-natural-number@>=2.0.0 <3.0.0",
+                                              "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz"
+                                            },
+                                            "minimist": {
+                                              "version": "1.2.0",
+                                              "from": "minimist@>=1.1.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                                            },
+                                            "sum-up": {
+                                              "version": "1.0.2",
+                                              "from": "sum-up@>=1.0.1 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.2.tgz"
+                                            }
+                                          }
+                                        },
+                                        "tar-stream": {
+                                          "version": "1.2.1",
+                                          "from": "tar-stream@>=1.1.1 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.2.1.tgz",
+                                          "dependencies": {
+                                            "bl": {
+                                              "version": "1.0.0",
+                                              "from": "bl@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
+                                            },
+                                            "end-of-stream": {
+                                              "version": "1.1.0",
+                                              "from": "end-of-stream@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                                              "dependencies": {
+                                                "once": {
+                                                  "version": "1.3.2",
+                                                  "from": "once@>=1.3.0 <2.0.0",
+                                                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                                  "dependencies": {
+                                                    "wrappy": {
+                                                      "version": "1.0.1",
+                                                      "from": "wrappy@>=1.0.0 <2.0.0",
+                                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "readable-stream": {
+                                              "version": "2.0.2",
+                                              "from": "readable-stream@>=2.0.0 <3.0.0",
+                                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                              "dependencies": {
+                                                "core-util-is": {
+                                                  "version": "1.0.1",
+                                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                                },
+                                                "inherits": {
+                                                  "version": "2.0.1",
+                                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                                },
+                                                "isarray": {
+                                                  "version": "0.0.1",
+                                                  "from": "isarray@0.0.1",
+                                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                                },
+                                                "process-nextick-args": {
+                                                  "version": "1.0.2",
+                                                  "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                                },
+                                                "string_decoder": {
+                                                  "version": "0.10.31",
+                                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                                },
+                                                "util-deprecate": {
+                                                  "version": "1.0.1",
+                                                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                                }
+                                              }
+                                            },
+                                            "xtend": {
+                                              "version": "4.0.0",
+                                              "from": "xtend@>=4.0.0 <5.0.0",
+                                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                            }
+                                          }
+                                        },
+                                        "through2": {
+                                          "version": "0.6.5",
+                                          "from": "through2@>=0.6.1 <0.7.0",
+                                          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                                          "dependencies": {
+                                            "readable-stream": {
+                                              "version": "1.0.33",
+                                              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                                              "dependencies": {
+                                                "core-util-is": {
+                                                  "version": "1.0.1",
+                                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                                },
+                                                "isarray": {
+                                                  "version": "0.0.1",
+                                                  "from": "isarray@0.0.1",
+                                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                                },
+                                                "string_decoder": {
+                                                  "version": "0.10.31",
+                                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                                },
+                                                "inherits": {
+                                                  "version": "2.0.1",
+                                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                                }
+                                              }
+                                            },
+                                            "xtend": {
+                                              "version": "4.0.0",
+                                              "from": "xtend@>=4.0.0 <4.1.0-0",
+                                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "decompress-tarbz2": {
+                                      "version": "3.1.0",
+                                      "from": "decompress-tarbz2@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-3.1.0.tgz",
+                                      "dependencies": {
+                                        "is-bzip2": {
+                                          "version": "1.0.0",
+                                          "from": "is-bzip2@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/is-bzip2/-/is-bzip2-1.0.0.tgz"
+                                        },
+                                        "seek-bzip": {
+                                          "version": "1.0.5",
+                                          "from": "seek-bzip@>=1.0.3 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
+                                          "dependencies": {
+                                            "commander": {
+                                              "version": "2.8.1",
+                                              "from": "commander@>=2.8.1 <2.9.0",
+                                              "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+                                              "dependencies": {
+                                                "graceful-readlink": {
+                                                  "version": "1.0.1",
+                                                  "from": "graceful-readlink@>=1.0.0",
+                                                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "strip-dirs": {
+                                          "version": "1.1.1",
+                                          "from": "strip-dirs@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                                          "dependencies": {
+                                            "is-absolute": {
+                                              "version": "0.1.7",
+                                              "from": "is-absolute@>=0.1.5 <0.2.0",
+                                              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                                              "dependencies": {
+                                                "is-relative": {
+                                                  "version": "0.1.3",
+                                                  "from": "is-relative@>=0.1.0 <0.2.0",
+                                                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                                                }
+                                              }
+                                            },
+                                            "is-natural-number": {
+                                              "version": "2.0.0",
+                                              "from": "is-natural-number@>=2.0.0 <3.0.0",
+                                              "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz"
+                                            },
+                                            "minimist": {
+                                              "version": "1.2.0",
+                                              "from": "minimist@>=1.1.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                                            },
+                                            "sum-up": {
+                                              "version": "1.0.2",
+                                              "from": "sum-up@>=1.0.1 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.2.tgz"
+                                            }
+                                          }
+                                        },
+                                        "tar-stream": {
+                                          "version": "1.2.1",
+                                          "from": "tar-stream@>=1.1.1 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.2.1.tgz",
+                                          "dependencies": {
+                                            "bl": {
+                                              "version": "1.0.0",
+                                              "from": "bl@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
+                                            },
+                                            "end-of-stream": {
+                                              "version": "1.1.0",
+                                              "from": "end-of-stream@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                                              "dependencies": {
+                                                "once": {
+                                                  "version": "1.3.2",
+                                                  "from": "once@>=1.3.0 <2.0.0",
+                                                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                                  "dependencies": {
+                                                    "wrappy": {
+                                                      "version": "1.0.1",
+                                                      "from": "wrappy@>=1.0.0 <2.0.0",
+                                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "readable-stream": {
+                                              "version": "2.0.2",
+                                              "from": "readable-stream@>=2.0.0 <3.0.0",
+                                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                              "dependencies": {
+                                                "core-util-is": {
+                                                  "version": "1.0.1",
+                                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                                },
+                                                "inherits": {
+                                                  "version": "2.0.1",
+                                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                                },
+                                                "isarray": {
+                                                  "version": "0.0.1",
+                                                  "from": "isarray@0.0.1",
+                                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                                },
+                                                "process-nextick-args": {
+                                                  "version": "1.0.2",
+                                                  "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                                },
+                                                "string_decoder": {
+                                                  "version": "0.10.31",
+                                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                                },
+                                                "util-deprecate": {
+                                                  "version": "1.0.1",
+                                                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                                }
+                                              }
+                                            },
+                                            "xtend": {
+                                              "version": "4.0.0",
+                                              "from": "xtend@>=4.0.0 <5.0.0",
+                                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                            }
+                                          }
+                                        },
+                                        "through2": {
+                                          "version": "0.6.5",
+                                          "from": "through2@>=0.6.1 <0.7.0",
+                                          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                                          "dependencies": {
+                                            "readable-stream": {
+                                              "version": "1.0.33",
+                                              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                                              "dependencies": {
+                                                "core-util-is": {
+                                                  "version": "1.0.1",
+                                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                                },
+                                                "isarray": {
+                                                  "version": "0.0.1",
+                                                  "from": "isarray@0.0.1",
+                                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                                },
+                                                "string_decoder": {
+                                                  "version": "0.10.31",
+                                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                                },
+                                                "inherits": {
+                                                  "version": "2.0.1",
+                                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                                }
+                                              }
+                                            },
+                                            "xtend": {
+                                              "version": "4.0.0",
+                                              "from": "xtend@>=4.0.0 <4.1.0-0",
+                                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "decompress-targz": {
+                                      "version": "3.1.0",
+                                      "from": "decompress-targz@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-3.1.0.tgz",
+                                      "dependencies": {
+                                        "is-gzip": {
+                                          "version": "1.0.0",
+                                          "from": "is-gzip@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz"
+                                        },
+                                        "strip-dirs": {
+                                          "version": "1.1.1",
+                                          "from": "strip-dirs@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                                          "dependencies": {
+                                            "is-absolute": {
+                                              "version": "0.1.7",
+                                              "from": "is-absolute@>=0.1.5 <0.2.0",
+                                              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                                              "dependencies": {
+                                                "is-relative": {
+                                                  "version": "0.1.3",
+                                                  "from": "is-relative@>=0.1.0 <0.2.0",
+                                                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                                                }
+                                              }
+                                            },
+                                            "is-natural-number": {
+                                              "version": "2.0.0",
+                                              "from": "is-natural-number@>=2.0.0 <3.0.0",
+                                              "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz"
+                                            },
+                                            "minimist": {
+                                              "version": "1.2.0",
+                                              "from": "minimist@>=1.1.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                                            },
+                                            "sum-up": {
+                                              "version": "1.0.2",
+                                              "from": "sum-up@>=1.0.1 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.2.tgz"
+                                            }
+                                          }
+                                        },
+                                        "tar-stream": {
+                                          "version": "1.2.1",
+                                          "from": "tar-stream@>=1.1.1 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.2.1.tgz",
+                                          "dependencies": {
+                                            "bl": {
+                                              "version": "1.0.0",
+                                              "from": "bl@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
+                                            },
+                                            "end-of-stream": {
+                                              "version": "1.1.0",
+                                              "from": "end-of-stream@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                                              "dependencies": {
+                                                "once": {
+                                                  "version": "1.3.2",
+                                                  "from": "once@>=1.3.0 <2.0.0",
+                                                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                                  "dependencies": {
+                                                    "wrappy": {
+                                                      "version": "1.0.1",
+                                                      "from": "wrappy@>=1.0.0 <2.0.0",
+                                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "readable-stream": {
+                                              "version": "2.0.2",
+                                              "from": "readable-stream@>=2.0.0 <3.0.0",
+                                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                              "dependencies": {
+                                                "core-util-is": {
+                                                  "version": "1.0.1",
+                                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                                },
+                                                "inherits": {
+                                                  "version": "2.0.1",
+                                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                                },
+                                                "isarray": {
+                                                  "version": "0.0.1",
+                                                  "from": "isarray@0.0.1",
+                                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                                },
+                                                "process-nextick-args": {
+                                                  "version": "1.0.2",
+                                                  "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                                },
+                                                "string_decoder": {
+                                                  "version": "0.10.31",
+                                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                                },
+                                                "util-deprecate": {
+                                                  "version": "1.0.1",
+                                                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                                }
+                                              }
+                                            },
+                                            "xtend": {
+                                              "version": "4.0.0",
+                                              "from": "xtend@>=4.0.0 <5.0.0",
+                                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                            }
+                                          }
+                                        },
+                                        "through2": {
+                                          "version": "0.6.5",
+                                          "from": "through2@>=0.6.1 <0.7.0",
+                                          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                                          "dependencies": {
+                                            "readable-stream": {
+                                              "version": "1.0.33",
+                                              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                                              "dependencies": {
+                                                "core-util-is": {
+                                                  "version": "1.0.1",
+                                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                                },
+                                                "isarray": {
+                                                  "version": "0.0.1",
+                                                  "from": "isarray@0.0.1",
+                                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                                },
+                                                "string_decoder": {
+                                                  "version": "0.10.31",
+                                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                                },
+                                                "inherits": {
+                                                  "version": "2.0.1",
+                                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                                }
+                                              }
+                                            },
+                                            "xtend": {
+                                              "version": "4.0.0",
+                                              "from": "xtend@>=4.0.0 <4.1.0-0",
+                                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "decompress-unzip": {
+                                      "version": "3.3.0",
+                                      "from": "decompress-unzip@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-3.3.0.tgz",
+                                      "dependencies": {
+                                        "is-zip": {
+                                          "version": "1.0.0",
+                                          "from": "is-zip@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/is-zip/-/is-zip-1.0.0.tgz"
+                                        },
+                                        "stat-mode": {
+                                          "version": "0.2.1",
+                                          "from": "stat-mode@>=0.2.0 <0.3.0",
+                                          "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.1.tgz"
+                                        },
+                                        "strip-dirs": {
+                                          "version": "1.1.1",
+                                          "from": "strip-dirs@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                                          "dependencies": {
+                                            "is-absolute": {
+                                              "version": "0.1.7",
+                                              "from": "is-absolute@>=0.1.5 <0.2.0",
+                                              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                                              "dependencies": {
+                                                "is-relative": {
+                                                  "version": "0.1.3",
+                                                  "from": "is-relative@>=0.1.0 <0.2.0",
+                                                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                                                }
+                                              }
+                                            },
+                                            "is-natural-number": {
+                                              "version": "2.0.0",
+                                              "from": "is-natural-number@>=2.0.0 <3.0.0",
+                                              "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz"
+                                            },
+                                            "minimist": {
+                                              "version": "1.2.0",
+                                              "from": "minimist@>=1.1.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                                            },
+                                            "sum-up": {
+                                              "version": "1.0.2",
+                                              "from": "sum-up@>=1.0.1 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.2.tgz"
+                                            }
+                                          }
+                                        },
+                                        "vinyl": {
+                                          "version": "0.5.1",
+                                          "from": "vinyl@>=0.5.0 <0.6.0",
+                                          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.1.tgz",
+                                          "dependencies": {
+                                            "clone": {
+                                              "version": "1.0.2",
+                                              "from": "clone@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+                                            },
+                                            "clone-stats": {
+                                              "version": "0.0.1",
+                                              "from": "clone-stats@>=0.0.1 <0.0.2",
+                                              "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                                            },
+                                            "replace-ext": {
+                                              "version": "0.0.1",
+                                              "from": "replace-ext@0.0.1",
+                                              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+                                            }
+                                          }
+                                        },
+                                        "yauzl": {
+                                          "version": "2.3.1",
+                                          "from": "yauzl@>=2.2.1 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.3.1.tgz",
+                                          "dependencies": {
+                                            "fd-slicer": {
+                                              "version": "1.0.1",
+                                              "from": "fd-slicer@>=1.0.1 <1.1.0",
+                                              "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz"
+                                            },
+                                            "pend": {
+                                              "version": "1.2.0",
+                                              "from": "pend@>=1.2.0 <1.3.0",
+                                              "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "vinyl-assign": {
+                                      "version": "1.2.0",
+                                      "from": "vinyl-assign@>=1.0.1 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/vinyl-assign/-/vinyl-assign-1.2.0.tgz",
+                                      "dependencies": {
+                                        "object-assign": {
+                                          "version": "3.0.0",
+                                          "from": "object-assign@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                                        },
+                                        "readable-stream": {
+                                          "version": "2.0.2",
+                                          "from": "readable-stream@>=2.0.0 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                          "dependencies": {
+                                            "core-util-is": {
+                                              "version": "1.0.1",
+                                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                            },
+                                            "inherits": {
+                                              "version": "2.0.1",
+                                              "from": "inherits@>=2.0.1 <2.1.0",
+                                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                            },
+                                            "isarray": {
+                                              "version": "0.0.1",
+                                              "from": "isarray@0.0.1",
+                                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                            },
+                                            "process-nextick-args": {
+                                              "version": "1.0.2",
+                                              "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                            },
+                                            "string_decoder": {
+                                              "version": "0.10.31",
+                                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                            },
+                                            "util-deprecate": {
+                                              "version": "1.0.1",
+                                              "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "gulp-util": {
+                                  "version": "3.0.6",
+                                  "from": "gulp-util@>=3.0.1 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.6.tgz",
+                                  "dependencies": {
+                                    "array-differ": {
+                                      "version": "1.0.0",
+                                      "from": "array-differ@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
+                                    },
+                                    "array-uniq": {
+                                      "version": "1.0.2",
+                                      "from": "array-uniq@>=1.0.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+                                    },
+                                    "beeper": {
+                                      "version": "1.1.0",
+                                      "from": "beeper@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
+                                    },
+                                    "dateformat": {
+                                      "version": "1.0.11",
+                                      "from": "dateformat@>=1.0.11 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz"
+                                    },
+                                    "lodash._reescape": {
+                                      "version": "3.0.0",
+                                      "from": "lodash._reescape@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+                                    },
+                                    "lodash._reevaluate": {
+                                      "version": "3.0.0",
+                                      "from": "lodash._reevaluate@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+                                    },
+                                    "lodash._reinterpolate": {
+                                      "version": "3.0.0",
+                                      "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+                                    },
+                                    "lodash.template": {
+                                      "version": "3.6.2",
+                                      "from": "lodash.template@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+                                      "dependencies": {
+                                        "lodash._basecopy": {
+                                          "version": "3.0.1",
+                                          "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                                        },
+                                        "lodash._basetostring": {
+                                          "version": "3.0.1",
+                                          "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                                        },
+                                        "lodash._basevalues": {
+                                          "version": "3.0.0",
+                                          "from": "lodash._basevalues@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+                                        },
+                                        "lodash._isiterateecall": {
+                                          "version": "3.0.9",
+                                          "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                                        },
+                                        "lodash.escape": {
+                                          "version": "3.0.0",
+                                          "from": "lodash.escape@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+                                        },
+                                        "lodash.keys": {
+                                          "version": "3.1.2",
+                                          "from": "lodash.keys@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                                          "dependencies": {
+                                            "lodash._getnative": {
+                                              "version": "3.9.1",
+                                              "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                                              "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                                            },
+                                            "lodash.isarguments": {
+                                              "version": "3.0.4",
+                                              "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                                              "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                                            },
+                                            "lodash.isarray": {
+                                              "version": "3.0.4",
+                                              "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                                              "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                                            }
+                                          }
+                                        },
+                                        "lodash.restparam": {
+                                          "version": "3.6.1",
+                                          "from": "lodash.restparam@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                                        },
+                                        "lodash.templatesettings": {
+                                          "version": "3.1.0",
+                                          "from": "lodash.templatesettings@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+                                        }
+                                      }
+                                    },
+                                    "minimist": {
+                                      "version": "1.2.0",
+                                      "from": "minimist@>=1.1.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                                    },
+                                    "multipipe": {
+                                      "version": "0.1.2",
+                                      "from": "multipipe@>=0.1.2 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+                                      "dependencies": {
+                                        "duplexer2": {
+                                          "version": "0.0.2",
+                                          "from": "duplexer2@0.0.2",
+                                          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                                          "dependencies": {
+                                            "readable-stream": {
+                                              "version": "1.1.13",
+                                              "from": "readable-stream@>=1.1.9 <1.2.0",
+                                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                                              "dependencies": {
+                                                "core-util-is": {
+                                                  "version": "1.0.1",
+                                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                                },
+                                                "isarray": {
+                                                  "version": "0.0.1",
+                                                  "from": "isarray@0.0.1",
+                                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                                },
+                                                "string_decoder": {
+                                                  "version": "0.10.31",
+                                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                                },
+                                                "inherits": {
+                                                  "version": "2.0.1",
+                                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "object-assign": {
+                                      "version": "3.0.0",
+                                      "from": "object-assign@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                                    },
+                                    "replace-ext": {
+                                      "version": "0.0.1",
+                                      "from": "replace-ext@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+                                    },
+                                    "vinyl": {
+                                      "version": "0.5.1",
+                                      "from": "vinyl@>=0.5.0 <0.6.0",
+                                      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.1.tgz",
+                                      "dependencies": {
+                                        "clone": {
+                                          "version": "1.0.2",
+                                          "from": "clone@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+                                        },
+                                        "clone-stats": {
+                                          "version": "0.0.1",
+                                          "from": "clone-stats@>=0.0.1 <0.0.2",
+                                          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "is-url": {
+                              "version": "1.2.1",
+                              "from": "is-url@>=1.2.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.1.tgz"
+                            },
+                            "object-assign": {
+                              "version": "2.1.1",
+                              "from": "object-assign@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+                            },
+                            "read-all-stream": {
+                              "version": "3.0.1",
+                              "from": "read-all-stream@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.0.1.tgz",
+                              "dependencies": {
+                                "pinkie-promise": {
+                                  "version": "1.0.0",
+                                  "from": "pinkie-promise@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+                                  "dependencies": {
+                                    "pinkie": {
+                                      "version": "1.0.0",
+                                      "from": "pinkie@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "readable-stream": {
+                                  "version": "2.0.2",
+                                  "from": "readable-stream@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                  "dependencies": {
+                                    "core-util-is": {
+                                      "version": "1.0.1",
+                                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@>=2.0.1 <2.1.0",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    },
+                                    "isarray": {
+                                      "version": "0.0.1",
+                                      "from": "isarray@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                    },
+                                    "process-nextick-args": {
+                                      "version": "1.0.2",
+                                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                    },
+                                    "string_decoder": {
+                                      "version": "0.10.31",
+                                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                    },
+                                    "util-deprecate": {
+                                      "version": "1.0.1",
+                                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "through2": {
+                              "version": "2.0.0",
+                              "from": "through2@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
+                              "dependencies": {
+                                "readable-stream": {
+                                  "version": "2.0.2",
+                                  "from": "readable-stream@>=2.0.0 <2.1.0",
+                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                  "dependencies": {
+                                    "core-util-is": {
+                                      "version": "1.0.1",
+                                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@>=2.0.1 <2.1.0",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    },
+                                    "isarray": {
+                                      "version": "0.0.1",
+                                      "from": "isarray@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                    },
+                                    "process-nextick-args": {
+                                      "version": "1.0.2",
+                                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                    },
+                                    "string_decoder": {
+                                      "version": "0.10.31",
+                                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                    },
+                                    "util-deprecate": {
+                                      "version": "1.0.1",
+                                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "xtend": {
+                                  "version": "4.0.0",
+                                  "from": "xtend@>=4.0.0 <4.1.0",
+                                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                }
+                              }
+                            },
+                            "vinyl": {
+                              "version": "0.4.6",
+                              "from": "vinyl@>=0.4.3 <0.5.0",
+                              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+                              "dependencies": {
+                                "clone": {
+                                  "version": "0.2.0",
+                                  "from": "clone@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+                                },
+                                "clone-stats": {
+                                  "version": "0.0.1",
+                                  "from": "clone-stats@>=0.0.1 <0.0.2",
+                                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                                }
+                              }
+                            },
+                            "ware": {
+                              "version": "1.3.0",
+                              "from": "ware@>=1.2.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
+                              "dependencies": {
+                                "wrap-fn": {
+                                  "version": "0.1.4",
+                                  "from": "wrap-fn@>=0.1.0 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.4.tgz",
+                                  "dependencies": {
+                                    "co": {
+                                      "version": "3.1.0",
+                                      "from": "co@3.1.0",
+                                      "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "each-async": {
+                          "version": "1.1.1",
+                          "from": "each-async@>=1.1.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
+                          "dependencies": {
+                            "onetime": {
+                              "version": "1.0.0",
+                              "from": "onetime@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz"
+                            },
+                            "set-immediate-shim": {
+                              "version": "1.0.1",
+                              "from": "set-immediate-shim@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "lazy-req": {
+                          "version": "1.1.0",
+                          "from": "lazy-req@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-1.1.0.tgz"
+                        },
+                        "os-filter-obj": {
+                          "version": "1.0.3",
+                          "from": "os-filter-obj@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/os-filter-obj/-/os-filter-obj-1.0.3.tgz"
+                        }
+                      }
+                    },
+                    "logalot": {
+                      "version": "2.1.0",
+                      "from": "logalot@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/logalot/-/logalot-2.1.0.tgz",
+                      "dependencies": {
+                        "figures": {
+                          "version": "1.3.5",
+                          "from": "figures@>=1.3.5 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
+                        },
+                        "squeak": {
+                          "version": "1.2.0",
+                          "from": "squeak@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/squeak/-/squeak-1.2.0.tgz",
+                          "dependencies": {
+                            "chalk": {
+                              "version": "0.5.1",
+                              "from": "chalk@>=0.5.1 <0.6.0",
+                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+                              "dependencies": {
+                                "ansi-styles": {
+                                  "version": "1.1.0",
+                                  "from": "ansi-styles@>=1.1.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+                                },
+                                "escape-string-regexp": {
+                                  "version": "1.0.3",
+                                  "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                },
+                                "has-ansi": {
+                                  "version": "0.1.0",
+                                  "from": "has-ansi@>=0.1.0 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "0.2.1",
+                                      "from": "ansi-regex@>=0.2.1 <0.3.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                                    }
+                                  }
+                                },
+                                "strip-ansi": {
+                                  "version": "0.3.0",
+                                  "from": "strip-ansi@>=0.3.0 <0.4.0",
+                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "0.2.1",
+                                      "from": "ansi-regex@>=0.2.1 <0.3.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                                    }
+                                  }
+                                },
+                                "supports-color": {
+                                  "version": "0.2.0",
+                                  "from": "supports-color@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+                                }
+                              }
+                            },
+                            "lpad-align": {
+                              "version": "1.1.0",
+                              "from": "lpad-align@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/lpad-align/-/lpad-align-1.1.0.tgz",
+                              "dependencies": {
+                                "longest": {
+                                  "version": "1.0.1",
+                                  "from": "longest@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                },
+                                "lpad": {
+                                  "version": "2.0.1",
+                                  "from": "lpad@>=2.0.1 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/lpad/-/lpad-2.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "is-gif": {
+                  "version": "1.0.0",
+                  "from": "is-gif@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-gif/-/is-gif-1.0.0.tgz"
+                }
+              }
+            },
+            "imagemin-jpegtran": {
+              "version": "4.3.0",
+              "from": "imagemin-jpegtran@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/imagemin-jpegtran/-/imagemin-jpegtran-4.3.0.tgz",
+              "dependencies": {
+                "is-jpg": {
+                  "version": "1.0.0",
+                  "from": "is-jpg@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-jpg/-/is-jpg-1.0.0.tgz"
+                },
+                "jpegtran-bin": {
+                  "version": "3.0.4",
+                  "from": "jpegtran-bin@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/jpegtran-bin/-/jpegtran-bin-3.0.4.tgz",
+                  "dependencies": {
+                    "bin-build": {
+                      "version": "2.1.2",
+                      "from": "bin-build@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/bin-build/-/bin-build-2.1.2.tgz",
+                      "dependencies": {
+                        "archive-type": {
+                          "version": "2.1.0",
+                          "from": "archive-type@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/archive-type/-/archive-type-2.1.0.tgz",
+                          "dependencies": {
+                            "file-type": {
+                              "version": "2.10.2",
+                              "from": "file-type@>=2.0.1 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/file-type/-/file-type-2.10.2.tgz"
+                            },
+                            "read-chunk": {
+                              "version": "1.0.1",
+                              "from": "read-chunk@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "decompress": {
+                          "version": "2.3.0",
+                          "from": "decompress@>=2.1.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/decompress/-/decompress-2.3.0.tgz",
+                          "dependencies": {
+                            "decompress-tar": {
+                              "version": "3.1.0",
+                              "from": "decompress-tar@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-3.1.0.tgz",
+                              "dependencies": {
+                                "is-tar": {
+                                  "version": "1.0.0",
+                                  "from": "is-tar@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-tar/-/is-tar-1.0.0.tgz"
+                                },
+                                "object-assign": {
+                                  "version": "2.1.1",
+                                  "from": "object-assign@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+                                },
+                                "strip-dirs": {
+                                  "version": "1.1.1",
+                                  "from": "strip-dirs@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                                  "dependencies": {
+                                    "is-absolute": {
+                                      "version": "0.1.7",
+                                      "from": "is-absolute@>=0.1.5 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                                      "dependencies": {
+                                        "is-relative": {
+                                          "version": "0.1.3",
+                                          "from": "is-relative@>=0.1.0 <0.2.0",
+                                          "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                                        }
+                                      }
+                                    },
+                                    "is-natural-number": {
+                                      "version": "2.0.0",
+                                      "from": "is-natural-number@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz"
+                                    },
+                                    "minimist": {
+                                      "version": "1.2.0",
+                                      "from": "minimist@>=1.1.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                                    },
+                                    "sum-up": {
+                                      "version": "1.0.2",
+                                      "from": "sum-up@>=1.0.1 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.2.tgz"
+                                    }
+                                  }
+                                },
+                                "tar-stream": {
+                                  "version": "1.2.1",
+                                  "from": "tar-stream@>=1.1.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.2.1.tgz",
+                                  "dependencies": {
+                                    "bl": {
+                                      "version": "1.0.0",
+                                      "from": "bl@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
+                                    },
+                                    "end-of-stream": {
+                                      "version": "1.1.0",
+                                      "from": "end-of-stream@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                                      "dependencies": {
+                                        "once": {
+                                          "version": "1.3.2",
+                                          "from": "once@>=1.3.0 <1.4.0",
+                                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                          "dependencies": {
+                                            "wrappy": {
+                                              "version": "1.0.1",
+                                              "from": "wrappy@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "readable-stream": {
+                                      "version": "2.0.2",
+                                      "from": "readable-stream@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                      "dependencies": {
+                                        "core-util-is": {
+                                          "version": "1.0.1",
+                                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                        },
+                                        "inherits": {
+                                          "version": "2.0.1",
+                                          "from": "inherits@>=2.0.1 <2.1.0",
+                                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        },
+                                        "isarray": {
+                                          "version": "0.0.1",
+                                          "from": "isarray@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        },
+                                        "process-nextick-args": {
+                                          "version": "1.0.2",
+                                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                        },
+                                        "string_decoder": {
+                                          "version": "0.10.31",
+                                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        },
+                                        "util-deprecate": {
+                                          "version": "1.0.1",
+                                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "xtend": {
+                                      "version": "4.0.0",
+                                      "from": "xtend@>=4.0.0 <4.1.0-0",
+                                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "through2": {
+                                  "version": "0.6.5",
+                                  "from": "through2@>=0.6.1 <0.7.0",
+                                  "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                                  "dependencies": {
+                                    "readable-stream": {
+                                      "version": "1.0.33",
+                                      "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                                      "dependencies": {
+                                        "core-util-is": {
+                                          "version": "1.0.1",
+                                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                        },
+                                        "isarray": {
+                                          "version": "0.0.1",
+                                          "from": "isarray@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        },
+                                        "string_decoder": {
+                                          "version": "0.10.31",
+                                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        },
+                                        "inherits": {
+                                          "version": "2.0.1",
+                                          "from": "inherits@>=2.0.1 <2.1.0",
+                                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "xtend": {
+                                      "version": "4.0.0",
+                                      "from": "xtend@>=4.0.0 <4.1.0-0",
+                                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "vinyl": {
+                                  "version": "0.4.6",
+                                  "from": "vinyl@>=0.4.3 <0.5.0",
+                                  "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+                                  "dependencies": {
+                                    "clone": {
+                                      "version": "0.2.0",
+                                      "from": "clone@>=0.2.0 <0.3.0",
+                                      "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+                                    },
+                                    "clone-stats": {
+                                      "version": "0.0.1",
+                                      "from": "clone-stats@>=0.0.1 <0.0.2",
+                                      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "decompress-tarbz2": {
+                              "version": "3.1.0",
+                              "from": "decompress-tarbz2@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-3.1.0.tgz",
+                              "dependencies": {
+                                "is-bzip2": {
+                                  "version": "1.0.0",
+                                  "from": "is-bzip2@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-bzip2/-/is-bzip2-1.0.0.tgz"
+                                },
+                                "object-assign": {
+                                  "version": "2.1.1",
+                                  "from": "object-assign@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+                                },
+                                "seek-bzip": {
+                                  "version": "1.0.5",
+                                  "from": "seek-bzip@>=1.0.3 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
+                                  "dependencies": {
+                                    "commander": {
+                                      "version": "2.8.1",
+                                      "from": "commander@>=2.8.1 <2.9.0",
+                                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+                                      "dependencies": {
+                                        "graceful-readlink": {
+                                          "version": "1.0.1",
+                                          "from": "graceful-readlink@>=1.0.0",
+                                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "strip-dirs": {
+                                  "version": "1.1.1",
+                                  "from": "strip-dirs@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                                  "dependencies": {
+                                    "is-absolute": {
+                                      "version": "0.1.7",
+                                      "from": "is-absolute@>=0.1.5 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                                      "dependencies": {
+                                        "is-relative": {
+                                          "version": "0.1.3",
+                                          "from": "is-relative@>=0.1.0 <0.2.0",
+                                          "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                                        }
+                                      }
+                                    },
+                                    "is-natural-number": {
+                                      "version": "2.0.0",
+                                      "from": "is-natural-number@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz"
+                                    },
+                                    "minimist": {
+                                      "version": "1.2.0",
+                                      "from": "minimist@>=1.1.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                                    },
+                                    "sum-up": {
+                                      "version": "1.0.2",
+                                      "from": "sum-up@>=1.0.1 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.2.tgz"
+                                    }
+                                  }
+                                },
+                                "tar-stream": {
+                                  "version": "1.2.1",
+                                  "from": "tar-stream@>=1.1.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.2.1.tgz",
+                                  "dependencies": {
+                                    "bl": {
+                                      "version": "1.0.0",
+                                      "from": "bl@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
+                                    },
+                                    "end-of-stream": {
+                                      "version": "1.1.0",
+                                      "from": "end-of-stream@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                                      "dependencies": {
+                                        "once": {
+                                          "version": "1.3.2",
+                                          "from": "once@>=1.3.0 <1.4.0",
+                                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                          "dependencies": {
+                                            "wrappy": {
+                                              "version": "1.0.1",
+                                              "from": "wrappy@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "readable-stream": {
+                                      "version": "2.0.2",
+                                      "from": "readable-stream@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                      "dependencies": {
+                                        "core-util-is": {
+                                          "version": "1.0.1",
+                                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                        },
+                                        "inherits": {
+                                          "version": "2.0.1",
+                                          "from": "inherits@>=2.0.1 <2.1.0",
+                                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        },
+                                        "isarray": {
+                                          "version": "0.0.1",
+                                          "from": "isarray@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        },
+                                        "process-nextick-args": {
+                                          "version": "1.0.2",
+                                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                        },
+                                        "string_decoder": {
+                                          "version": "0.10.31",
+                                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        },
+                                        "util-deprecate": {
+                                          "version": "1.0.1",
+                                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "xtend": {
+                                      "version": "4.0.0",
+                                      "from": "xtend@>=4.0.0 <5.0.0",
+                                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "through2": {
+                                  "version": "0.6.5",
+                                  "from": "through2@>=0.6.1 <0.7.0",
+                                  "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                                  "dependencies": {
+                                    "readable-stream": {
+                                      "version": "1.0.33",
+                                      "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                                      "dependencies": {
+                                        "core-util-is": {
+                                          "version": "1.0.1",
+                                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                        },
+                                        "isarray": {
+                                          "version": "0.0.1",
+                                          "from": "isarray@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        },
+                                        "string_decoder": {
+                                          "version": "0.10.31",
+                                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        },
+                                        "inherits": {
+                                          "version": "2.0.1",
+                                          "from": "inherits@>=2.0.1 <2.1.0",
+                                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "xtend": {
+                                      "version": "4.0.0",
+                                      "from": "xtend@>=4.0.0 <4.1.0-0",
+                                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "vinyl": {
+                                  "version": "0.4.6",
+                                  "from": "vinyl@>=0.4.3 <0.5.0",
+                                  "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+                                  "dependencies": {
+                                    "clone": {
+                                      "version": "0.2.0",
+                                      "from": "clone@>=0.2.0 <0.3.0",
+                                      "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+                                    },
+                                    "clone-stats": {
+                                      "version": "0.0.1",
+                                      "from": "clone-stats@>=0.0.1 <0.0.2",
+                                      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "decompress-targz": {
+                              "version": "3.1.0",
+                              "from": "decompress-targz@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-3.1.0.tgz",
+                              "dependencies": {
+                                "is-gzip": {
+                                  "version": "1.0.0",
+                                  "from": "is-gzip@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz"
+                                },
+                                "object-assign": {
+                                  "version": "2.1.1",
+                                  "from": "object-assign@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+                                },
+                                "strip-dirs": {
+                                  "version": "1.1.1",
+                                  "from": "strip-dirs@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                                  "dependencies": {
+                                    "is-absolute": {
+                                      "version": "0.1.7",
+                                      "from": "is-absolute@>=0.1.5 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                                      "dependencies": {
+                                        "is-relative": {
+                                          "version": "0.1.3",
+                                          "from": "is-relative@>=0.1.0 <0.2.0",
+                                          "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                                        }
+                                      }
+                                    },
+                                    "is-natural-number": {
+                                      "version": "2.0.0",
+                                      "from": "is-natural-number@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz"
+                                    },
+                                    "minimist": {
+                                      "version": "1.2.0",
+                                      "from": "minimist@>=1.1.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                                    },
+                                    "sum-up": {
+                                      "version": "1.0.2",
+                                      "from": "sum-up@>=1.0.1 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.2.tgz"
+                                    }
+                                  }
+                                },
+                                "tar-stream": {
+                                  "version": "1.2.1",
+                                  "from": "tar-stream@>=1.1.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.2.1.tgz",
+                                  "dependencies": {
+                                    "bl": {
+                                      "version": "1.0.0",
+                                      "from": "bl@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
+                                    },
+                                    "end-of-stream": {
+                                      "version": "1.1.0",
+                                      "from": "end-of-stream@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                                      "dependencies": {
+                                        "once": {
+                                          "version": "1.3.2",
+                                          "from": "once@>=1.3.0 <1.4.0",
+                                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                          "dependencies": {
+                                            "wrappy": {
+                                              "version": "1.0.1",
+                                              "from": "wrappy@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "readable-stream": {
+                                      "version": "2.0.2",
+                                      "from": "readable-stream@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                      "dependencies": {
+                                        "core-util-is": {
+                                          "version": "1.0.1",
+                                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                        },
+                                        "inherits": {
+                                          "version": "2.0.1",
+                                          "from": "inherits@>=2.0.1 <2.1.0",
+                                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        },
+                                        "isarray": {
+                                          "version": "0.0.1",
+                                          "from": "isarray@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        },
+                                        "process-nextick-args": {
+                                          "version": "1.0.2",
+                                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                        },
+                                        "string_decoder": {
+                                          "version": "0.10.31",
+                                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        },
+                                        "util-deprecate": {
+                                          "version": "1.0.1",
+                                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "xtend": {
+                                      "version": "4.0.0",
+                                      "from": "xtend@>=4.0.0 <4.1.0-0",
+                                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "through2": {
+                                  "version": "0.6.5",
+                                  "from": "through2@>=0.6.1 <0.7.0",
+                                  "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                                  "dependencies": {
+                                    "readable-stream": {
+                                      "version": "1.0.33",
+                                      "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                                      "dependencies": {
+                                        "core-util-is": {
+                                          "version": "1.0.1",
+                                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                        },
+                                        "isarray": {
+                                          "version": "0.0.1",
+                                          "from": "isarray@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        },
+                                        "string_decoder": {
+                                          "version": "0.10.31",
+                                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        },
+                                        "inherits": {
+                                          "version": "2.0.1",
+                                          "from": "inherits@>=2.0.1 <2.1.0",
+                                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "xtend": {
+                                      "version": "4.0.0",
+                                      "from": "xtend@>=4.0.0 <4.1.0-0",
+                                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "vinyl": {
+                                  "version": "0.4.6",
+                                  "from": "vinyl@>=0.4.3 <0.5.0",
+                                  "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+                                  "dependencies": {
+                                    "clone": {
+                                      "version": "0.2.0",
+                                      "from": "clone@>=0.2.0 <0.3.0",
+                                      "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+                                    },
+                                    "clone-stats": {
+                                      "version": "0.0.1",
+                                      "from": "clone-stats@>=0.0.1 <0.0.2",
+                                      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "decompress-unzip": {
+                              "version": "3.3.0",
+                              "from": "decompress-unzip@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-3.3.0.tgz",
+                              "dependencies": {
+                                "is-zip": {
+                                  "version": "1.0.0",
+                                  "from": "is-zip@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-zip/-/is-zip-1.0.0.tgz"
+                                },
+                                "read-all-stream": {
+                                  "version": "3.0.1",
+                                  "from": "read-all-stream@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.0.1.tgz",
+                                  "dependencies": {
+                                    "pinkie-promise": {
+                                      "version": "1.0.0",
+                                      "from": "pinkie-promise@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+                                      "dependencies": {
+                                        "pinkie": {
+                                          "version": "1.0.0",
+                                          "from": "pinkie@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
+                                        }
+                                      }
+                                    },
+                                    "readable-stream": {
+                                      "version": "2.0.2",
+                                      "from": "readable-stream@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                      "dependencies": {
+                                        "core-util-is": {
+                                          "version": "1.0.1",
+                                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                        },
+                                        "inherits": {
+                                          "version": "2.0.1",
+                                          "from": "inherits@>=2.0.1 <2.1.0",
+                                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        },
+                                        "isarray": {
+                                          "version": "0.0.1",
+                                          "from": "isarray@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        },
+                                        "process-nextick-args": {
+                                          "version": "1.0.2",
+                                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                        },
+                                        "string_decoder": {
+                                          "version": "0.10.31",
+                                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        },
+                                        "util-deprecate": {
+                                          "version": "1.0.1",
+                                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "stat-mode": {
+                                  "version": "0.2.1",
+                                  "from": "stat-mode@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.1.tgz"
+                                },
+                                "strip-dirs": {
+                                  "version": "1.1.1",
+                                  "from": "strip-dirs@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                                  "dependencies": {
+                                    "is-absolute": {
+                                      "version": "0.1.7",
+                                      "from": "is-absolute@>=0.1.5 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                                      "dependencies": {
+                                        "is-relative": {
+                                          "version": "0.1.3",
+                                          "from": "is-relative@>=0.1.0 <0.2.0",
+                                          "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                                        }
+                                      }
+                                    },
+                                    "is-natural-number": {
+                                      "version": "2.0.0",
+                                      "from": "is-natural-number@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz"
+                                    },
+                                    "minimist": {
+                                      "version": "1.2.0",
+                                      "from": "minimist@>=1.1.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                                    },
+                                    "sum-up": {
+                                      "version": "1.0.2",
+                                      "from": "sum-up@>=1.0.1 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.2.tgz"
+                                    }
+                                  }
+                                },
+                                "vinyl": {
+                                  "version": "0.5.1",
+                                  "from": "vinyl@>=0.5.0 <0.6.0",
+                                  "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.1.tgz",
+                                  "dependencies": {
+                                    "clone": {
+                                      "version": "1.0.2",
+                                      "from": "clone@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+                                    },
+                                    "clone-stats": {
+                                      "version": "0.0.1",
+                                      "from": "clone-stats@>=0.0.1 <0.0.2",
+                                      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                                    },
+                                    "replace-ext": {
+                                      "version": "0.0.1",
+                                      "from": "replace-ext@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "yauzl": {
+                                  "version": "2.3.1",
+                                  "from": "yauzl@>=2.2.1 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.3.1.tgz",
+                                  "dependencies": {
+                                    "fd-slicer": {
+                                      "version": "1.0.1",
+                                      "from": "fd-slicer@>=1.0.1 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz"
+                                    },
+                                    "pend": {
+                                      "version": "1.2.0",
+                                      "from": "pend@>=1.2.0 <1.3.0",
+                                      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "vinyl-assign": {
+                              "version": "1.2.0",
+                              "from": "vinyl-assign@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/vinyl-assign/-/vinyl-assign-1.2.0.tgz",
+                              "dependencies": {
+                                "object-assign": {
+                                  "version": "3.0.0",
+                                  "from": "object-assign@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                                },
+                                "readable-stream": {
+                                  "version": "2.0.2",
+                                  "from": "readable-stream@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                  "dependencies": {
+                                    "core-util-is": {
+                                      "version": "1.0.1",
+                                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@>=2.0.1 <2.1.0",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    },
+                                    "isarray": {
+                                      "version": "0.0.1",
+                                      "from": "isarray@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                    },
+                                    "process-nextick-args": {
+                                      "version": "1.0.2",
+                                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                    },
+                                    "string_decoder": {
+                                      "version": "0.10.31",
+                                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                    },
+                                    "util-deprecate": {
+                                      "version": "1.0.1",
+                                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "download": {
+                          "version": "4.2.0",
+                          "from": "download@>=4.0.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/download/-/download-4.2.0.tgz",
+                          "dependencies": {
+                            "caw": {
+                              "version": "1.1.0",
+                              "from": "caw@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/caw/-/caw-1.1.0.tgz",
+                              "dependencies": {
+                                "get-proxy": {
+                                  "version": "1.0.1",
+                                  "from": "get-proxy@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-1.0.1.tgz",
+                                  "dependencies": {
+                                    "rc": {
+                                      "version": "0.5.5",
+                                      "from": "rc@>=0.5.5 <0.6.0",
+                                      "resolved": "https://registry.npmjs.org/rc/-/rc-0.5.5.tgz",
+                                      "dependencies": {
+                                        "minimist": {
+                                          "version": "0.0.10",
+                                          "from": "minimist@>=0.0.7 <0.1.0",
+                                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                                        },
+                                        "deep-extend": {
+                                          "version": "0.2.11",
+                                          "from": "deep-extend@>=0.2.5 <0.3.0",
+                                          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+                                        },
+                                        "strip-json-comments": {
+                                          "version": "0.1.3",
+                                          "from": "strip-json-comments@>=0.1.0 <0.2.0",
+                                          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+                                        },
+                                        "ini": {
+                                          "version": "1.3.4",
+                                          "from": "ini@>=1.3.0 <1.4.0",
+                                          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "is-obj": {
+                                  "version": "1.0.0",
+                                  "from": "is-obj@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.0.tgz"
+                                },
+                                "object-assign": {
+                                  "version": "3.0.0",
+                                  "from": "object-assign@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                                },
+                                "tunnel-agent": {
+                                  "version": "0.4.1",
+                                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+                                }
+                              }
+                            },
+                            "each-async": {
+                              "version": "1.1.1",
+                              "from": "each-async@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
+                              "dependencies": {
+                                "onetime": {
+                                  "version": "1.0.0",
+                                  "from": "onetime@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz"
+                                },
+                                "set-immediate-shim": {
+                                  "version": "1.0.1",
+                                  "from": "set-immediate-shim@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "filenamify": {
+                              "version": "1.2.0",
+                              "from": "filenamify@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.0.tgz",
+                              "dependencies": {
+                                "filename-reserved-regex": {
+                                  "version": "1.0.0",
+                                  "from": "filename-reserved-regex@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz"
+                                },
+                                "strip-outer": {
+                                  "version": "1.0.0",
+                                  "from": "strip-outer@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.0.tgz",
+                                  "dependencies": {
+                                    "escape-string-regexp": {
+                                      "version": "1.0.3",
+                                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                    }
+                                  }
+                                },
+                                "trim-repeated": {
+                                  "version": "1.0.0",
+                                  "from": "trim-repeated@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+                                  "dependencies": {
+                                    "escape-string-regexp": {
+                                      "version": "1.0.3",
+                                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "got": {
+                              "version": "2.9.2",
+                              "from": "got@>=2.3.2 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/got/-/got-2.9.2.tgz",
+                              "dependencies": {
+                                "duplexify": {
+                                  "version": "3.4.2",
+                                  "from": "duplexify@>=3.2.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
+                                  "dependencies": {
+                                    "end-of-stream": {
+                                      "version": "1.0.0",
+                                      "from": "end-of-stream@1.0.0",
+                                      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                                      "dependencies": {
+                                        "once": {
+                                          "version": "1.3.2",
+                                          "from": "once@>=1.3.0 <1.4.0",
+                                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                          "dependencies": {
+                                            "wrappy": {
+                                              "version": "1.0.1",
+                                              "from": "wrappy@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "readable-stream": {
+                                      "version": "2.0.2",
+                                      "from": "readable-stream@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                      "dependencies": {
+                                        "core-util-is": {
+                                          "version": "1.0.1",
+                                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                        },
+                                        "inherits": {
+                                          "version": "2.0.1",
+                                          "from": "inherits@>=2.0.1 <2.1.0",
+                                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        },
+                                        "isarray": {
+                                          "version": "0.0.1",
+                                          "from": "isarray@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        },
+                                        "process-nextick-args": {
+                                          "version": "1.0.2",
+                                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                        },
+                                        "string_decoder": {
+                                          "version": "0.10.31",
+                                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        },
+                                        "util-deprecate": {
+                                          "version": "1.0.1",
+                                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "infinity-agent": {
+                                  "version": "2.0.3",
+                                  "from": "infinity-agent@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz"
+                                },
+                                "is-stream": {
+                                  "version": "1.0.1",
+                                  "from": "is-stream@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz"
+                                },
+                                "lowercase-keys": {
+                                  "version": "1.0.0",
+                                  "from": "lowercase-keys@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
+                                },
+                                "nested-error-stacks": {
+                                  "version": "1.0.1",
+                                  "from": "nested-error-stacks@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.1.tgz",
+                                  "dependencies": {
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "prepend-http": {
+                                  "version": "1.0.2",
+                                  "from": "prepend-http@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.2.tgz"
+                                },
+                                "read-all-stream": {
+                                  "version": "2.2.0",
+                                  "from": "read-all-stream@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-2.2.0.tgz",
+                                  "dependencies": {
+                                    "readable-stream": {
+                                      "version": "2.0.2",
+                                      "from": "readable-stream@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                      "dependencies": {
+                                        "core-util-is": {
+                                          "version": "1.0.1",
+                                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                        },
+                                        "inherits": {
+                                          "version": "2.0.1",
+                                          "from": "inherits@>=2.0.1 <2.1.0",
+                                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        },
+                                        "isarray": {
+                                          "version": "0.0.1",
+                                          "from": "isarray@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        },
+                                        "process-nextick-args": {
+                                          "version": "1.0.2",
+                                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                        },
+                                        "string_decoder": {
+                                          "version": "0.10.31",
+                                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        },
+                                        "util-deprecate": {
+                                          "version": "1.0.1",
+                                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "statuses": {
+                                  "version": "1.2.1",
+                                  "from": "statuses@>=1.2.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+                                },
+                                "timed-out": {
+                                  "version": "2.0.0",
+                                  "from": "timed-out@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "gulp-decompress": {
+                              "version": "1.1.0",
+                              "from": "gulp-decompress@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/gulp-decompress/-/gulp-decompress-1.1.0.tgz",
+                              "dependencies": {
+                                "archive-type": {
+                                  "version": "3.0.1",
+                                  "from": "archive-type@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/archive-type/-/archive-type-3.0.1.tgz",
+                                  "dependencies": {
+                                    "file-type": {
+                                      "version": "2.10.2",
+                                      "from": "file-type@>=2.0.1 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/file-type/-/file-type-2.10.2.tgz",
+                                      "dependencies": {
+                                        "read-chunk": {
+                                          "version": "1.0.1",
+                                          "from": "read-chunk@>=1.0.1 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-1.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "gulp-util": {
+                                  "version": "3.0.6",
+                                  "from": "gulp-util@>=3.0.1 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.6.tgz",
+                                  "dependencies": {
+                                    "array-differ": {
+                                      "version": "1.0.0",
+                                      "from": "array-differ@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
+                                    },
+                                    "array-uniq": {
+                                      "version": "1.0.2",
+                                      "from": "array-uniq@>=1.0.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+                                    },
+                                    "beeper": {
+                                      "version": "1.1.0",
+                                      "from": "beeper@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
+                                    },
+                                    "dateformat": {
+                                      "version": "1.0.11",
+                                      "from": "dateformat@>=1.0.11 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz"
+                                    },
+                                    "lodash._reescape": {
+                                      "version": "3.0.0",
+                                      "from": "lodash._reescape@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+                                    },
+                                    "lodash._reevaluate": {
+                                      "version": "3.0.0",
+                                      "from": "lodash._reevaluate@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+                                    },
+                                    "lodash._reinterpolate": {
+                                      "version": "3.0.0",
+                                      "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+                                    },
+                                    "lodash.template": {
+                                      "version": "3.6.2",
+                                      "from": "lodash.template@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+                                      "dependencies": {
+                                        "lodash._basecopy": {
+                                          "version": "3.0.1",
+                                          "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                                        },
+                                        "lodash._basetostring": {
+                                          "version": "3.0.1",
+                                          "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                                        },
+                                        "lodash._basevalues": {
+                                          "version": "3.0.0",
+                                          "from": "lodash._basevalues@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+                                        },
+                                        "lodash._isiterateecall": {
+                                          "version": "3.0.9",
+                                          "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                                        },
+                                        "lodash.escape": {
+                                          "version": "3.0.0",
+                                          "from": "lodash.escape@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+                                        },
+                                        "lodash.keys": {
+                                          "version": "3.1.2",
+                                          "from": "lodash.keys@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                                          "dependencies": {
+                                            "lodash._getnative": {
+                                              "version": "3.9.1",
+                                              "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                                              "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                                            },
+                                            "lodash.isarguments": {
+                                              "version": "3.0.4",
+                                              "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                                              "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                                            },
+                                            "lodash.isarray": {
+                                              "version": "3.0.4",
+                                              "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                                              "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                                            }
+                                          }
+                                        },
+                                        "lodash.restparam": {
+                                          "version": "3.6.1",
+                                          "from": "lodash.restparam@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                                        },
+                                        "lodash.templatesettings": {
+                                          "version": "3.1.0",
+                                          "from": "lodash.templatesettings@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+                                        }
+                                      }
+                                    },
+                                    "minimist": {
+                                      "version": "1.2.0",
+                                      "from": "minimist@>=1.1.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                                    },
+                                    "multipipe": {
+                                      "version": "0.1.2",
+                                      "from": "multipipe@>=0.1.2 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+                                      "dependencies": {
+                                        "duplexer2": {
+                                          "version": "0.0.2",
+                                          "from": "duplexer2@0.0.2",
+                                          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                                          "dependencies": {
+                                            "readable-stream": {
+                                              "version": "1.1.13",
+                                              "from": "readable-stream@>=1.1.9 <1.2.0",
+                                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                                              "dependencies": {
+                                                "core-util-is": {
+                                                  "version": "1.0.1",
+                                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                                },
+                                                "isarray": {
+                                                  "version": "0.0.1",
+                                                  "from": "isarray@0.0.1",
+                                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                                },
+                                                "string_decoder": {
+                                                  "version": "0.10.31",
+                                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                                },
+                                                "inherits": {
+                                                  "version": "2.0.1",
+                                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "object-assign": {
+                                      "version": "3.0.0",
+                                      "from": "object-assign@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                                    },
+                                    "replace-ext": {
+                                      "version": "0.0.1",
+                                      "from": "replace-ext@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+                                    },
+                                    "vinyl": {
+                                      "version": "0.5.1",
+                                      "from": "vinyl@>=0.5.0 <0.6.0",
+                                      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.1.tgz",
+                                      "dependencies": {
+                                        "clone": {
+                                          "version": "1.0.2",
+                                          "from": "clone@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+                                        },
+                                        "clone-stats": {
+                                          "version": "0.0.1",
+                                          "from": "clone-stats@>=0.0.1 <0.0.2",
+                                          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "is-url": {
+                              "version": "1.2.1",
+                              "from": "is-url@>=1.2.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.1.tgz"
+                            },
+                            "object-assign": {
+                              "version": "2.1.1",
+                              "from": "object-assign@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+                            },
+                            "read-all-stream": {
+                              "version": "3.0.1",
+                              "from": "read-all-stream@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.0.1.tgz",
+                              "dependencies": {
+                                "pinkie-promise": {
+                                  "version": "1.0.0",
+                                  "from": "pinkie-promise@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+                                  "dependencies": {
+                                    "pinkie": {
+                                      "version": "1.0.0",
+                                      "from": "pinkie@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "readable-stream": {
+                                  "version": "2.0.2",
+                                  "from": "readable-stream@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                  "dependencies": {
+                                    "core-util-is": {
+                                      "version": "1.0.1",
+                                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@>=2.0.1 <2.1.0",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    },
+                                    "isarray": {
+                                      "version": "0.0.1",
+                                      "from": "isarray@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                    },
+                                    "process-nextick-args": {
+                                      "version": "1.0.2",
+                                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                    },
+                                    "string_decoder": {
+                                      "version": "0.10.31",
+                                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                    },
+                                    "util-deprecate": {
+                                      "version": "1.0.1",
+                                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "vinyl": {
+                              "version": "0.4.6",
+                              "from": "vinyl@>=0.4.3 <0.5.0",
+                              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+                              "dependencies": {
+                                "clone": {
+                                  "version": "0.2.0",
+                                  "from": "clone@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+                                },
+                                "clone-stats": {
+                                  "version": "0.0.1",
+                                  "from": "clone-stats@>=0.0.1 <0.0.2",
+                                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                                }
+                              }
+                            },
+                            "ware": {
+                              "version": "1.3.0",
+                              "from": "ware@>=1.2.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
+                              "dependencies": {
+                                "wrap-fn": {
+                                  "version": "0.1.4",
+                                  "from": "wrap-fn@>=0.1.0 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.4.tgz",
+                                  "dependencies": {
+                                    "co": {
+                                      "version": "3.1.0",
+                                      "from": "co@3.1.0",
+                                      "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "exec-series": {
+                          "version": "1.0.2",
+                          "from": "exec-series@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/exec-series/-/exec-series-1.0.2.tgz",
+                          "dependencies": {
+                            "async-each-series": {
+                              "version": "1.0.0",
+                              "from": "async-each-series@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "rimraf": {
+                          "version": "2.4.2",
+                          "from": "rimraf@>=2.2.6 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.2.tgz",
+                          "dependencies": {
+                            "glob": {
+                              "version": "5.0.14",
+                              "from": "glob@>=5.0.14 <6.0.0",
+                              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
+                              "dependencies": {
+                                "inflight": {
+                                  "version": "1.0.4",
+                                  "from": "inflight@>=1.0.4 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.1",
+                                      "from": "wrappy@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                },
+                                "minimatch": {
+                                  "version": "2.0.10",
+                                  "from": "minimatch@>=2.0.1 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                                  "dependencies": {
+                                    "brace-expansion": {
+                                      "version": "1.1.0",
+                                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                                      "dependencies": {
+                                        "balanced-match": {
+                                          "version": "0.2.0",
+                                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                                        },
+                                        "concat-map": {
+                                          "version": "0.0.1",
+                                          "from": "concat-map@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "once": {
+                                  "version": "1.3.2",
+                                  "from": "once@>=1.3.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.1",
+                                      "from": "wrappy@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "path-is-absolute": {
+                                  "version": "1.0.0",
+                                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "tempfile": {
+                          "version": "1.1.1",
+                          "from": "tempfile@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz",
+                          "dependencies": {
+                            "os-tmpdir": {
+                              "version": "1.0.1",
+                              "from": "os-tmpdir@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                            },
+                            "uuid": {
+                              "version": "2.0.1",
+                              "from": "uuid@>=2.0.1 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
+                            }
+                          }
+                        },
+                        "url-regex": {
+                          "version": "2.1.3",
+                          "from": "url-regex@>=2.0.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/url-regex/-/url-regex-2.1.3.tgz",
+                          "dependencies": {
+                            "ip-regex": {
+                              "version": "1.0.3",
+                              "from": "ip-regex@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-1.0.3.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "bin-wrapper": {
+                      "version": "3.0.2",
+                      "from": "bin-wrapper@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/bin-wrapper/-/bin-wrapper-3.0.2.tgz",
+                      "dependencies": {
+                        "bin-check": {
+                          "version": "2.0.0",
+                          "from": "bin-check@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/bin-check/-/bin-check-2.0.0.tgz",
+                          "dependencies": {
+                            "executable": {
+                              "version": "1.1.0",
+                              "from": "executable@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/executable/-/executable-1.1.0.tgz"
+                            }
+                          }
+                        },
+                        "bin-version-check": {
+                          "version": "2.1.0",
+                          "from": "bin-version-check@>=2.1.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-2.1.0.tgz",
+                          "dependencies": {
+                            "bin-version": {
+                              "version": "1.0.4",
+                              "from": "bin-version@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/bin-version/-/bin-version-1.0.4.tgz",
+                              "dependencies": {
+                                "find-versions": {
+                                  "version": "1.1.3",
+                                  "from": "find-versions@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-1.1.3.tgz",
+                                  "dependencies": {
+                                    "array-uniq": {
+                                      "version": "1.0.2",
+                                      "from": "array-uniq@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+                                    },
+                                    "semver-regex": {
+                                      "version": "1.0.0",
+                                      "from": "semver-regex@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-1.0.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "minimist": {
+                              "version": "1.2.0",
+                              "from": "minimist@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                            },
+                            "semver": {
+                              "version": "4.3.6",
+                              "from": "semver@>=4.0.3 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+                            },
+                            "semver-truncate": {
+                              "version": "1.0.0",
+                              "from": "semver-truncate@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "download": {
+                          "version": "4.2.0",
+                          "from": "download@>=4.0.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/download/-/download-4.2.0.tgz",
+                          "dependencies": {
+                            "caw": {
+                              "version": "1.1.0",
+                              "from": "caw@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/caw/-/caw-1.1.0.tgz",
+                              "dependencies": {
+                                "get-proxy": {
+                                  "version": "1.0.1",
+                                  "from": "get-proxy@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-1.0.1.tgz",
+                                  "dependencies": {
+                                    "rc": {
+                                      "version": "0.5.5",
+                                      "from": "rc@>=0.5.5 <0.6.0",
+                                      "resolved": "https://registry.npmjs.org/rc/-/rc-0.5.5.tgz",
+                                      "dependencies": {
+                                        "minimist": {
+                                          "version": "0.0.10",
+                                          "from": "minimist@>=0.0.7 <0.1.0",
+                                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                                        },
+                                        "deep-extend": {
+                                          "version": "0.2.11",
+                                          "from": "deep-extend@>=0.2.5 <0.3.0",
+                                          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+                                        },
+                                        "strip-json-comments": {
+                                          "version": "0.1.3",
+                                          "from": "strip-json-comments@>=0.1.0 <0.2.0",
+                                          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+                                        },
+                                        "ini": {
+                                          "version": "1.3.4",
+                                          "from": "ini@>=1.3.0 <1.4.0",
+                                          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "is-obj": {
+                                  "version": "1.0.0",
+                                  "from": "is-obj@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.0.tgz"
+                                },
+                                "object-assign": {
+                                  "version": "3.0.0",
+                                  "from": "object-assign@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                                },
+                                "tunnel-agent": {
+                                  "version": "0.4.1",
+                                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+                                }
+                              }
+                            },
+                            "filenamify": {
+                              "version": "1.2.0",
+                              "from": "filenamify@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.0.tgz",
+                              "dependencies": {
+                                "filename-reserved-regex": {
+                                  "version": "1.0.0",
+                                  "from": "filename-reserved-regex@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz"
+                                },
+                                "strip-outer": {
+                                  "version": "1.0.0",
+                                  "from": "strip-outer@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.0.tgz",
+                                  "dependencies": {
+                                    "escape-string-regexp": {
+                                      "version": "1.0.3",
+                                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                    }
+                                  }
+                                },
+                                "trim-repeated": {
+                                  "version": "1.0.0",
+                                  "from": "trim-repeated@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+                                  "dependencies": {
+                                    "escape-string-regexp": {
+                                      "version": "1.0.3",
+                                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "got": {
+                              "version": "2.9.2",
+                              "from": "got@>=2.3.2 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/got/-/got-2.9.2.tgz",
+                              "dependencies": {
+                                "duplexify": {
+                                  "version": "3.4.2",
+                                  "from": "duplexify@>=3.2.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
+                                  "dependencies": {
+                                    "end-of-stream": {
+                                      "version": "1.0.0",
+                                      "from": "end-of-stream@1.0.0",
+                                      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                                      "dependencies": {
+                                        "once": {
+                                          "version": "1.3.2",
+                                          "from": "once@>=1.3.0 <1.4.0",
+                                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                          "dependencies": {
+                                            "wrappy": {
+                                              "version": "1.0.1",
+                                              "from": "wrappy@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "readable-stream": {
+                                      "version": "2.0.2",
+                                      "from": "readable-stream@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                      "dependencies": {
+                                        "core-util-is": {
+                                          "version": "1.0.1",
+                                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                        },
+                                        "inherits": {
+                                          "version": "2.0.1",
+                                          "from": "inherits@>=2.0.1 <2.1.0",
+                                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        },
+                                        "isarray": {
+                                          "version": "0.0.1",
+                                          "from": "isarray@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        },
+                                        "process-nextick-args": {
+                                          "version": "1.0.2",
+                                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                        },
+                                        "string_decoder": {
+                                          "version": "0.10.31",
+                                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        },
+                                        "util-deprecate": {
+                                          "version": "1.0.1",
+                                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "infinity-agent": {
+                                  "version": "2.0.3",
+                                  "from": "infinity-agent@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz"
+                                },
+                                "is-stream": {
+                                  "version": "1.0.1",
+                                  "from": "is-stream@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz"
+                                },
+                                "lowercase-keys": {
+                                  "version": "1.0.0",
+                                  "from": "lowercase-keys@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
+                                },
+                                "nested-error-stacks": {
+                                  "version": "1.0.1",
+                                  "from": "nested-error-stacks@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.1.tgz",
+                                  "dependencies": {
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "prepend-http": {
+                                  "version": "1.0.2",
+                                  "from": "prepend-http@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.2.tgz"
+                                },
+                                "read-all-stream": {
+                                  "version": "2.2.0",
+                                  "from": "read-all-stream@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-2.2.0.tgz",
+                                  "dependencies": {
+                                    "readable-stream": {
+                                      "version": "2.0.2",
+                                      "from": "readable-stream@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                      "dependencies": {
+                                        "core-util-is": {
+                                          "version": "1.0.1",
+                                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                        },
+                                        "inherits": {
+                                          "version": "2.0.1",
+                                          "from": "inherits@>=2.0.1 <2.1.0",
+                                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        },
+                                        "isarray": {
+                                          "version": "0.0.1",
+                                          "from": "isarray@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        },
+                                        "process-nextick-args": {
+                                          "version": "1.0.2",
+                                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                        },
+                                        "string_decoder": {
+                                          "version": "0.10.31",
+                                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        },
+                                        "util-deprecate": {
+                                          "version": "1.0.1",
+                                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "statuses": {
+                                  "version": "1.2.1",
+                                  "from": "statuses@>=1.2.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+                                },
+                                "timed-out": {
+                                  "version": "2.0.0",
+                                  "from": "timed-out@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "gulp-decompress": {
+                              "version": "1.1.0",
+                              "from": "gulp-decompress@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/gulp-decompress/-/gulp-decompress-1.1.0.tgz",
+                              "dependencies": {
+                                "archive-type": {
+                                  "version": "3.0.1",
+                                  "from": "archive-type@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/archive-type/-/archive-type-3.0.1.tgz",
+                                  "dependencies": {
+                                    "file-type": {
+                                      "version": "2.10.2",
+                                      "from": "file-type@>=2.0.1 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/file-type/-/file-type-2.10.2.tgz",
+                                      "dependencies": {
+                                        "read-chunk": {
+                                          "version": "1.0.1",
+                                          "from": "read-chunk@>=1.0.1 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-1.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "decompress": {
+                                  "version": "2.3.0",
+                                  "from": "decompress@>=2.1.1 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/decompress/-/decompress-2.3.0.tgz",
+                                  "dependencies": {
+                                    "decompress-tar": {
+                                      "version": "3.1.0",
+                                      "from": "decompress-tar@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-3.1.0.tgz",
+                                      "dependencies": {
+                                        "is-tar": {
+                                          "version": "1.0.0",
+                                          "from": "is-tar@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/is-tar/-/is-tar-1.0.0.tgz"
+                                        },
+                                        "strip-dirs": {
+                                          "version": "1.1.1",
+                                          "from": "strip-dirs@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                                          "dependencies": {
+                                            "is-absolute": {
+                                              "version": "0.1.7",
+                                              "from": "is-absolute@>=0.1.5 <0.2.0",
+                                              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                                              "dependencies": {
+                                                "is-relative": {
+                                                  "version": "0.1.3",
+                                                  "from": "is-relative@>=0.1.0 <0.2.0",
+                                                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                                                }
+                                              }
+                                            },
+                                            "is-natural-number": {
+                                              "version": "2.0.0",
+                                              "from": "is-natural-number@>=2.0.0 <3.0.0",
+                                              "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz"
+                                            },
+                                            "minimist": {
+                                              "version": "1.2.0",
+                                              "from": "minimist@>=1.1.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                                            },
+                                            "sum-up": {
+                                              "version": "1.0.2",
+                                              "from": "sum-up@>=1.0.1 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.2.tgz"
+                                            }
+                                          }
+                                        },
+                                        "tar-stream": {
+                                          "version": "1.2.1",
+                                          "from": "tar-stream@>=1.1.1 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.2.1.tgz",
+                                          "dependencies": {
+                                            "bl": {
+                                              "version": "1.0.0",
+                                              "from": "bl@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
+                                            },
+                                            "end-of-stream": {
+                                              "version": "1.1.0",
+                                              "from": "end-of-stream@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                                              "dependencies": {
+                                                "once": {
+                                                  "version": "1.3.2",
+                                                  "from": "once@>=1.3.0 <2.0.0",
+                                                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                                  "dependencies": {
+                                                    "wrappy": {
+                                                      "version": "1.0.1",
+                                                      "from": "wrappy@>=1.0.0 <2.0.0",
+                                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "readable-stream": {
+                                              "version": "2.0.2",
+                                              "from": "readable-stream@>=2.0.0 <3.0.0",
+                                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                              "dependencies": {
+                                                "core-util-is": {
+                                                  "version": "1.0.1",
+                                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                                },
+                                                "inherits": {
+                                                  "version": "2.0.1",
+                                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                                },
+                                                "isarray": {
+                                                  "version": "0.0.1",
+                                                  "from": "isarray@0.0.1",
+                                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                                },
+                                                "process-nextick-args": {
+                                                  "version": "1.0.2",
+                                                  "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                                },
+                                                "string_decoder": {
+                                                  "version": "0.10.31",
+                                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                                },
+                                                "util-deprecate": {
+                                                  "version": "1.0.1",
+                                                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                                }
+                                              }
+                                            },
+                                            "xtend": {
+                                              "version": "4.0.0",
+                                              "from": "xtend@>=4.0.0 <5.0.0",
+                                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                            }
+                                          }
+                                        },
+                                        "through2": {
+                                          "version": "0.6.5",
+                                          "from": "through2@>=0.6.1 <0.7.0",
+                                          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                                          "dependencies": {
+                                            "readable-stream": {
+                                              "version": "1.0.33",
+                                              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                                              "dependencies": {
+                                                "core-util-is": {
+                                                  "version": "1.0.1",
+                                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                                },
+                                                "isarray": {
+                                                  "version": "0.0.1",
+                                                  "from": "isarray@0.0.1",
+                                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                                },
+                                                "string_decoder": {
+                                                  "version": "0.10.31",
+                                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                                },
+                                                "inherits": {
+                                                  "version": "2.0.1",
+                                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                                }
+                                              }
+                                            },
+                                            "xtend": {
+                                              "version": "4.0.0",
+                                              "from": "xtend@>=4.0.0 <4.1.0-0",
+                                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "decompress-tarbz2": {
+                                      "version": "3.1.0",
+                                      "from": "decompress-tarbz2@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-3.1.0.tgz",
+                                      "dependencies": {
+                                        "is-bzip2": {
+                                          "version": "1.0.0",
+                                          "from": "is-bzip2@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/is-bzip2/-/is-bzip2-1.0.0.tgz"
+                                        },
+                                        "seek-bzip": {
+                                          "version": "1.0.5",
+                                          "from": "seek-bzip@>=1.0.3 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
+                                          "dependencies": {
+                                            "commander": {
+                                              "version": "2.8.1",
+                                              "from": "commander@>=2.8.1 <2.9.0",
+                                              "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+                                              "dependencies": {
+                                                "graceful-readlink": {
+                                                  "version": "1.0.1",
+                                                  "from": "graceful-readlink@>=1.0.0",
+                                                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "strip-dirs": {
+                                          "version": "1.1.1",
+                                          "from": "strip-dirs@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                                          "dependencies": {
+                                            "is-absolute": {
+                                              "version": "0.1.7",
+                                              "from": "is-absolute@>=0.1.5 <0.2.0",
+                                              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                                              "dependencies": {
+                                                "is-relative": {
+                                                  "version": "0.1.3",
+                                                  "from": "is-relative@>=0.1.0 <0.2.0",
+                                                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                                                }
+                                              }
+                                            },
+                                            "is-natural-number": {
+                                              "version": "2.0.0",
+                                              "from": "is-natural-number@>=2.0.0 <3.0.0",
+                                              "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz"
+                                            },
+                                            "minimist": {
+                                              "version": "1.2.0",
+                                              "from": "minimist@>=1.1.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                                            },
+                                            "sum-up": {
+                                              "version": "1.0.2",
+                                              "from": "sum-up@>=1.0.1 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.2.tgz"
+                                            }
+                                          }
+                                        },
+                                        "tar-stream": {
+                                          "version": "1.2.1",
+                                          "from": "tar-stream@>=1.1.1 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.2.1.tgz",
+                                          "dependencies": {
+                                            "bl": {
+                                              "version": "1.0.0",
+                                              "from": "bl@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
+                                            },
+                                            "end-of-stream": {
+                                              "version": "1.1.0",
+                                              "from": "end-of-stream@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                                              "dependencies": {
+                                                "once": {
+                                                  "version": "1.3.2",
+                                                  "from": "once@>=1.3.0 <2.0.0",
+                                                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                                  "dependencies": {
+                                                    "wrappy": {
+                                                      "version": "1.0.1",
+                                                      "from": "wrappy@>=1.0.0 <2.0.0",
+                                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "readable-stream": {
+                                              "version": "2.0.2",
+                                              "from": "readable-stream@>=2.0.0 <3.0.0",
+                                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                              "dependencies": {
+                                                "core-util-is": {
+                                                  "version": "1.0.1",
+                                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                                },
+                                                "inherits": {
+                                                  "version": "2.0.1",
+                                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                                },
+                                                "isarray": {
+                                                  "version": "0.0.1",
+                                                  "from": "isarray@0.0.1",
+                                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                                },
+                                                "process-nextick-args": {
+                                                  "version": "1.0.2",
+                                                  "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                                },
+                                                "string_decoder": {
+                                                  "version": "0.10.31",
+                                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                                },
+                                                "util-deprecate": {
+                                                  "version": "1.0.1",
+                                                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                                }
+                                              }
+                                            },
+                                            "xtend": {
+                                              "version": "4.0.0",
+                                              "from": "xtend@>=4.0.0 <5.0.0",
+                                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                            }
+                                          }
+                                        },
+                                        "through2": {
+                                          "version": "0.6.5",
+                                          "from": "through2@>=0.6.1 <0.7.0",
+                                          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                                          "dependencies": {
+                                            "readable-stream": {
+                                              "version": "1.0.33",
+                                              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                                              "dependencies": {
+                                                "core-util-is": {
+                                                  "version": "1.0.1",
+                                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                                },
+                                                "isarray": {
+                                                  "version": "0.0.1",
+                                                  "from": "isarray@0.0.1",
+                                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                                },
+                                                "string_decoder": {
+                                                  "version": "0.10.31",
+                                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                                },
+                                                "inherits": {
+                                                  "version": "2.0.1",
+                                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                                }
+                                              }
+                                            },
+                                            "xtend": {
+                                              "version": "4.0.0",
+                                              "from": "xtend@>=4.0.0 <4.1.0-0",
+                                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "decompress-targz": {
+                                      "version": "3.1.0",
+                                      "from": "decompress-targz@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-3.1.0.tgz",
+                                      "dependencies": {
+                                        "is-gzip": {
+                                          "version": "1.0.0",
+                                          "from": "is-gzip@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz"
+                                        },
+                                        "strip-dirs": {
+                                          "version": "1.1.1",
+                                          "from": "strip-dirs@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                                          "dependencies": {
+                                            "is-absolute": {
+                                              "version": "0.1.7",
+                                              "from": "is-absolute@>=0.1.5 <0.2.0",
+                                              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                                              "dependencies": {
+                                                "is-relative": {
+                                                  "version": "0.1.3",
+                                                  "from": "is-relative@>=0.1.0 <0.2.0",
+                                                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                                                }
+                                              }
+                                            },
+                                            "is-natural-number": {
+                                              "version": "2.0.0",
+                                              "from": "is-natural-number@>=2.0.0 <3.0.0",
+                                              "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz"
+                                            },
+                                            "minimist": {
+                                              "version": "1.2.0",
+                                              "from": "minimist@>=1.1.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                                            },
+                                            "sum-up": {
+                                              "version": "1.0.2",
+                                              "from": "sum-up@>=1.0.1 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.2.tgz"
+                                            }
+                                          }
+                                        },
+                                        "tar-stream": {
+                                          "version": "1.2.1",
+                                          "from": "tar-stream@>=1.1.1 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.2.1.tgz",
+                                          "dependencies": {
+                                            "bl": {
+                                              "version": "1.0.0",
+                                              "from": "bl@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
+                                            },
+                                            "end-of-stream": {
+                                              "version": "1.1.0",
+                                              "from": "end-of-stream@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                                              "dependencies": {
+                                                "once": {
+                                                  "version": "1.3.2",
+                                                  "from": "once@>=1.3.0 <2.0.0",
+                                                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                                  "dependencies": {
+                                                    "wrappy": {
+                                                      "version": "1.0.1",
+                                                      "from": "wrappy@>=1.0.0 <2.0.0",
+                                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "readable-stream": {
+                                              "version": "2.0.2",
+                                              "from": "readable-stream@>=2.0.0 <3.0.0",
+                                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                              "dependencies": {
+                                                "core-util-is": {
+                                                  "version": "1.0.1",
+                                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                                },
+                                                "inherits": {
+                                                  "version": "2.0.1",
+                                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                                },
+                                                "isarray": {
+                                                  "version": "0.0.1",
+                                                  "from": "isarray@0.0.1",
+                                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                                },
+                                                "process-nextick-args": {
+                                                  "version": "1.0.2",
+                                                  "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                                },
+                                                "string_decoder": {
+                                                  "version": "0.10.31",
+                                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                                },
+                                                "util-deprecate": {
+                                                  "version": "1.0.1",
+                                                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                                }
+                                              }
+                                            },
+                                            "xtend": {
+                                              "version": "4.0.0",
+                                              "from": "xtend@>=4.0.0 <5.0.0",
+                                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                            }
+                                          }
+                                        },
+                                        "through2": {
+                                          "version": "0.6.5",
+                                          "from": "through2@>=0.6.1 <0.7.0",
+                                          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                                          "dependencies": {
+                                            "readable-stream": {
+                                              "version": "1.0.33",
+                                              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                                              "dependencies": {
+                                                "core-util-is": {
+                                                  "version": "1.0.1",
+                                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                                },
+                                                "isarray": {
+                                                  "version": "0.0.1",
+                                                  "from": "isarray@0.0.1",
+                                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                                },
+                                                "string_decoder": {
+                                                  "version": "0.10.31",
+                                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                                },
+                                                "inherits": {
+                                                  "version": "2.0.1",
+                                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                                }
+                                              }
+                                            },
+                                            "xtend": {
+                                              "version": "4.0.0",
+                                              "from": "xtend@>=4.0.0 <4.1.0-0",
+                                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "decompress-unzip": {
+                                      "version": "3.3.0",
+                                      "from": "decompress-unzip@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-3.3.0.tgz",
+                                      "dependencies": {
+                                        "is-zip": {
+                                          "version": "1.0.0",
+                                          "from": "is-zip@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/is-zip/-/is-zip-1.0.0.tgz"
+                                        },
+                                        "stat-mode": {
+                                          "version": "0.2.1",
+                                          "from": "stat-mode@>=0.2.0 <0.3.0",
+                                          "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.1.tgz"
+                                        },
+                                        "strip-dirs": {
+                                          "version": "1.1.1",
+                                          "from": "strip-dirs@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                                          "dependencies": {
+                                            "is-absolute": {
+                                              "version": "0.1.7",
+                                              "from": "is-absolute@>=0.1.5 <0.2.0",
+                                              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                                              "dependencies": {
+                                                "is-relative": {
+                                                  "version": "0.1.3",
+                                                  "from": "is-relative@>=0.1.0 <0.2.0",
+                                                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                                                }
+                                              }
+                                            },
+                                            "is-natural-number": {
+                                              "version": "2.0.0",
+                                              "from": "is-natural-number@>=2.0.0 <3.0.0",
+                                              "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz"
+                                            },
+                                            "minimist": {
+                                              "version": "1.2.0",
+                                              "from": "minimist@>=1.1.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                                            },
+                                            "sum-up": {
+                                              "version": "1.0.2",
+                                              "from": "sum-up@>=1.0.1 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.2.tgz"
+                                            }
+                                          }
+                                        },
+                                        "vinyl": {
+                                          "version": "0.5.1",
+                                          "from": "vinyl@>=0.5.0 <0.6.0",
+                                          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.1.tgz",
+                                          "dependencies": {
+                                            "clone": {
+                                              "version": "1.0.2",
+                                              "from": "clone@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+                                            },
+                                            "clone-stats": {
+                                              "version": "0.0.1",
+                                              "from": "clone-stats@>=0.0.1 <0.0.2",
+                                              "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                                            },
+                                            "replace-ext": {
+                                              "version": "0.0.1",
+                                              "from": "replace-ext@0.0.1",
+                                              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+                                            }
+                                          }
+                                        },
+                                        "yauzl": {
+                                          "version": "2.3.1",
+                                          "from": "yauzl@>=2.2.1 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.3.1.tgz",
+                                          "dependencies": {
+                                            "fd-slicer": {
+                                              "version": "1.0.1",
+                                              "from": "fd-slicer@>=1.0.1 <1.1.0",
+                                              "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz"
+                                            },
+                                            "pend": {
+                                              "version": "1.2.0",
+                                              "from": "pend@>=1.2.0 <1.3.0",
+                                              "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "vinyl-assign": {
+                                      "version": "1.2.0",
+                                      "from": "vinyl-assign@>=1.0.1 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/vinyl-assign/-/vinyl-assign-1.2.0.tgz",
+                                      "dependencies": {
+                                        "object-assign": {
+                                          "version": "3.0.0",
+                                          "from": "object-assign@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                                        },
+                                        "readable-stream": {
+                                          "version": "2.0.2",
+                                          "from": "readable-stream@>=2.0.0 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                          "dependencies": {
+                                            "core-util-is": {
+                                              "version": "1.0.1",
+                                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                            },
+                                            "inherits": {
+                                              "version": "2.0.1",
+                                              "from": "inherits@>=2.0.1 <2.1.0",
+                                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                            },
+                                            "isarray": {
+                                              "version": "0.0.1",
+                                              "from": "isarray@0.0.1",
+                                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                            },
+                                            "process-nextick-args": {
+                                              "version": "1.0.2",
+                                              "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                            },
+                                            "string_decoder": {
+                                              "version": "0.10.31",
+                                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                            },
+                                            "util-deprecate": {
+                                              "version": "1.0.1",
+                                              "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "gulp-util": {
+                                  "version": "3.0.6",
+                                  "from": "gulp-util@>=3.0.1 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.6.tgz",
+                                  "dependencies": {
+                                    "array-differ": {
+                                      "version": "1.0.0",
+                                      "from": "array-differ@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
+                                    },
+                                    "array-uniq": {
+                                      "version": "1.0.2",
+                                      "from": "array-uniq@>=1.0.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+                                    },
+                                    "beeper": {
+                                      "version": "1.1.0",
+                                      "from": "beeper@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
+                                    },
+                                    "dateformat": {
+                                      "version": "1.0.11",
+                                      "from": "dateformat@>=1.0.11 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz"
+                                    },
+                                    "lodash._reescape": {
+                                      "version": "3.0.0",
+                                      "from": "lodash._reescape@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+                                    },
+                                    "lodash._reevaluate": {
+                                      "version": "3.0.0",
+                                      "from": "lodash._reevaluate@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+                                    },
+                                    "lodash._reinterpolate": {
+                                      "version": "3.0.0",
+                                      "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+                                    },
+                                    "lodash.template": {
+                                      "version": "3.6.2",
+                                      "from": "lodash.template@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+                                      "dependencies": {
+                                        "lodash._basecopy": {
+                                          "version": "3.0.1",
+                                          "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                                        },
+                                        "lodash._basetostring": {
+                                          "version": "3.0.1",
+                                          "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                                        },
+                                        "lodash._basevalues": {
+                                          "version": "3.0.0",
+                                          "from": "lodash._basevalues@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+                                        },
+                                        "lodash._isiterateecall": {
+                                          "version": "3.0.9",
+                                          "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                                        },
+                                        "lodash.escape": {
+                                          "version": "3.0.0",
+                                          "from": "lodash.escape@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+                                        },
+                                        "lodash.keys": {
+                                          "version": "3.1.2",
+                                          "from": "lodash.keys@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                                          "dependencies": {
+                                            "lodash._getnative": {
+                                              "version": "3.9.1",
+                                              "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                                              "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                                            },
+                                            "lodash.isarguments": {
+                                              "version": "3.0.4",
+                                              "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                                              "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                                            },
+                                            "lodash.isarray": {
+                                              "version": "3.0.4",
+                                              "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                                              "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                                            }
+                                          }
+                                        },
+                                        "lodash.restparam": {
+                                          "version": "3.6.1",
+                                          "from": "lodash.restparam@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                                        },
+                                        "lodash.templatesettings": {
+                                          "version": "3.1.0",
+                                          "from": "lodash.templatesettings@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+                                        }
+                                      }
+                                    },
+                                    "minimist": {
+                                      "version": "1.2.0",
+                                      "from": "minimist@>=1.1.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                                    },
+                                    "multipipe": {
+                                      "version": "0.1.2",
+                                      "from": "multipipe@>=0.1.2 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+                                      "dependencies": {
+                                        "duplexer2": {
+                                          "version": "0.0.2",
+                                          "from": "duplexer2@0.0.2",
+                                          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                                          "dependencies": {
+                                            "readable-stream": {
+                                              "version": "1.1.13",
+                                              "from": "readable-stream@>=1.1.9 <1.2.0",
+                                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                                              "dependencies": {
+                                                "core-util-is": {
+                                                  "version": "1.0.1",
+                                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                                },
+                                                "isarray": {
+                                                  "version": "0.0.1",
+                                                  "from": "isarray@0.0.1",
+                                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                                },
+                                                "string_decoder": {
+                                                  "version": "0.10.31",
+                                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                                },
+                                                "inherits": {
+                                                  "version": "2.0.1",
+                                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "object-assign": {
+                                      "version": "3.0.0",
+                                      "from": "object-assign@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                                    },
+                                    "replace-ext": {
+                                      "version": "0.0.1",
+                                      "from": "replace-ext@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+                                    },
+                                    "vinyl": {
+                                      "version": "0.5.1",
+                                      "from": "vinyl@>=0.5.0 <0.6.0",
+                                      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.1.tgz",
+                                      "dependencies": {
+                                        "clone": {
+                                          "version": "1.0.2",
+                                          "from": "clone@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+                                        },
+                                        "clone-stats": {
+                                          "version": "0.0.1",
+                                          "from": "clone-stats@>=0.0.1 <0.0.2",
+                                          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "is-url": {
+                              "version": "1.2.1",
+                              "from": "is-url@>=1.2.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.1.tgz"
+                            },
+                            "object-assign": {
+                              "version": "2.1.1",
+                              "from": "object-assign@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+                            },
+                            "read-all-stream": {
+                              "version": "3.0.1",
+                              "from": "read-all-stream@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.0.1.tgz",
+                              "dependencies": {
+                                "pinkie-promise": {
+                                  "version": "1.0.0",
+                                  "from": "pinkie-promise@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+                                  "dependencies": {
+                                    "pinkie": {
+                                      "version": "1.0.0",
+                                      "from": "pinkie@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "readable-stream": {
+                                  "version": "2.0.2",
+                                  "from": "readable-stream@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                  "dependencies": {
+                                    "core-util-is": {
+                                      "version": "1.0.1",
+                                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@>=2.0.1 <2.1.0",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    },
+                                    "isarray": {
+                                      "version": "0.0.1",
+                                      "from": "isarray@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                    },
+                                    "process-nextick-args": {
+                                      "version": "1.0.2",
+                                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                    },
+                                    "string_decoder": {
+                                      "version": "0.10.31",
+                                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                    },
+                                    "util-deprecate": {
+                                      "version": "1.0.1",
+                                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "vinyl": {
+                              "version": "0.4.6",
+                              "from": "vinyl@>=0.4.3 <0.5.0",
+                              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+                              "dependencies": {
+                                "clone": {
+                                  "version": "0.2.0",
+                                  "from": "clone@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+                                },
+                                "clone-stats": {
+                                  "version": "0.0.1",
+                                  "from": "clone-stats@>=0.0.1 <0.0.2",
+                                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                                }
+                              }
+                            },
+                            "ware": {
+                              "version": "1.3.0",
+                              "from": "ware@>=1.2.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
+                              "dependencies": {
+                                "wrap-fn": {
+                                  "version": "0.1.4",
+                                  "from": "wrap-fn@>=0.1.0 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.4.tgz",
+                                  "dependencies": {
+                                    "co": {
+                                      "version": "3.1.0",
+                                      "from": "co@3.1.0",
+                                      "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "each-async": {
+                          "version": "1.1.1",
+                          "from": "each-async@>=1.1.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
+                          "dependencies": {
+                            "onetime": {
+                              "version": "1.0.0",
+                              "from": "onetime@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz"
+                            },
+                            "set-immediate-shim": {
+                              "version": "1.0.1",
+                              "from": "set-immediate-shim@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "lazy-req": {
+                          "version": "1.1.0",
+                          "from": "lazy-req@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-1.1.0.tgz"
+                        },
+                        "os-filter-obj": {
+                          "version": "1.0.3",
+                          "from": "os-filter-obj@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/os-filter-obj/-/os-filter-obj-1.0.3.tgz"
+                        }
+                      }
+                    },
+                    "logalot": {
+                      "version": "2.1.0",
+                      "from": "logalot@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/logalot/-/logalot-2.1.0.tgz",
+                      "dependencies": {
+                        "figures": {
+                          "version": "1.3.5",
+                          "from": "figures@>=1.3.5 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
+                        },
+                        "squeak": {
+                          "version": "1.2.0",
+                          "from": "squeak@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/squeak/-/squeak-1.2.0.tgz",
+                          "dependencies": {
+                            "chalk": {
+                              "version": "0.5.1",
+                              "from": "chalk@>=0.5.1 <0.6.0",
+                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+                              "dependencies": {
+                                "ansi-styles": {
+                                  "version": "1.1.0",
+                                  "from": "ansi-styles@>=1.1.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+                                },
+                                "escape-string-regexp": {
+                                  "version": "1.0.3",
+                                  "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                },
+                                "has-ansi": {
+                                  "version": "0.1.0",
+                                  "from": "has-ansi@>=0.1.0 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "0.2.1",
+                                      "from": "ansi-regex@>=0.2.1 <0.3.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                                    }
+                                  }
+                                },
+                                "strip-ansi": {
+                                  "version": "0.3.0",
+                                  "from": "strip-ansi@>=0.3.0 <0.4.0",
+                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "0.2.1",
+                                      "from": "ansi-regex@>=0.2.1 <0.3.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                                    }
+                                  }
+                                },
+                                "supports-color": {
+                                  "version": "0.2.0",
+                                  "from": "supports-color@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+                                }
+                              }
+                            },
+                            "lpad-align": {
+                              "version": "1.1.0",
+                              "from": "lpad-align@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/lpad-align/-/lpad-align-1.1.0.tgz",
+                              "dependencies": {
+                                "longest": {
+                                  "version": "1.0.1",
+                                  "from": "longest@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                },
+                                "lpad": {
+                                  "version": "2.0.1",
+                                  "from": "lpad@>=2.0.1 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/lpad/-/lpad-2.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "through2": {
+                  "version": "2.0.0",
+                  "from": "through2@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "2.0.2",
+                      "from": "readable-stream@>=2.0.0 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.2",
+                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.1",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "xtend": {
+                      "version": "4.0.0",
+                      "from": "xtend@>=4.0.0 <4.1.0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "imagemin-optipng": {
+              "version": "4.3.0",
+              "from": "imagemin-optipng@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/imagemin-optipng/-/imagemin-optipng-4.3.0.tgz",
+              "dependencies": {
+                "exec-buffer": {
+                  "version": "2.0.1",
+                  "from": "exec-buffer@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/exec-buffer/-/exec-buffer-2.0.1.tgz",
+                  "dependencies": {
+                    "rimraf": {
+                      "version": "2.4.2",
+                      "from": "rimraf@>=2.2.6 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.2.tgz",
+                      "dependencies": {
+                        "glob": {
+                          "version": "5.0.14",
+                          "from": "glob@>=5.0.14 <6.0.0",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
+                          "dependencies": {
+                            "inflight": {
+                              "version": "1.0.4",
+                              "from": "inflight@>=1.0.4 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "wrappy@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "minimatch": {
+                              "version": "2.0.10",
+                              "from": "minimatch@>=2.0.1 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                              "dependencies": {
+                                "brace-expansion": {
+                                  "version": "1.1.0",
+                                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                                  "dependencies": {
+                                    "balanced-match": {
+                                      "version": "0.2.0",
+                                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                                    },
+                                    "concat-map": {
+                                      "version": "0.0.1",
+                                      "from": "concat-map@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "once": {
+                              "version": "1.3.2",
+                              "from": "once@>=1.3.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "wrappy@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "path-is-absolute": {
+                              "version": "1.0.0",
+                              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "tempfile": {
+                      "version": "1.1.1",
+                      "from": "tempfile@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz",
+                      "dependencies": {
+                        "os-tmpdir": {
+                          "version": "1.0.1",
+                          "from": "os-tmpdir@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                        },
+                        "uuid": {
+                          "version": "2.0.1",
+                          "from": "uuid@>=2.0.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "is-png": {
+                  "version": "1.0.0",
+                  "from": "is-png@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-png/-/is-png-1.0.0.tgz"
+                },
+                "optipng-bin": {
+                  "version": "3.0.2",
+                  "from": "optipng-bin@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/optipng-bin/-/optipng-bin-3.0.2.tgz",
+                  "dependencies": {
+                    "bin-build": {
+                      "version": "2.1.2",
+                      "from": "bin-build@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/bin-build/-/bin-build-2.1.2.tgz",
+                      "dependencies": {
+                        "archive-type": {
+                          "version": "2.1.0",
+                          "from": "archive-type@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/archive-type/-/archive-type-2.1.0.tgz",
+                          "dependencies": {
+                            "file-type": {
+                              "version": "2.10.2",
+                              "from": "file-type@>=2.0.1 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/file-type/-/file-type-2.10.2.tgz"
+                            },
+                            "read-chunk": {
+                              "version": "1.0.1",
+                              "from": "read-chunk@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "decompress": {
+                          "version": "2.3.0",
+                          "from": "decompress@>=2.1.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/decompress/-/decompress-2.3.0.tgz",
+                          "dependencies": {
+                            "decompress-tar": {
+                              "version": "3.1.0",
+                              "from": "decompress-tar@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-3.1.0.tgz",
+                              "dependencies": {
+                                "is-tar": {
+                                  "version": "1.0.0",
+                                  "from": "is-tar@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-tar/-/is-tar-1.0.0.tgz"
+                                },
+                                "object-assign": {
+                                  "version": "2.1.1",
+                                  "from": "object-assign@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+                                },
+                                "strip-dirs": {
+                                  "version": "1.1.1",
+                                  "from": "strip-dirs@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                                  "dependencies": {
+                                    "is-absolute": {
+                                      "version": "0.1.7",
+                                      "from": "is-absolute@>=0.1.5 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                                      "dependencies": {
+                                        "is-relative": {
+                                          "version": "0.1.3",
+                                          "from": "is-relative@>=0.1.0 <0.2.0",
+                                          "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                                        }
+                                      }
+                                    },
+                                    "is-natural-number": {
+                                      "version": "2.0.0",
+                                      "from": "is-natural-number@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz"
+                                    },
+                                    "minimist": {
+                                      "version": "1.2.0",
+                                      "from": "minimist@>=1.1.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                                    },
+                                    "sum-up": {
+                                      "version": "1.0.2",
+                                      "from": "sum-up@>=1.0.1 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.2.tgz"
+                                    }
+                                  }
+                                },
+                                "tar-stream": {
+                                  "version": "1.2.1",
+                                  "from": "tar-stream@>=1.1.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.2.1.tgz",
+                                  "dependencies": {
+                                    "bl": {
+                                      "version": "1.0.0",
+                                      "from": "bl@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
+                                    },
+                                    "end-of-stream": {
+                                      "version": "1.1.0",
+                                      "from": "end-of-stream@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                                      "dependencies": {
+                                        "once": {
+                                          "version": "1.3.2",
+                                          "from": "once@>=1.3.0 <1.4.0",
+                                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                          "dependencies": {
+                                            "wrappy": {
+                                              "version": "1.0.1",
+                                              "from": "wrappy@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "readable-stream": {
+                                      "version": "2.0.2",
+                                      "from": "readable-stream@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                      "dependencies": {
+                                        "core-util-is": {
+                                          "version": "1.0.1",
+                                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                        },
+                                        "inherits": {
+                                          "version": "2.0.1",
+                                          "from": "inherits@>=2.0.1 <2.1.0",
+                                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        },
+                                        "isarray": {
+                                          "version": "0.0.1",
+                                          "from": "isarray@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        },
+                                        "process-nextick-args": {
+                                          "version": "1.0.2",
+                                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                        },
+                                        "string_decoder": {
+                                          "version": "0.10.31",
+                                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        },
+                                        "util-deprecate": {
+                                          "version": "1.0.1",
+                                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "xtend": {
+                                      "version": "4.0.0",
+                                      "from": "xtend@>=4.0.0 <4.1.0-0",
+                                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "vinyl": {
+                                  "version": "0.4.6",
+                                  "from": "vinyl@>=0.4.3 <0.5.0",
+                                  "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+                                  "dependencies": {
+                                    "clone": {
+                                      "version": "0.2.0",
+                                      "from": "clone@>=0.2.0 <0.3.0",
+                                      "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+                                    },
+                                    "clone-stats": {
+                                      "version": "0.0.1",
+                                      "from": "clone-stats@>=0.0.1 <0.0.2",
+                                      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "decompress-tarbz2": {
+                              "version": "3.1.0",
+                              "from": "decompress-tarbz2@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-3.1.0.tgz",
+                              "dependencies": {
+                                "is-bzip2": {
+                                  "version": "1.0.0",
+                                  "from": "is-bzip2@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-bzip2/-/is-bzip2-1.0.0.tgz"
+                                },
+                                "object-assign": {
+                                  "version": "2.1.1",
+                                  "from": "object-assign@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+                                },
+                                "seek-bzip": {
+                                  "version": "1.0.5",
+                                  "from": "seek-bzip@>=1.0.3 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
+                                  "dependencies": {
+                                    "commander": {
+                                      "version": "2.8.1",
+                                      "from": "commander@>=2.8.1 <2.9.0",
+                                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+                                      "dependencies": {
+                                        "graceful-readlink": {
+                                          "version": "1.0.1",
+                                          "from": "graceful-readlink@>=1.0.0",
+                                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "strip-dirs": {
+                                  "version": "1.1.1",
+                                  "from": "strip-dirs@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                                  "dependencies": {
+                                    "is-absolute": {
+                                      "version": "0.1.7",
+                                      "from": "is-absolute@>=0.1.5 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                                      "dependencies": {
+                                        "is-relative": {
+                                          "version": "0.1.3",
+                                          "from": "is-relative@>=0.1.0 <0.2.0",
+                                          "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                                        }
+                                      }
+                                    },
+                                    "is-natural-number": {
+                                      "version": "2.0.0",
+                                      "from": "is-natural-number@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz"
+                                    },
+                                    "minimist": {
+                                      "version": "1.2.0",
+                                      "from": "minimist@>=1.1.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                                    },
+                                    "sum-up": {
+                                      "version": "1.0.2",
+                                      "from": "sum-up@>=1.0.1 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.2.tgz"
+                                    }
+                                  }
+                                },
+                                "tar-stream": {
+                                  "version": "1.2.1",
+                                  "from": "tar-stream@>=1.1.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.2.1.tgz",
+                                  "dependencies": {
+                                    "bl": {
+                                      "version": "1.0.0",
+                                      "from": "bl@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
+                                    },
+                                    "end-of-stream": {
+                                      "version": "1.1.0",
+                                      "from": "end-of-stream@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                                      "dependencies": {
+                                        "once": {
+                                          "version": "1.3.2",
+                                          "from": "once@>=1.3.0 <1.4.0",
+                                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                          "dependencies": {
+                                            "wrappy": {
+                                              "version": "1.0.1",
+                                              "from": "wrappy@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "readable-stream": {
+                                      "version": "2.0.2",
+                                      "from": "readable-stream@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                      "dependencies": {
+                                        "core-util-is": {
+                                          "version": "1.0.1",
+                                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                        },
+                                        "inherits": {
+                                          "version": "2.0.1",
+                                          "from": "inherits@>=2.0.1 <2.1.0",
+                                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        },
+                                        "isarray": {
+                                          "version": "0.0.1",
+                                          "from": "isarray@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        },
+                                        "process-nextick-args": {
+                                          "version": "1.0.2",
+                                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                        },
+                                        "string_decoder": {
+                                          "version": "0.10.31",
+                                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        },
+                                        "util-deprecate": {
+                                          "version": "1.0.1",
+                                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "xtend": {
+                                      "version": "4.0.0",
+                                      "from": "xtend@>=4.0.0 <5.0.0",
+                                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "vinyl": {
+                                  "version": "0.4.6",
+                                  "from": "vinyl@>=0.4.3 <0.5.0",
+                                  "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+                                  "dependencies": {
+                                    "clone": {
+                                      "version": "0.2.0",
+                                      "from": "clone@>=0.2.0 <0.3.0",
+                                      "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+                                    },
+                                    "clone-stats": {
+                                      "version": "0.0.1",
+                                      "from": "clone-stats@>=0.0.1 <0.0.2",
+                                      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "decompress-targz": {
+                              "version": "3.1.0",
+                              "from": "decompress-targz@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-3.1.0.tgz",
+                              "dependencies": {
+                                "is-gzip": {
+                                  "version": "1.0.0",
+                                  "from": "is-gzip@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz"
+                                },
+                                "object-assign": {
+                                  "version": "2.1.1",
+                                  "from": "object-assign@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+                                },
+                                "strip-dirs": {
+                                  "version": "1.1.1",
+                                  "from": "strip-dirs@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                                  "dependencies": {
+                                    "is-absolute": {
+                                      "version": "0.1.7",
+                                      "from": "is-absolute@>=0.1.5 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                                      "dependencies": {
+                                        "is-relative": {
+                                          "version": "0.1.3",
+                                          "from": "is-relative@>=0.1.0 <0.2.0",
+                                          "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                                        }
+                                      }
+                                    },
+                                    "is-natural-number": {
+                                      "version": "2.0.0",
+                                      "from": "is-natural-number@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz"
+                                    },
+                                    "minimist": {
+                                      "version": "1.2.0",
+                                      "from": "minimist@>=1.1.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                                    },
+                                    "sum-up": {
+                                      "version": "1.0.2",
+                                      "from": "sum-up@>=1.0.1 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.2.tgz"
+                                    }
+                                  }
+                                },
+                                "tar-stream": {
+                                  "version": "1.2.1",
+                                  "from": "tar-stream@>=1.1.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.2.1.tgz",
+                                  "dependencies": {
+                                    "bl": {
+                                      "version": "1.0.0",
+                                      "from": "bl@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
+                                    },
+                                    "end-of-stream": {
+                                      "version": "1.1.0",
+                                      "from": "end-of-stream@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                                      "dependencies": {
+                                        "once": {
+                                          "version": "1.3.2",
+                                          "from": "once@>=1.3.0 <1.4.0",
+                                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                          "dependencies": {
+                                            "wrappy": {
+                                              "version": "1.0.1",
+                                              "from": "wrappy@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "readable-stream": {
+                                      "version": "2.0.2",
+                                      "from": "readable-stream@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                      "dependencies": {
+                                        "core-util-is": {
+                                          "version": "1.0.1",
+                                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                        },
+                                        "inherits": {
+                                          "version": "2.0.1",
+                                          "from": "inherits@>=2.0.1 <2.1.0",
+                                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        },
+                                        "isarray": {
+                                          "version": "0.0.1",
+                                          "from": "isarray@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        },
+                                        "process-nextick-args": {
+                                          "version": "1.0.2",
+                                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                        },
+                                        "string_decoder": {
+                                          "version": "0.10.31",
+                                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        },
+                                        "util-deprecate": {
+                                          "version": "1.0.1",
+                                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "xtend": {
+                                      "version": "4.0.0",
+                                      "from": "xtend@>=4.0.0 <4.1.0-0",
+                                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "vinyl": {
+                                  "version": "0.4.6",
+                                  "from": "vinyl@>=0.4.3 <0.5.0",
+                                  "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+                                  "dependencies": {
+                                    "clone": {
+                                      "version": "0.2.0",
+                                      "from": "clone@>=0.2.0 <0.3.0",
+                                      "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+                                    },
+                                    "clone-stats": {
+                                      "version": "0.0.1",
+                                      "from": "clone-stats@>=0.0.1 <0.0.2",
+                                      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "decompress-unzip": {
+                              "version": "3.3.0",
+                              "from": "decompress-unzip@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-3.3.0.tgz",
+                              "dependencies": {
+                                "is-zip": {
+                                  "version": "1.0.0",
+                                  "from": "is-zip@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-zip/-/is-zip-1.0.0.tgz"
+                                },
+                                "read-all-stream": {
+                                  "version": "3.0.1",
+                                  "from": "read-all-stream@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.0.1.tgz",
+                                  "dependencies": {
+                                    "pinkie-promise": {
+                                      "version": "1.0.0",
+                                      "from": "pinkie-promise@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+                                      "dependencies": {
+                                        "pinkie": {
+                                          "version": "1.0.0",
+                                          "from": "pinkie@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
+                                        }
+                                      }
+                                    },
+                                    "readable-stream": {
+                                      "version": "2.0.2",
+                                      "from": "readable-stream@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                      "dependencies": {
+                                        "core-util-is": {
+                                          "version": "1.0.1",
+                                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                        },
+                                        "inherits": {
+                                          "version": "2.0.1",
+                                          "from": "inherits@>=2.0.1 <2.1.0",
+                                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        },
+                                        "isarray": {
+                                          "version": "0.0.1",
+                                          "from": "isarray@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        },
+                                        "process-nextick-args": {
+                                          "version": "1.0.2",
+                                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                        },
+                                        "string_decoder": {
+                                          "version": "0.10.31",
+                                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        },
+                                        "util-deprecate": {
+                                          "version": "1.0.1",
+                                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "stat-mode": {
+                                  "version": "0.2.1",
+                                  "from": "stat-mode@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.1.tgz"
+                                },
+                                "strip-dirs": {
+                                  "version": "1.1.1",
+                                  "from": "strip-dirs@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                                  "dependencies": {
+                                    "is-absolute": {
+                                      "version": "0.1.7",
+                                      "from": "is-absolute@>=0.1.5 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                                      "dependencies": {
+                                        "is-relative": {
+                                          "version": "0.1.3",
+                                          "from": "is-relative@>=0.1.0 <0.2.0",
+                                          "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                                        }
+                                      }
+                                    },
+                                    "is-natural-number": {
+                                      "version": "2.0.0",
+                                      "from": "is-natural-number@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz"
+                                    },
+                                    "minimist": {
+                                      "version": "1.2.0",
+                                      "from": "minimist@>=1.1.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                                    },
+                                    "sum-up": {
+                                      "version": "1.0.2",
+                                      "from": "sum-up@>=1.0.1 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.2.tgz"
+                                    }
+                                  }
+                                },
+                                "through2": {
+                                  "version": "2.0.0",
+                                  "from": "through2@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
+                                  "dependencies": {
+                                    "readable-stream": {
+                                      "version": "2.0.2",
+                                      "from": "readable-stream@>=2.0.0 <2.1.0",
+                                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                      "dependencies": {
+                                        "core-util-is": {
+                                          "version": "1.0.1",
+                                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                        },
+                                        "inherits": {
+                                          "version": "2.0.1",
+                                          "from": "inherits@>=2.0.1 <2.1.0",
+                                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        },
+                                        "isarray": {
+                                          "version": "0.0.1",
+                                          "from": "isarray@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        },
+                                        "process-nextick-args": {
+                                          "version": "1.0.2",
+                                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                        },
+                                        "string_decoder": {
+                                          "version": "0.10.31",
+                                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        },
+                                        "util-deprecate": {
+                                          "version": "1.0.1",
+                                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "xtend": {
+                                      "version": "4.0.0",
+                                      "from": "xtend@>=4.0.0 <4.1.0-0",
+                                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "vinyl": {
+                                  "version": "0.5.1",
+                                  "from": "vinyl@>=0.5.0 <0.6.0",
+                                  "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.1.tgz",
+                                  "dependencies": {
+                                    "clone": {
+                                      "version": "1.0.2",
+                                      "from": "clone@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+                                    },
+                                    "clone-stats": {
+                                      "version": "0.0.1",
+                                      "from": "clone-stats@>=0.0.1 <0.0.2",
+                                      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                                    },
+                                    "replace-ext": {
+                                      "version": "0.0.1",
+                                      "from": "replace-ext@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "yauzl": {
+                                  "version": "2.3.1",
+                                  "from": "yauzl@>=2.2.1 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.3.1.tgz",
+                                  "dependencies": {
+                                    "fd-slicer": {
+                                      "version": "1.0.1",
+                                      "from": "fd-slicer@>=1.0.1 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz"
+                                    },
+                                    "pend": {
+                                      "version": "1.2.0",
+                                      "from": "pend@>=1.2.0 <1.3.0",
+                                      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "vinyl-assign": {
+                              "version": "1.2.0",
+                              "from": "vinyl-assign@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/vinyl-assign/-/vinyl-assign-1.2.0.tgz",
+                              "dependencies": {
+                                "object-assign": {
+                                  "version": "3.0.0",
+                                  "from": "object-assign@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                                },
+                                "readable-stream": {
+                                  "version": "2.0.2",
+                                  "from": "readable-stream@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                  "dependencies": {
+                                    "core-util-is": {
+                                      "version": "1.0.1",
+                                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@>=2.0.1 <2.1.0",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    },
+                                    "isarray": {
+                                      "version": "0.0.1",
+                                      "from": "isarray@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                    },
+                                    "process-nextick-args": {
+                                      "version": "1.0.2",
+                                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                    },
+                                    "string_decoder": {
+                                      "version": "0.10.31",
+                                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                    },
+                                    "util-deprecate": {
+                                      "version": "1.0.1",
+                                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "download": {
+                          "version": "4.2.0",
+                          "from": "download@>=4.0.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/download/-/download-4.2.0.tgz",
+                          "dependencies": {
+                            "caw": {
+                              "version": "1.1.0",
+                              "from": "caw@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/caw/-/caw-1.1.0.tgz",
+                              "dependencies": {
+                                "get-proxy": {
+                                  "version": "1.0.1",
+                                  "from": "get-proxy@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-1.0.1.tgz",
+                                  "dependencies": {
+                                    "rc": {
+                                      "version": "0.5.5",
+                                      "from": "rc@>=0.5.5 <0.6.0",
+                                      "resolved": "https://registry.npmjs.org/rc/-/rc-0.5.5.tgz",
+                                      "dependencies": {
+                                        "minimist": {
+                                          "version": "0.0.10",
+                                          "from": "minimist@>=0.0.7 <0.1.0",
+                                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                                        },
+                                        "deep-extend": {
+                                          "version": "0.2.11",
+                                          "from": "deep-extend@>=0.2.5 <0.3.0",
+                                          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+                                        },
+                                        "strip-json-comments": {
+                                          "version": "0.1.3",
+                                          "from": "strip-json-comments@>=0.1.0 <0.2.0",
+                                          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+                                        },
+                                        "ini": {
+                                          "version": "1.3.4",
+                                          "from": "ini@>=1.3.0 <1.4.0",
+                                          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "is-obj": {
+                                  "version": "1.0.0",
+                                  "from": "is-obj@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.0.tgz"
+                                },
+                                "object-assign": {
+                                  "version": "3.0.0",
+                                  "from": "object-assign@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                                },
+                                "tunnel-agent": {
+                                  "version": "0.4.1",
+                                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+                                }
+                              }
+                            },
+                            "each-async": {
+                              "version": "1.1.1",
+                              "from": "each-async@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
+                              "dependencies": {
+                                "onetime": {
+                                  "version": "1.0.0",
+                                  "from": "onetime@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz"
+                                },
+                                "set-immediate-shim": {
+                                  "version": "1.0.1",
+                                  "from": "set-immediate-shim@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "filenamify": {
+                              "version": "1.2.0",
+                              "from": "filenamify@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.0.tgz",
+                              "dependencies": {
+                                "filename-reserved-regex": {
+                                  "version": "1.0.0",
+                                  "from": "filename-reserved-regex@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz"
+                                },
+                                "strip-outer": {
+                                  "version": "1.0.0",
+                                  "from": "strip-outer@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.0.tgz",
+                                  "dependencies": {
+                                    "escape-string-regexp": {
+                                      "version": "1.0.3",
+                                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                    }
+                                  }
+                                },
+                                "trim-repeated": {
+                                  "version": "1.0.0",
+                                  "from": "trim-repeated@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+                                  "dependencies": {
+                                    "escape-string-regexp": {
+                                      "version": "1.0.3",
+                                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "got": {
+                              "version": "2.9.2",
+                              "from": "got@>=2.3.2 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/got/-/got-2.9.2.tgz",
+                              "dependencies": {
+                                "duplexify": {
+                                  "version": "3.4.2",
+                                  "from": "duplexify@>=3.2.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
+                                  "dependencies": {
+                                    "end-of-stream": {
+                                      "version": "1.0.0",
+                                      "from": "end-of-stream@1.0.0",
+                                      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                                      "dependencies": {
+                                        "once": {
+                                          "version": "1.3.2",
+                                          "from": "once@>=1.3.0 <1.4.0",
+                                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                          "dependencies": {
+                                            "wrappy": {
+                                              "version": "1.0.1",
+                                              "from": "wrappy@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "readable-stream": {
+                                      "version": "2.0.2",
+                                      "from": "readable-stream@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                      "dependencies": {
+                                        "core-util-is": {
+                                          "version": "1.0.1",
+                                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                        },
+                                        "inherits": {
+                                          "version": "2.0.1",
+                                          "from": "inherits@>=2.0.1 <2.1.0",
+                                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        },
+                                        "isarray": {
+                                          "version": "0.0.1",
+                                          "from": "isarray@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        },
+                                        "process-nextick-args": {
+                                          "version": "1.0.2",
+                                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                        },
+                                        "string_decoder": {
+                                          "version": "0.10.31",
+                                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        },
+                                        "util-deprecate": {
+                                          "version": "1.0.1",
+                                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "infinity-agent": {
+                                  "version": "2.0.3",
+                                  "from": "infinity-agent@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz"
+                                },
+                                "is-stream": {
+                                  "version": "1.0.1",
+                                  "from": "is-stream@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz"
+                                },
+                                "lowercase-keys": {
+                                  "version": "1.0.0",
+                                  "from": "lowercase-keys@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
+                                },
+                                "nested-error-stacks": {
+                                  "version": "1.0.1",
+                                  "from": "nested-error-stacks@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.1.tgz",
+                                  "dependencies": {
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "prepend-http": {
+                                  "version": "1.0.2",
+                                  "from": "prepend-http@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.2.tgz"
+                                },
+                                "read-all-stream": {
+                                  "version": "2.2.0",
+                                  "from": "read-all-stream@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-2.2.0.tgz",
+                                  "dependencies": {
+                                    "readable-stream": {
+                                      "version": "2.0.2",
+                                      "from": "readable-stream@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                      "dependencies": {
+                                        "core-util-is": {
+                                          "version": "1.0.1",
+                                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                        },
+                                        "inherits": {
+                                          "version": "2.0.1",
+                                          "from": "inherits@>=2.0.1 <2.1.0",
+                                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        },
+                                        "isarray": {
+                                          "version": "0.0.1",
+                                          "from": "isarray@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        },
+                                        "process-nextick-args": {
+                                          "version": "1.0.2",
+                                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                        },
+                                        "string_decoder": {
+                                          "version": "0.10.31",
+                                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        },
+                                        "util-deprecate": {
+                                          "version": "1.0.1",
+                                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "statuses": {
+                                  "version": "1.2.1",
+                                  "from": "statuses@>=1.2.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+                                },
+                                "timed-out": {
+                                  "version": "2.0.0",
+                                  "from": "timed-out@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "gulp-decompress": {
+                              "version": "1.1.0",
+                              "from": "gulp-decompress@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/gulp-decompress/-/gulp-decompress-1.1.0.tgz",
+                              "dependencies": {
+                                "archive-type": {
+                                  "version": "3.0.1",
+                                  "from": "archive-type@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/archive-type/-/archive-type-3.0.1.tgz",
+                                  "dependencies": {
+                                    "file-type": {
+                                      "version": "2.10.2",
+                                      "from": "file-type@>=2.0.1 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/file-type/-/file-type-2.10.2.tgz",
+                                      "dependencies": {
+                                        "read-chunk": {
+                                          "version": "1.0.1",
+                                          "from": "read-chunk@>=1.0.1 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-1.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "gulp-util": {
+                                  "version": "3.0.6",
+                                  "from": "gulp-util@>=3.0.1 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.6.tgz",
+                                  "dependencies": {
+                                    "array-differ": {
+                                      "version": "1.0.0",
+                                      "from": "array-differ@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
+                                    },
+                                    "array-uniq": {
+                                      "version": "1.0.2",
+                                      "from": "array-uniq@>=1.0.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+                                    },
+                                    "beeper": {
+                                      "version": "1.1.0",
+                                      "from": "beeper@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
+                                    },
+                                    "dateformat": {
+                                      "version": "1.0.11",
+                                      "from": "dateformat@>=1.0.11 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz"
+                                    },
+                                    "lodash._reescape": {
+                                      "version": "3.0.0",
+                                      "from": "lodash._reescape@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+                                    },
+                                    "lodash._reevaluate": {
+                                      "version": "3.0.0",
+                                      "from": "lodash._reevaluate@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+                                    },
+                                    "lodash._reinterpolate": {
+                                      "version": "3.0.0",
+                                      "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+                                    },
+                                    "lodash.template": {
+                                      "version": "3.6.2",
+                                      "from": "lodash.template@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+                                      "dependencies": {
+                                        "lodash._basecopy": {
+                                          "version": "3.0.1",
+                                          "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                                        },
+                                        "lodash._basetostring": {
+                                          "version": "3.0.1",
+                                          "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                                        },
+                                        "lodash._basevalues": {
+                                          "version": "3.0.0",
+                                          "from": "lodash._basevalues@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+                                        },
+                                        "lodash._isiterateecall": {
+                                          "version": "3.0.9",
+                                          "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                                        },
+                                        "lodash.escape": {
+                                          "version": "3.0.0",
+                                          "from": "lodash.escape@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+                                        },
+                                        "lodash.keys": {
+                                          "version": "3.1.2",
+                                          "from": "lodash.keys@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                                          "dependencies": {
+                                            "lodash._getnative": {
+                                              "version": "3.9.1",
+                                              "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                                              "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                                            },
+                                            "lodash.isarguments": {
+                                              "version": "3.0.4",
+                                              "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                                              "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                                            },
+                                            "lodash.isarray": {
+                                              "version": "3.0.4",
+                                              "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                                              "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                                            }
+                                          }
+                                        },
+                                        "lodash.restparam": {
+                                          "version": "3.6.1",
+                                          "from": "lodash.restparam@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                                        },
+                                        "lodash.templatesettings": {
+                                          "version": "3.1.0",
+                                          "from": "lodash.templatesettings@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+                                        }
+                                      }
+                                    },
+                                    "minimist": {
+                                      "version": "1.2.0",
+                                      "from": "minimist@>=1.1.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                                    },
+                                    "multipipe": {
+                                      "version": "0.1.2",
+                                      "from": "multipipe@>=0.1.2 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+                                      "dependencies": {
+                                        "duplexer2": {
+                                          "version": "0.0.2",
+                                          "from": "duplexer2@0.0.2",
+                                          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                                          "dependencies": {
+                                            "readable-stream": {
+                                              "version": "1.1.13",
+                                              "from": "readable-stream@>=1.1.9 <1.2.0",
+                                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                                              "dependencies": {
+                                                "core-util-is": {
+                                                  "version": "1.0.1",
+                                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                                },
+                                                "isarray": {
+                                                  "version": "0.0.1",
+                                                  "from": "isarray@0.0.1",
+                                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                                },
+                                                "string_decoder": {
+                                                  "version": "0.10.31",
+                                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                                },
+                                                "inherits": {
+                                                  "version": "2.0.1",
+                                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "object-assign": {
+                                      "version": "3.0.0",
+                                      "from": "object-assign@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                                    },
+                                    "replace-ext": {
+                                      "version": "0.0.1",
+                                      "from": "replace-ext@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+                                    },
+                                    "vinyl": {
+                                      "version": "0.5.1",
+                                      "from": "vinyl@>=0.5.0 <0.6.0",
+                                      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.1.tgz",
+                                      "dependencies": {
+                                        "clone": {
+                                          "version": "1.0.2",
+                                          "from": "clone@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+                                        },
+                                        "clone-stats": {
+                                          "version": "0.0.1",
+                                          "from": "clone-stats@>=0.0.1 <0.0.2",
+                                          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "is-url": {
+                              "version": "1.2.1",
+                              "from": "is-url@>=1.2.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.1.tgz"
+                            },
+                            "object-assign": {
+                              "version": "2.1.1",
+                              "from": "object-assign@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+                            },
+                            "read-all-stream": {
+                              "version": "3.0.1",
+                              "from": "read-all-stream@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.0.1.tgz",
+                              "dependencies": {
+                                "pinkie-promise": {
+                                  "version": "1.0.0",
+                                  "from": "pinkie-promise@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+                                  "dependencies": {
+                                    "pinkie": {
+                                      "version": "1.0.0",
+                                      "from": "pinkie@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "readable-stream": {
+                                  "version": "2.0.2",
+                                  "from": "readable-stream@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                  "dependencies": {
+                                    "core-util-is": {
+                                      "version": "1.0.1",
+                                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@>=2.0.1 <2.1.0",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    },
+                                    "isarray": {
+                                      "version": "0.0.1",
+                                      "from": "isarray@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                    },
+                                    "process-nextick-args": {
+                                      "version": "1.0.2",
+                                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                    },
+                                    "string_decoder": {
+                                      "version": "0.10.31",
+                                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                    },
+                                    "util-deprecate": {
+                                      "version": "1.0.1",
+                                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "through2": {
+                              "version": "2.0.0",
+                              "from": "through2@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
+                              "dependencies": {
+                                "readable-stream": {
+                                  "version": "2.0.2",
+                                  "from": "readable-stream@>=2.0.0 <2.1.0",
+                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                  "dependencies": {
+                                    "core-util-is": {
+                                      "version": "1.0.1",
+                                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@>=2.0.1 <2.1.0",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    },
+                                    "isarray": {
+                                      "version": "0.0.1",
+                                      "from": "isarray@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                    },
+                                    "process-nextick-args": {
+                                      "version": "1.0.2",
+                                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                    },
+                                    "string_decoder": {
+                                      "version": "0.10.31",
+                                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                    },
+                                    "util-deprecate": {
+                                      "version": "1.0.1",
+                                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "xtend": {
+                                  "version": "4.0.0",
+                                  "from": "xtend@>=4.0.0 <4.1.0",
+                                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                }
+                              }
+                            },
+                            "vinyl": {
+                              "version": "0.4.6",
+                              "from": "vinyl@>=0.4.3 <0.5.0",
+                              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+                              "dependencies": {
+                                "clone": {
+                                  "version": "0.2.0",
+                                  "from": "clone@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+                                },
+                                "clone-stats": {
+                                  "version": "0.0.1",
+                                  "from": "clone-stats@>=0.0.1 <0.0.2",
+                                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                                }
+                              }
+                            },
+                            "ware": {
+                              "version": "1.3.0",
+                              "from": "ware@>=1.2.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
+                              "dependencies": {
+                                "wrap-fn": {
+                                  "version": "0.1.4",
+                                  "from": "wrap-fn@>=0.1.0 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.4.tgz",
+                                  "dependencies": {
+                                    "co": {
+                                      "version": "3.1.0",
+                                      "from": "co@3.1.0",
+                                      "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "exec-series": {
+                          "version": "1.0.2",
+                          "from": "exec-series@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/exec-series/-/exec-series-1.0.2.tgz",
+                          "dependencies": {
+                            "async-each-series": {
+                              "version": "1.0.0",
+                              "from": "async-each-series@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "rimraf": {
+                          "version": "2.4.2",
+                          "from": "rimraf@>=2.2.6 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.2.tgz",
+                          "dependencies": {
+                            "glob": {
+                              "version": "5.0.14",
+                              "from": "glob@>=5.0.14 <6.0.0",
+                              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
+                              "dependencies": {
+                                "inflight": {
+                                  "version": "1.0.4",
+                                  "from": "inflight@>=1.0.4 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.1",
+                                      "from": "wrappy@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                },
+                                "minimatch": {
+                                  "version": "2.0.10",
+                                  "from": "minimatch@>=2.0.1 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                                  "dependencies": {
+                                    "brace-expansion": {
+                                      "version": "1.1.0",
+                                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                                      "dependencies": {
+                                        "balanced-match": {
+                                          "version": "0.2.0",
+                                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                                        },
+                                        "concat-map": {
+                                          "version": "0.0.1",
+                                          "from": "concat-map@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "once": {
+                                  "version": "1.3.2",
+                                  "from": "once@>=1.3.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.1",
+                                      "from": "wrappy@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "path-is-absolute": {
+                                  "version": "1.0.0",
+                                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "tempfile": {
+                          "version": "1.1.1",
+                          "from": "tempfile@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz",
+                          "dependencies": {
+                            "os-tmpdir": {
+                              "version": "1.0.1",
+                              "from": "os-tmpdir@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                            },
+                            "uuid": {
+                              "version": "2.0.1",
+                              "from": "uuid@>=2.0.1 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
+                            }
+                          }
+                        },
+                        "url-regex": {
+                          "version": "2.1.3",
+                          "from": "url-regex@>=2.0.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/url-regex/-/url-regex-2.1.3.tgz",
+                          "dependencies": {
+                            "ip-regex": {
+                              "version": "1.0.3",
+                              "from": "ip-regex@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-1.0.3.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "bin-wrapper": {
+                      "version": "3.0.2",
+                      "from": "bin-wrapper@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/bin-wrapper/-/bin-wrapper-3.0.2.tgz",
+                      "dependencies": {
+                        "bin-check": {
+                          "version": "2.0.0",
+                          "from": "bin-check@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/bin-check/-/bin-check-2.0.0.tgz",
+                          "dependencies": {
+                            "executable": {
+                              "version": "1.1.0",
+                              "from": "executable@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/executable/-/executable-1.1.0.tgz"
+                            }
+                          }
+                        },
+                        "bin-version-check": {
+                          "version": "2.1.0",
+                          "from": "bin-version-check@>=2.1.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-2.1.0.tgz",
+                          "dependencies": {
+                            "bin-version": {
+                              "version": "1.0.4",
+                              "from": "bin-version@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/bin-version/-/bin-version-1.0.4.tgz",
+                              "dependencies": {
+                                "find-versions": {
+                                  "version": "1.1.3",
+                                  "from": "find-versions@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-1.1.3.tgz",
+                                  "dependencies": {
+                                    "array-uniq": {
+                                      "version": "1.0.2",
+                                      "from": "array-uniq@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+                                    },
+                                    "semver-regex": {
+                                      "version": "1.0.0",
+                                      "from": "semver-regex@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-1.0.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "minimist": {
+                              "version": "1.2.0",
+                              "from": "minimist@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                            },
+                            "semver": {
+                              "version": "4.3.6",
+                              "from": "semver@>=4.0.3 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+                            },
+                            "semver-truncate": {
+                              "version": "1.0.0",
+                              "from": "semver-truncate@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "download": {
+                          "version": "4.2.0",
+                          "from": "download@>=4.0.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/download/-/download-4.2.0.tgz",
+                          "dependencies": {
+                            "caw": {
+                              "version": "1.1.0",
+                              "from": "caw@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/caw/-/caw-1.1.0.tgz",
+                              "dependencies": {
+                                "get-proxy": {
+                                  "version": "1.0.1",
+                                  "from": "get-proxy@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-1.0.1.tgz",
+                                  "dependencies": {
+                                    "rc": {
+                                      "version": "0.5.5",
+                                      "from": "rc@>=0.5.5 <0.6.0",
+                                      "resolved": "https://registry.npmjs.org/rc/-/rc-0.5.5.tgz",
+                                      "dependencies": {
+                                        "minimist": {
+                                          "version": "0.0.10",
+                                          "from": "minimist@>=0.0.7 <0.1.0",
+                                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                                        },
+                                        "deep-extend": {
+                                          "version": "0.2.11",
+                                          "from": "deep-extend@>=0.2.5 <0.3.0",
+                                          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+                                        },
+                                        "strip-json-comments": {
+                                          "version": "0.1.3",
+                                          "from": "strip-json-comments@>=0.1.0 <0.2.0",
+                                          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+                                        },
+                                        "ini": {
+                                          "version": "1.3.4",
+                                          "from": "ini@>=1.3.0 <1.4.0",
+                                          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "is-obj": {
+                                  "version": "1.0.0",
+                                  "from": "is-obj@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.0.tgz"
+                                },
+                                "object-assign": {
+                                  "version": "3.0.0",
+                                  "from": "object-assign@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                                },
+                                "tunnel-agent": {
+                                  "version": "0.4.1",
+                                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+                                }
+                              }
+                            },
+                            "filenamify": {
+                              "version": "1.2.0",
+                              "from": "filenamify@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.0.tgz",
+                              "dependencies": {
+                                "filename-reserved-regex": {
+                                  "version": "1.0.0",
+                                  "from": "filename-reserved-regex@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz"
+                                },
+                                "strip-outer": {
+                                  "version": "1.0.0",
+                                  "from": "strip-outer@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.0.tgz",
+                                  "dependencies": {
+                                    "escape-string-regexp": {
+                                      "version": "1.0.3",
+                                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                    }
+                                  }
+                                },
+                                "trim-repeated": {
+                                  "version": "1.0.0",
+                                  "from": "trim-repeated@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+                                  "dependencies": {
+                                    "escape-string-regexp": {
+                                      "version": "1.0.3",
+                                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "got": {
+                              "version": "2.9.2",
+                              "from": "got@>=2.3.2 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/got/-/got-2.9.2.tgz",
+                              "dependencies": {
+                                "duplexify": {
+                                  "version": "3.4.2",
+                                  "from": "duplexify@>=3.2.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
+                                  "dependencies": {
+                                    "end-of-stream": {
+                                      "version": "1.0.0",
+                                      "from": "end-of-stream@1.0.0",
+                                      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                                      "dependencies": {
+                                        "once": {
+                                          "version": "1.3.2",
+                                          "from": "once@>=1.3.0 <1.4.0",
+                                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                          "dependencies": {
+                                            "wrappy": {
+                                              "version": "1.0.1",
+                                              "from": "wrappy@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "readable-stream": {
+                                      "version": "2.0.2",
+                                      "from": "readable-stream@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                      "dependencies": {
+                                        "core-util-is": {
+                                          "version": "1.0.1",
+                                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                        },
+                                        "inherits": {
+                                          "version": "2.0.1",
+                                          "from": "inherits@>=2.0.1 <2.1.0",
+                                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        },
+                                        "isarray": {
+                                          "version": "0.0.1",
+                                          "from": "isarray@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        },
+                                        "process-nextick-args": {
+                                          "version": "1.0.2",
+                                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                        },
+                                        "string_decoder": {
+                                          "version": "0.10.31",
+                                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        },
+                                        "util-deprecate": {
+                                          "version": "1.0.1",
+                                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "infinity-agent": {
+                                  "version": "2.0.3",
+                                  "from": "infinity-agent@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz"
+                                },
+                                "is-stream": {
+                                  "version": "1.0.1",
+                                  "from": "is-stream@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz"
+                                },
+                                "lowercase-keys": {
+                                  "version": "1.0.0",
+                                  "from": "lowercase-keys@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
+                                },
+                                "nested-error-stacks": {
+                                  "version": "1.0.1",
+                                  "from": "nested-error-stacks@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.1.tgz",
+                                  "dependencies": {
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "prepend-http": {
+                                  "version": "1.0.2",
+                                  "from": "prepend-http@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.2.tgz"
+                                },
+                                "read-all-stream": {
+                                  "version": "2.2.0",
+                                  "from": "read-all-stream@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-2.2.0.tgz",
+                                  "dependencies": {
+                                    "readable-stream": {
+                                      "version": "2.0.2",
+                                      "from": "readable-stream@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                      "dependencies": {
+                                        "core-util-is": {
+                                          "version": "1.0.1",
+                                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                        },
+                                        "inherits": {
+                                          "version": "2.0.1",
+                                          "from": "inherits@>=2.0.1 <2.1.0",
+                                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                        },
+                                        "isarray": {
+                                          "version": "0.0.1",
+                                          "from": "isarray@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        },
+                                        "process-nextick-args": {
+                                          "version": "1.0.2",
+                                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                        },
+                                        "string_decoder": {
+                                          "version": "0.10.31",
+                                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        },
+                                        "util-deprecate": {
+                                          "version": "1.0.1",
+                                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "statuses": {
+                                  "version": "1.2.1",
+                                  "from": "statuses@>=1.2.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+                                },
+                                "timed-out": {
+                                  "version": "2.0.0",
+                                  "from": "timed-out@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "gulp-decompress": {
+                              "version": "1.1.0",
+                              "from": "gulp-decompress@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/gulp-decompress/-/gulp-decompress-1.1.0.tgz",
+                              "dependencies": {
+                                "archive-type": {
+                                  "version": "3.0.1",
+                                  "from": "archive-type@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/archive-type/-/archive-type-3.0.1.tgz",
+                                  "dependencies": {
+                                    "file-type": {
+                                      "version": "2.10.2",
+                                      "from": "file-type@>=2.0.1 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/file-type/-/file-type-2.10.2.tgz",
+                                      "dependencies": {
+                                        "read-chunk": {
+                                          "version": "1.0.1",
+                                          "from": "read-chunk@>=1.0.1 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-1.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "decompress": {
+                                  "version": "2.3.0",
+                                  "from": "decompress@>=2.1.1 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/decompress/-/decompress-2.3.0.tgz",
+                                  "dependencies": {
+                                    "decompress-tar": {
+                                      "version": "3.1.0",
+                                      "from": "decompress-tar@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-3.1.0.tgz",
+                                      "dependencies": {
+                                        "is-tar": {
+                                          "version": "1.0.0",
+                                          "from": "is-tar@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/is-tar/-/is-tar-1.0.0.tgz"
+                                        },
+                                        "strip-dirs": {
+                                          "version": "1.1.1",
+                                          "from": "strip-dirs@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                                          "dependencies": {
+                                            "is-absolute": {
+                                              "version": "0.1.7",
+                                              "from": "is-absolute@>=0.1.5 <0.2.0",
+                                              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                                              "dependencies": {
+                                                "is-relative": {
+                                                  "version": "0.1.3",
+                                                  "from": "is-relative@>=0.1.0 <0.2.0",
+                                                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                                                }
+                                              }
+                                            },
+                                            "is-natural-number": {
+                                              "version": "2.0.0",
+                                              "from": "is-natural-number@>=2.0.0 <3.0.0",
+                                              "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz"
+                                            },
+                                            "minimist": {
+                                              "version": "1.2.0",
+                                              "from": "minimist@>=1.1.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                                            },
+                                            "sum-up": {
+                                              "version": "1.0.2",
+                                              "from": "sum-up@>=1.0.1 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.2.tgz"
+                                            }
+                                          }
+                                        },
+                                        "tar-stream": {
+                                          "version": "1.2.1",
+                                          "from": "tar-stream@>=1.1.1 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.2.1.tgz",
+                                          "dependencies": {
+                                            "bl": {
+                                              "version": "1.0.0",
+                                              "from": "bl@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
+                                            },
+                                            "end-of-stream": {
+                                              "version": "1.1.0",
+                                              "from": "end-of-stream@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                                              "dependencies": {
+                                                "once": {
+                                                  "version": "1.3.2",
+                                                  "from": "once@>=1.3.0 <2.0.0",
+                                                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                                  "dependencies": {
+                                                    "wrappy": {
+                                                      "version": "1.0.1",
+                                                      "from": "wrappy@>=1.0.0 <2.0.0",
+                                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "readable-stream": {
+                                              "version": "2.0.2",
+                                              "from": "readable-stream@>=2.0.0 <3.0.0",
+                                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                              "dependencies": {
+                                                "core-util-is": {
+                                                  "version": "1.0.1",
+                                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                                },
+                                                "inherits": {
+                                                  "version": "2.0.1",
+                                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                                },
+                                                "isarray": {
+                                                  "version": "0.0.1",
+                                                  "from": "isarray@0.0.1",
+                                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                                },
+                                                "process-nextick-args": {
+                                                  "version": "1.0.2",
+                                                  "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                                },
+                                                "string_decoder": {
+                                                  "version": "0.10.31",
+                                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                                },
+                                                "util-deprecate": {
+                                                  "version": "1.0.1",
+                                                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                                }
+                                              }
+                                            },
+                                            "xtend": {
+                                              "version": "4.0.0",
+                                              "from": "xtend@>=4.0.0 <5.0.0",
+                                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                            }
+                                          }
+                                        },
+                                        "through2": {
+                                          "version": "0.6.5",
+                                          "from": "through2@>=0.6.1 <0.7.0",
+                                          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                                          "dependencies": {
+                                            "readable-stream": {
+                                              "version": "1.0.33",
+                                              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                                              "dependencies": {
+                                                "core-util-is": {
+                                                  "version": "1.0.1",
+                                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                                },
+                                                "isarray": {
+                                                  "version": "0.0.1",
+                                                  "from": "isarray@0.0.1",
+                                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                                },
+                                                "string_decoder": {
+                                                  "version": "0.10.31",
+                                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                                },
+                                                "inherits": {
+                                                  "version": "2.0.1",
+                                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                                }
+                                              }
+                                            },
+                                            "xtend": {
+                                              "version": "4.0.0",
+                                              "from": "xtend@>=4.0.0 <4.1.0-0",
+                                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "decompress-tarbz2": {
+                                      "version": "3.1.0",
+                                      "from": "decompress-tarbz2@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-3.1.0.tgz",
+                                      "dependencies": {
+                                        "is-bzip2": {
+                                          "version": "1.0.0",
+                                          "from": "is-bzip2@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/is-bzip2/-/is-bzip2-1.0.0.tgz"
+                                        },
+                                        "seek-bzip": {
+                                          "version": "1.0.5",
+                                          "from": "seek-bzip@>=1.0.3 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
+                                          "dependencies": {
+                                            "commander": {
+                                              "version": "2.8.1",
+                                              "from": "commander@>=2.8.1 <2.9.0",
+                                              "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+                                              "dependencies": {
+                                                "graceful-readlink": {
+                                                  "version": "1.0.1",
+                                                  "from": "graceful-readlink@>=1.0.0",
+                                                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "strip-dirs": {
+                                          "version": "1.1.1",
+                                          "from": "strip-dirs@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                                          "dependencies": {
+                                            "is-absolute": {
+                                              "version": "0.1.7",
+                                              "from": "is-absolute@>=0.1.5 <0.2.0",
+                                              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                                              "dependencies": {
+                                                "is-relative": {
+                                                  "version": "0.1.3",
+                                                  "from": "is-relative@>=0.1.0 <0.2.0",
+                                                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                                                }
+                                              }
+                                            },
+                                            "is-natural-number": {
+                                              "version": "2.0.0",
+                                              "from": "is-natural-number@>=2.0.0 <3.0.0",
+                                              "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz"
+                                            },
+                                            "minimist": {
+                                              "version": "1.2.0",
+                                              "from": "minimist@>=1.1.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                                            },
+                                            "sum-up": {
+                                              "version": "1.0.2",
+                                              "from": "sum-up@>=1.0.1 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.2.tgz"
+                                            }
+                                          }
+                                        },
+                                        "tar-stream": {
+                                          "version": "1.2.1",
+                                          "from": "tar-stream@>=1.1.1 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.2.1.tgz",
+                                          "dependencies": {
+                                            "bl": {
+                                              "version": "1.0.0",
+                                              "from": "bl@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
+                                            },
+                                            "end-of-stream": {
+                                              "version": "1.1.0",
+                                              "from": "end-of-stream@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                                              "dependencies": {
+                                                "once": {
+                                                  "version": "1.3.2",
+                                                  "from": "once@>=1.3.0 <2.0.0",
+                                                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                                  "dependencies": {
+                                                    "wrappy": {
+                                                      "version": "1.0.1",
+                                                      "from": "wrappy@>=1.0.0 <2.0.0",
+                                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "readable-stream": {
+                                              "version": "2.0.2",
+                                              "from": "readable-stream@>=2.0.0 <3.0.0",
+                                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                              "dependencies": {
+                                                "core-util-is": {
+                                                  "version": "1.0.1",
+                                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                                },
+                                                "inherits": {
+                                                  "version": "2.0.1",
+                                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                                },
+                                                "isarray": {
+                                                  "version": "0.0.1",
+                                                  "from": "isarray@0.0.1",
+                                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                                },
+                                                "process-nextick-args": {
+                                                  "version": "1.0.2",
+                                                  "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                                },
+                                                "string_decoder": {
+                                                  "version": "0.10.31",
+                                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                                },
+                                                "util-deprecate": {
+                                                  "version": "1.0.1",
+                                                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                                }
+                                              }
+                                            },
+                                            "xtend": {
+                                              "version": "4.0.0",
+                                              "from": "xtend@>=4.0.0 <5.0.0",
+                                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                            }
+                                          }
+                                        },
+                                        "through2": {
+                                          "version": "0.6.5",
+                                          "from": "through2@>=0.6.1 <0.7.0",
+                                          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                                          "dependencies": {
+                                            "readable-stream": {
+                                              "version": "1.0.33",
+                                              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                                              "dependencies": {
+                                                "core-util-is": {
+                                                  "version": "1.0.1",
+                                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                                },
+                                                "isarray": {
+                                                  "version": "0.0.1",
+                                                  "from": "isarray@0.0.1",
+                                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                                },
+                                                "string_decoder": {
+                                                  "version": "0.10.31",
+                                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                                },
+                                                "inherits": {
+                                                  "version": "2.0.1",
+                                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                                }
+                                              }
+                                            },
+                                            "xtend": {
+                                              "version": "4.0.0",
+                                              "from": "xtend@>=4.0.0 <4.1.0-0",
+                                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "decompress-targz": {
+                                      "version": "3.1.0",
+                                      "from": "decompress-targz@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-3.1.0.tgz",
+                                      "dependencies": {
+                                        "is-gzip": {
+                                          "version": "1.0.0",
+                                          "from": "is-gzip@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz"
+                                        },
+                                        "strip-dirs": {
+                                          "version": "1.1.1",
+                                          "from": "strip-dirs@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                                          "dependencies": {
+                                            "is-absolute": {
+                                              "version": "0.1.7",
+                                              "from": "is-absolute@>=0.1.5 <0.2.0",
+                                              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                                              "dependencies": {
+                                                "is-relative": {
+                                                  "version": "0.1.3",
+                                                  "from": "is-relative@>=0.1.0 <0.2.0",
+                                                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                                                }
+                                              }
+                                            },
+                                            "is-natural-number": {
+                                              "version": "2.0.0",
+                                              "from": "is-natural-number@>=2.0.0 <3.0.0",
+                                              "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz"
+                                            },
+                                            "minimist": {
+                                              "version": "1.2.0",
+                                              "from": "minimist@>=1.1.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                                            },
+                                            "sum-up": {
+                                              "version": "1.0.2",
+                                              "from": "sum-up@>=1.0.1 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.2.tgz"
+                                            }
+                                          }
+                                        },
+                                        "tar-stream": {
+                                          "version": "1.2.1",
+                                          "from": "tar-stream@>=1.1.1 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.2.1.tgz",
+                                          "dependencies": {
+                                            "bl": {
+                                              "version": "1.0.0",
+                                              "from": "bl@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
+                                            },
+                                            "end-of-stream": {
+                                              "version": "1.1.0",
+                                              "from": "end-of-stream@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                                              "dependencies": {
+                                                "once": {
+                                                  "version": "1.3.2",
+                                                  "from": "once@>=1.3.0 <2.0.0",
+                                                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                                  "dependencies": {
+                                                    "wrappy": {
+                                                      "version": "1.0.1",
+                                                      "from": "wrappy@>=1.0.0 <2.0.0",
+                                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "readable-stream": {
+                                              "version": "2.0.2",
+                                              "from": "readable-stream@>=2.0.0 <3.0.0",
+                                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                              "dependencies": {
+                                                "core-util-is": {
+                                                  "version": "1.0.1",
+                                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                                },
+                                                "inherits": {
+                                                  "version": "2.0.1",
+                                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                                },
+                                                "isarray": {
+                                                  "version": "0.0.1",
+                                                  "from": "isarray@0.0.1",
+                                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                                },
+                                                "process-nextick-args": {
+                                                  "version": "1.0.2",
+                                                  "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                                },
+                                                "string_decoder": {
+                                                  "version": "0.10.31",
+                                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                                },
+                                                "util-deprecate": {
+                                                  "version": "1.0.1",
+                                                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                                }
+                                              }
+                                            },
+                                            "xtend": {
+                                              "version": "4.0.0",
+                                              "from": "xtend@>=4.0.0 <5.0.0",
+                                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                            }
+                                          }
+                                        },
+                                        "through2": {
+                                          "version": "0.6.5",
+                                          "from": "through2@>=0.6.1 <0.7.0",
+                                          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                                          "dependencies": {
+                                            "readable-stream": {
+                                              "version": "1.0.33",
+                                              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                                              "dependencies": {
+                                                "core-util-is": {
+                                                  "version": "1.0.1",
+                                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                                },
+                                                "isarray": {
+                                                  "version": "0.0.1",
+                                                  "from": "isarray@0.0.1",
+                                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                                },
+                                                "string_decoder": {
+                                                  "version": "0.10.31",
+                                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                                },
+                                                "inherits": {
+                                                  "version": "2.0.1",
+                                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                                }
+                                              }
+                                            },
+                                            "xtend": {
+                                              "version": "4.0.0",
+                                              "from": "xtend@>=4.0.0 <4.1.0-0",
+                                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "decompress-unzip": {
+                                      "version": "3.3.0",
+                                      "from": "decompress-unzip@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-3.3.0.tgz",
+                                      "dependencies": {
+                                        "is-zip": {
+                                          "version": "1.0.0",
+                                          "from": "is-zip@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/is-zip/-/is-zip-1.0.0.tgz"
+                                        },
+                                        "stat-mode": {
+                                          "version": "0.2.1",
+                                          "from": "stat-mode@>=0.2.0 <0.3.0",
+                                          "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.1.tgz"
+                                        },
+                                        "strip-dirs": {
+                                          "version": "1.1.1",
+                                          "from": "strip-dirs@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                                          "dependencies": {
+                                            "is-absolute": {
+                                              "version": "0.1.7",
+                                              "from": "is-absolute@>=0.1.5 <0.2.0",
+                                              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                                              "dependencies": {
+                                                "is-relative": {
+                                                  "version": "0.1.3",
+                                                  "from": "is-relative@>=0.1.0 <0.2.0",
+                                                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                                                }
+                                              }
+                                            },
+                                            "is-natural-number": {
+                                              "version": "2.0.0",
+                                              "from": "is-natural-number@>=2.0.0 <3.0.0",
+                                              "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz"
+                                            },
+                                            "minimist": {
+                                              "version": "1.2.0",
+                                              "from": "minimist@>=1.1.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                                            },
+                                            "sum-up": {
+                                              "version": "1.0.2",
+                                              "from": "sum-up@>=1.0.1 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.2.tgz"
+                                            }
+                                          }
+                                        },
+                                        "vinyl": {
+                                          "version": "0.5.1",
+                                          "from": "vinyl@>=0.5.0 <0.6.0",
+                                          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.1.tgz",
+                                          "dependencies": {
+                                            "clone": {
+                                              "version": "1.0.2",
+                                              "from": "clone@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+                                            },
+                                            "clone-stats": {
+                                              "version": "0.0.1",
+                                              "from": "clone-stats@>=0.0.1 <0.0.2",
+                                              "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                                            },
+                                            "replace-ext": {
+                                              "version": "0.0.1",
+                                              "from": "replace-ext@0.0.1",
+                                              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+                                            }
+                                          }
+                                        },
+                                        "yauzl": {
+                                          "version": "2.3.1",
+                                          "from": "yauzl@>=2.2.1 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.3.1.tgz",
+                                          "dependencies": {
+                                            "fd-slicer": {
+                                              "version": "1.0.1",
+                                              "from": "fd-slicer@>=1.0.1 <1.1.0",
+                                              "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz"
+                                            },
+                                            "pend": {
+                                              "version": "1.2.0",
+                                              "from": "pend@>=1.2.0 <1.3.0",
+                                              "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "vinyl-assign": {
+                                      "version": "1.2.0",
+                                      "from": "vinyl-assign@>=1.0.1 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/vinyl-assign/-/vinyl-assign-1.2.0.tgz",
+                                      "dependencies": {
+                                        "object-assign": {
+                                          "version": "3.0.0",
+                                          "from": "object-assign@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                                        },
+                                        "readable-stream": {
+                                          "version": "2.0.2",
+                                          "from": "readable-stream@>=2.0.0 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                          "dependencies": {
+                                            "core-util-is": {
+                                              "version": "1.0.1",
+                                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                            },
+                                            "inherits": {
+                                              "version": "2.0.1",
+                                              "from": "inherits@>=2.0.1 <2.1.0",
+                                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                            },
+                                            "isarray": {
+                                              "version": "0.0.1",
+                                              "from": "isarray@0.0.1",
+                                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                            },
+                                            "process-nextick-args": {
+                                              "version": "1.0.2",
+                                              "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                            },
+                                            "string_decoder": {
+                                              "version": "0.10.31",
+                                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                            },
+                                            "util-deprecate": {
+                                              "version": "1.0.1",
+                                              "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "gulp-util": {
+                                  "version": "3.0.6",
+                                  "from": "gulp-util@>=3.0.1 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.6.tgz",
+                                  "dependencies": {
+                                    "array-differ": {
+                                      "version": "1.0.0",
+                                      "from": "array-differ@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
+                                    },
+                                    "array-uniq": {
+                                      "version": "1.0.2",
+                                      "from": "array-uniq@>=1.0.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+                                    },
+                                    "beeper": {
+                                      "version": "1.1.0",
+                                      "from": "beeper@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
+                                    },
+                                    "dateformat": {
+                                      "version": "1.0.11",
+                                      "from": "dateformat@>=1.0.11 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz"
+                                    },
+                                    "lodash._reescape": {
+                                      "version": "3.0.0",
+                                      "from": "lodash._reescape@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+                                    },
+                                    "lodash._reevaluate": {
+                                      "version": "3.0.0",
+                                      "from": "lodash._reevaluate@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+                                    },
+                                    "lodash._reinterpolate": {
+                                      "version": "3.0.0",
+                                      "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+                                    },
+                                    "lodash.template": {
+                                      "version": "3.6.2",
+                                      "from": "lodash.template@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+                                      "dependencies": {
+                                        "lodash._basecopy": {
+                                          "version": "3.0.1",
+                                          "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                                        },
+                                        "lodash._basetostring": {
+                                          "version": "3.0.1",
+                                          "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                                        },
+                                        "lodash._basevalues": {
+                                          "version": "3.0.0",
+                                          "from": "lodash._basevalues@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+                                        },
+                                        "lodash._isiterateecall": {
+                                          "version": "3.0.9",
+                                          "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                                        },
+                                        "lodash.escape": {
+                                          "version": "3.0.0",
+                                          "from": "lodash.escape@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+                                        },
+                                        "lodash.keys": {
+                                          "version": "3.1.2",
+                                          "from": "lodash.keys@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                                          "dependencies": {
+                                            "lodash._getnative": {
+                                              "version": "3.9.1",
+                                              "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                                              "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                                            },
+                                            "lodash.isarguments": {
+                                              "version": "3.0.4",
+                                              "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                                              "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                                            },
+                                            "lodash.isarray": {
+                                              "version": "3.0.4",
+                                              "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                                              "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                                            }
+                                          }
+                                        },
+                                        "lodash.restparam": {
+                                          "version": "3.6.1",
+                                          "from": "lodash.restparam@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                                        },
+                                        "lodash.templatesettings": {
+                                          "version": "3.1.0",
+                                          "from": "lodash.templatesettings@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+                                        }
+                                      }
+                                    },
+                                    "minimist": {
+                                      "version": "1.2.0",
+                                      "from": "minimist@>=1.1.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                                    },
+                                    "multipipe": {
+                                      "version": "0.1.2",
+                                      "from": "multipipe@>=0.1.2 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+                                      "dependencies": {
+                                        "duplexer2": {
+                                          "version": "0.0.2",
+                                          "from": "duplexer2@0.0.2",
+                                          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                                          "dependencies": {
+                                            "readable-stream": {
+                                              "version": "1.1.13",
+                                              "from": "readable-stream@>=1.1.9 <1.2.0",
+                                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                                              "dependencies": {
+                                                "core-util-is": {
+                                                  "version": "1.0.1",
+                                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                                },
+                                                "isarray": {
+                                                  "version": "0.0.1",
+                                                  "from": "isarray@0.0.1",
+                                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                                },
+                                                "string_decoder": {
+                                                  "version": "0.10.31",
+                                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                                },
+                                                "inherits": {
+                                                  "version": "2.0.1",
+                                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "object-assign": {
+                                      "version": "3.0.0",
+                                      "from": "object-assign@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                                    },
+                                    "replace-ext": {
+                                      "version": "0.0.1",
+                                      "from": "replace-ext@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+                                    },
+                                    "vinyl": {
+                                      "version": "0.5.1",
+                                      "from": "vinyl@>=0.5.0 <0.6.0",
+                                      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.1.tgz",
+                                      "dependencies": {
+                                        "clone": {
+                                          "version": "1.0.2",
+                                          "from": "clone@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+                                        },
+                                        "clone-stats": {
+                                          "version": "0.0.1",
+                                          "from": "clone-stats@>=0.0.1 <0.0.2",
+                                          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "is-url": {
+                              "version": "1.2.1",
+                              "from": "is-url@>=1.2.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.1.tgz"
+                            },
+                            "object-assign": {
+                              "version": "2.1.1",
+                              "from": "object-assign@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+                            },
+                            "read-all-stream": {
+                              "version": "3.0.1",
+                              "from": "read-all-stream@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.0.1.tgz",
+                              "dependencies": {
+                                "pinkie-promise": {
+                                  "version": "1.0.0",
+                                  "from": "pinkie-promise@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+                                  "dependencies": {
+                                    "pinkie": {
+                                      "version": "1.0.0",
+                                      "from": "pinkie@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "readable-stream": {
+                                  "version": "2.0.2",
+                                  "from": "readable-stream@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                  "dependencies": {
+                                    "core-util-is": {
+                                      "version": "1.0.1",
+                                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@>=2.0.1 <2.1.0",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    },
+                                    "isarray": {
+                                      "version": "0.0.1",
+                                      "from": "isarray@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                    },
+                                    "process-nextick-args": {
+                                      "version": "1.0.2",
+                                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                    },
+                                    "string_decoder": {
+                                      "version": "0.10.31",
+                                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                    },
+                                    "util-deprecate": {
+                                      "version": "1.0.1",
+                                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "through2": {
+                              "version": "2.0.0",
+                              "from": "through2@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
+                              "dependencies": {
+                                "readable-stream": {
+                                  "version": "2.0.2",
+                                  "from": "readable-stream@>=2.0.0 <2.1.0",
+                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                  "dependencies": {
+                                    "core-util-is": {
+                                      "version": "1.0.1",
+                                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@>=2.0.1 <2.1.0",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    },
+                                    "isarray": {
+                                      "version": "0.0.1",
+                                      "from": "isarray@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                    },
+                                    "process-nextick-args": {
+                                      "version": "1.0.2",
+                                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                    },
+                                    "string_decoder": {
+                                      "version": "0.10.31",
+                                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                    },
+                                    "util-deprecate": {
+                                      "version": "1.0.1",
+                                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "xtend": {
+                                  "version": "4.0.0",
+                                  "from": "xtend@>=4.0.0 <4.1.0",
+                                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                }
+                              }
+                            },
+                            "vinyl": {
+                              "version": "0.4.6",
+                              "from": "vinyl@>=0.4.3 <0.5.0",
+                              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+                              "dependencies": {
+                                "clone": {
+                                  "version": "0.2.0",
+                                  "from": "clone@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+                                },
+                                "clone-stats": {
+                                  "version": "0.0.1",
+                                  "from": "clone-stats@>=0.0.1 <0.0.2",
+                                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                                }
+                              }
+                            },
+                            "ware": {
+                              "version": "1.3.0",
+                              "from": "ware@>=1.2.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
+                              "dependencies": {
+                                "wrap-fn": {
+                                  "version": "0.1.4",
+                                  "from": "wrap-fn@>=0.1.0 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.4.tgz",
+                                  "dependencies": {
+                                    "co": {
+                                      "version": "3.1.0",
+                                      "from": "co@3.1.0",
+                                      "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "each-async": {
+                          "version": "1.1.1",
+                          "from": "each-async@>=1.1.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
+                          "dependencies": {
+                            "onetime": {
+                              "version": "1.0.0",
+                              "from": "onetime@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz"
+                            },
+                            "set-immediate-shim": {
+                              "version": "1.0.1",
+                              "from": "set-immediate-shim@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "lazy-req": {
+                          "version": "1.1.0",
+                          "from": "lazy-req@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-1.1.0.tgz"
+                        },
+                        "os-filter-obj": {
+                          "version": "1.0.3",
+                          "from": "os-filter-obj@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/os-filter-obj/-/os-filter-obj-1.0.3.tgz"
+                        }
+                      }
+                    },
+                    "logalot": {
+                      "version": "2.1.0",
+                      "from": "logalot@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/logalot/-/logalot-2.1.0.tgz",
+                      "dependencies": {
+                        "figures": {
+                          "version": "1.3.5",
+                          "from": "figures@>=1.3.5 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
+                        },
+                        "squeak": {
+                          "version": "1.2.0",
+                          "from": "squeak@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/squeak/-/squeak-1.2.0.tgz",
+                          "dependencies": {
+                            "chalk": {
+                              "version": "0.5.1",
+                              "from": "chalk@>=0.5.1 <0.6.0",
+                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+                              "dependencies": {
+                                "ansi-styles": {
+                                  "version": "1.1.0",
+                                  "from": "ansi-styles@>=1.1.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+                                },
+                                "escape-string-regexp": {
+                                  "version": "1.0.3",
+                                  "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                },
+                                "has-ansi": {
+                                  "version": "0.1.0",
+                                  "from": "has-ansi@>=0.1.0 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "0.2.1",
+                                      "from": "ansi-regex@>=0.2.1 <0.3.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                                    }
+                                  }
+                                },
+                                "strip-ansi": {
+                                  "version": "0.3.0",
+                                  "from": "strip-ansi@>=0.3.0 <0.4.0",
+                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "0.2.1",
+                                      "from": "ansi-regex@>=0.2.1 <0.3.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                                    }
+                                  }
+                                },
+                                "supports-color": {
+                                  "version": "0.2.0",
+                                  "from": "supports-color@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+                                }
+                              }
+                            },
+                            "lpad-align": {
+                              "version": "1.1.0",
+                              "from": "lpad-align@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/lpad-align/-/lpad-align-1.1.0.tgz",
+                              "dependencies": {
+                                "longest": {
+                                  "version": "1.0.1",
+                                  "from": "longest@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                },
+                                "lpad": {
+                                  "version": "2.0.1",
+                                  "from": "lpad@>=2.0.1 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/lpad/-/lpad-2.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "imagemin-svgo": {
+              "version": "4.1.2",
+              "from": "imagemin-svgo@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/imagemin-svgo/-/imagemin-svgo-4.1.2.tgz",
+              "dependencies": {
+                "is-svg": {
+                  "version": "1.1.1",
+                  "from": "is-svg@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-1.1.1.tgz"
+                },
+                "svgo": {
+                  "version": "0.5.6",
+                  "from": "svgo@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.5.6.tgz",
+                  "dependencies": {
+                    "sax": {
+                      "version": "1.1.1",
+                      "from": "sax@>=1.1.1 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.1.tgz"
+                    },
+                    "coa": {
+                      "version": "1.0.1",
+                      "from": "coa@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.1.tgz",
+                      "dependencies": {
+                        "q": {
+                          "version": "1.4.1",
+                          "from": "q@>=1.1.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
+                        }
+                      }
+                    },
+                    "js-yaml": {
+                      "version": "3.3.1",
+                      "from": "js-yaml@>=3.3.1 <3.4.0",
+                      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
+                      "dependencies": {
+                        "argparse": {
+                          "version": "1.0.2",
+                          "from": "argparse@>=1.0.2 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+                          "dependencies": {
+                            "lodash": {
+                              "version": "3.10.1",
+                              "from": "lodash@>=3.2.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                            },
+                            "sprintf-js": {
+                              "version": "1.0.3",
+                              "from": "sprintf-js@>=1.0.2 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                            }
+                          }
+                        },
+                        "esprima": {
+                          "version": "2.2.0",
+                          "from": "esprima@>=2.2.0 <2.3.0",
+                          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz"
+                        }
+                      }
+                    },
+                    "colors": {
+                      "version": "1.1.2",
+                      "from": "colors@>=1.1.2 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
+                    },
+                    "whet.extend": {
+                      "version": "0.9.9",
+                      "from": "whet.extend@>=0.9.9 <0.10.0",
+                      "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "pretty-bytes": {
+          "version": "1.0.4",
+          "from": "pretty-bytes@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
+          "dependencies": {
+            "get-stdin": {
+              "version": "4.0.1",
+              "from": "get-stdin@>=4.0.1 <5.0.0",
+              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+            },
+            "meow": {
+              "version": "3.3.0",
+              "from": "meow@>=3.1.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
+              "dependencies": {
+                "camelcase-keys": {
+                  "version": "1.0.0",
+                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.2.1",
+                      "from": "camelcase@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                    },
+                    "map-obj": {
+                      "version": "1.0.1",
+                      "from": "map-obj@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                    }
+                  }
+                },
+                "indent-string": {
+                  "version": "1.2.2",
+                  "from": "indent-string@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+                  "dependencies": {
+                    "repeating": {
+                      "version": "1.1.3",
+                      "from": "repeating@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.1",
+                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "minimist": {
+                  "version": "1.2.0",
+                  "from": "minimist@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                },
+                "object-assign": {
+                  "version": "3.0.0",
+                  "from": "object-assign@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "grunt-contrib-requirejs": {
+      "version": "0.4.4",
+      "from": "grunt-contrib-requirejs@>=0.4.4 <0.5.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-requirejs/-/grunt-contrib-requirejs-0.4.4.tgz"
+    },
+    "grunt-contrib-watch": {
+      "version": "0.6.1",
+      "from": "grunt-contrib-watch@>=0.6.1 <0.7.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-0.6.1.tgz",
+      "dependencies": {
+        "gaze": {
+          "version": "0.5.1",
+          "from": "gaze@>=0.5.1 <0.6.0",
+          "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
+          "dependencies": {
+            "globule": {
+              "version": "0.1.0",
+              "from": "globule@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+              "dependencies": {
+                "lodash": {
+                  "version": "1.0.2",
+                  "from": "lodash@>=1.0.1 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
+                },
+                "glob": {
+                  "version": "3.1.21",
+                  "from": "glob@>=3.1.21 <3.2.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "1.2.3",
+                      "from": "graceful-fs@>=1.2.0 <1.3.0",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                    },
+                    "inherits": {
+                      "version": "1.0.0",
+                      "from": "inherits@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "0.2.14",
+                  "from": "minimatch@>=0.2.11 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.6.5",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tiny-lr-fork": {
+          "version": "0.0.5",
+          "from": "tiny-lr-fork@0.0.5",
+          "resolved": "https://registry.npmjs.org/tiny-lr-fork/-/tiny-lr-fork-0.0.5.tgz",
+          "dependencies": {
+            "qs": {
+              "version": "0.5.6",
+              "from": "qs@>=0.5.2 <0.6.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz"
+            },
+            "faye-websocket": {
+              "version": "0.4.4",
+              "from": "faye-websocket@>=0.4.3 <0.5.0",
+              "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz"
+            },
+            "noptify": {
+              "version": "0.0.3",
+              "from": "noptify@>=0.0.3 <0.1.0",
+              "resolved": "https://registry.npmjs.org/noptify/-/noptify-0.0.3.tgz",
+              "dependencies": {
+                "nopt": {
+                  "version": "2.0.0",
+                  "from": "nopt@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz",
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.0.7",
+                      "from": "abbrev@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "debug": {
+              "version": "0.7.4",
+              "from": "debug@>=0.7.0 <0.8.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+            }
+          }
+        },
+        "lodash": {
+          "version": "2.4.2",
+          "from": "lodash@>=2.4.1 <2.5.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+        },
+        "async": {
+          "version": "0.2.10",
+          "from": "async@>=0.2.9 <0.3.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+        }
+      }
+    },
+    "grunt-eslint": {
+      "version": "15.0.0",
+      "from": "grunt-eslint@>=15.0.0 <16.0.0",
+      "resolved": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-15.0.0.tgz",
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.1",
+          "from": "chalk@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.1.0",
+              "from": "ansi-styles@>=2.1.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.0",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "from": "supports-color@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+            }
+          }
+        },
+        "eslint": {
+          "version": "0.23.0",
+          "from": "eslint@>=0.23.0 <0.24.0",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-0.23.0.tgz",
+          "dependencies": {
+            "concat-stream": {
+              "version": "1.5.0",
+              "from": "concat-stream@>=1.4.6 <2.0.0",
+              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "typedarray": {
+                  "version": "0.0.6",
+                  "from": "typedarray@>=0.0.5 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                },
+                "readable-stream": {
+                  "version": "2.0.2",
+                  "from": "readable-stream@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.2",
+                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.1",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "debug": {
+              "version": "2.2.0",
+              "from": "debug@>=2.1.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "ms@0.7.1",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                }
+              }
+            },
+            "doctrine": {
+              "version": "0.6.4",
+              "from": "doctrine@>=0.6.2 <0.7.0",
+              "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.6.4.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "1.1.6",
+                  "from": "esutils@>=1.1.6 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                }
+              }
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+            },
+            "escope": {
+              "version": "3.2.0",
+              "from": "escope@>=3.1.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/escope/-/escope-3.2.0.tgz",
+              "dependencies": {
+                "es6-map": {
+                  "version": "0.1.1",
+                  "from": "es6-map@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.1.tgz",
+                  "dependencies": {
+                    "d": {
+                      "version": "0.1.1",
+                      "from": "d@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                    },
+                    "es5-ext": {
+                      "version": "0.10.7",
+                      "from": "es5-ext@>=0.10.4 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
+                      "dependencies": {
+                        "es6-symbol": {
+                          "version": "2.0.1",
+                          "from": "es6-symbol@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "es6-iterator": {
+                      "version": "0.1.3",
+                      "from": "es6-iterator@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                      "dependencies": {
+                        "es6-symbol": {
+                          "version": "2.0.1",
+                          "from": "es6-symbol@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "es6-set": {
+                      "version": "0.1.1",
+                      "from": "es6-set@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.1.tgz"
+                    },
+                    "es6-symbol": {
+                      "version": "0.1.1",
+                      "from": "es6-symbol@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
+                    },
+                    "event-emitter": {
+                      "version": "0.3.3",
+                      "from": "event-emitter@>=0.3.1 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
+                    }
+                  }
+                },
+                "es6-weak-map": {
+                  "version": "0.1.4",
+                  "from": "es6-weak-map@>=0.1.2 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
+                  "dependencies": {
+                    "d": {
+                      "version": "0.1.1",
+                      "from": "d@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                    },
+                    "es5-ext": {
+                      "version": "0.10.7",
+                      "from": "es5-ext@>=0.10.6 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz"
+                    },
+                    "es6-iterator": {
+                      "version": "0.1.3",
+                      "from": "es6-iterator@>=0.1.3 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
+                    },
+                    "es6-symbol": {
+                      "version": "2.0.1",
+                      "from": "es6-symbol@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                    }
+                  }
+                },
+                "esrecurse": {
+                  "version": "3.1.1",
+                  "from": "esrecurse@>=3.1.1 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz"
+                },
+                "estraverse": {
+                  "version": "3.1.0",
+                  "from": "estraverse@>=3.1.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz"
+                }
+              }
+            },
+            "espree": {
+              "version": "2.2.4",
+              "from": "espree@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.4.tgz"
+            },
+            "estraverse": {
+              "version": "2.0.0",
+              "from": "estraverse@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-2.0.0.tgz"
+            },
+            "estraverse-fb": {
+              "version": "1.3.1",
+              "from": "estraverse-fb@>=1.3.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz"
+            },
+            "globals": {
+              "version": "8.6.0",
+              "from": "globals@>=8.0.0 <9.0.0",
+              "resolved": "https://registry.npmjs.org/globals/-/globals-8.6.0.tgz"
+            },
+            "inquirer": {
+              "version": "0.8.5",
+              "from": "inquirer@>=0.8.2 <0.9.0",
+              "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.5.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1",
+                  "from": "ansi-regex@>=1.1.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                },
+                "cli-width": {
+                  "version": "1.0.1",
+                  "from": "cli-width@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.0.1.tgz"
+                },
+                "figures": {
+                  "version": "1.3.5",
+                  "from": "figures@>=1.3.5 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
+                },
+                "lodash": {
+                  "version": "3.10.1",
+                  "from": "lodash@>=3.3.1 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                },
+                "readline2": {
+                  "version": "0.1.1",
+                  "from": "readline2@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+                  "dependencies": {
+                    "mute-stream": {
+                      "version": "0.0.4",
+                      "from": "mute-stream@0.0.4",
+                      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
+                    },
+                    "strip-ansi": {
+                      "version": "2.0.1",
+                      "from": "strip-ansi@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz"
+                    }
+                  }
+                },
+                "rx": {
+                  "version": "2.5.3",
+                  "from": "rx@>=2.4.3 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz"
+                },
+                "through": {
+                  "version": "2.3.8",
+                  "from": "through@>=2.3.6 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                }
+              }
+            },
+            "is-my-json-valid": {
+              "version": "2.12.1",
+              "from": "is-my-json-valid@>=2.10.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.1.tgz",
+              "dependencies": {
+                "generate-function": {
+                  "version": "2.0.0",
+                  "from": "generate-function@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                },
+                "generate-object-property": {
+                  "version": "1.2.0",
+                  "from": "generate-object-property@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                  "dependencies": {
+                    "is-property": {
+                      "version": "1.0.2",
+                      "from": "is-property@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                    }
+                  }
+                },
+                "jsonpointer": {
+                  "version": "1.1.0",
+                  "from": "jsonpointer@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
+                },
+                "xtend": {
+                  "version": "4.0.0",
+                  "from": "xtend@>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                }
+              }
+            },
+            "js-yaml": {
+              "version": "3.4.0",
+              "from": "js-yaml@>=3.2.5 <4.0.0",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.0.tgz",
+              "dependencies": {
+                "argparse": {
+                  "version": "1.0.2",
+                  "from": "argparse@>=1.0.2 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+                  "dependencies": {
+                    "lodash": {
+                      "version": "3.10.1",
+                      "from": "lodash@>=3.2.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                    },
+                    "sprintf-js": {
+                      "version": "1.0.3",
+                      "from": "sprintf-js@>=1.0.2 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                    }
+                  }
+                },
+                "esprima": {
+                  "version": "2.2.0",
+                  "from": "esprima@>=2.2.0 <2.3.0",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz"
+                }
+              }
+            },
+            "minimatch": {
+              "version": "2.0.10",
+              "from": "minimatch@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.0",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.1.1",
+              "from": "object-assign@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+            },
+            "optionator": {
+              "version": "0.5.0",
+              "from": "optionator@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+              "dependencies": {
+                "prelude-ls": {
+                  "version": "1.1.2",
+                  "from": "prelude-ls@>=1.1.1 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+                },
+                "deep-is": {
+                  "version": "0.1.3",
+                  "from": "deep-is@>=0.1.2 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+                },
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                },
+                "type-check": {
+                  "version": "0.3.1",
+                  "from": "type-check@>=0.3.1 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
+                },
+                "levn": {
+                  "version": "0.2.5",
+                  "from": "levn@>=0.2.5 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
+                },
+                "fast-levenshtein": {
+                  "version": "1.0.7",
+                  "from": "fast-levenshtein@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.0",
+              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+            },
+            "strip-json-comments": {
+              "version": "1.0.4",
+              "from": "strip-json-comments@>=1.0.1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+            },
+            "text-table": {
+              "version": "0.2.0",
+              "from": "text-table@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
+            },
+            "user-home": {
+              "version": "1.1.1",
+              "from": "user-home@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+            },
+            "xml-escape": {
+              "version": "1.0.0",
+              "from": "xml-escape@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "grunt-karma": {
+      "version": "0.11.2",
+      "from": "grunt-karma@>=0.11.0 <0.12.0",
+      "resolved": "https://registry.npmjs.org/grunt-karma/-/grunt-karma-0.11.2.tgz",
+      "dependencies": {
+        "lodash": {
+          "version": "3.9.3",
+          "from": "lodash@>=3.9.3 <3.10.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
+        }
+      }
+    },
+    "grunt-postcss": {
+      "version": "0.5.5",
+      "from": "grunt-postcss@>=0.5.1 <0.6.0",
+      "resolved": "https://registry.npmjs.org/grunt-postcss/-/grunt-postcss-0.5.5.tgz",
+      "dependencies": {
+        "bluebird": {
+          "version": "2.9.34",
+          "from": "bluebird@>=2.9.33 <3.0.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz"
+        },
+        "chalk": {
+          "version": "1.1.1",
+          "from": "chalk@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.1.0",
+              "from": "ansi-styles@>=2.1.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.0",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "from": "supports-color@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+            }
+          }
+        },
+        "diff": {
+          "version": "1.4.0",
+          "from": "diff@>=1.3.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz"
+        },
+        "postcss": {
+          "version": "4.1.16",
+          "from": "postcss@>=4.1.8 <5.0.0",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.1.16.tgz",
+          "dependencies": {
+            "es6-promise": {
+              "version": "2.3.0",
+              "from": "es6-promise@>=2.3.0 <2.4.0",
+              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz"
+            },
+            "source-map": {
+              "version": "0.4.4",
+              "from": "source-map@>=0.4.2 <0.5.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                }
+              }
+            },
+            "js-base64": {
+              "version": "2.1.9",
+              "from": "js-base64@>=2.1.8 <2.2.0",
+              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
+            }
+          }
+        }
+      }
+    },
+    "grunt-px-to-rem": {
+      "version": "0.4.0",
+      "from": "grunt-px-to-rem@>=0.4.0 <0.5.0",
+      "resolved": "https://registry.npmjs.org/grunt-px-to-rem/-/grunt-px-to-rem-0.4.0.tgz",
+      "dependencies": {
+        "postcss": {
+          "version": "4.0.6",
+          "from": "postcss@>=4.0.6 <4.1.0",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.0.6.tgz",
+          "dependencies": {
+            "source-map": {
+              "version": "0.2.0",
+              "from": "source-map@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                }
+              }
+            },
+            "js-base64": {
+              "version": "2.1.9",
+              "from": "js-base64@>=2.1.7 <2.2.0",
+              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
+            }
+          }
+        },
+        "chalk": {
+          "version": "1.0.0",
+          "from": "chalk@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.1.0",
+              "from": "ansi-styles@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+            },
+            "has-ansi": {
+              "version": "1.0.3",
+              "from": "has-ansi@>=1.0.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1",
+                  "from": "ansi-regex@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                },
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@>=4.0.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "2.0.1",
+              "from": "strip-ansi@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1",
+                  "from": "ansi-regex@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "1.3.1",
+              "from": "supports-color@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "grunt-sass": {
+      "version": "1.0.0",
+      "from": "grunt-sass@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/grunt-sass/-/grunt-sass-1.0.0.tgz",
+      "dependencies": {
+        "each-async": {
+          "version": "1.1.1",
+          "from": "each-async@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
+          "dependencies": {
+            "onetime": {
+              "version": "1.0.0",
+              "from": "onetime@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz"
+            },
+            "set-immediate-shim": {
+              "version": "1.0.1",
+              "from": "set-immediate-shim@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
+            }
+          }
+        },
+        "node-sass": {
+          "version": "3.2.0",
+          "from": "node-sass@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.2.0.tgz",
+          "dependencies": {
+            "async-foreach": {
+              "version": "0.1.3",
+              "from": "async-foreach@>=0.1.3 <0.2.0",
+              "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz"
+            },
+            "chalk": {
+              "version": "1.1.1",
+              "from": "chalk@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.1.0",
+                  "from": "ansi-styles@>=2.1.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.0",
+                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "from": "supports-color@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                }
+              }
+            },
+            "gaze": {
+              "version": "0.5.1",
+              "from": "gaze@>=0.5.1 <0.6.0",
+              "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
+              "dependencies": {
+                "globule": {
+                  "version": "0.1.0",
+                  "from": "globule@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+                  "dependencies": {
+                    "lodash": {
+                      "version": "1.0.2",
+                      "from": "lodash@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
+                    },
+                    "glob": {
+                      "version": "3.1.21",
+                      "from": "glob@>=3.1.21 <3.2.0",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "1.2.3",
+                          "from": "graceful-fs@>=1.2.0 <1.3.0",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                        },
+                        "inherits": {
+                          "version": "1.0.0",
+                          "from": "inherits@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "minimatch": {
+                      "version": "0.2.14",
+                      "from": "minimatch@>=0.2.11 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.6.5",
+                          "from": "lru-cache@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.1",
+                          "from": "sigmund@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "get-stdin": {
+              "version": "4.0.1",
+              "from": "get-stdin@>=4.0.1 <5.0.0",
+              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+            },
+            "glob": {
+              "version": "5.0.14",
+              "from": "glob@>=5.0.3 <6.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "2.0.10",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.2",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                }
+              }
+            },
+            "meow": {
+              "version": "3.3.0",
+              "from": "meow@>=3.1.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
+              "dependencies": {
+                "camelcase-keys": {
+                  "version": "1.0.0",
+                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.2.1",
+                      "from": "camelcase@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                    },
+                    "map-obj": {
+                      "version": "1.0.1",
+                      "from": "map-obj@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                    }
+                  }
+                },
+                "indent-string": {
+                  "version": "1.2.2",
+                  "from": "indent-string@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+                  "dependencies": {
+                    "repeating": {
+                      "version": "1.1.3",
+                      "from": "repeating@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.1",
+                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "minimist": {
+                  "version": "1.2.0",
+                  "from": "minimist@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                },
+                "object-assign": {
+                  "version": "3.0.0",
+                  "from": "object-assign@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                }
+              }
+            },
+            "nan": {
+              "version": "1.9.0",
+              "from": "nan@>=1.8.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-1.9.0.tgz"
+            },
+            "npmconf": {
+              "version": "2.1.2",
+              "from": "npmconf@>=2.1.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
+              "dependencies": {
+                "config-chain": {
+                  "version": "1.1.9",
+                  "from": "config-chain@>=1.1.8 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
+                  "dependencies": {
+                    "proto-list": {
+                      "version": "1.2.4",
+                      "from": "proto-list@>=1.2.1 <1.3.0",
+                      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "ini": {
+                  "version": "1.3.4",
+                  "from": "ini@>=1.2.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                },
+                "nopt": {
+                  "version": "3.0.3",
+                  "from": "nopt@>=3.0.1 <3.1.0",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.0.7",
+                      "from": "abbrev@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.2",
+                  "from": "once@>=1.3.0 <1.4.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "osenv": {
+                  "version": "0.1.3",
+                  "from": "osenv@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+                  "dependencies": {
+                    "os-homedir": {
+                      "version": "1.0.1",
+                      "from": "os-homedir@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+                    },
+                    "os-tmpdir": {
+                      "version": "1.0.1",
+                      "from": "os-tmpdir@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                    }
+                  }
+                },
+                "semver": {
+                  "version": "4.3.6",
+                  "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+                },
+                "uid-number": {
+                  "version": "0.0.5",
+                  "from": "uid-number@0.0.5",
+                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
+                }
+              }
+            },
+            "pangyp": {
+              "version": "2.3.0",
+              "from": "pangyp@>=2.2.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/pangyp/-/pangyp-2.3.0.tgz",
+              "dependencies": {
+                "fstream": {
+                  "version": "1.0.7",
+                  "from": "fstream@>=1.0.3 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.7.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "glob": {
+                  "version": "4.3.5",
+                  "from": "glob@>=4.3.5 <4.4.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "once": {
+                      "version": "1.3.2",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "graceful-fs": {
+                  "version": "3.0.8",
+                  "from": "graceful-fs@>=3.0.5 <3.1.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+                },
+                "minimatch": {
+                  "version": "2.0.10",
+                  "from": "minimatch@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "nopt": {
+                  "version": "3.0.3",
+                  "from": "nopt@>=3.0.1 <3.1.0",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.0.7",
+                      "from": "abbrev@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                    }
+                  }
+                },
+                "npmlog": {
+                  "version": "1.0.0",
+                  "from": "npmlog@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.0.0.tgz",
+                  "dependencies": {
+                    "ansi": {
+                      "version": "0.3.0",
+                      "from": "ansi@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
+                    },
+                    "are-we-there-yet": {
+                      "version": "1.0.4",
+                      "from": "are-we-there-yet@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
+                      "dependencies": {
+                        "delegates": {
+                          "version": "0.1.0",
+                          "from": "delegates@>=0.1.0 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
+                        },
+                        "readable-stream": {
+                          "version": "1.1.13",
+                          "from": "readable-stream@>=1.1.13 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "isarray@0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@>=2.0.1 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "gauge": {
+                      "version": "1.0.2",
+                      "from": "gauge@>=1.0.2 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.0.2.tgz",
+                      "dependencies": {
+                        "has-unicode": {
+                          "version": "1.0.0",
+                          "from": "has-unicode@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "osenv": {
+                  "version": "0.1.3",
+                  "from": "osenv@>=0.0.0 <1.0.0",
+                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+                  "dependencies": {
+                    "os-homedir": {
+                      "version": "1.0.1",
+                      "from": "os-homedir@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+                    },
+                    "os-tmpdir": {
+                      "version": "1.0.1",
+                      "from": "os-tmpdir@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                    }
+                  }
+                },
+                "request": {
+                  "version": "2.51.0",
+                  "from": "request@>=2.51.0 <2.52.0",
+                  "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
+                  "dependencies": {
+                    "bl": {
+                      "version": "0.9.4",
+                      "from": "bl@>=0.9.0 <0.10.0",
+                      "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                      "dependencies": {
+                        "readable-stream": {
+                          "version": "1.0.33",
+                          "from": "readable-stream@>=1.0.26 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "isarray@0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@>=2.0.1 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "caseless": {
+                      "version": "0.8.0",
+                      "from": "caseless@>=0.8.0 <0.9.0",
+                      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
+                    },
+                    "forever-agent": {
+                      "version": "0.5.2",
+                      "from": "forever-agent@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                    },
+                    "form-data": {
+                      "version": "0.2.0",
+                      "from": "form-data@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                      "dependencies": {
+                        "async": {
+                          "version": "0.9.2",
+                          "from": "async@>=0.9.0 <0.10.0",
+                          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                        },
+                        "mime-types": {
+                          "version": "2.0.14",
+                          "from": "mime-types@>=2.0.3 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+                          "dependencies": {
+                            "mime-db": {
+                              "version": "1.12.0",
+                              "from": "mime-db@>=1.12.0 <1.13.0",
+                              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "json-stringify-safe": {
+                      "version": "5.0.1",
+                      "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                    },
+                    "mime-types": {
+                      "version": "1.0.2",
+                      "from": "mime-types@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                    },
+                    "node-uuid": {
+                      "version": "1.4.3",
+                      "from": "node-uuid@>=1.4.0 <1.5.0",
+                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                    },
+                    "qs": {
+                      "version": "2.3.3",
+                      "from": "qs@>=2.3.1 <2.4.0",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+                    },
+                    "tunnel-agent": {
+                      "version": "0.4.1",
+                      "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+                    },
+                    "tough-cookie": {
+                      "version": "2.0.0",
+                      "from": "tough-cookie@>=0.12.0",
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
+                    },
+                    "http-signature": {
+                      "version": "0.10.1",
+                      "from": "http-signature@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "0.1.5",
+                          "from": "assert-plus@>=0.1.5 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                        },
+                        "asn1": {
+                          "version": "0.1.11",
+                          "from": "asn1@0.1.11",
+                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                        },
+                        "ctype": {
+                          "version": "0.5.3",
+                          "from": "ctype@0.5.3",
+                          "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                        }
+                      }
+                    },
+                    "oauth-sign": {
+                      "version": "0.5.0",
+                      "from": "oauth-sign@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
+                    },
+                    "hawk": {
+                      "version": "1.1.1",
+                      "from": "hawk@1.1.1",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                      "dependencies": {
+                        "hoek": {
+                          "version": "0.9.1",
+                          "from": "hoek@>=0.9.0 <0.10.0",
+                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                        },
+                        "boom": {
+                          "version": "0.4.2",
+                          "from": "boom@>=0.4.0 <0.5.0",
+                          "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                        },
+                        "cryptiles": {
+                          "version": "0.2.2",
+                          "from": "cryptiles@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                        },
+                        "sntp": {
+                          "version": "0.2.4",
+                          "from": "sntp@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                        }
+                      }
+                    },
+                    "aws-sign2": {
+                      "version": "0.5.0",
+                      "from": "aws-sign2@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                    },
+                    "stringstream": {
+                      "version": "0.0.4",
+                      "from": "stringstream@>=0.0.4 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                    },
+                    "combined-stream": {
+                      "version": "0.0.7",
+                      "from": "combined-stream@>=0.0.5 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "0.0.5",
+                          "from": "delayed-stream@0.0.5",
+                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "rimraf": {
+                  "version": "2.2.8",
+                  "from": "rimraf@>=2.2.8 <2.3.0",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                },
+                "semver": {
+                  "version": "4.3.6",
+                  "from": "semver@>=4.3.6 <4.4.0",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+                },
+                "tar": {
+                  "version": "1.0.3",
+                  "from": "tar@>=1.0.3 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
+                  "dependencies": {
+                    "block-stream": {
+                      "version": "0.0.8",
+                      "from": "block-stream@*",
+                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "which": {
+                  "version": "1.0.9",
+                  "from": "which@>=1.0.8 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
+                }
+              }
+            },
+            "request": {
+              "version": "2.61.0",
+              "from": "request@>=2.55.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.61.0.tgz",
+              "dependencies": {
+                "bl": {
+                  "version": "1.0.0",
+                  "from": "bl@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "2.0.2",
+                      "from": "readable-stream@>=2.0.0 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.2",
+                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.1",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.11.0",
+                  "from": "caseless@>=0.11.0 <0.12.0",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+                },
+                "extend": {
+                  "version": "3.0.0",
+                  "from": "extend@>=3.0.0 <3.1.0",
+                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+                },
+                "forever-agent": {
+                  "version": "0.6.1",
+                  "from": "forever-agent@>=0.6.0 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                },
+                "form-data": {
+                  "version": "1.0.0-rc3",
+                  "from": "form-data@>=1.0.0-rc1 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "1.4.2",
+                      "from": "async@>=1.4.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz"
+                    }
+                  }
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                },
+                "mime-types": {
+                  "version": "2.1.5",
+                  "from": "mime-types@>=2.1.2 <2.2.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.5.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.17.0",
+                      "from": "mime-db@>=1.17.0 <1.18.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.17.0.tgz"
+                    }
+                  }
+                },
+                "node-uuid": {
+                  "version": "1.4.3",
+                  "from": "node-uuid@>=1.4.0 <1.5.0",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                },
+                "qs": {
+                  "version": "4.0.0",
+                  "from": "qs@>=4.0.0 <4.1.0",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.1",
+                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+                },
+                "tough-cookie": {
+                  "version": "2.0.0",
+                  "from": "tough-cookie@>=0.12.0",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
+                },
+                "http-signature": {
+                  "version": "0.11.0",
+                  "from": "http-signature@>=0.11.0 <0.12.0",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "assert-plus@>=0.1.5 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "asn1@0.1.11",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "from": "ctype@0.5.3",
+                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.8.0",
+                  "from": "oauth-sign@>=0.8.0 <0.9.0",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+                },
+                "hawk": {
+                  "version": "3.1.0",
+                  "from": "hawk@>=3.1.0 <3.2.0",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "2.14.0",
+                      "from": "hoek@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
+                    },
+                    "boom": {
+                      "version": "2.8.0",
+                      "from": "boom@>=2.8.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "2.0.4",
+                      "from": "cryptiles@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "from": "sntp@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                    }
+                  }
+                },
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "from": "aws-sign2@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                },
+                "stringstream": {
+                  "version": "0.0.4",
+                  "from": "stringstream@>=0.0.4 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                },
+                "combined-stream": {
+                  "version": "1.0.5",
+                  "from": "combined-stream@>=1.0.1 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "1.0.0",
+                      "from": "delayed-stream@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                    }
+                  }
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "from": "isstream@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                },
+                "har-validator": {
+                  "version": "1.8.0",
+                  "from": "har-validator@>=1.6.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
+                  "dependencies": {
+                    "bluebird": {
+                      "version": "2.9.34",
+                      "from": "bluebird@>=2.9.30 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz"
+                    },
+                    "commander": {
+                      "version": "2.8.1",
+                      "from": "commander@>=2.8.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+                      "dependencies": {
+                        "graceful-readlink": {
+                          "version": "1.0.1",
+                          "from": "graceful-readlink@>=1.0.0",
+                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "is-my-json-valid": {
+                      "version": "2.12.1",
+                      "from": "is-my-json-valid@>=2.12.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.1.tgz",
+                      "dependencies": {
+                        "generate-function": {
+                          "version": "2.0.0",
+                          "from": "generate-function@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                        },
+                        "generate-object-property": {
+                          "version": "1.2.0",
+                          "from": "generate-object-property@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                          "dependencies": {
+                            "is-property": {
+                              "version": "1.0.2",
+                              "from": "is-property@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                            }
+                          }
+                        },
+                        "jsonpointer": {
+                          "version": "1.1.0",
+                          "from": "jsonpointer@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
+                        },
+                        "xtend": {
+                          "version": "4.0.0",
+                          "from": "xtend@>=4.0.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "sass-graph": {
+              "version": "2.0.1",
+              "from": "sass-graph@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.0.1.tgz",
+              "dependencies": {
+                "lodash": {
+                  "version": "3.10.1",
+                  "from": "lodash@>=3.8.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                },
+                "yargs": {
+                  "version": "3.21.0",
+                  "from": "yargs@>=3.8.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.21.0.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.2.1",
+                      "from": "camelcase@>=1.2.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                    },
+                    "cliui": {
+                      "version": "2.1.0",
+                      "from": "cliui@>=2.1.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                      "dependencies": {
+                        "center-align": {
+                          "version": "0.1.1",
+                          "from": "center-align@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.1.tgz",
+                          "dependencies": {
+                            "align-text": {
+                              "version": "0.1.3",
+                              "from": "align-text@>=0.1.0 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                              "dependencies": {
+                                "kind-of": {
+                                  "version": "2.0.1",
+                                  "from": "kind-of@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                                  "dependencies": {
+                                    "is-buffer": {
+                                      "version": "1.0.2",
+                                      "from": "is-buffer@>=1.0.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.0.2.tgz"
+                                    }
+                                  }
+                                },
+                                "longest": {
+                                  "version": "1.0.1",
+                                  "from": "longest@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                },
+                                "repeat-string": {
+                                  "version": "1.5.2",
+                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "right-align": {
+                          "version": "0.1.3",
+                          "from": "right-align@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                          "dependencies": {
+                            "align-text": {
+                              "version": "0.1.3",
+                              "from": "align-text@>=0.1.0 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                              "dependencies": {
+                                "kind-of": {
+                                  "version": "2.0.1",
+                                  "from": "kind-of@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                                  "dependencies": {
+                                    "is-buffer": {
+                                      "version": "1.0.2",
+                                      "from": "is-buffer@>=1.0.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.0.2.tgz"
+                                    }
+                                  }
+                                },
+                                "longest": {
+                                  "version": "1.0.1",
+                                  "from": "longest@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                },
+                                "repeat-string": {
+                                  "version": "1.5.2",
+                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "wordwrap": {
+                          "version": "0.0.2",
+                          "from": "wordwrap@0.0.2",
+                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                        }
+                      }
+                    },
+                    "decamelize": {
+                      "version": "1.0.0",
+                      "from": "decamelize@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
+                    },
+                    "os-locale": {
+                      "version": "1.2.0",
+                      "from": "os-locale@>=1.2.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.2.0.tgz",
+                      "dependencies": {
+                        "exec-file-sync": {
+                          "version": "2.0.0",
+                          "from": "exec-file-sync@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/exec-file-sync/-/exec-file-sync-2.0.0.tgz",
+                          "dependencies": {
+                            "is-obj": {
+                              "version": "1.0.0",
+                              "from": "is-obj@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.0.tgz"
+                            },
+                            "object-assign": {
+                              "version": "3.0.0",
+                              "from": "object-assign@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                            },
+                            "spawn-sync": {
+                              "version": "1.0.13",
+                              "from": "spawn-sync@>=1.0.11 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.13.tgz",
+                              "dependencies": {
+                                "concat-stream": {
+                                  "version": "1.5.0",
+                                  "from": "concat-stream@>=1.4.7 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+                                  "dependencies": {
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@>=2.0.1 <2.1.0",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    },
+                                    "typedarray": {
+                                      "version": "0.0.6",
+                                      "from": "typedarray@>=0.0.5 <0.1.0",
+                                      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                                    },
+                                    "readable-stream": {
+                                      "version": "2.0.2",
+                                      "from": "readable-stream@>=2.0.0 <2.1.0",
+                                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                      "dependencies": {
+                                        "core-util-is": {
+                                          "version": "1.0.1",
+                                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                        },
+                                        "isarray": {
+                                          "version": "0.0.1",
+                                          "from": "isarray@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        },
+                                        "process-nextick-args": {
+                                          "version": "1.0.2",
+                                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                        },
+                                        "string_decoder": {
+                                          "version": "0.10.31",
+                                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        },
+                                        "util-deprecate": {
+                                          "version": "1.0.1",
+                                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "os-shim": {
+                                  "version": "0.1.3",
+                                  "from": "os-shim@>=0.1.2 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "lcid": {
+                          "version": "1.0.0",
+                          "from": "lcid@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                          "dependencies": {
+                            "invert-kv": {
+                              "version": "1.0.0",
+                              "from": "invert-kv@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "window-size": {
+                      "version": "0.1.2",
+                      "from": "window-size@>=0.1.2 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.2.tgz"
+                    },
+                    "y18n": {
+                      "version": "3.1.0",
+                      "from": "y18n@>=3.1.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.1.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "object-assign": {
+          "version": "2.1.1",
+          "from": "object-assign@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+        }
+      }
+    },
+    "grunt-shell": {
+      "version": "1.1.2",
+      "from": "grunt-shell@>=1.1.2 <1.2.0",
+      "resolved": "https://registry.npmjs.org/grunt-shell/-/grunt-shell-1.1.2.tgz",
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.1",
+          "from": "chalk@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.1.0",
+              "from": "ansi-styles@>=2.1.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.0",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "from": "supports-color@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "grunt-svgmin": {
+      "version": "2.0.1",
+      "from": "grunt-svgmin@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/grunt-svgmin/-/grunt-svgmin-2.0.1.tgz",
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.1",
+          "from": "chalk@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.1.0",
+              "from": "ansi-styles@>=2.1.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.0",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "from": "supports-color@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+            }
+          }
+        },
+        "each-async": {
+          "version": "1.1.1",
+          "from": "each-async@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
+          "dependencies": {
+            "onetime": {
+              "version": "1.0.0",
+              "from": "onetime@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz"
+            },
+            "set-immediate-shim": {
+              "version": "1.0.1",
+              "from": "set-immediate-shim@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
+            }
+          }
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "from": "log-symbols@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz"
+        },
+        "pretty-bytes": {
+          "version": "1.0.4",
+          "from": "pretty-bytes@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
+          "dependencies": {
+            "get-stdin": {
+              "version": "4.0.1",
+              "from": "get-stdin@>=4.0.1 <5.0.0",
+              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+            },
+            "meow": {
+              "version": "3.3.0",
+              "from": "meow@>=3.1.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
+              "dependencies": {
+                "camelcase-keys": {
+                  "version": "1.0.0",
+                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.2.1",
+                      "from": "camelcase@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                    },
+                    "map-obj": {
+                      "version": "1.0.1",
+                      "from": "map-obj@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                    }
+                  }
+                },
+                "indent-string": {
+                  "version": "1.2.2",
+                  "from": "indent-string@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+                  "dependencies": {
+                    "repeating": {
+                      "version": "1.1.3",
+                      "from": "repeating@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.1",
+                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "minimist": {
+                  "version": "1.2.0",
+                  "from": "minimist@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                },
+                "object-assign": {
+                  "version": "3.0.0",
+                  "from": "object-assign@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "svgo": {
+          "version": "0.5.6",
+          "from": "svgo@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.5.6.tgz",
+          "dependencies": {
+            "sax": {
+              "version": "1.1.1",
+              "from": "sax@>=1.1.1 <1.2.0",
+              "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.1.tgz"
+            },
+            "coa": {
+              "version": "1.0.1",
+              "from": "coa@>=1.0.1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.1.tgz",
+              "dependencies": {
+                "q": {
+                  "version": "1.4.1",
+                  "from": "q@>=1.1.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
+                }
+              }
+            },
+            "js-yaml": {
+              "version": "3.3.1",
+              "from": "js-yaml@>=3.3.1 <3.4.0",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
+              "dependencies": {
+                "argparse": {
+                  "version": "1.0.2",
+                  "from": "argparse@>=1.0.2 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+                  "dependencies": {
+                    "lodash": {
+                      "version": "3.10.1",
+                      "from": "lodash@>=3.2.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                    },
+                    "sprintf-js": {
+                      "version": "1.0.3",
+                      "from": "sprintf-js@>=1.0.2 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                    }
+                  }
+                },
+                "esprima": {
+                  "version": "2.2.0",
+                  "from": "esprima@>=2.2.0 <2.3.0",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz"
+                }
+              }
+            },
+            "colors": {
+              "version": "1.1.2",
+              "from": "colors@>=1.1.2 <1.2.0",
+              "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
+            },
+            "whet.extend": {
+              "version": "0.9.9",
+              "from": "whet.extend@>=0.9.9 <0.10.0",
+              "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz"
+            }
+          }
+        }
+      }
+    },
+    "grunt-svgstore": {
+      "version": "0.5.0",
+      "from": "grunt-svgstore@>=0.5.0 <0.6.0",
+      "resolved": "https://registry.npmjs.org/grunt-svgstore/-/grunt-svgstore-0.5.0.tgz",
+      "dependencies": {
+        "chalk": {
+          "version": "0.4.0",
+          "from": "chalk@>=0.4.0 <0.5.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+          "dependencies": {
+            "has-color": {
+              "version": "0.1.7",
+              "from": "has-color@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
+            },
+            "ansi-styles": {
+              "version": "1.0.0",
+              "from": "ansi-styles@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
+            },
+            "strip-ansi": {
+              "version": "0.1.1",
+              "from": "strip-ansi@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
+            }
+          }
+        },
+        "cheerio": {
+          "version": "0.18.0",
+          "from": "cheerio@>=0.18.0 <0.19.0",
+          "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.18.0.tgz",
+          "dependencies": {
+            "CSSselect": {
+              "version": "0.4.1",
+              "from": "CSSselect@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.4.1.tgz",
+              "dependencies": {
+                "CSSwhat": {
+                  "version": "0.4.7",
+                  "from": "CSSwhat@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz"
+                },
+                "domutils": {
+                  "version": "1.4.3",
+                  "from": "domutils@>=1.4.0 <1.5.0",
+                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
+                  "dependencies": {
+                    "domelementtype": {
+                      "version": "1.3.0",
+                      "from": "domelementtype@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "entities": {
+              "version": "1.1.1",
+              "from": "entities@>=1.1.1 <1.2.0",
+              "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+            },
+            "htmlparser2": {
+              "version": "3.8.3",
+              "from": "htmlparser2@>=3.8.1 <3.9.0",
+              "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+              "dependencies": {
+                "domhandler": {
+                  "version": "2.3.0",
+                  "from": "domhandler@>=2.3.0 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
+                },
+                "domutils": {
+                  "version": "1.5.1",
+                  "from": "domutils@>=1.5.0 <1.6.0",
+                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz"
+                },
+                "domelementtype": {
+                  "version": "1.3.0",
+                  "from": "domelementtype@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+                },
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "readable-stream@>=1.1.0 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "entities": {
+                  "version": "1.0.0",
+                  "from": "entities@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
+                }
+              }
+            },
+            "dom-serializer": {
+              "version": "0.0.1",
+              "from": "dom-serializer@>=0.0.0 <0.1.0",
+              "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.0.1.tgz",
+              "dependencies": {
+                "domelementtype": {
+                  "version": "1.1.3",
+                  "from": "domelementtype@>=1.1.1 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
+                }
+              }
+            },
+            "lodash": {
+              "version": "2.4.2",
+              "from": "lodash@>=2.4.1 <2.5.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+            }
+          }
+        },
+        "js-beautify": {
+          "version": "1.5.10",
+          "from": "js-beautify@>=1.5.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.5.10.tgz",
+          "dependencies": {
+            "config-chain": {
+              "version": "1.1.9",
+              "from": "config-chain@>=1.1.5 <1.2.0",
+              "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
+              "dependencies": {
+                "proto-list": {
+                  "version": "1.2.4",
+                  "from": "proto-list@>=1.2.1 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
+                },
+                "ini": {
+                  "version": "1.3.4",
+                  "from": "ini@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                }
+              }
+            },
+            "nopt": {
+              "version": "3.0.3",
+              "from": "nopt@>=3.0.1 <3.1.0",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.0.7",
+                  "from": "abbrev@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                }
+              }
+            }
+          }
+        },
+        "multiline": {
+          "version": "0.3.4",
+          "from": "multiline@>=0.3.4 <0.4.0",
+          "resolved": "https://registry.npmjs.org/multiline/-/multiline-0.3.4.tgz",
+          "dependencies": {
+            "strip-indent": {
+              "version": "0.1.3",
+              "from": "strip-indent@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-0.1.3.tgz"
+            }
+          }
+        },
+        "handlebars": {
+          "version": "2.0.0",
+          "from": "handlebars@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-2.0.0.tgz",
+          "dependencies": {
+            "optimist": {
+              "version": "0.3.7",
+              "from": "optimist@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                }
+              }
+            },
+            "uglify-js": {
+              "version": "2.3.6",
+              "from": "uglify-js@>=2.3.0 <2.4.0",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@>=0.2.6 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                },
+                "source-map": {
+                  "version": "0.1.43",
+                  "from": "source-map@>=0.1.7 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "jasmine-core": {
+      "version": "2.3.4",
+      "from": "jasmine-core@*",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.3.4.tgz"
+    },
+    "karma": {
+      "version": "0.12.37",
+      "from": "karma@>=0.12.36 <0.13.0",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-0.12.37.tgz",
+      "dependencies": {
+        "chokidar": {
+          "version": "1.0.5",
+          "from": "chokidar@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.5.tgz",
+          "dependencies": {
+            "anymatch": {
+              "version": "1.3.0",
+              "from": "anymatch@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+              "dependencies": {
+                "micromatch": {
+                  "version": "2.2.0",
+                  "from": "micromatch@>=2.1.5 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.2.0.tgz",
+                  "dependencies": {
+                    "arr-diff": {
+                      "version": "1.1.0",
+                      "from": "arr-diff@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
+                      "dependencies": {
+                        "arr-flatten": {
+                          "version": "1.0.1",
+                          "from": "arr-flatten@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
+                        },
+                        "array-slice": {
+                          "version": "0.2.3",
+                          "from": "array-slice@>=0.2.3 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
+                        }
+                      }
+                    },
+                    "array-unique": {
+                      "version": "0.2.1",
+                      "from": "array-unique@>=0.2.1 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
+                    },
+                    "braces": {
+                      "version": "1.8.1",
+                      "from": "braces@>=1.8.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.1.tgz",
+                      "dependencies": {
+                        "expand-range": {
+                          "version": "1.8.1",
+                          "from": "expand-range@>=1.8.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
+                          "dependencies": {
+                            "fill-range": {
+                              "version": "2.2.2",
+                              "from": "fill-range@>=2.1.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
+                              "dependencies": {
+                                "is-number": {
+                                  "version": "1.1.2",
+                                  "from": "is-number@>=1.1.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz"
+                                },
+                                "isobject": {
+                                  "version": "1.0.2",
+                                  "from": "isobject@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz"
+                                },
+                                "randomatic": {
+                                  "version": "1.1.0",
+                                  "from": "randomatic@>=1.1.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz"
+                                },
+                                "repeat-string": {
+                                  "version": "1.5.2",
+                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "lazy-cache": {
+                          "version": "0.2.3",
+                          "from": "lazy-cache@>=0.2.3 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.3.tgz"
+                        },
+                        "preserve": {
+                          "version": "0.2.0",
+                          "from": "preserve@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+                        },
+                        "repeat-element": {
+                          "version": "1.1.2",
+                          "from": "repeat-element@>=1.1.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+                        }
+                      }
+                    },
+                    "expand-brackets": {
+                      "version": "0.1.4",
+                      "from": "expand-brackets@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz"
+                    },
+                    "extglob": {
+                      "version": "0.3.1",
+                      "from": "extglob@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.1.tgz",
+                      "dependencies": {
+                        "ansi-green": {
+                          "version": "0.1.1",
+                          "from": "ansi-green@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
+                          "dependencies": {
+                            "ansi-wrap": {
+                              "version": "0.1.0",
+                              "from": "ansi-wrap@0.1.0",
+                              "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
+                            }
+                          }
+                        },
+                        "is-extglob": {
+                          "version": "1.0.0",
+                          "from": "is-extglob@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                        },
+                        "success-symbol": {
+                          "version": "0.1.0",
+                          "from": "success-symbol@>=0.1.0 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz"
+                        }
+                      }
+                    },
+                    "filename-regex": {
+                      "version": "2.0.0",
+                      "from": "filename-regex@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
+                    },
+                    "kind-of": {
+                      "version": "1.1.0",
+                      "from": "kind-of@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
+                    },
+                    "object.omit": {
+                      "version": "1.1.0",
+                      "from": "object.omit@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-1.1.0.tgz",
+                      "dependencies": {
+                        "for-own": {
+                          "version": "0.1.3",
+                          "from": "for-own@>=0.1.3 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
+                          "dependencies": {
+                            "for-in": {
+                              "version": "0.1.4",
+                              "from": "for-in@>=0.1.4 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
+                            }
+                          }
+                        },
+                        "isobject": {
+                          "version": "1.0.2",
+                          "from": "isobject@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "parse-glob": {
+                      "version": "3.0.2",
+                      "from": "parse-glob@>=3.0.1 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
+                      "dependencies": {
+                        "glob-base": {
+                          "version": "0.2.0",
+                          "from": "glob-base@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz"
+                        },
+                        "is-dotfile": {
+                          "version": "1.0.1",
+                          "from": "is-dotfile@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.1.tgz"
+                        },
+                        "is-extglob": {
+                          "version": "1.0.0",
+                          "from": "is-extglob@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "regex-cache": {
+                      "version": "0.4.2",
+                      "from": "regex-cache@>=0.4.2 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
+                      "dependencies": {
+                        "is-equal-shallow": {
+                          "version": "0.1.3",
+                          "from": "is-equal-shallow@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+                        },
+                        "is-primitive": {
+                          "version": "2.0.0",
+                          "from": "is-primitive@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "arrify": {
+              "version": "1.0.0",
+              "from": "arrify@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
+            },
+            "async-each": {
+              "version": "0.1.6",
+              "from": "async-each@>=0.1.5 <0.2.0",
+              "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
+            },
+            "glob-parent": {
+              "version": "1.2.0",
+              "from": "glob-parent@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz"
+            },
+            "is-binary-path": {
+              "version": "1.0.1",
+              "from": "is-binary-path@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+              "dependencies": {
+                "binary-extensions": {
+                  "version": "1.3.1",
+                  "from": "binary-extensions@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.1.tgz"
+                }
+              }
+            },
+            "is-glob": {
+              "version": "1.1.3",
+              "from": "is-glob@>=1.1.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
+            },
+            "path-is-absolute": {
+              "version": "1.0.0",
+              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+            },
+            "readdirp": {
+              "version": "1.4.0",
+              "from": "readdirp@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.4.0.tgz",
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "4.1.2",
+                  "from": "graceful-fs@>=4.1.2 <4.2.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                },
+                "minimatch": {
+                  "version": "0.2.14",
+                  "from": "minimatch@>=0.2.12 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.6.5",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.26-2 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "fsevents": {
+              "version": "0.3.8",
+              "from": "fsevents@>=0.3.1 <0.4.0",
+              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.8.tgz",
+              "dependencies": {
+                "nan": {
+                  "version": "2.0.5",
+                  "from": "nan@>=2.0.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/nan/-/nan-2.0.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "colors": {
+          "version": "1.1.2",
+          "from": "colors@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
+        },
+        "connect": {
+          "version": "2.30.2",
+          "from": "connect@>=2.29.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/connect/-/connect-2.30.2.tgz",
+          "dependencies": {
+            "basic-auth-connect": {
+              "version": "1.0.0",
+              "from": "basic-auth-connect@1.0.0",
+              "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz"
+            },
+            "body-parser": {
+              "version": "1.13.3",
+              "from": "body-parser@>=1.13.3 <1.14.0",
+              "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.13.3.tgz",
+              "dependencies": {
+                "iconv-lite": {
+                  "version": "0.4.11",
+                  "from": "iconv-lite@0.4.11",
+                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz"
+                },
+                "on-finished": {
+                  "version": "2.3.0",
+                  "from": "on-finished@>=2.3.0 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+                  "dependencies": {
+                    "ee-first": {
+                      "version": "1.1.1",
+                      "from": "ee-first@1.1.1",
+                      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+                    }
+                  }
+                },
+                "raw-body": {
+                  "version": "2.1.2",
+                  "from": "raw-body@>=2.1.2 <2.2.0",
+                  "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.2.tgz",
+                  "dependencies": {
+                    "unpipe": {
+                      "version": "1.0.0",
+                      "from": "unpipe@1.0.0",
+                      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "bytes": {
+              "version": "2.1.0",
+              "from": "bytes@2.1.0",
+              "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz"
+            },
+            "cookie": {
+              "version": "0.1.3",
+              "from": "cookie@0.1.3",
+              "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz"
+            },
+            "cookie-parser": {
+              "version": "1.3.5",
+              "from": "cookie-parser@>=1.3.5 <1.4.0",
+              "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.5.tgz"
+            },
+            "cookie-signature": {
+              "version": "1.0.6",
+              "from": "cookie-signature@1.0.6",
+              "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
+            },
+            "compression": {
+              "version": "1.5.2",
+              "from": "compression@>=1.5.2 <1.6.0",
+              "resolved": "https://registry.npmjs.org/compression/-/compression-1.5.2.tgz",
+              "dependencies": {
+                "accepts": {
+                  "version": "1.2.12",
+                  "from": "accepts@>=1.2.12 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.12.tgz",
+                  "dependencies": {
+                    "mime-types": {
+                      "version": "2.1.5",
+                      "from": "mime-types@>=2.1.4 <2.2.0",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.5.tgz",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.17.0",
+                          "from": "mime-db@>=1.17.0 <1.18.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.17.0.tgz"
+                        }
+                      }
+                    },
+                    "negotiator": {
+                      "version": "0.5.3",
+                      "from": "negotiator@0.5.3",
+                      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
+                    }
+                  }
+                },
+                "compressible": {
+                  "version": "2.0.5",
+                  "from": "compressible@>=2.0.5 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.5.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.17.0",
+                      "from": "mime-db@>=1.17.0 <1.18.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.17.0.tgz"
+                    }
+                  }
+                },
+                "vary": {
+                  "version": "1.0.1",
+                  "from": "vary@>=1.0.1 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
+                }
+              }
+            },
+            "connect-timeout": {
+              "version": "1.6.2",
+              "from": "connect-timeout@>=1.6.2 <1.7.0",
+              "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.6.2.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "ms@0.7.1",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                }
+              }
+            },
+            "content-type": {
+              "version": "1.0.1",
+              "from": "content-type@>=1.0.1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
+            },
+            "csurf": {
+              "version": "1.8.3",
+              "from": "csurf@>=1.8.3 <1.9.0",
+              "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.8.3.tgz",
+              "dependencies": {
+                "csrf": {
+                  "version": "3.0.0",
+                  "from": "csrf@>=3.0.0 <3.1.0",
+                  "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.0.0.tgz",
+                  "dependencies": {
+                    "base64-url": {
+                      "version": "1.2.1",
+                      "from": "base64-url@1.2.1",
+                      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
+                    },
+                    "rndm": {
+                      "version": "1.1.0",
+                      "from": "rndm@>=1.1.0 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.1.0.tgz"
+                    },
+                    "scmp": {
+                      "version": "1.0.0",
+                      "from": "scmp@1.0.0",
+                      "resolved": "https://registry.npmjs.org/scmp/-/scmp-1.0.0.tgz"
+                    },
+                    "uid-safe": {
+                      "version": "2.0.0",
+                      "from": "uid-safe@>=2.0.0 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "debug": {
+              "version": "2.2.0",
+              "from": "debug@>=2.2.0 <2.3.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "ms@0.7.1",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                }
+              }
+            },
+            "depd": {
+              "version": "1.0.1",
+              "from": "depd@>=1.0.1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
+            },
+            "errorhandler": {
+              "version": "1.4.2",
+              "from": "errorhandler@>=1.4.2 <1.5.0",
+              "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.4.2.tgz",
+              "dependencies": {
+                "accepts": {
+                  "version": "1.2.12",
+                  "from": "accepts@>=1.2.12 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.12.tgz",
+                  "dependencies": {
+                    "mime-types": {
+                      "version": "2.1.5",
+                      "from": "mime-types@>=2.1.4 <2.2.0",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.5.tgz",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.17.0",
+                          "from": "mime-db@>=1.17.0 <1.18.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.17.0.tgz"
+                        }
+                      }
+                    },
+                    "negotiator": {
+                      "version": "0.5.3",
+                      "from": "negotiator@0.5.3",
+                      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
+                    }
+                  }
+                },
+                "escape-html": {
+                  "version": "1.0.2",
+                  "from": "escape-html@1.0.2",
+                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz"
+                }
+              }
+            },
+            "express-session": {
+              "version": "1.11.3",
+              "from": "express-session@>=1.11.3 <1.12.0",
+              "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.11.3.tgz",
+              "dependencies": {
+                "crc": {
+                  "version": "3.3.0",
+                  "from": "crc@3.3.0",
+                  "resolved": "https://registry.npmjs.org/crc/-/crc-3.3.0.tgz"
+                },
+                "uid-safe": {
+                  "version": "2.0.0",
+                  "from": "uid-safe@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.0.0.tgz",
+                  "dependencies": {
+                    "base64-url": {
+                      "version": "1.2.1",
+                      "from": "base64-url@1.2.1",
+                      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "finalhandler": {
+              "version": "0.4.0",
+              "from": "finalhandler@0.4.0",
+              "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.0.tgz",
+              "dependencies": {
+                "escape-html": {
+                  "version": "1.0.2",
+                  "from": "escape-html@1.0.2",
+                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz"
+                },
+                "on-finished": {
+                  "version": "2.3.0",
+                  "from": "on-finished@>=2.3.0 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+                  "dependencies": {
+                    "ee-first": {
+                      "version": "1.1.1",
+                      "from": "ee-first@1.1.1",
+                      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+                    }
+                  }
+                },
+                "unpipe": {
+                  "version": "1.0.0",
+                  "from": "unpipe@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+                }
+              }
+            },
+            "fresh": {
+              "version": "0.3.0",
+              "from": "fresh@0.3.0",
+              "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
+            },
+            "http-errors": {
+              "version": "1.3.1",
+              "from": "http-errors@>=1.3.1 <1.4.0",
+              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "statuses": {
+                  "version": "1.2.1",
+                  "from": "statuses@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+                }
+              }
+            },
+            "method-override": {
+              "version": "2.3.5",
+              "from": "method-override@>=2.3.5 <2.4.0",
+              "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.3.5.tgz",
+              "dependencies": {
+                "methods": {
+                  "version": "1.1.1",
+                  "from": "methods@>=1.1.1 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.1.tgz"
+                },
+                "vary": {
+                  "version": "1.0.1",
+                  "from": "vary@>=1.0.1 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
+                }
+              }
+            },
+            "morgan": {
+              "version": "1.6.1",
+              "from": "morgan@>=1.6.1 <1.7.0",
+              "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.6.1.tgz",
+              "dependencies": {
+                "basic-auth": {
+                  "version": "1.0.3",
+                  "from": "basic-auth@>=1.0.3 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.3.tgz"
+                },
+                "on-finished": {
+                  "version": "2.3.0",
+                  "from": "on-finished@>=2.3.0 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+                  "dependencies": {
+                    "ee-first": {
+                      "version": "1.1.1",
+                      "from": "ee-first@1.1.1",
+                      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "multiparty": {
+              "version": "3.3.2",
+              "from": "multiparty@3.3.2",
+              "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-3.3.2.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "readable-stream@>=1.1.9 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "stream-counter": {
+                  "version": "0.2.0",
+                  "from": "stream-counter@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz"
+                }
+              }
+            },
+            "on-headers": {
+              "version": "1.0.0",
+              "from": "on-headers@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.0.tgz"
+            },
+            "parseurl": {
+              "version": "1.3.0",
+              "from": "parseurl@>=1.3.0 <1.4.0",
+              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
+            },
+            "pause": {
+              "version": "0.1.0",
+              "from": "pause@0.1.0",
+              "resolved": "https://registry.npmjs.org/pause/-/pause-0.1.0.tgz"
+            },
+            "qs": {
+              "version": "4.0.0",
+              "from": "qs@4.0.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
+            },
+            "response-time": {
+              "version": "2.3.1",
+              "from": "response-time@>=2.3.1 <2.4.0",
+              "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.3.1.tgz"
+            },
+            "serve-favicon": {
+              "version": "2.3.0",
+              "from": "serve-favicon@>=2.3.0 <2.4.0",
+              "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.3.0.tgz",
+              "dependencies": {
+                "etag": {
+                  "version": "1.7.0",
+                  "from": "etag@>=1.7.0 <1.8.0",
+                  "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
+                },
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "ms@0.7.1",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                }
+              }
+            },
+            "serve-index": {
+              "version": "1.7.2",
+              "from": "serve-index@>=1.7.2 <1.8.0",
+              "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.7.2.tgz",
+              "dependencies": {
+                "accepts": {
+                  "version": "1.2.12",
+                  "from": "accepts@>=1.2.12 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.12.tgz",
+                  "dependencies": {
+                    "negotiator": {
+                      "version": "0.5.3",
+                      "from": "negotiator@0.5.3",
+                      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
+                    }
+                  }
+                },
+                "batch": {
+                  "version": "0.5.2",
+                  "from": "batch@0.5.2",
+                  "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.2.tgz"
+                },
+                "escape-html": {
+                  "version": "1.0.2",
+                  "from": "escape-html@1.0.2",
+                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz"
+                },
+                "mime-types": {
+                  "version": "2.1.5",
+                  "from": "mime-types@>=2.1.4 <2.2.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.5.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.17.0",
+                      "from": "mime-db@>=1.17.0 <1.18.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.17.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "serve-static": {
+              "version": "1.10.0",
+              "from": "serve-static@>=1.10.0 <1.11.0",
+              "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.0.tgz",
+              "dependencies": {
+                "escape-html": {
+                  "version": "1.0.2",
+                  "from": "escape-html@1.0.2",
+                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz"
+                },
+                "send": {
+                  "version": "0.13.0",
+                  "from": "send@0.13.0",
+                  "resolved": "https://registry.npmjs.org/send/-/send-0.13.0.tgz",
+                  "dependencies": {
+                    "destroy": {
+                      "version": "1.0.3",
+                      "from": "destroy@1.0.3",
+                      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
+                    },
+                    "etag": {
+                      "version": "1.7.0",
+                      "from": "etag@>=1.7.0 <1.8.0",
+                      "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
+                    },
+                    "ms": {
+                      "version": "0.7.1",
+                      "from": "ms@0.7.1",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                    },
+                    "on-finished": {
+                      "version": "2.3.0",
+                      "from": "on-finished@>=2.3.0 <2.4.0",
+                      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+                      "dependencies": {
+                        "ee-first": {
+                          "version": "1.1.1",
+                          "from": "ee-first@1.1.1",
+                          "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+                        }
+                      }
+                    },
+                    "range-parser": {
+                      "version": "1.0.2",
+                      "from": "range-parser@>=1.0.2 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.2.tgz"
+                    },
+                    "statuses": {
+                      "version": "1.2.1",
+                      "from": "statuses@>=1.2.1 <1.3.0",
+                      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "type-is": {
+              "version": "1.6.7",
+              "from": "type-is@>=1.6.6 <1.7.0",
+              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.7.tgz",
+              "dependencies": {
+                "media-typer": {
+                  "version": "0.3.0",
+                  "from": "media-typer@0.3.0",
+                  "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+                },
+                "mime-types": {
+                  "version": "2.1.5",
+                  "from": "mime-types@>=2.1.5 <2.2.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.5.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.17.0",
+                      "from": "mime-db@>=1.17.0 <1.18.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.17.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "utils-merge": {
+              "version": "1.0.0",
+              "from": "utils-merge@1.0.0",
+              "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+            },
+            "vhost": {
+              "version": "3.0.1",
+              "from": "vhost@>=3.0.1 <3.1.0",
+              "resolved": "https://registry.npmjs.org/vhost/-/vhost-3.0.1.tgz"
+            }
+          }
+        },
+        "di": {
+          "version": "0.0.1",
+          "from": "di@>=0.0.1 <0.0.2",
+          "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz"
+        },
+        "glob": {
+          "version": "5.0.14",
+          "from": "glob@>=5.0.6 <6.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.4",
+              "from": "inflight@>=1.0.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "once": {
+              "version": "1.3.2",
+              "from": "once@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.0",
+              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+            }
+          }
+        },
+        "graceful-fs": {
+          "version": "3.0.8",
+          "from": "graceful-fs@>=3.0.6 <4.0.0",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+        },
+        "http-proxy": {
+          "version": "0.10.4",
+          "from": "http-proxy@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.10.4.tgz",
+          "dependencies": {
+            "colors": {
+              "version": "0.6.2",
+              "from": "colors@>=0.0.0 <1.0.0",
+              "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+            },
+            "pkginfo": {
+              "version": "0.3.0",
+              "from": "pkginfo@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
+            },
+            "utile": {
+              "version": "0.2.1",
+              "from": "utile@>=0.2.1 <0.3.0",
+              "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@>=0.2.9 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                },
+                "deep-equal": {
+                  "version": "1.0.0",
+                  "from": "deep-equal@*",
+                  "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz"
+                },
+                "i": {
+                  "version": "0.3.3",
+                  "from": "i@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/i/-/i-0.3.3.tgz"
+                },
+                "ncp": {
+                  "version": "0.4.2",
+                  "from": "ncp@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "from": "lodash@>=3.8.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+        },
+        "log4js": {
+          "version": "0.6.26",
+          "from": "log4js@>=0.6.25 <0.7.0",
+          "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.26.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "from": "async@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+            },
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.2 <1.1.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "semver": {
+              "version": "4.3.6",
+              "from": "semver@>=4.3.3 <4.4.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+            },
+            "underscore": {
+              "version": "1.8.2",
+              "from": "underscore@1.8.2",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.2.tgz"
+            }
+          }
+        },
+        "mime": {
+          "version": "1.3.4",
+          "from": "mime@>=1.3.4 <2.0.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "from": "minimatch@>=2.0.7 <3.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.0",
+              "from": "brace-expansion@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.2.0",
+                  "from": "balanced-match@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "from": "concat-map@0.0.1",
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "from": "optimist@>=0.6.1 <0.7.0",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.3",
+              "from": "wordwrap@>=0.0.2 <0.1.0",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+            },
+            "minimist": {
+              "version": "0.0.10",
+              "from": "minimist@>=0.0.1 <0.1.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+            }
+          }
+        },
+        "q": {
+          "version": "1.4.1",
+          "from": "q@>=1.4.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
+        },
+        "rimraf": {
+          "version": "2.4.2",
+          "from": "rimraf@>=2.3.3 <3.0.0",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.2.tgz"
+        },
+        "socket.io": {
+          "version": "0.9.16",
+          "from": "socket.io@0.9.16",
+          "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-0.9.16.tgz",
+          "dependencies": {
+            "socket.io-client": {
+              "version": "0.9.16",
+              "from": "socket.io-client@0.9.16",
+              "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-0.9.16.tgz",
+              "dependencies": {
+                "uglify-js": {
+                  "version": "1.2.5",
+                  "from": "uglify-js@1.2.5",
+                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.5.tgz"
+                },
+                "ws": {
+                  "version": "0.4.32",
+                  "from": "ws@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.32.tgz",
+                  "dependencies": {
+                    "commander": {
+                      "version": "2.1.0",
+                      "from": "commander@>=2.1.0 <2.2.0",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz"
+                    },
+                    "nan": {
+                      "version": "1.0.0",
+                      "from": "nan@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz"
+                    },
+                    "tinycolor": {
+                      "version": "0.0.1",
+                      "from": "tinycolor@>=0.0.0 <1.0.0",
+                      "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
+                    },
+                    "options": {
+                      "version": "0.0.6",
+                      "from": "options@>=0.0.5",
+                      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
+                    }
+                  }
+                },
+                "xmlhttprequest": {
+                  "version": "1.4.2",
+                  "from": "xmlhttprequest@1.4.2",
+                  "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz"
+                },
+                "active-x-obfuscator": {
+                  "version": "0.0.1",
+                  "from": "active-x-obfuscator@0.0.1",
+                  "resolved": "https://registry.npmjs.org/active-x-obfuscator/-/active-x-obfuscator-0.0.1.tgz",
+                  "dependencies": {
+                    "zeparser": {
+                      "version": "0.0.5",
+                      "from": "zeparser@0.0.5",
+                      "resolved": "https://registry.npmjs.org/zeparser/-/zeparser-0.0.5.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "policyfile": {
+              "version": "0.0.4",
+              "from": "policyfile@0.0.4",
+              "resolved": "https://registry.npmjs.org/policyfile/-/policyfile-0.0.4.tgz"
+            },
+            "base64id": {
+              "version": "0.1.0",
+              "from": "base64id@0.1.0",
+              "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
+            },
+            "redis": {
+              "version": "0.7.3",
+              "from": "redis@0.7.3",
+              "resolved": "https://registry.npmjs.org/redis/-/redis-0.7.3.tgz"
+            }
+          }
+        },
+        "source-map": {
+          "version": "0.4.4",
+          "from": "source-map@>=0.4.2 <0.5.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "dependencies": {
+            "amdefine": {
+              "version": "1.0.0",
+              "from": "amdefine@>=0.0.4",
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+            }
+          }
+        },
+        "useragent": {
+          "version": "2.1.7",
+          "from": "useragent@>=2.1.6 <3.0.0",
+          "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.1.7.tgz",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.2.4",
+              "from": "lru-cache@>=2.2.0 <2.3.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz"
+            }
+          }
+        }
+      }
+    },
+    "karma-chrome-launcher": {
+      "version": "0.1.12",
+      "from": "karma-chrome-launcher@>=0.1.12 <0.2.0",
+      "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-0.1.12.tgz",
+      "dependencies": {
+        "which": {
+          "version": "1.1.1",
+          "from": "which@>=1.0.9 <2.0.0",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.1.1.tgz",
+          "dependencies": {
+            "is-absolute": {
+              "version": "0.1.7",
+              "from": "is-absolute@>=0.1.7 <0.2.0",
+              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+              "dependencies": {
+                "is-relative": {
+                  "version": "0.1.3",
+                  "from": "is-relative@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "karma-coverage": {
+      "version": "0.4.2",
+      "from": "karma-coverage@>=0.4.2 <0.5.0",
+      "resolved": "https://registry.npmjs.org/karma-coverage/-/karma-coverage-0.4.2.tgz",
+      "dependencies": {
+        "istanbul": {
+          "version": "0.3.18",
+          "from": "istanbul@>=0.3.15 <0.4.0",
+          "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.3.18.tgz",
+          "dependencies": {
+            "esprima": {
+              "version": "2.5.0",
+              "from": "esprima@>=2.5.0 <2.6.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.5.0.tgz"
+            },
+            "escodegen": {
+              "version": "1.6.1",
+              "from": "escodegen@>=1.6.0 <1.7.0",
+              "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
+              "dependencies": {
+                "estraverse": {
+                  "version": "1.9.3",
+                  "from": "estraverse@>=1.9.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
+                },
+                "esutils": {
+                  "version": "1.1.6",
+                  "from": "esutils@>=1.1.6 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
+                },
+                "esprima": {
+                  "version": "1.2.5",
+                  "from": "esprima@>=1.2.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
+                },
+                "optionator": {
+                  "version": "0.5.0",
+                  "from": "optionator@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+                  "dependencies": {
+                    "prelude-ls": {
+                      "version": "1.1.2",
+                      "from": "prelude-ls@>=1.1.1 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+                    },
+                    "deep-is": {
+                      "version": "0.1.3",
+                      "from": "deep-is@>=0.1.2 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+                    },
+                    "type-check": {
+                      "version": "0.3.1",
+                      "from": "type-check@>=0.3.1 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
+                    },
+                    "levn": {
+                      "version": "0.2.5",
+                      "from": "levn@>=0.2.5 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
+                    },
+                    "fast-levenshtein": {
+                      "version": "1.0.7",
+                      "from": "fast-levenshtein@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.1.43",
+                  "from": "source-map@>=0.1.40 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "handlebars": {
+              "version": "3.0.0",
+              "from": "handlebars@3.0.0",
+              "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.0.tgz",
+              "dependencies": {
+                "optimist": {
+                  "version": "0.6.1",
+                  "from": "optimist@>=0.6.1 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.10",
+                      "from": "minimist@>=0.0.1 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.1.43",
+                  "from": "source-map@>=0.1.40 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                    }
+                  }
+                },
+                "uglify-js": {
+                  "version": "2.3.6",
+                  "from": "uglify-js@>=2.3.0 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.2.10",
+                      "from": "async@>=0.2.6 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                    },
+                    "optimist": {
+                      "version": "0.3.7",
+                      "from": "optimist@>=0.3.5 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "nopt": {
+              "version": "3.0.3",
+              "from": "nopt@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz"
+            },
+            "fileset": {
+              "version": "0.2.1",
+              "from": "fileset@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "5.0.14",
+                  "from": "glob@>=5.0.0 <6.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "which": {
+              "version": "1.0.9",
+              "from": "which@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
+            },
+            "async": {
+              "version": "1.4.2",
+              "from": "async@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz"
+            },
+            "supports-color": {
+              "version": "1.3.1",
+              "from": "supports-color@>=1.3.0 <1.4.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+            },
+            "abbrev": {
+              "version": "1.0.7",
+              "from": "abbrev@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+            },
+            "wordwrap": {
+              "version": "0.0.3",
+              "from": "wordwrap@>=0.0.0 <0.1.0",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+            },
+            "resolve": {
+              "version": "1.1.6",
+              "from": "resolve@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
+            },
+            "js-yaml": {
+              "version": "3.4.0",
+              "from": "js-yaml@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.0.tgz",
+              "dependencies": {
+                "argparse": {
+                  "version": "1.0.2",
+                  "from": "argparse@>=1.0.2 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+                  "dependencies": {
+                    "lodash": {
+                      "version": "3.10.1",
+                      "from": "lodash@>=3.2.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                    },
+                    "sprintf-js": {
+                      "version": "1.0.3",
+                      "from": "sprintf-js@>=1.0.2 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                    }
+                  }
+                },
+                "esprima": {
+                  "version": "2.2.0",
+                  "from": "esprima@>=2.2.0 <2.3.0",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz"
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.2",
+              "from": "once@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "dateformat": {
+          "version": "1.0.11",
+          "from": "dateformat@>=1.0.6 <2.0.0",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
+          "dependencies": {
+            "get-stdin": {
+              "version": "4.0.1",
+              "from": "get-stdin@*",
+              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+            },
+            "meow": {
+              "version": "3.3.0",
+              "from": "meow@*",
+              "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
+              "dependencies": {
+                "camelcase-keys": {
+                  "version": "1.0.0",
+                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.2.1",
+                      "from": "camelcase@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                    },
+                    "map-obj": {
+                      "version": "1.0.1",
+                      "from": "map-obj@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                    }
+                  }
+                },
+                "indent-string": {
+                  "version": "1.2.2",
+                  "from": "indent-string@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+                  "dependencies": {
+                    "repeating": {
+                      "version": "1.1.3",
+                      "from": "repeating@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.1",
+                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "minimist": {
+                  "version": "1.2.0",
+                  "from": "minimist@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                },
+                "object-assign": {
+                  "version": "3.0.0",
+                  "from": "object-assign@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "from": "minimatch@>=2.0.8 <3.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.0",
+              "from": "brace-expansion@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.2.0",
+                  "from": "balanced-match@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "from": "concat-map@0.0.1",
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "source-map": {
+          "version": "0.4.4",
+          "from": "source-map@>=0.4.2 <0.5.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "dependencies": {
+            "amdefine": {
+              "version": "1.0.0",
+              "from": "amdefine@>=0.0.4",
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "karma-jasmine": {
+      "version": "0.3.6",
+      "from": "karma-jasmine@>=0.3.5 <0.4.0",
+      "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-0.3.6.tgz"
+    },
+    "karma-phantomjs-launcher": {
+      "version": "0.2.1",
+      "from": "karma-phantomjs-launcher@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/karma-phantomjs-launcher/-/karma-phantomjs-launcher-0.2.1.tgz",
+      "dependencies": {
+        "lodash": {
+          "version": "3.10.1",
+          "from": "lodash@>=3.10.1 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+        }
+      }
+    },
+    "karma-requirejs": {
+      "version": "0.2.2",
+      "from": "karma-requirejs@>=0.2.2 <0.3.0",
+      "resolved": "https://registry.npmjs.org/karma-requirejs/-/karma-requirejs-0.2.2.tgz"
+    },
+    "load-grunt-tasks": {
+      "version": "3.2.0",
+      "from": "load-grunt-tasks@>=3.2.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-3.2.0.tgz",
+      "dependencies": {
+        "findup-sync": {
+          "version": "0.2.1",
+          "from": "findup-sync@>=0.2.1 <0.3.0",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "4.3.5",
+              "from": "glob@>=4.3.0 <4.4.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "2.0.10",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.2",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "multimatch": {
+          "version": "2.0.0",
+          "from": "multimatch@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.0.0.tgz",
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "array-differ@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
+            },
+            "array-union": {
+              "version": "1.0.1",
+              "from": "array-union@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
+              "dependencies": {
+                "array-uniq": {
+                  "version": "1.0.2",
+                  "from": "array-uniq@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+                }
+              }
+            },
+            "minimatch": {
+              "version": "2.0.10",
+              "from": "minimatch@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.0",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "from": "mkdirp@>=0.5.1 <0.6.0",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "from": "minimist@0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+        }
+      }
+    },
+    "phantomjs": {
+      "version": "1.9.18",
+      "from": "phantomjs@>=1.9.17 <1.10.0",
+      "resolved": "https://registry.npmjs.org/phantomjs/-/phantomjs-1.9.18.tgz",
+      "dependencies": {
+        "adm-zip": {
+          "version": "0.4.4",
+          "from": "adm-zip@0.4.4",
+          "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
+        },
+        "fs-extra": {
+          "version": "0.23.1",
+          "from": "fs-extra@>=0.23.1 <0.24.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.23.1.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "4.1.2",
+              "from": "graceful-fs@>=4.1.2 <5.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+            },
+            "jsonfile": {
+              "version": "2.2.1",
+              "from": "jsonfile@>=2.1.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.1.tgz"
+            },
+            "path-is-absolute": {
+              "version": "1.0.0",
+              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+            },
+            "rimraf": {
+              "version": "2.4.2",
+              "from": "rimraf@>=2.2.8 <3.0.0",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.2.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "5.0.14",
+                  "from": "glob@>=5.0.14 <6.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "2.0.10",
+                      "from": "minimatch@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.0",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.2.0",
+                              "from": "balanced-match@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.2",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "kew": {
+          "version": "0.4.0",
+          "from": "kew@0.4.0",
+          "resolved": "https://registry.npmjs.org/kew/-/kew-0.4.0.tgz"
+        },
+        "npmconf": {
+          "version": "2.1.1",
+          "from": "npmconf@2.1.1",
+          "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.1.tgz",
+          "dependencies": {
+            "config-chain": {
+              "version": "1.1.9",
+              "from": "config-chain@>=1.1.8 <1.2.0",
+              "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
+              "dependencies": {
+                "proto-list": {
+                  "version": "1.2.4",
+                  "from": "proto-list@>=1.2.1 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <2.1.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "ini": {
+              "version": "1.3.4",
+              "from": "ini@>=1.2.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+            },
+            "nopt": {
+              "version": "3.0.3",
+              "from": "nopt@>=3.0.1 <3.1.0",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.0.7",
+                  "from": "abbrev@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.2",
+              "from": "once@>=1.3.0 <1.4.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "osenv": {
+              "version": "0.1.3",
+              "from": "osenv@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+              "dependencies": {
+                "os-homedir": {
+                  "version": "1.0.1",
+                  "from": "os-homedir@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+                },
+                "os-tmpdir": {
+                  "version": "1.0.1",
+                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                }
+              }
+            },
+            "semver": {
+              "version": "4.3.6",
+              "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+            },
+            "uid-number": {
+              "version": "0.0.5",
+              "from": "uid-number@0.0.5",
+              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
+            }
+          }
+        },
+        "progress": {
+          "version": "1.1.8",
+          "from": "progress@1.1.8",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
+        },
+        "request": {
+          "version": "2.42.0",
+          "from": "request@2.42.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.42.0.tgz",
+          "dependencies": {
+            "bl": {
+              "version": "0.9.4",
+              "from": "bl@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.26 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "caseless": {
+              "version": "0.6.0",
+              "from": "caseless@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz"
+            },
+            "forever-agent": {
+              "version": "0.5.2",
+              "from": "forever-agent@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+            },
+            "qs": {
+              "version": "1.2.2",
+              "from": "qs@>=1.2.0 <1.3.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+            },
+            "mime-types": {
+              "version": "1.0.2",
+              "from": "mime-types@>=1.0.1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+            },
+            "node-uuid": {
+              "version": "1.4.3",
+              "from": "node-uuid@>=1.4.0 <1.5.0",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+            },
+            "tunnel-agent": {
+              "version": "0.4.1",
+              "from": "tunnel-agent@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+            },
+            "tough-cookie": {
+              "version": "2.0.0",
+              "from": "tough-cookie@>=0.12.0",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
+            },
+            "form-data": {
+              "version": "0.1.4",
+              "from": "form-data@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+              "dependencies": {
+                "combined-stream": {
+                  "version": "0.0.7",
+                  "from": "combined-stream@>=0.0.4 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "from": "delayed-stream@0.0.5",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                    }
+                  }
+                },
+                "mime": {
+                  "version": "1.2.11",
+                  "from": "mime@>=1.2.11 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                },
+                "async": {
+                  "version": "0.9.2",
+                  "from": "async@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                }
+              }
+            },
+            "http-signature": {
+              "version": "0.10.1",
+              "from": "http-signature@>=0.10.0 <0.11.0",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.1.5",
+                  "from": "assert-plus@>=0.1.5 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                },
+                "asn1": {
+                  "version": "0.1.11",
+                  "from": "asn1@0.1.11",
+                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                },
+                "ctype": {
+                  "version": "0.5.3",
+                  "from": "ctype@0.5.3",
+                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.4.0",
+              "from": "oauth-sign@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz"
+            },
+            "hawk": {
+              "version": "1.1.1",
+              "from": "hawk@1.1.1",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+              "dependencies": {
+                "hoek": {
+                  "version": "0.9.1",
+                  "from": "hoek@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                },
+                "boom": {
+                  "version": "0.4.2",
+                  "from": "boom@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                },
+                "cryptiles": {
+                  "version": "0.2.2",
+                  "from": "cryptiles@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                },
+                "sntp": {
+                  "version": "0.2.4",
+                  "from": "sntp@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                }
+              }
+            },
+            "aws-sign2": {
+              "version": "0.5.0",
+              "from": "aws-sign2@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+            },
+            "stringstream": {
+              "version": "0.0.4",
+              "from": "stringstream@>=0.0.4 <0.1.0",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+            }
+          }
+        },
+        "request-progress": {
+          "version": "0.3.1",
+          "from": "request-progress@0.3.1",
+          "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
+          "dependencies": {
+            "throttleit": {
+              "version": "0.0.2",
+              "from": "throttleit@>=0.0.2 <0.1.0",
+              "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
+            }
+          }
+        },
+        "which": {
+          "version": "1.0.9",
+          "from": "which@>=1.0.5 <1.1.0",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
+        }
+      }
+    },
+    "requirejs": {
+      "version": "2.1.20",
+      "from": "requirejs@>=2.1.18 <3.0.0",
+      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.20.tgz"
+    },
+    "time-grunt": {
+      "version": "1.2.1",
+      "from": "time-grunt@>=1.2.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/time-grunt/-/time-grunt-1.2.1.tgz",
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.1",
+          "from": "chalk@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.1.0",
+              "from": "ansi-styles@>=2.1.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.0",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "from": "supports-color@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+            }
+          }
+        },
+        "date-time": {
+          "version": "1.0.0",
+          "from": "date-time@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/date-time/-/date-time-1.0.0.tgz"
+        },
+        "figures": {
+          "version": "1.3.5",
+          "from": "figures@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
+        },
+        "hooker": {
+          "version": "0.2.3",
+          "from": "hooker@>=0.2.3 <0.3.0",
+          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
+        },
+        "number-is-nan": {
+          "version": "1.0.0",
+          "from": "number-is-nan@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+        },
+        "pretty-ms": {
+          "version": "1.4.0",
+          "from": "pretty-ms@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-1.4.0.tgz",
+          "dependencies": {
+            "get-stdin": {
+              "version": "4.0.1",
+              "from": "get-stdin@>=4.0.1 <5.0.0",
+              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+            },
+            "is-finite": {
+              "version": "1.0.1",
+              "from": "is-finite@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz"
+            },
+            "meow": {
+              "version": "3.3.0",
+              "from": "meow@>=3.3.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
+              "dependencies": {
+                "camelcase-keys": {
+                  "version": "1.0.0",
+                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.2.1",
+                      "from": "camelcase@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                    },
+                    "map-obj": {
+                      "version": "1.0.1",
+                      "from": "map-obj@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                    }
+                  }
+                },
+                "indent-string": {
+                  "version": "1.2.2",
+                  "from": "indent-string@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+                  "dependencies": {
+                    "repeating": {
+                      "version": "1.1.3",
+                      "from": "repeating@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz"
+                    }
+                  }
+                },
+                "minimist": {
+                  "version": "1.2.0",
+                  "from": "minimist@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                },
+                "object-assign": {
+                  "version": "3.0.0",
+                  "from": "object-assign@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                }
+              }
+            },
+            "parse-ms": {
+              "version": "1.0.0",
+              "from": "parse-ms@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.0.tgz"
+            },
+            "plur": {
+              "version": "1.0.0",
+              "from": "plur@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz"
+            }
+          }
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "from": "text-table@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
+        }
+      }
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,6 @@
 {
   "name": "membership",
   "private": true,
-  "version": "0.0.0",
   "devDependencies": {
     "autoprefixer-core": "^5.2.0",
     "bower": "^1.4.1",


### PR DESCRIPTION
Testing `npm shrinkwrap` to see if it improves builds.

- Locks recursive dependencies which improves stability
- Potential performance increases as we are more likely to be able to use the cache between builds due to having locked versions.


@rtyley @afiore 