### PR TITLE
Fix syntax error on promoTertiary action

### DIFF
--- a/frontend/app/views/fragments/promos/promoTertiary.scala.html
+++ b/frontend/app/views/fragments/promos/promoTertiary.scala.html
@@ -13,7 +13,7 @@
         </div>
         @for(link <- linkOpt) {
             <div class="promo-tertiary__action">
-                <a class="action action--external" href="@link.href" @link.idOpt.map(id => s"id='$id'")>
+                <a class="action action--external" href="@link.href" @link.idOpt.map{ id => id="@id" }>
                     @link.title
                     @fragments.actionIcon("arrow-right")
                 </a>

--- a/functional-tests/src/main/scala/com/gu/membership/pages/LandingPage.scala
+++ b/functional-tests/src/main/scala/com/gu/membership/pages/LandingPage.scala
@@ -10,7 +10,7 @@ class LandingPage(driver: WebDriver) extends BaseMembershipPage(driver) {
   private def becomeAFriendLink = driver.findElement(By.cssSelector(".qa-friend-join"))
   private def becomeASupporterLink = driver.findElement(By.cssSelector(".qa-package-supporter"))
   private def becomeAPartnerLink = driver.findElement(By.cssSelector(".qa-package-partner"))
-  private def learnPatronLink = driver.findElement(By.cssSelector(".qa-learn-patron"))
+  private def learnPatronLink = driver.findElement(By.id("qa-learn-patron"))
 
 
   def clickBecomeAFriend = {


### PR DESCRIPTION
Fix syntax error on promoTertiary action. A QA id was being output as `id="'qa-learn-patron'"` when it should be `id="qa-learn-patron"`.

@TesterSpike 