### PR TITLE
Update CTA.js link for Become a Member to /choose-tier

### DIFF
--- a/frontend/assets/javascripts/src/modules/events/cta.js
+++ b/frontend/assets/javascripts/src/modules/events/cta.js
@@ -9,7 +9,7 @@ define([
         join: {
             id: 'join',
             label: 'Become a member',
-            href: '/join'
+            href: '/choose-tier'
         },
         upgrade: {
             id: 'upgrade',

--- a/frontend/assets/javascripts/tests/spec/identityPopup.spec.js
+++ b/frontend/assets/javascripts/tests/spec/identityPopup.spec.js
@@ -5,7 +5,7 @@ define(['src/modules/identityPopup'], function (identityPopup) {
     describe('Identity Popup Tests', function () {
 
         it('returnUrl populated with currentUrl', function () {
-            var currentUrl = '/join';
+            var currentUrl = '/choose-tier';
 
             expect(identityPopup.populateReturnUrl(HREF, currentUrl)).toBe(
                 'https://profile.thegulocal.com/signin?returnUrl=https://mem.thegulocal.com' + currentUrl + '&skipConfirmation=true'
@@ -13,7 +13,7 @@ define(['src/modules/identityPopup'], function (identityPopup) {
         });
 
         it('returnUrl populated with currentUrl that contains parameters', function () {
-            var currentUrl = '/join?param1=1&param2=2';
+            var currentUrl = '/choose-tier?param1=1&param2=2';
 
             expect(identityPopup.populateReturnUrl(HREF, currentUrl)).toBe(
                 'https://profile.thegulocal.com/signin?returnUrl=https://mem.thegulocal.com' + currentUrl + '&skipConfirmation=true'


### PR DESCRIPTION
Remove some old references to `/join` which has now been removed and redirects to `/`, in this case the equivalent page should actually be `/choose-tier`.

@afiore 