### PR TITLE
Handle tier downgrades correctly

### DIFF
--- a/frontend/app/model/Zuora.scala
+++ b/frontend/app/model/Zuora.scala
@@ -28,7 +28,7 @@ object Zuora {
     // TODO: is there a better way?
     val annual = nextPaymentDate == serviceStartDate.plusYears(1)
   }
-  case class RatePlan(id: String, name: String) extends ZuoraQuery
+  case class RatePlan(id: String, name: String, productRatePlanId: String) extends ZuoraQuery
   case class RatePlanCharge(id: String, chargedThroughDate: Option[DateTime], effectiveStartDate: DateTime,
                             price: Float) extends ZuoraQuery
   case class Subscription(id: String, version: Int, termStartDate: DateTime, contractAcceptanceDate: DateTime) extends ZuoraQuery
@@ -262,8 +262,8 @@ object ZuoraDeserializer {
       result("ProductName"))
   }
 
-  implicit val ratePlanReader = ZuoraQueryReader("RatePlan", Seq("Id", "Name")) { result =>
-    RatePlan(result("Id"), result("Name"))
+  implicit val ratePlanReader = ZuoraQueryReader("RatePlan", Seq("Id", "Name", "ProductRatePlanId")) { result =>
+    RatePlan(result("Id"), result("Name"), result("ProductRatePlanId"))
   }
 
   implicit val ratePlanChargeReader = ZuoraQueryReader("RatePlanCharge", Seq("Id", "ChargedThroughDate", "EffectiveStartDate", "Price")) { result =>

--- a/frontend/app/services/zuora/Rest.scala
+++ b/frontend/app/services/zuora/Rest.scala
@@ -61,7 +61,7 @@ object Rest {
   }
 
   case class Feature(id: String, featureCode: String)
-  case class RatePlan(id: String, productId: String, productName: String, subscriptionProductFeatures: List[Rest.Feature], ratePlanCharges: List[RatePlanCharge]) {
+  case class RatePlan(id: String, productId: String, productRatePlanId: String, productName: String, subscriptionProductFeatures: List[Rest.Feature], ratePlanCharges: List[RatePlanCharge]) {
     def isWhitelisted(productIds: Set[String]): Boolean = productIds.contains(productId)
   }
   case class RatePlanCharge(name: String, id: String)

--- a/frontend/test/model/ZuoraDeserializerTest.scala
+++ b/frontend/test/model/ZuoraDeserializerTest.scala
@@ -150,7 +150,7 @@ class ZuoraDeserializerTest extends Specification {
 
       ratePlans.size mustEqual 1
 
-      ratePlans(0) mustEqual RatePlan("2c92c0f94878e828014879176ff831c4", "Partner - annual")
+      ratePlans(0) mustEqual RatePlan("2c92c0f94878e828014879176ff831c4","Partner - annual", "ProductRatePlanId")
     }
 
     "extract a RatePlanCharge" in {

--- a/frontend/test/resources/model/zuora/rateplans.xml
+++ b/frontend/test/resources/model/zuora/rateplans.xml
@@ -8,6 +8,7 @@
                 <ns1:records xsi:type="ns2:RatePlan" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns2="http://object.api.zuora.com/">
                     <ns2:Id>2c92c0f94878e828014879176ff831c4</ns2:Id>
                     <ns2:Name>Partner - annual</ns2:Name>
+                    <ns2:ProductRatePlanId>ProductRatePlanId</ns2:ProductRatePlanId>
                 </ns1:records>
                 <ns1:size>1</ns1:size>
             </ns1:result>

--- a/frontend/test/services/SubscriptionServiceTest.scala
+++ b/frontend/test/services/SubscriptionServiceTest.scala
@@ -16,7 +16,7 @@ class SubscriptionServiceTest extends Specification {
 
       val subscriptionDetails = SubscriptionDetails(
         Subscription("some id", 1, startDate, startDate),
-        RatePlan("RatePlanId", "Product name - annual"),
+        RatePlan("RatePlanId", "Product name - annual", "productRatePlanId"),
         RatePlanCharge("RatePlanChargeId", Some(endDate), startDate, 12.0f)
       )
 

--- a/frontend/test/services/SubscriptionServiceTest.scala
+++ b/frontend/test/services/SubscriptionServiceTest.scala
@@ -58,7 +58,7 @@ class SubscriptionServiceTest extends Specification {
     import SubscriptionService.findCurrentSubscriptionStatus
 
     val now = DateTime.now()
-    def version(v: Int): Subscription = Subscription(v.toString, v, now, now )
+    def version(v: Int): Subscription = Subscription(v.toString, v, now, now)
     def amend(v: Int, contractEffectiveDate: DateTime): Amendment =
       Amendment(v.toString, "TEST", contractEffectiveDate, v.toString)
 
@@ -78,8 +78,6 @@ class SubscriptionServiceTest extends Specification {
         Seq(version(1),version(2)),
         Seq(amend(1, now.plusMonths(1)))
       ).currentVersion mustEqual version(1)
-
     }
-
   }
 }

--- a/frontend/test/services/SubscriptionServiceTest.scala
+++ b/frontend/test/services/SubscriptionServiceTest.scala
@@ -2,11 +2,12 @@ package services
 
 import com.gu.membership.model.{FriendTierPlan, PaidTierPlan}
 import com.gu.membership.salesforce.Tier
-import com.gu.membership.salesforce.Tier.{Friend, Supporter, Partner, Patron}
+import com.gu.membership.salesforce.Tier.{Supporter, Partner, Patron}
 import model.{FreeEventTickets, Books}
 import org.specs2.mutable.Specification
 import model.Zuora._
 import org.joda.time.DateTime
+import com.github.nscala_time.time.Imports._
 
 class SubscriptionServiceTest extends Specification {
   "SubscriptionService" should {
@@ -70,13 +71,13 @@ class SubscriptionServiceTest extends Specification {
 
       findCurrentSubscriptionStatus(
         Seq(version(1),version(2)),
-        Seq(amend(1, now))
+        Seq(amend(1, now - 1.minutes))
       ).currentVersion mustEqual version(2)
     }
     "returns the latest subscription when future amendments exists" in {
       findCurrentSubscriptionStatus(
         Seq(version(1),version(2)),
-        Seq(amend(1, now.plusMonths(1)))
+        Seq(amend(1, now + 1.month))
       ).currentVersion mustEqual version(1)
     }
   }

--- a/frontend/test/services/zuora/ZuoraRestResponseReadersTest.scala
+++ b/frontend/test/services/zuora/ZuoraRestResponseReadersTest.scala
@@ -35,6 +35,7 @@ class ZuoraRestResponseReadersTest extends Specification {
           "id" -> "Rate Plan Id",
           "productId" -> "Product Id",
           "productName" -> "Product Name",
+          "productRatePlanId" -> "Product Rate Plan Id",
           "ratePlanCharges" -> JsArray(Nil),
           "subscriptionProductFeatures" -> features)
       ))
@@ -72,7 +73,7 @@ class ZuoraRestResponseReadersTest extends Specification {
                           DateTime.parse("2013-02-01"),
                           DateTime.parse("2014-02-01"),
                           DateTime.parse("2013-02-01"),
-                          Rest.RatePlan("Rate Plan Id", "Product Id", "Product Name", Nil, Nil) :: Nil,
+                          Rest.RatePlan("Rate Plan Id", "Product Id", "Product Rate Plan Id", "Product Name", Nil, Nil) :: Nil,
                           Rest.Active))
     }
 


### PR DESCRIPTION
Once a paid member decides to downgrade, we still charge for the entire subscription term and record a subscription amendment that will make the downgrade effective only after the end of the current term. This PR ensures that partner and patron benefits are correctly recognised throughout the duration of their term. This involves a combination of REST and SOAP api calls, as the REST representation of a Zuora subscription currently provides no information about the currently valid rate plan.  

Trello: https://trello.com/c/lz2j3ZPH/78-handle-tier-downgrade-correctly
@tudorraul @chrisjowen 