### PR TITLE
Fix welcome sign out redirect

### DIFF
--- a/frontend/app/configuration/Links.scala
+++ b/frontend/app/configuration/Links.scala
@@ -1,5 +1,7 @@
 package configuration
 
+import controllers.routes
+
 object Links {
   val guardianCookiePolicy = "http://www.theguardian.com/info/cookies"
   val guardianPrivacyPolicy = "http://www.theguardian.com/help/privacy-policy"
@@ -16,3 +18,31 @@ object Links {
   val membershipBuildingBlog = "http://theguardian.com/membership/midland-goods-shed-progress/"
   val membershipPollyToynbeeArticle = "http://www.theguardian.com/membership/2015/feb/06/polly-toynbee-if-you-read-the-guardian-join-the-guardian"
 }
+
+object ProfileLinks {
+
+  val commentActivity = s"${Config.idWebAppUrl}/user/id/"
+
+  val editProfile = s"${Config.idWebAppUrl}/public/edit"
+
+  val editProfileMembership = s"${Config.idWebAppUrl}/membership/edit"
+
+  val emailPreferences = s"${Config.idWebAppUrl}/email-prefs"
+
+  val changePassword = s"${Config.idWebAppUrl}/password/change"
+
+  def signOut(path: String) = {
+
+    val baseUrl = s"${Config.idWebAppUrl}/signout"
+    val exclusions = Seq(
+      routes.FrontPage.welcome.url
+    )
+
+    if(exclusions.contains(path)) {
+      s"$baseUrl?returnUrl=${Config.membershipUrl}"
+    } else baseUrl
+
+  }
+
+}
+

--- a/frontend/app/controllers/FrontPage.scala
+++ b/frontend/app/controllers/FrontPage.scala
@@ -179,7 +179,7 @@ trait FrontPage extends Controller {
       )
     )
 
-    Ok(views.html.welcome(slideShowImages))
+    Ok(views.html.welcome(PageInfo("Welcome", request.path, None), slideShowImages))
   }
 }
 

--- a/frontend/app/controllers/FrontPage.scala
+++ b/frontend/app/controllers/FrontPage.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import play.api.mvc.Controller
-import model.{EventBrandCollection, Grid, ResponsiveImageGenerator, ResponsiveImageGroup}
+import model._
 import services.{EventbriteService, GuardianLiveEventService, LocalEventService, MasterclassEventService}
 
 trait FrontPage extends Controller {

--- a/frontend/app/views/fragments/global/controlNavigation.scala.html
+++ b/frontend/app/views/fragments/global/controlNavigation.scala.html
@@ -1,6 +1,7 @@
 @(pageInfo: model.PageInfo)
 
 @import configuration.Config
+@import configuration.ProfileLinks
 
 <ul class="nav-control u-cf" role="menubar">
     <li class="nav-control__item">
@@ -26,22 +27,22 @@
         <nav role="navigation" class="nav-popup is-hidden js-identity-menu" aria-label="Profile menu">
             <ul class="nav-popup__list">
                 <li class="nav-popup__item">
-                    <a href="@Config.idWebAppUrl/user/id/" class="nav-popup__link js-identity-menu-comment-activity">Comment activity</a>
+                    <a href="@ProfileLinks.commentActivity" class="nav-popup__link js-identity-menu-comment-activity">Comment activity</a>
                 </li>
                 <li class="nav-popup__item">
                     <a class="nav-popup__link js-identity-menu-edit-profile"
                        id="qa-identity-nav-edit"
-                       href="@Config.idWebAppUrl/public/edit"
-                       data-member-href="@Config.idWebAppUrl/membership/edit">Edit profile</a>
+                       href="@ProfileLinks.editProfile"
+                       data-member-href="@ProfileLinks.editProfileMembership">Edit profile</a>
                 </li>
                 <li class="nav-popup__item">
-                    <a href="@Config.idWebAppUrl/email-prefs" class="nav-popup__link">Email preferences</a>
+                    <a href="@ProfileLinks.emailPreferences" class="nav-popup__link">Email preferences</a>
                 </li>
                 <li class="nav-popup__item">
-                    <a href="@Config.idWebAppUrl/password/change" class="nav-popup__link">Change password</a>
+                    <a href="@ProfileLinks.changePassword" class="nav-popup__link">Change password</a>
                 </li>
                 <li class="nav-popup__item">
-                    <a href="@Config.idWebAppUrl/signout" class="nav-popup__link">Sign out</a>
+                    <a href="@ProfileLinks.signOut(pageInfo.url)" class="nav-popup__link">Sign out</a>
                 </li>
             </ul>
         </nav>

--- a/frontend/app/views/welcome.scala.html
+++ b/frontend/app/views/welcome.scala.html
@@ -1,4 +1,4 @@
-@(pageImages: Seq[model.ResponsiveImageGroup])
+@(pageInfo: model.PageInfo, pageImages: Seq[model.ResponsiveImageGroup])
 
 @import configuration.Links
 @import views.support.Asset
@@ -16,7 +16,7 @@
     </div>
 }
 
-@main("Home Page") {
+@main(pageInfo.title, pageInfo=pageInfo) {
 
     <main role="main" class="l-constrained">
 


### PR DESCRIPTION
A fix for https://trello.com/c/0zwp1cVG/66-bug-redirect-users-back-to-main-homepage-when-signing-out-from-welcome

When users are signed in they are redirected to `/welcome`. On clicking sign-out they  are kept on that page, it would make more sense for them to be redirected to the homepage `/`.

- Model profile links
- Extend sign-out link so that `/welcome` redirects to homepage on sign-out. Welcome is intended for signed in users

@afiore 