### PR TITLE
Move CSS bower_components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,9 @@ tmp
 project/project
 project/target
 
+bower_components
 */public/javascripts
 */public/stylesheets
-*/assets/stylesheets/components/bower-components/
 */assets/javascripts/lib/bower-components/
 
 frontend/conf/keys.conf

--- a/frontend/assets/stylesheets/.bowerrc
+++ b/frontend/assets/stylesheets/.bowerrc
@@ -1,3 +1,3 @@
 {
-    "directory": "components/bower-components"
+    "directory": "bower_components"
 }

--- a/frontend/assets/stylesheets/_mixins.scss
+++ b/frontend/assets/stylesheets/_mixins.scss
@@ -2,14 +2,14 @@
 // Mixins
 // =============================================================================
 
-@import 'components/bower-components/sass-mq/mq';
+@import 'bower_components/sass-mq/mq';
 
 // Guss - https://github.com/guardian/guss
 $guss-rem-baseline: 16px;
-@import 'components/bower-components/guss-rem/rem';
-@import 'components/bower-components/guss-typography/typography';
-@import 'components/bower-components/guss-layout/columns';
-@import 'components/bower-components/guss-layout/row';
+@import 'bower_components/guss-rem/rem';
+@import 'bower_components/guss-typography/typography';
+@import 'bower_components/guss-layout/columns';
+@import 'bower_components/guss-layout/row';
 
 // Grid system
 // =============================================================================

--- a/frontend/assets/stylesheets/_vars.scss
+++ b/frontend/assets/stylesheets/_vars.scss
@@ -14,8 +14,8 @@ $browser-supports-flexbox: true !default;
 // =============================================================================
 
 @import 'functions';
-@import 'components/bower-components/guss-colours/_colours.scss';
-@import 'components/bower-components/pasteup-palette/src/_palette';
+@import 'bower_components/guss-colours/_colours.scss';
+@import 'bower_components/pasteup-palette/src/_palette';
 
 $guss-colours: $pasteup-palette;
 
@@ -150,7 +150,7 @@ $transition-duration-medium: .5s;
 // =============================================================================
 
 $guss-column-rule: none;
-@import 'components/bower-components/guss-grid-system/grid-system';
+@import 'bower_components/guss-grid-system/grid-system';
 
 // Breakpoints
 // =============================================================================

--- a/frontend/assets/stylesheets/_webfonts.scss
+++ b/frontend/assets/stylesheets/_webfonts.scss
@@ -1,6 +1,6 @@
 $guss-webfonts-base-url: '//pasteup.guim.co.uk/fonts/';
 
-@import 'components/bower-components/guss-webfonts/src/_webfonts.scss';
+@import 'bower_components/guss-webfonts/src/_webfonts.scss';
 
 @include guss-webfonts(
     (

--- a/frontend/assets/stylesheets/event-card.scss
+++ b/frontend/assets/stylesheets/event-card.scss
@@ -1,7 +1,7 @@
 @import 'vars';
 @import 'functions';
 @import 'mixins';
-@import 'components/bower-components/guss-webfonts/src/_webfonts.mixins';
+@import 'bower_components/guss-webfonts/src/_webfonts.mixins';
 
 /* ==========================================================================
    Event Card

--- a/frontend/assets/stylesheets/tools.style.scss
+++ b/frontend/assets/stylesheets/tools.style.scss
@@ -2,9 +2,9 @@
    Event Overview Styles
    ========================================================================== */
 @import 'tools/vars';
-@import 'components/bower-components/sass-mq/mq';
-@import 'components/bower-components/guss-typography/typography';
-@import 'components/bower-components/guss-rem/rem';
+@import 'bower_components/sass-mq/mq';
+@import 'bower_components/guss-typography/typography';
+@import 'bower_components/guss-rem/rem';
 
 /* ==========================================================================
    Base

--- a/frontend/assets/stylesheets/tools/_webfonts.scss
+++ b/frontend/assets/stylesheets/tools/_webfonts.scss
@@ -1,6 +1,6 @@
 $guss-webfonts-base-url: '//pasteup.guim.co.uk/fonts/';
 
-@import '../components/bower-components/guss-webfonts/src/_webfonts.scss';
+@import '../bower_components/guss-webfonts/src/_webfonts.scss';
 
 @include guss-webfonts(
     (

--- a/setup.sh
+++ b/setup.sh
@@ -33,7 +33,7 @@ install_bower() {
 
         banner "Installing Bower CSS modules"
         pushd assets/stylesheets
-        rm -rf components/bower-components
+        rm -rf bower_components
         bower install
         popd
     else


### PR DESCRIPTION
Follows on from https://github.com/guardian/membership-frontend/pull/740

Having bower-components inside our general modules/components directory was bugging me as it causes a bit of naming/conceptual confusion as there's a merging of third-party libraries and our code component styles. Same word but different concepts (we could possibly use Modules for our
stuff to avoid this naming overlap).

This PR moves CSS bower components up into the top level and uses the default name of bower_components (the less deviation from the defaults the better imo).

Similar process to follow for JS, but CSS is lower risk so trying this first.