### PR TITLE
Potential fix for signed in homepage encoding issue

### DIFF
--- a/frontend/app/utils/GuMemCookie.scala
+++ b/frontend/app/utils/GuMemCookie.scala
@@ -6,7 +6,7 @@ import play.api.libs.json.{JsObject, Json}
 object GuMemCookie {
 
   def encodeUserJson(json: JsObject): String = {
-    Base64.encodeBase64URLSafeString(Json.stringify(json).getBytes)
+    Base64.encodeBase64URLSafeString(Json.stringify(json).getBytes("UTF-8"))
   }
 
 }


### PR DESCRIPTION
Suggested fix from @theefer (https://github.com/guardian/membership-frontend/issues/744) for encoding issues on the signed-in homepage (e.g., Sébastian).

The fix certainly makes sense, but I've not been able to repeat the encoding issue on Mac or Windows, but I know @rtyley has been able to repeat it on linux.

@rtyley Would you mind testing this branch locally as I know you've been able to repeat it?