### PR TITLE
Added label for no free member tickets

### DIFF
--- a/frontend/app/model/Eventbrite.scala
+++ b/frontend/app/model/Eventbrite.scala
@@ -150,6 +150,8 @@ object Eventbrite {
 
     val isSoldOut = allTickets.forall(_.isSoldOut) || ticketsSold >= capacity
 
+    val noFreeMembers = !allTickets.exists(_.isComplimentary)
+
     val isFree = primaryTicket.free
 
     val salesDates = TicketSaleDates.datesFor(eventTimes, primaryTicket)

--- a/frontend/app/model/Eventbrite.scala
+++ b/frontend/app/model/Eventbrite.scala
@@ -150,7 +150,7 @@ object Eventbrite {
 
     val isSoldOut = allTickets.forall(_.isSoldOut) || ticketsSold >= capacity
 
-    val noFreeMembers = !allTickets.exists(_.isComplimentary)
+    val hasFreeMembersTickets = allTickets.exists(_.isComplimentary)
 
     val isFree = primaryTicket.free
 

--- a/frontend/app/views/fragments/event/overviewSection.scala.html
+++ b/frontend/app/views/fragments/event/overviewSection.scala.html
@@ -63,7 +63,7 @@
                             }
                             case ticketing: InternalTicketing => {
 
-                                @if(ticketing.noFreeMembers && event.isInstanceOf[GuLiveEvent]) {
+                                @if(!ticketing.hasFreeMembersTickets && event.isInstanceOf[GuLiveEvent]) {
                                     @eventTrait("No Free Members Ticket", "important")
                                 }
 

--- a/frontend/app/views/fragments/event/overviewSection.scala.html
+++ b/frontend/app/views/fragments/event/overviewSection.scala.html
@@ -62,6 +62,11 @@
                                 @eventTrait("Not Sold though Eventbrite", "noteworthy")
                             }
                             case ticketing: InternalTicketing => {
+
+                                @if(ticketing.noFreeMembers && event.isInstanceOf[GuLiveEvent]) {
+                                    @eventTrait("No Free Members Ticket", "important")
+                                }
+
                                 @if(ticketing.isFree) {
                                     @eventTrait("Free Event", "moderate")
                                 }


### PR DESCRIPTION
The understanding from https://trello.com/c/Lh5JzZw7/64-add-a-no-free-members-ticket-warning-to-the-event-overview is that tickets without complimentary events should show this label