### PR TITLE
Renamed No Free Members Ticket to Member's ticket

### DIFF
--- a/frontend/app/model/Eventbrite.scala
+++ b/frontend/app/model/Eventbrite.scala
@@ -102,7 +102,7 @@ object Eventbrite {
     val isHidden = hidden.contains(true)
 
     val isMemberBenefit = isHidden && name.toLowerCase.startsWith("guardian member")
-    val isComplimentary = isHidden && free && name.toLowerCase.startsWith("member's ticket at no extra cost")
+    val isComplimentary = isHidden && name.toLowerCase.startsWith("member's ticket at no extra cost")
 
     val isSoldOut = on_sale_status.contains("SOLD_OUT") || quantity_sold >= quantity_total
 
@@ -150,8 +150,6 @@ object Eventbrite {
 
     val isSoldOut = allTickets.forall(_.isSoldOut) || ticketsSold >= capacity
 
-    val hasFreeMembersTickets = allTickets.exists(_.isComplimentary)
-
     val isFree = primaryTicket.free
 
     val salesDates = TicketSaleDates.datesFor(eventTimes, primaryTicket)
@@ -168,6 +166,7 @@ object Eventbrite {
 
     val isPossiblyMissingDiscount = !isFree && memberDiscountOpt.isEmpty
 
+    val isPossiblyMissingComplimentaryTicket = !isFree && !complimentaryTickets.exists(_.free)
   }
 
   case class DiscountBenefitTicketing(generalRelease: EBTicketClass, member: EBTicketClass) {

--- a/frontend/app/views/fragments/event/overviewSection.scala.html
+++ b/frontend/app/views/fragments/event/overviewSection.scala.html
@@ -64,7 +64,7 @@
                             case ticketing: InternalTicketing => {
 
                                 @if(!ticketing.hasFreeMembersTickets && event.isInstanceOf[GuLiveEvent]) {
-                                    @eventTrait("No Free Members Ticket", "important")
+                                    @eventTrait("Member's ticket", "important")
                                 }
 
                                 @if(ticketing.isFree) {

--- a/frontend/app/views/fragments/event/overviewSection.scala.html
+++ b/frontend/app/views/fragments/event/overviewSection.scala.html
@@ -63,16 +63,16 @@
                             }
                             case ticketing: InternalTicketing => {
 
-                                @if(!ticketing.hasFreeMembersTickets && event.isInstanceOf[GuLiveEvent]) {
-                                    @eventTrait("Member's ticket", "important")
+                                @if(ticketing.isPossiblyMissingComplimentaryTicket && event.isInstanceOf[GuLiveEvent]) {
+                                    @eventTrait("Missing Member's ticket at no extra cost", "important")
+                                }
+
+                                @if(ticketing.isPossiblyMissingDiscount) {
+                                    @eventTrait("Missing Discount", "important")
                                 }
 
                                 @if(ticketing.isFree) {
                                     @eventTrait("Free Event", "moderate")
-                                }
-
-                                @if(ticketing.isPossiblyMissingDiscount) {
-                                    @eventTrait("No Discount", "important")
                                 }
 
                                 @if(ticketing.isSoldOut) {


### PR DESCRIPTION
The term free for member tickets has tax implications and thus needed to be removed despite it been back office code. 