### PR TITLE
Implement Json endpoint for fetching the number of free event tickets

### DIFF
--- a/frontend/app/controllers/Subscription.scala
+++ b/frontend/app/controllers/Subscription.scala
@@ -2,11 +2,13 @@ package controllers
 
 import com.gu.membership.stripe.Stripe
 import com.gu.membership.stripe.Stripe.Serializer._
+import model.FreeEventTickets
 import play.api.data.Forms._
 import play.api.data._
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json.Json
 import play.api.mvc._
+import services.MemberService
 
 import scala.concurrent.Future
 
@@ -20,6 +22,15 @@ trait Subscription extends Controller {
       ).recover {
         case error: Stripe.Error => Forbidden(Json.toJson(error))
       }
+  }
+
+  def ticketsLeft() = AjaxPaidMemberAction.async { implicit request =>
+    for {
+      (_, subscription) <- request.touchpointBackend.subscriptionService.accountWithLatestMembershipSubscription(request.member)
+      ticketsUsedCount <- request.touchpointBackend.subscriptionService.getUsageCountWithinTerm(subscription, FreeEventTickets.unitOfMeasure)
+    } yield {
+      Ok(Json.obj("ticketsLeft" -> ticketsUsedCount.map(FreeEventTickets.allowance - _)))
+    }
   }
 
   def updateCardPreflight() = Cors.andThen(CachedAction) { Ok.withHeaders(ACCESS_CONTROL_ALLOW_HEADERS -> "Csrf-Token") }

--- a/frontend/app/controllers/Subscription.scala
+++ b/frontend/app/controllers/Subscription.scala
@@ -24,7 +24,7 @@ trait Subscription extends Controller {
       }
   }
 
-  def ticketsLeft() = AjaxPaidMemberAction.async { implicit request =>
+  def remainingTickets() = AjaxPaidMemberAction.async { implicit request =>
     for {
       (_, subscription) <- request.touchpointBackend.subscriptionService.accountWithLatestMembershipSubscription(request.member)
       ticketsUsedCount <- request.touchpointBackend.subscriptionService.getUsageCountWithinTerm(subscription, FreeEventTickets.unitOfMeasure)

--- a/frontend/app/controllers/Subscription.scala
+++ b/frontend/app/controllers/Subscription.scala
@@ -29,7 +29,10 @@ trait Subscription extends Controller {
       (_, subscription) <- request.touchpointBackend.subscriptionService.accountWithLatestMembershipSubscription(request.member)
       ticketsUsedCount <- request.touchpointBackend.subscriptionService.getUsageCountWithinTerm(subscription, FreeEventTickets.unitOfMeasure)
     } yield {
-      Ok(Json.obj("ticketsLeft" -> ticketsUsedCount.map(FreeEventTickets.allowance - _)))
+      Ok(Json.obj(
+        "totalAllocation" -> FreeEventTickets.allowance,
+        "remainingAllocation" -> ticketsUsedCount.map(FreeEventTickets.allowance - _)
+      ))
     }
   }
 

--- a/frontend/app/views/event/guardianLive.scala.html
+++ b/frontend/app/views/event/guardianLive.scala.html
@@ -8,10 +8,7 @@
             title="Events, discussions, debates, interviews, keynote speeches and festivals exclusively for Guardian Members",
             logo=Logos.guardianLive
         )
-        <div class="status-bar status-bar--listing js-remaining-tickets">
-            @fragments.inlineIcon("tickets", List("icon-inline--medium", "icon-inline--offset"))
-            <span class="js-remaining-tickets__text"></span>
-        </div>
+        @fragments.event.remainingTickets("listing", Seq.empty)
         @fragments.event.listing(eventPortfolio, "Sorry, no matching events were found.", showPastEvents=true)
     </main>
 

--- a/frontend/app/views/event/guardianLive.scala.html
+++ b/frontend/app/views/event/guardianLive.scala.html
@@ -8,6 +8,10 @@
             title="Events, discussions, debates, interviews, keynote speeches and festivals exclusively for Guardian Members",
             logo=Logos.guardianLive
         )
+        <div class="status-bar status-bar--listing js-remaining-tickets">
+            @fragments.inlineIcon("tickets", List("icon-inline--medium", "icon-inline--offset"))
+            <span class="js-remaining-tickets__text"></span>
+        </div>
         @fragments.event.listing(eventPortfolio, "Sorry, no matching events were found.", showPastEvents=true)
     </main>
 

--- a/frontend/app/views/event/page.scala.html
+++ b/frontend/app/views/event/page.scala.html
@@ -52,11 +52,8 @@
         </div>
     </div>
 
-    @if(event.isBookable) {
-        <div class="status-bar status-bar--listing l-constrained js-remaining-tickets">
-            @fragments.inlineIcon("tickets", List("icon-inline--medium", "icon-inline--offset"))
-            <span class="js-remaining-tickets__text"></span>
-        </div>
+    @if(event.isBookable && event.isInstanceOf[GuLiveEvent]) {
+        @fragments.event.remainingTickets("event", List("l-constrained"))
     }
 
     @* Limited availability messaging *@

--- a/frontend/app/views/event/page.scala.html
+++ b/frontend/app/views/event/page.scala.html
@@ -52,6 +52,13 @@
         </div>
     </div>
 
+    @if(event.isBookable) {
+        <div class="status-bar status-bar--listing l-constrained js-remaining-tickets">
+            @fragments.inlineIcon("tickets", List("icon-inline--medium", "icon-inline--offset"))
+            <span class="js-remaining-tickets__text"></span>
+        </div>
+    }
+
     @* Limited availability messaging *@
     @if(event.isBookable && event.isLimitedAvailability) {
         <div class="event-extra l-constrained">

--- a/frontend/app/views/fragments/event/remainingTickets.scala.html
+++ b/frontend/app/views/fragments/event/remainingTickets.scala.html
@@ -1,0 +1,6 @@
+@(mode: String, classes: Seq[String] = Seq.empty)
+
+<div class="status-bar status-bar--listing js-remaining-tickets @classes.mkString(" ")" data-mode="@mode">
+    @fragments.inlineIcon("tickets", List("icon-inline--medium", "icon-inline--offset"))
+    <span class="js-remaining-tickets__text"></span>
+</div>

--- a/frontend/assets/javascripts/src/main.js
+++ b/frontend/assets/javascripts/src/main.js
@@ -13,6 +13,7 @@ require([
     'src/modules/modal',
     'src/modules/events/cta',
     'src/modules/events/filter',
+    'src/modules/events/remainingTickets',
     'src/modules/events/eventPriceEnhance',
     'src/modules/form',
     'src/modules/form/processSubmit',
@@ -37,6 +38,7 @@ require([
     modal,
     cta,
     filter,
+    remainingTickets,
     eventPriceEnhance,
     processSubmit,
     form,
@@ -75,6 +77,7 @@ require([
     // Events
     cta.init();
     filter.init();
+    remainingTickets.init();
     eventPriceEnhance.init();
 
     // Forms

--- a/frontend/assets/javascripts/src/modules/events/remainingTickets.js
+++ b/frontend/assets/javascripts/src/modules/events/remainingTickets.js
@@ -13,7 +13,7 @@ define(['$', 'ajax', 'src/utils/user'], function ($, ajax, userUtil) {
             'You can use one of your',
             '<strong>' + props.total + '</strong>',
             'allocated member tickets',
-            ((props.mode === 'event') ? 'for this event' : 'for any Guardian Live event')
+            ((props.mode === 'event') ? 'for this event.' : 'for any Guardian Live event.')
         ];
 
         var returningUserMessageParts = [
@@ -22,7 +22,7 @@ define(['$', 'ajax', 'src/utils/user'], function ($, ajax, userUtil) {
             'of',
             '<strong>' + props.total + '</strong>',
             'allocated member tickets remaining.',
-            ((props.mode === 'event') ? null : 'You can use these for any Guardian Live event.')
+            ((props.mode === 'event') ? 'You can use one for this event.' : 'You can use these for any Guardian Live event.')
         ];
 
         var messageParts = (props.remaining === props.total) ? newUserMessageParts : returningUserMessageParts;

--- a/frontend/assets/javascripts/src/modules/events/remainingTickets.js
+++ b/frontend/assets/javascripts/src/modules/events/remainingTickets.js
@@ -1,0 +1,46 @@
+define(['$', 'ajax', 'src/utils/user'], function ($, ajax, userUtil) {
+    'use strict';
+
+    var SELECTOR = '.js-remaining-tickets';
+    var ACTIVE_CLASS = 'is-active';
+
+    function getTicketsRemaining(elem, textElem) {
+        ajax({
+            url: '/subscription/remaining-tickets',
+            type: 'json'
+        }).then(function(data) {
+
+            var total = data.totalAllocation;
+            var remaining = data.remainingAllocation;
+
+            if (remaining > 0) {
+                textElem.html([
+                    '<strong>' + remaining + '</strong>',
+                    'of',
+                    '<strong>' + total + '</strong>',
+                    'allocated member tickets remaining.',
+                    'You can use these for any Guardian Live event.'
+                ].join(' '));
+                elem.addClass(ACTIVE_CLASS);
+            }
+        });
+    }
+
+    function init() {
+        var elem = $(SELECTOR);
+        var textElem = $('.js-remaining-tickets__text');
+        if(!elem.length) {
+            return;
+        }
+        userUtil.getMemberDetail(function (memberDetail, hasTier) {
+            if (hasTier) {
+                getTicketsRemaining(elem, textElem);
+            }
+        });
+    }
+
+    return {
+        init: init
+    };
+
+});

--- a/frontend/assets/javascripts/src/modules/welcome.js
+++ b/frontend/assets/javascripts/src/modules/welcome.js
@@ -8,8 +8,8 @@ define(['src/utils/user'], function(userUtil) {
     function init() {
         var redirectUrl = urlMappings[window.location.pathname] || false;
         if (redirectUrl) {
-            userUtil.getMemberDetail(function (memberDetail) {
-                if (userUtil.hasTier(memberDetail)) {
+            userUtil.getMemberDetail(function (memberDetail, hasTier) {
+                if (hasTier) {
                     window.location.href = redirectUrl;
                 }
             });

--- a/frontend/assets/javascripts/src/utils/user.js
+++ b/frontend/assets/javascripts/src/utils/user.js
@@ -51,9 +51,15 @@ define([
                 callback.apply(this, args);
             });
         };
+        var hasTier = function(memberDetail) {
+            return !!(memberDetail && memberDetail.tier);
+        };
 
         return function (callback, overRideCallbacks) {
-            // for testing purposes to mimic a reload of the javascript and hence a clearing of the callbacks array
+            /**
+             * For testing purposes to mimic a reload of the javascript
+             * and hence a clearing of the callbacks array
+             */
             callbacks = overRideCallbacks || callbacks;
 
             var membershipUser;
@@ -62,7 +68,7 @@ define([
             if (identityUser) {
                 membershipUser = cookie.getDecodedCookie(MEM_USER_COOKIE_KEY);
                 if ((membershipUser && membershipUser.userId) === identityUser.id) {
-                    callback(membershipUser);
+                    callback(membershipUser, hasTier(membershipUser));
                 } else {
                     callbacks.push(callback);
 
@@ -71,7 +77,7 @@ define([
                             url: '/user/me',
                             method: 'get',
                             success: function (resp) {
-                                invokeCallbacks([resp]);
+                                invokeCallbacks([resp, hasTier(resp)]);
                                 pendingXHR = null;
                             }
                         });
@@ -83,13 +89,8 @@ define([
         };
     }());
 
-    var hasTier = function(memberDetail) {
-        return !!(memberDetail && memberDetail.tier);
-    };
-
     return {
         isLoggedIn: isLoggedIn,
-        hasTier: hasTier,
         getUserFromCookie: getUserFromCookie,
         getMemberDetail: getMemberDetail,
         idCookieAdapter: idCookieAdapter

--- a/frontend/assets/stylesheets/components/_messages.scss
+++ b/frontend/assets/stylesheets/components/_messages.scss
@@ -1,3 +1,32 @@
+/* ==========================================================================
+   Messages
+   ========================================================================== */
+
+/* ==========================================================================
+   Message: Status Bar
+   ========================================================================== */
+
+.status-bar {
+    @include fs-data(4);
+    color: color(neutral-2);
+    background-color: color(neutral-5);
+    padding: ($gs-baseline / 2) $gs-gutter;
+    opacity: 0;
+    transition: opacity .5s ease;
+}
+.status-bar.is-active {
+    opacity: 1;
+}
+.status-bar--listing {
+    @include mq(desktop) {
+        padding-left: gs-span(2.5);
+    }
+}
+
+/* ==========================================================================
+   Messages: Flash message
+   ========================================================================== */
+
 .flash-message {
     @include fs-data(4);
     margin-top: rem(12px);

--- a/frontend/assets/stylesheets/objects/_icons.scss
+++ b/frontend/assets/stylesheets/objects/_icons.scss
@@ -75,6 +75,9 @@
     top: -2px;
     margin-right: rem($gs-baseline / 4);
 }
+.icon-inline--offset {
+    margin-right: 5px;
+}
 .icon-inline--top {
     vertical-align: top;
 }

--- a/frontend/conf/dev.conf
+++ b/frontend/conf/dev.conf
@@ -42,7 +42,7 @@ touchpoint.backend.default=DEV
 touchpoint.backend.test=UAT
 
 staff.authorised.emails.groups = "membership.dev"
-zuora.free-event-tickets-allowance = 2
+zuora.free-event-tickets-allowance = 6
 
 activity.tracking.bcrypt.salt="$2a$10$oL3umggRoHlQuvgoYpWDx."
 activity.tracking.bcrypt.pepper="dummy-pepper"

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -47,7 +47,7 @@ GET            /staff/event-details               controllers.Staff.eventDetails
 # Subscription
 POST           /subscription/update-card          controllers.Subscription.updateCard
 OPTIONS        /subscription/update-card          controllers.Subscription.updateCardPreflight
-GET            /subscription/tickets-left         controllers.Subscription.ticketsLeft
+GET            /subscription/remaining-tickets    controllers.Subscription.remainingTickets
 
 # Events
 GET            /events                            controllers.Event.list

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -47,6 +47,7 @@ GET            /staff/event-details               controllers.Staff.eventDetails
 # Subscription
 POST           /subscription/update-card          controllers.Subscription.updateCard
 OPTIONS        /subscription/update-card          controllers.Subscription.updateCardPreflight
+GET            /subscription/tickets-left         controllers.Subscription.ticketsLeft
 
 # Events
 GET            /events                            controllers.Event.list


### PR DESCRIPTION
This PR demotes `memberTierFeatures` to a private method, and refactors it so that it accepts a subscription instead of a member object. Additionally, it updates `getUsageCountWithinTerm` changing its return type from plain `Int` to `Option[Int]`. In this case, the intended semantics for `None` is that the usage is not entitled to free event tickets, while `Some` implies instead that the user has such benefit.

@rtyley 