### PR TITLE
Don't call /subscription/remaining-tickets if < Partner

### DIFF
--- a/frontend/assets/javascripts/src/modules/events/remainingTickets.js
+++ b/frontend/assets/javascripts/src/modules/events/remainingTickets.js
@@ -1,4 +1,9 @@
-define(['$', 'ajax', 'src/utils/user'], function ($, ajax, userUtil) {
+define([
+    '$',
+    'ajax',
+    'lodash/collection/contains',
+    'src/utils/user'
+], function ($, ajax, contains, userUtil) {
     'use strict';
 
     var ELEM_SELECTOR = '.js-remaining-tickets';
@@ -40,7 +45,7 @@ define(['$', 'ajax', 'src/utils/user'], function ($, ajax, userUtil) {
         }
 
         userUtil.getMemberDetail(function (memberDetail, hasTier) {
-            if (hasTier) {
+            if (hasTier && contains(['Partner', 'Patron'], memberDetail.tier)) {
                 ajax({
                     url: '/subscription/remaining-tickets',
                     type: 'json'


### PR DESCRIPTION
Minor tweak to avoid calling `/subscription/remaining-tickets` if our tier is < Partner. We weren't showing the banner before, but this just ensures we don't even try to make the call in the first place.

@afiore 