### PR TITLE
Design Consistency: Layout / global fixes

### DIFF
--- a/frontend/assets/stylesheets/components/_slideshow.scss
+++ b/frontend/assets/stylesheets/components/_slideshow.scss
@@ -42,7 +42,7 @@
     position: absolute;
     bottom: 0;
     color: $white;
-    z-index: 2;
+    z-index: 1;
     padding: $gs-gutter / 2;
     padding-top: $gs-gutter * 2;
 
@@ -131,9 +131,7 @@ $_slideshow-fefature-height-desktop: 460px;
     }
 
     .slideshow__detail {
-        @include mq(mobileLandscape) {
-            padding-left: $gs-gutter * 2;
-        }
+        padding-left: $gs-gutter * 2;
     }
 }
 

--- a/frontend/assets/stylesheets/objects/_links.scss
+++ b/frontend/assets/stylesheets/objects/_links.scss
@@ -5,7 +5,6 @@
 a,
 .fake-link {
     overflow: hidden;
-    color: $c-link;
     cursor: pointer;
     text-decoration: none;
 


### PR DESCRIPTION
- z-index bug on welcome slideshow overlaying mobile navigation
- Remove default colour from link, already scoped to text styles in `.copy` class and only needed there by default. Resolves a number of design consistency issues.

**Nav Before**
![screen shot 2015-09-10 at 17 45 50](https://cloud.githubusercontent.com/assets/123386/9794612/05cce598-57e4-11e5-916d-2b1cd594823f.png)

**Nav After**
![screen shot 2015-09-10 at 17 44 52](https://cloud.githubusercontent.com/assets/123386/9794610/05b769ca-57e4-11e5-81dc-b9a8568e8743.png)
