### PR TITLE
Design Consistency: Fix dummy new badge in packageChanger

### DIFF
--- a/frontend/app/views/fragments/tier/packageChanger.scala.html
+++ b/frontend/app/views/fragments/tier/packageChanger.scala.html
@@ -28,7 +28,7 @@
                 @for(highlight <- Benefits.details(tier).highlights) {
                     <li>
                         @if(highlight.isNew) {
-                            <strong>New</strong>
+                            @fragments.inlineIcon("new-arrow", List("icon-inline--badge", "icon-inline--brand"))
                         }
                         @highlight.description
                     </li>


### PR DESCRIPTION
Left a test version in here :flushed:, should be a hand-drawn icon, not just "**New**"
![screen shot 2015-09-11 at 13 55 44](https://cloud.githubusercontent.com/assets/123386/9815295/ce2999de-588c-11e5-95bd-057364b94335.png)

@afiore 