### PR TITLE
Analytics: Add custom dimensions for recording users state

### DIFF
--- a/frontend/assets/javascripts/src/modules/analytics/ga.js
+++ b/frontend/assets/javascripts/src/modules/analytics/ga.js
@@ -1,6 +1,11 @@
 /* global ga: true */
-define(function() {
+define(['src/utils/user'], function(user) {
     'use strict';
+
+    var dimensions = {
+        signedIn: 'dimension1',
+        member: 'dimension2'
+    };
 
     function init() {
         /*eslint-disable */
@@ -9,6 +14,8 @@ define(function() {
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
         /*eslint-enable */
+
+        var isLoggedIn = user.isLoggedIn();
 
         ga('create', guardian.googleAnalytics.trackingId, {
             'allowLinker': true,
@@ -24,7 +31,16 @@ define(function() {
          */
         ga('require', 'linkid', 'linkid.js');
 
-        ga('send', 'pageview');
+
+        if(isLoggedIn) {
+            ga('set', dimensions.signedIn, isLoggedIn);
+            user.getMemberDetail(function(memberDetail, hasTier) {
+                ga('set', dimensions.member, hasTier);
+                ga('send', 'pageview');
+            });
+        } else {
+            ga('send', 'pageview');
+        }
     }
 
     return {

--- a/frontend/assets/javascripts/src/utils/user.js
+++ b/frontend/assets/javascripts/src/utils/user.js
@@ -84,7 +84,7 @@ define([
                     }
                 }
             } else {
-                callback(null);
+                callback(null, false);
             }
         };
     }());


### PR DESCRIPTION
Add custom dimensions for recording users state

- Record if user is signed in
- Record if user is a Member

The plan is to monitor this data and if these dimensions are recorded correctly we'll look at also recording the actual tier of Membership (Supporter/Partner etc.)

These dimensions should give us some insight as to how existing members and signed in users are using the site.

See: https://support.google.com/analytics/answer/2709828

@dominickendrick @tudorraul 