### PR TITLE
Upgrade zxcvbn to v3.5

### DIFF
--- a/frontend/Gruntfile.js
+++ b/frontend/Gruntfile.js
@@ -161,7 +161,7 @@ module.exports = function (grunt) {
                 flatten: true
             },
             zxcvbn: {
-                src: '<%= dirs.assets.javascripts %>/lib/bower-components/zxcvbn/zxcvbn.js',
+                src: '<%= dirs.assets.javascripts %>/lib/bower-components/zxcvbn/dist/zxcvbn.js',
                 dest: '<%= dirs.publicDir.javascripts %>/lib/zxcvbn/',
                 expand: true,
                 flatten: true

--- a/frontend/app/views/patterns/patterns.scala.html
+++ b/frontend/app/views/patterns/patterns.scala.html
@@ -395,7 +395,7 @@
         @fragments.tier.tierTrail(Tier.Partner, showCaption=false)
     }
 
-    @pattern("Package - Promo") {
+    @pattern("Package: Promo") {
         <ul class="grid grid--3up-stacked">
             <li class="grid__item">
                 @fragments.tier.packagePromo(Tier.Friend)
@@ -409,20 +409,26 @@
         </ul>
     }
 
-    @pattern("Package - Stack") {
+    @pattern("Package: Stack") {
         @fragments.tier.packageStack(Tier.Partner)
     }
 
-    @pattern("Flash Message - Success") {
+    @pattern("Flash Message: Success") {
         @fragments.notifications.flashMessage(FlashMessage.success("A successful Message!"))
     }
 
-    @pattern("Flash Message - Failure") {
+    @pattern("Flash Message: Failure") {
         @fragments.notifications.flashMessage(FlashMessage.error("An error Message!"))
     }
 
-    @pattern("FAQ - Answers", "FAQ answers") {
+    @pattern("FAQ", "FAQ answers") {
         @fragments.common.faqs(model.Faq.help.take(4))
+    }
+
+    @pattern("Forms: Create password") {
+        <form action="" class="js-form">
+            @fragments.form.createPassword()
+        </form>
     }
 
     </main>

--- a/frontend/assets/javascripts/bower.json
+++ b/frontend/assets/javascripts/bower.json
@@ -6,7 +6,7 @@
     "bean": "~1.0.6",
     "domready": "~1.0.5",
     "reqwest": "~1.1.0",
-    "zxcvbn": "90b7d2908d1305e0ab9f0fe0d983041e546af760",
+    "zxcvbn": "3.5.0",
     "curl": "~0.8.10",
     "raven-js": "~1.1.16",
     "lodash-amd": "~3.10.0",

--- a/frontend/assets/javascripts/src/modules/form.js
+++ b/frontend/assets/javascripts/src/modules/form.js
@@ -65,6 +65,7 @@ define([
     'use strict';
 
     var init = function () {
+
         if (form) {
             validation.init();
             address.init();

--- a/frontend/assets/javascripts/src/modules/form/helper/password.js
+++ b/frontend/assets/javascripts/src/modules/form/helper/password.js
@@ -1,4 +1,3 @@
-/*global zxcvbn */
 define(function () {
     'use strict';
 
@@ -23,7 +22,7 @@ define(function () {
         ]
     };
 
-    var checkStrength = function(strengthIndicator, strengthInput) {
+    var checkStrength = function(zxcvbn, strengthIndicator, strengthInput) {
         var score = zxcvbn(strengthInput.value).score;
         var label = CONFIG.text.passwordLabel + ': ' + CONFIG.passwordLabels[score];
         var strengthLabel = document.querySelector(SELECTORS.strengthLabel);
@@ -42,23 +41,24 @@ define(function () {
         }
     };
 
-    var addListeners = function (strengthIndicator, strengthInput) {
+    var addListeners = function (zxcvbn, strengthIndicator, strengthInput) {
         strengthIndicator.classList.toggle(HIDDEN_CLASS);
         strengthInput.addEventListener('keyup', function() {
-            checkStrength(strengthIndicator, strengthInput);
+            checkStrength(zxcvbn, strengthIndicator, strengthInput);
         });
     };
 
-    /**
-     * Async load in zxcvbn lib as it is ~700kb!
-     */
     var init = function() {
         var strengthIndicator = document.querySelector(SELECTORS.strengthIndicator);
         var strengthInput = document.querySelector(SELECTORS.strengthInput);
 
         if(strengthIndicator && strengthInput) {
-            require(['js!zxcvbn'], function() {
-                addListeners(strengthIndicator, strengthInput);
+            /**
+             * Async load in zxcvbn lib as it is ~700kb!
+             * Loads as an AMD module as of version ~3.5
+             */
+            require(['zxcvbn'], function(zxcvbn) {
+                addListeners(zxcvbn, strengthIndicator, strengthInput);
             });
         }
     };

--- a/frontend/assets/javascripts/src/modules/form/validation/listeners.js
+++ b/frontend/assets/javascripts/src/modules/form/validation/listeners.js
@@ -27,6 +27,10 @@ define([
      * if the form does not have payment capabilities then just submit the form
      */
     var addSubmitListener = function () {
+        if(!SUBMIT_ELEM) {
+            return;
+        }
+
         bean.on(SUBMIT_ELEM, 'click', function (e) {
             e.preventDefault();
 

--- a/frontend/assets/javascripts/src/modules/metrics/forms.js
+++ b/frontend/assets/javascripts/src/modules/metrics/forms.js
@@ -74,20 +74,27 @@ define([
 
     function init() {
         var formAction;
+
         if (window.ga && formUtil) {
+
             formAction = formUtil.elem.getAttribute('action');
+
             bean.on(window, 'beforeunload.formMetrics', function() {
                 recordAbandonedForm(formAction);
             });
-            bean.on(formUtil.elem.querySelector('[type="submit"]'), 'click', function() {
-                // Unbind `beforeunload` listener as form submission counts as `beforeunload`
-                bean.off(window, 'beforeunload.formMetrics');
-                if (formUtil.errs.length) {
-                    recordFormWithErrors(formAction);
-                } else {
-                    recordFormSuccess(formAction);
-                }
-            });
+
+            var formSubmit = formUtil.elem.querySelector('[type="submit"]');
+            if(formSubmit) {
+                bean.on(formSubmit, 'click', function() {
+                    // Unbind `beforeunload` listener as form submission counts as `beforeunload`
+                    bean.off(window, 'beforeunload.formMetrics');
+                    if (formUtil.errs.length) {
+                        recordFormWithErrors(formAction);
+                    } else {
+                        recordFormSuccess(formAction);
+                    }
+                });
+            }
         }
     }
 


### PR DESCRIPTION
- Updates to explicit version number now that `zxcvbn` has stabilised a bit with version 3.5. No longer using git hash(!)
- Allows us to use zxcvbn as an AMD module rather than having to load as a global.
- Add a few robustness checks discovered in related form modules whilst testing password strength as standalone pattern.

![password mov](https://cloud.githubusercontent.com/assets/123386/9874084/e540ddb4-5b9b-11e5-9647-f5d55789a462.gif)

@rtyley @tudorraul 