### PR TITLE
Warn on staff event-overview if ticket sales end before event start

### DIFF
--- a/frontend/app/views/fragments/event/overviewSection.scala.html
+++ b/frontend/app/views/fragments/event/overviewSection.scala.html
@@ -1,7 +1,9 @@
+@import org.joda.time.format.PeriodFormat
 @(title: String, events: Seq[model.RichEvent.RichEvent])
 @import configuration.Config
 @import model.Eventbrite.{ExternalTicketing, InternalTicketing}
 @import model.RichEvent.{LocalEvent, GuLiveEvent, MasterclassEvent}
+@import views.support.Dates._
 
 @eventTrait(text: String, identifier: String = "") = {
     <li class="event-trait@if(identifier){ @(s"event-trait--$identifier")}">
@@ -69,6 +71,10 @@
 
                                 @if(ticketing.isPossiblyMissingDiscount) {
                                     @eventTrait("Missing Discount", "important")
+                                }
+
+                                @for((earlyEnd, tickets) <- ticketing.ticketsEndingSaleBeforeEvent) {
+                                    @eventTrait(s"Ticket sales end ${earlyEnd.toString(PeriodFormat.getDefault())} before event start: ${tickets.map(_.name).mkString(", ")}", "important")
                                 }
 
                                 @if(ticketing.isFree) {

--- a/frontend/app/views/support/Dates.scala
+++ b/frontend/app/views/support/Dates.scala
@@ -1,14 +1,15 @@
 package views.support
 
 import com.github.nscala_time.time.Imports._
-import org.joda.time.Instant
-import org.joda.time.Interval
+import org.joda.time.{PeriodType, Instant, Interval}
 import org.joda.time.format.PeriodFormat
 import play.twirl.api.Html
 
 object Dates {
 
   val humanPeriodFormat = PeriodFormat.getDefault()
+
+  val YearMonthDayHours = PeriodType.yearMonthDayTime.withMinutesRemoved.withSecondsRemoved.withMillisRemoved
 
   implicit class RichPeriod(period: Period) {
     lazy val pretty = period.withMillis(0).toString(humanPeriodFormat)


### PR DESCRIPTION
After discussion Sophie Kinsella (Assistant events manager on Membership), we agreed that it would be helpful to make sure events haven't accidentally been created with ticket sales ending substantially before the event start.

https://membership.theguardian.com/staff/event-overview

![image](https://cloud.githubusercontent.com/assets/52038/9907965/75851622-5c89-11e5-8d6d-692e5f8fbadf.png)

I've set the warning label to show if ticket sales end earlier than 2 hours before the event. I also had to exclude 'Guestlists' as these seem to often end before the event starts.

https://trello.com/c/9SatPfOJ/110-warn-when-ticket-sales-end-long-before-event-start

cc @chrisjowen 