### PR TITLE
Filter Error: duplicate define: jquery

### DIFF
--- a/frontend/assets/javascripts/src/main.js
+++ b/frontend/assets/javascripts/src/main.js
@@ -1,5 +1,6 @@
 require([
     'ajax',
+    'src/modules/raven',
     'src/modules/analytics/setup',
     'src/modules/welcome',
     'src/modules/slideshow',
@@ -20,11 +21,10 @@ require([
     'src/modules/identityPopup',
     'src/modules/identityPopupDetails',
     'src/modules/metrics',
-    'src/modules/patterns',
-    // Add new dependencies ABOVE this
-    'raven'
+    'src/modules/patterns'
 ], function(
     ajax,
+    raven,
     analytics,
     welcome,
     slideshow,
@@ -49,14 +49,8 @@ require([
 ) {
     'use strict';
 
-    /*global Raven */
-    // set up Raven, which speaks to Sentry to track errors
-    Raven.config('https://e159339ea7504924ac248ba52242db96@app.getsentry.com/29912', {
-        whitelistUrls: ['membership.theguardian.com/assets/'],
-        tags: { build_number: guardian.membership.buildNumber }
-    }).install();
-
     ajax.init({page: {ajaxUrl: ''}});
+    raven.init('https://e159339ea7504924ac248ba52242db96@app.getsentry.com/29912');
 
     analytics.init();
 

--- a/frontend/assets/javascripts/src/modules/raven.js
+++ b/frontend/assets/javascripts/src/modules/raven.js
@@ -1,0 +1,22 @@
+/* global Raven */
+define(['raven'], function () {
+    'use strict';
+
+    function init(dsn) {
+        /**
+         * Set up Raven, which speaks to Sentry to track errors
+         */
+        Raven.config(dsn, {
+            whitelistUrls: ['membership.theguardian.com/assets/'],
+            tags: { build_number: guardian.membership.buildNumber },
+            ignoreErrors: [
+                /duplicate define: jquery/
+            ]
+        }).install();
+    }
+
+    return {
+        init: init
+    };
+
+});


### PR DESCRIPTION
We get quite a few errors on Membership for `Error: duplicate define: jquery` (see https://app.getsentry.com/the-guardian/membership/group/31343105/). We don't use jQuery on the site but I *think* this is a side-effect of jQuery being AMD compatible and so if it's loaded by a user/browser-extension you might get this warning. 

This PR is a test of using Raven's `ignoreErrors` to filter this out.

- Extract raven config into module
- Add filter for Error: duplicate define: jquery

@tudorraul 