### PR TITLE
Adjust signed in reporting

### DIFF
--- a/frontend/assets/javascripts/src/modules/analytics/ga.js
+++ b/frontend/assets/javascripts/src/modules/analytics/ga.js
@@ -32,13 +32,15 @@ define(['src/utils/user'], function(user) {
         ga('require', 'linkid', 'linkid.js');
 
 
+        ga('set', dimensions.signedIn, isLoggedIn.toString());
+
         if(isLoggedIn) {
-            ga('set', dimensions.signedIn, isLoggedIn);
             user.getMemberDetail(function(memberDetail, hasTier) {
-                ga('set', dimensions.member, hasTier);
+                ga('set', dimensions.member, hasTier.toString());
                 ga('send', 'pageview');
             });
         } else {
+            ga('set', dimensions.member, 'false');
             ga('send', 'pageview');
         }
     }


### PR DESCRIPTION
After testing this, we need a couple of tweaks to the signed-in member reporting to make this useful.

- GA dimensions take a string, without `toString()` the state just shows as `1`.
- We need to log the false state too, so this rejigs things to log signed-out / non-member too.

Currently looks like this:

![screen shot 2015-09-18 at 11 12 09](https://cloud.githubusercontent.com/assets/123386/9957248/7ea3724e-5df6-11e5-9f34-8e659a31ef85.png)

But we want it to look like this (from Subscriptions):

![screen shot 2015-09-18 at 11 15 57](https://cloud.githubusercontent.com/assets/123386/9957296/a792dece-5df6-11e5-870d-8465b858ca36.png)

@tudorraul @chrisjowen 
