### PR TITLE
What's on prep: Remove tagged events list

### DIFF
--- a/frontend/app/services/EventbriteService.scala
+++ b/frontend/app/services/EventbriteService.scala
@@ -54,7 +54,7 @@ trait EventbriteService extends WebServiceHelper[EBObject, EBError] {
 
   def mkRichEvent(event: EBEvent): Future[RichEvent]
   def getFeaturedEvents: Seq[RichEvent]
-  def getTaggedEvents(tag: String): Seq[RichEvent]
+  def getTaggedEvents(tag: String): Seq[RichEvent] = Seq.empty
   def getEventsArchive: Option[Seq[RichEvent]] = Some(eventsArchive)
   def getPartnerEvents: Seq[RichEvent] = events.filter(_.providerOpt.isDefined)
 
@@ -131,7 +131,6 @@ object GuardianLiveEventService extends LiveService {
     yield GuLiveEvent(event, gridImageOpt, contentApiService.content(event.id))
 
   override def getFeaturedEvents: Seq[RichEvent] = EventbriteServiceHelpers.getFeaturedEvents(eventsOrderingTask.get(), events)
-  override def getTaggedEvents(tag: String): Seq[RichEvent] = events.filter(_.name.text.toLowerCase.contains(tag))
   override def start() {
     super.start()
     eventsOrderingTask.start()
@@ -147,7 +146,6 @@ object LocalEventService extends LiveService {
     yield LocalEvent(event, gridImageOpt, contentApiService.content(event.id))
 
   override def getFeaturedEvents: Seq[RichEvent] = EventbriteServiceHelpers.getFeaturedEvents(Nil, events)
-  override def getTaggedEvents(tag: String): Seq[RichEvent] = events.filter(_.name.text.toLowerCase.contains(tag))
 
   override def start() {
     super.start()


### PR DESCRIPTION
This is some prep for https://github.com/guardian/membership-frontend/pull/774.

It turns out we have a tagged list page for `/events` (in addition to Masterclasses). However it only matches on title, so it's weird…

See this amazing page with just events with "Burt" in the title:

![screen shot 2015-09-21 at 11 31 30](https://cloud.githubusercontent.com/assets/123386/9990029/922d1656-6055-11e5-89b3-726590b38beb.png)

We don't link to this anywhere and as we're revisiting how we do filtering on events pages now is probably the time to clean it out, as I don't think it's an expected feature.