### PR TITLE
Slide, rather than fade status bar

### DIFF
--- a/frontend/app/views/fragments/event/remainingTickets.scala.html
+++ b/frontend/app/views/fragments/event/remainingTickets.scala.html
@@ -1,6 +1,8 @@
 @(mode: String, classes: Seq[String] = Seq.empty)
 
 <div class="status-bar status-bar--listing js-remaining-tickets @classes.mkString(" ")" data-mode="@mode">
-    @fragments.inlineIcon("tickets", List("icon-inline--medium", "icon-inline--offset"))
-    <span class="js-remaining-tickets__text"></span>
+    <div class="status-bar__inner">
+        @fragments.inlineIcon("tickets", List("icon-inline--medium", "icon-inline--offset"))
+        <span class="js-remaining-tickets__text"></span>
+    </div>
 </div>

--- a/frontend/assets/stylesheets/components/_messages.scss
+++ b/frontend/assets/stylesheets/components/_messages.scss
@@ -10,16 +10,19 @@
     @include fs-data(4);
     color: color(neutral-2);
     background-color: color(neutral-5);
-    padding: ($gs-baseline / 2) $gs-gutter;
-    opacity: 0;
-    transition: opacity .5s ease;
+    overflow: hidden;
+    max-height: 0;
+    transition: max-height 1.5s ease-in;
+}
+.status-bar__inner {
+    margin: ($gs-baseline / 2) $gs-gutter;
 }
 .status-bar.is-active {
-    opacity: 1;
+    max-height: 100px;
 }
-.status-bar--listing {
+.status-bar--listing .status-bar__inner {
     @include mq(desktop) {
-        padding-left: gs-span(2.5);
+        margin-left: gs-span(2.5);
     }
 }
 


### PR DESCRIPTION
Tweak to the free tickets status bar. Previously we faded it in, but now we slide it in:

![slide mov](https://cloud.githubusercontent.com/assets/123386/9997471/39f0d278-6084-11e5-8d85-3e9b93b57d4d.gif)

This avoids the current issue with having to *reserve* the space for it when fading in to avoid a jump.

**Before**
![screen shot 2015-09-21 at 17 12 18](https://cloud.githubusercontent.com/assets/123386/9997492/4f3a8e30-6084-11e5-94fc-d646749d01c9.png)

**After**
![screen shot 2015-09-21 at 17 12 22](https://cloud.githubusercontent.com/assets/123386/9997491/4e011df4-6084-11e5-8d8b-76c1cfe940db.png)

@tudorraul 