### PR TITLE
Update homepage video

### DIFF
--- a/frontend/app/configuration/Videos.scala
+++ b/frontend/app/configuration/Videos.scala
@@ -6,7 +6,6 @@ import model.{Video, ResponsiveImageGroup, ResponsiveImageGenerator}
 object Videos {
 
   private val whatIsMembershipPlaceholder = ResponsiveImageGenerator(
-    // ff2fdc0b1cd540445ab0c57b3efe8f08eba2e213
     id="0f0b186b9acd3c32ae47e445e07fe5b128250d7f/0_0_1800_1080",
     sizes=List(1000, 500)
   )

--- a/frontend/app/configuration/Videos.scala
+++ b/frontend/app/configuration/Videos.scala
@@ -5,8 +5,9 @@ import model.{Video, ResponsiveImageGroup, ResponsiveImageGenerator}
 
 object Videos {
 
-  private val videoPlaceholder = ResponsiveImageGenerator(
-    id="267569fecb462c61718f7e8cf50a8995ebddee5d/0_0_2280_1368",
+  private val whatIsMembershipPlaceholder = ResponsiveImageGenerator(
+    // ff2fdc0b1cd540445ab0c57b3efe8f08eba2e213
+    id="0f0b186b9acd3c32ae47e445e07fe5b128250d7f/0_0_1800_1080",
     sizes=List(1000, 500)
   )
 
@@ -15,9 +16,14 @@ object Videos {
     posterImage=Some(
       ResponsiveImageGroup(
         altText=Some("What is Guardian Members?"),
-        availableImages=videoPlaceholder
+        availableImages=whatIsMembershipPlaceholder
       )
     )
+  )
+
+  private val supportersPlaceholder = ResponsiveImageGenerator(
+    id="267569fecb462c61718f7e8cf50a8995ebddee5d/0_0_2280_1368",
+    sizes=List(1000, 500)
   )
 
   val supporters = Video(
@@ -25,7 +31,7 @@ object Videos {
     posterImage=Some(
       ResponsiveImageGroup(
         altText=Some("If you read the Guardian, join the Guardian"),
-        availableImages=videoPlaceholder
+        availableImages=supportersPlaceholder
       )
     )
   )

--- a/frontend/app/configuration/Videos.scala
+++ b/frontend/app/configuration/Videos.scala
@@ -11,16 +11,7 @@ object Videos {
   )
 
   val whatIsMembership = Video(
-    srcUrl="//www.youtube.com/embed/7JnYthFvYEk?enablejsapi=1&wmode=transparent",
-    posterImage=Some(
-      ResponsiveImageGroup(
-        altText=Some("If you read the Guardian, join the Guardian"),
-        availableImages=videoPlaceholder
-      )
-    )
-  )
-  val whatIsMembershipAlt = Video(
-    srcUrl="//www.youtube.com/embed/z_IFkfuEuz0?enablejsapi=1&wmode=transparent",
+    srcUrl="//www.youtube.com/embed/oRowh6Nzt4c?enablejsapi=1&wmode=transparent",
     posterImage=Some(
       ResponsiveImageGroup(
         altText=Some("What is Guardian Members?"),
@@ -28,6 +19,7 @@ object Videos {
       )
     )
   )
+
   val supporters = Video(
     srcUrl="//www.youtube.com/embed/pIg3BCr1mwY?enablejsapi=1&wmode=transparent",
     posterImage=Some(

--- a/frontend/app/views/index.scala.html
+++ b/frontend/app/views/index.scala.html
@@ -48,8 +48,8 @@
             </div>
             <div class="listing__content">
                 @fragments.media.videoPreview(
-                    configuration.Videos.whatIsMembershipAlt,
-                    "Alan Rusbridger, Polly Toynbee, Jonathan Freedland, Owen Jones and Zoe Williams introduce Guardian Members."
+                    configuration.Videos.whatIsMembership,
+                    "Polly Toynbee, Owen Jones, Ewen MacAskill and Hugh Muir introduce Guardian Members."
                 )
                 @fragments.common.jumpLink("Benefits of membership", "#why-join")
             </div>

--- a/frontend/app/views/patterns/patterns.scala.html
+++ b/frontend/app/views/patterns/patterns.scala.html
@@ -296,21 +296,6 @@
         }
     }
 
-    @pattern("Promo - Video") {
-        <div class="page-slice page-slice--slim l-constrained">
-            @fragments.promos.promoVideoSecondary(
-                "If you believe in Guardian journalism, become a Guardian Member",
-                video=Videos.whatIsMembership,
-                toneClass=Some("tone-trans-brand")) {
-                <div class="text-feature">
-                    <p> Alan Rusbridger, Polly Toynbee, Jonathan Freedland, Owen Jones and Zoe Williams talk about why readers play such an important part of the Guardian.</p>
-                    <p>Sign up as a member, you’ll be supporting free, independent journalism and helping us create original, compelling stories.</p>
-                </div>
-                <a class="action u-no-top-margin" href="#">Join today</a>
-            }
-        </div>
-    }
-
     @pattern("Promo - Quote") {
         @fragments.promos.promoQuote(
             Asset.at("images/common/katharine-viner-cutout.png"),


### PR DESCRIPTION
This PR updates the "What is membership?" video on the homepage from [this old video](https://youtu.be/z_IFkfuEuz0) to [this new video](https://youtu.be/oRowh6Nzt4c), along with its associated copy and placeholder image.

This also gave me an opportunity to remove references to an "alternate" (actually identical) version of this video which for some reason was only used in the `/patterns` page.

***Before***
![crop2015-09-25-13h49m59s95](https://cloud.githubusercontent.com/assets/5122968/10100940/3276a156-638d-11e5-8f4c-aa9f41f681a4.jpg)

***After***
![crop2015-09-25-13h50m21s65](https://cloud.githubusercontent.com/assets/5122968/10100943/39be6de0-638d-11e5-92e3-a70640af47fa.jpg)

@davidrapson 