### PR TITLE
Try to reduce some noise in raven errors

### DIFF
--- a/frontend/assets/javascripts/src/modules/analytics/facebook.js
+++ b/frontend/assets/javascripts/src/modules/analytics/facebook.js
@@ -1,4 +1,4 @@
-/* global fbq, _fbq */
+/* global fbq */
 /* eslint-disable no-unused-vars, no-underscore-dangle */
 define(['lodash/collection/forEach'], function(forEach) {
     'use strict';

--- a/frontend/assets/javascripts/src/modules/analytics/omniture.js
+++ b/frontend/assets/javascripts/src/modules/analytics/omniture.js
@@ -1,4 +1,4 @@
-/*global Raven */
+/*global Raven, s_gi */
 define([
     'src/utils/user'
 ], function (user) {
@@ -9,15 +9,13 @@ define([
     var MEMBERSHIP_STRING = 'Membership';
 
     function init() {
-        require('js!omniture').then(onSuccess, function(err) {
-            Raven.captureException(err);
+        require('js!omniture').then(onSuccess, function(e) {
+            Raven.captureException(e, {tags: { level: 'info' }});
         });
     }
 
     function onSuccess() {
-        /*global s_gi: true */
         var s = s_gi('guardiangu-network');
-        var s_code;
         var identityUser = user.getUserFromCookie();
         var identityId = identityUser && identityUser.id;
         var referrerArray = document.referrer.split('/');
@@ -35,17 +33,17 @@ define([
         s.eVar5 = NONE_STRING;
 
         user.getMemberDetail(function (memberDetail) {
+            var tier;
             if (memberDetail) {
-                var tier = memberDetail && (memberDetail.tier && memberDetail.tier.toLowerCase());
+                tier = memberDetail && (memberDetail.tier && memberDetail.tier.toLowerCase());
                 if (tier) {
                     s.eVar5 = tier;
                 }
             }
             s.prop2 = GU_ID_STRING + ':' + (identityId ? identityId : NONE_STRING);
-            s_code = s.t();
+            var s_code = s && s.t();
 
             if (s_code) {
-                /*jslint evil: true */
                 document.write(s_code);
             }
         });

--- a/frontend/assets/javascripts/src/modules/raven.js
+++ b/frontend/assets/javascripts/src/modules/raven.js
@@ -7,11 +7,10 @@ define(['raven'], function () {
          * Set up Raven, which speaks to Sentry to track errors
          */
         Raven.config(dsn, {
-            whitelistUrls: ['membership.theguardian.com/assets/'],
+            whitelistUrls: [ /membership\.theguardian\.com/ ],
             tags: { build_number: guardian.membership.buildNumber },
-            ignoreErrors: [
-                /duplicate define: jquery/
-            ]
+            ignoreErrors: [ /duplicate define: jquery/ ],
+            ignoreUrls: [ /platform\.twitter\.com/ ]
         }).install();
     }
 


### PR DESCRIPTION
We generally get quite a bit of noise in our JS error tracking (e.g., https://app.getsentry.com/the-guardian/membership/group/65170122/) trying to reduce this a bit. Tested with omniture validator tool as it touches that code.

@joelochlann @rtyley 