### PR TITLE
No special treatment for programming partner events in listing

### DIFF
--- a/frontend/app/controllers/WhatsOn.scala
+++ b/frontend/app/controllers/WhatsOn.scala
@@ -41,14 +41,12 @@ trait WhatsOn extends Controller with ActivityTracking {
 
     val locationOpt = request.getQueryString("location").filter(_.trim.nonEmpty)
     val featuredEvents = EventGroup("Featured", guLiveEvents.getFeaturedEvents)
-    val partnerEvents =  EventGroup("Programming partner events", guLiveEvents.getPartnerEvents)
     val events = EventGroup("What's on", chronologicalSort(locationOpt.fold(allEvents)(allEventsByLocation)))
 
     Ok(views.html.event.eventsList(
       pageInfo,
       events,
       featuredEvents,
-      partnerEvents,
       locationFilterItems,
       locationOpt
     ))

--- a/frontend/app/views/event/eventsList.scala.html
+++ b/frontend/app/views/event/eventsList.scala.html
@@ -2,7 +2,6 @@
     pageInfo: model.PageInfo,
     events: model.RichEvent.EventGroup,
     featuredEvents: model.RichEvent.EventGroup,
-    partnerEvents: model.RichEvent.EventGroup,
     locations: Seq[model.RichEvent.FilterItem],
     selectedLocation: Option[String]
 )
@@ -11,12 +10,12 @@
 
 @eventsToShow = @{
     /**
-     * - If no location is set exclude featured and partner events from the main listing.
+     * - If no location is set exclude featured events from the main listing.
      * - If the user has an active filter, display all expected events in the main listing.
-     *   Featured + partner containers are no longer shown.
+     *   Featured container is no longer shown.
      */
     if(selectedLocation.isEmpty) {
-        events.copy(events = events.events.diff(featuredEvents.events ++ partnerEvents.events))
+        events.copy(events = events.events.diff(featuredEvents.events))
     } else events
 }
 
@@ -42,10 +41,6 @@
             }
 
             @fragments.eventListings.listing(eventsToShow, Some("Sorry, no matching events were found."), isLead=true, isFilterable=false)
-
-            @if(selectedLocation.isEmpty) {
-                @fragments.eventListings.listing(partnerEvents, None)
-            }
         </div>
     </main>
 


### PR DESCRIPTION
As discussed in sprint planning, we're moving partner events into the main listing as there's no business need to keep them separate and is a simpler approach.

**Before (separate container)**
![screen shot 2015-10-01 at 11 30 39](https://cloud.githubusercontent.com/assets/123386/10218631/3530dfe0-6830-11e5-906c-37af935d0c0a.png)

**After (programming partner events in main list)**
![screen shot 2015-10-01 at 11 30 30](https://cloud.githubusercontent.com/assets/123386/10218635/447d484e-6830-11e5-9cb7-f79fd556364c.png)

@joelochlann 