### PR TITLE
Correct max field lengths

### DIFF
--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -188,7 +188,7 @@ trait Joiner extends Controller with ActivityTracking with LazyLogging {
           result
         }.recover {
           case error: Stripe.Error => Forbidden(Json.toJson(error))
-	  case error: ResultError => Forbidden
+      	  case error: ResultError => Forbidden
           case error: ScalaforceError => Forbidden
           case error: MemberServiceError => Forbidden
         }

--- a/frontend/app/views/fragments/form/addressDetail.scala.html
+++ b/frontend/app/views/fragments/form/addressDetail.scala.html
@@ -59,6 +59,8 @@
                    name="@(formType).lineOne"
                    value="@address1"
                    id="address-line-one-@(formType)"
+                   @* Salesforce accepts up to 255 chars but this field gets concatenated with address line 2 *@
+                   maxlength="126"
                    class="input-text js-address-line-one"
                    @if(addressRequired == true){required aria-required="true"} />
             @fragments.form.errorMessage(s"Please enter your ${heading.toLowerCase()} first line")
@@ -70,6 +72,8 @@
                    name="@(formType).lineTwo"
                    value="@address2"
                    id="address-line-two-@(formType)"
+                   @* Salesforce accepts up to 255 chars but this field gets concatenated with address line 1 *@
+                   maxlength="126"
                    class="input-text js-address-line-two"/>
         </div>
 
@@ -79,6 +83,7 @@
                    name="@(formType).town"
                    value="@town"
                    id="town-@(formType)"
+                   maxlength="40"
                    class="input-text js-town"
                    @if(addressRequired == true){required aria-required="true"} />
             @fragments.form.errorMessage(s"Please enter your ${heading.toLowerCase()} town")
@@ -94,6 +99,8 @@
                        name="@(formType).countyOrState"
                        value="@county"
                        id="county-or-state-@(formType)"
+                       @* This length is limited by Zuora. Salesforce accepts up to 40 chars *@
+                       maxlength="32"
                        class="input-text js-county-or-state"/>
             </div>
         </div>
@@ -104,7 +111,7 @@
                    name="@(formType).postCode"
                    value="@postcode"
                    id="postCode-@(formType)"
-                   maxlength="20"
+                   maxlength="10"
                    class="input-text js-postcode"
                    required
                    aria-required="true"/>

--- a/frontend/app/views/fragments/form/nameDetail.scala.html
+++ b/frontend/app/views/fragments/form/nameDetail.scala.html
@@ -18,6 +18,7 @@
             <input type="text"
                    name="name.first"
                    id="name-first"
+                   maxlength="40"
                    value="@firstName"
                    class="input-text js-name-first"
                    required
@@ -30,6 +31,7 @@
             <input type="text"
                    name="name.last"
                    id="name-last"
+                   maxlength="80"
                    value="@lastName"
                    class="input-text js-name-last"
                    required

--- a/frontend/app/views/fragments/form/nameDetail.scala.html
+++ b/frontend/app/views/fragments/form/nameDetail.scala.html
@@ -18,7 +18,13 @@
             <input type="text"
                    name="name.first"
                    id="name-first"
-                   maxlength="40"
+                   @*
+                   * Zuora's PaymentMethod request imposes this size limit.
+                   * Although in membership we don't send the name because it's a credit card payment,
+                   * in subscriptions we do because it's a direct debit. So for consistency the
+                   * same size limit is imposed here.
+                   *@
+                   maxlength="30"
                    value="@firstName"
                    class="input-text js-name-first"
                    required
@@ -31,7 +37,7 @@
             <input type="text"
                    name="name.last"
                    id="name-last"
-                   maxlength="80"
+                   maxlength="50"
                    value="@lastName"
                    class="input-text js-name-last"
                    required


### PR DESCRIPTION
This ensures that for all form fields in membership checkout, the lowest field size limit imposed by any of our third-party services (or our own backend) is enforced by the browser. Here's some info on what the limiting factor is in each case:

**First name:** 30 (Zuora, FirstName in the direct debit PaymentMethod request)
**Last name:** 50 (backend validation in subs)
**Address line 1:** 126 (Salesforce MailingStreet has a 255 limit, but we send address line 1 and 2 concatenated with ', ')
**Address line 2:** 126
**Town:** 40 (Salesforce MailingCity)
**County:** 32 (Zuora County field in Contact object in Subscribe request)
**Postcode:** 10 (Acxiom)