### PR TITLE
Try and get grid image for masterclasses event

### DIFF
--- a/frontend/app/model/RichEvent.scala
+++ b/frontend/app/model/RichEvent.scala
@@ -118,12 +118,13 @@ object RichEvent {
 
   case class MasterclassEvent(
     event: EBEvent,
-    data: Option[MasterclassData]
+    data: Option[MasterclassData],
+    image: Option[GridImage]
   ) extends RichEvent {
     val detailsUrl = routes.Event.details(event.slug).url
     val hasLargeImage = false
     val canHavePriorityBooking = false
-    val imgOpt = data.flatMap(_.images)
+    val imgOpt = image.map(ResponsiveImageGroup(_)).orElse(data.flatMap(_.images))
     val socialImgUrl = imgOpt.map(_.defaultImage)
     val schema = EventSchema.from(this)
     val tags = event.description.map(_.html).flatMap(MasterclassEvent.extractTags).getOrElse(Nil)

--- a/frontend/test/model/MasterclassEventTest.scala
+++ b/frontend/test/model/MasterclassEventTest.scala
@@ -37,14 +37,14 @@ class MasterclassEventTest extends Specification {
   "MasterclassEvent" should {
     "extract tags when they are present" in {
       val event = Resource.getJson("model/eventbrite/event-with-tag.json").as[EBEvent]
-      val mcEvent = MasterclassEvent(event, None)
+      val mcEvent = MasterclassEvent(event, None, None)
 
       mcEvent.tags mustEqual Seq("writing", "creative writing", "genre writing")
     }
 
     "return an empty list when tags are not present" in {
       val event = Resource.getJson("model/eventbrite/event-without-tag.json").as[EBEvent]
-      val mcEvent = MasterclassEvent(event, None)
+      val mcEvent = MasterclassEvent(event, None, None)
 
       mcEvent.tags mustEqual Nil
     }

--- a/frontend/test/services/MasterclassEventsProviderTest.scala
+++ b/frontend/test/services/MasterclassEventsProviderTest.scala
@@ -13,7 +13,7 @@ class MasterclassEventsProviderTest extends Specification {
     "only show masterclasses which have discount tickets available for members" in {
       val response = Resource.getJson("model/eventbrite/events-with-member-tickets.json").as[EBResponse[EBEvent]]
 
-      val events = response.data.map { event => MasterclassEvent(event, None) }
+      val events = response.data.map { event => MasterclassEvent(event, None, None) }
 
       val availableEvents = events.filter(MasterclassesWithAvailableMemberDiscounts)
 


### PR DESCRIPTION
Currently some Masterclasses events don't have images, this is because there is one article linking to multiple eventbrite links. We use eventbrite as the source of truth whereas on theguardian.com the article is the source of truth so there's a mismatch of approaches here which causes conflicts.

As the Masterclasses team already use the comment builder for tagging we might as well avoid the need to have eventbrite ids in CAPI (blergh) and just allow them to provide a link to a grid image in the same way we do with live/local.

This PR attempts to use a grid image url or otherwise fallback to the CAPI lookup.

**Current**
![screen shot 2015-10-05 at 17 42 23](https://cloud.githubusercontent.com/assets/123386/10287038/cf26b8a8-6b88-11e5-9386-d8a7ebaa5407.png)

**Dev events using grid image comment**
![screen shot 2015-10-05 at 17 36 25](https://cloud.githubusercontent.com/assets/123386/10287048/df8ec082-6b88-11e5-998d-bdb9a586a05d.png)

**Default masterclasses**
![screen shot 2015-10-05 at 17 45 15](https://cloud.githubusercontent.com/assets/123386/10287055/e6cdecba-6b88-11e5-84d8-56ef9efcd201.png)

@joelochlann @rtyley 