### PR TITLE
Log the user's identity ID to raven / sentry

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,6 +12,7 @@
         "curly": [2, "all"],
         "no-trailing-spaces": 2,
         "quotes": [2, "single"],
-        "wrap-iife": 2
+        "wrap-iife": 2,
+        "no-console": 1
     }
 }

--- a/frontend/assets/javascripts/src/modules/raven.js
+++ b/frontend/assets/javascripts/src/modules/raven.js
@@ -1,14 +1,22 @@
 /* global Raven */
-define(['raven'], function () {
+define(['src/utils/user', 'raven'], function (user) {
     'use strict';
 
     function init(dsn) {
+
+        var tags = { build_number: guardian.membership.buildNumber };
+        var cookieUser = user.getUserFromCookie();
+
+        if (cookieUser) {
+            tags.userIdentityId = cookieUser.id;
+        }
+
         /**
          * Set up Raven, which speaks to Sentry to track errors
          */
         Raven.config(dsn, {
             whitelistUrls: [ /membership\.theguardian\.com/ ],
-            tags: { build_number: guardian.membership.buildNumber },
+            tags: tags,
             ignoreErrors: [ /duplicate define: jquery/ ],
             ignoreUrls: [ /platform\.twitter\.com/ ]
         }).install();


### PR DESCRIPTION
Also update the eslint no-console rule to only emit warnings for local development