### PR TITLE
Check that the members API is consistent with tier info in the app

### DIFF
--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -32,6 +32,8 @@ object Config {
   val membershipUrl = config.getString("membership.url")
   val membershipHost = Uri.parse(Config.membershipUrl).host.get
 
+  val membersDataAPIUrl = config.getString("members-data-api.url")
+
   val membershipFeedback = config.getString("membership.feedback")
 
   val idWebAppUrl = config.getString("identity.webapp.url")

--- a/frontend/app/monitoring/membersDataAPIMetrics.scala
+++ b/frontend/app/monitoring/membersDataAPIMetrics.scala
@@ -1,0 +1,7 @@
+package monitoring
+
+import com.gu.monitoring.StatusMetrics
+
+object MembersDataAPIMetrics extends Metrics with StatusMetrics {
+  override val service: String = "Members Data API"
+}

--- a/frontend/app/services/MembersDataAPI.scala
+++ b/frontend/app/services/MembersDataAPI.scala
@@ -1,0 +1,65 @@
+package services
+
+import com.gu.membership.salesforce.{Member, Tier}
+import com.gu.membership.util.WebServiceHelper
+import com.gu.monitoring.StatusMetrics
+import configuration.Config
+import monitoring.MembersDataAPIMetrics
+import play.api.Logger
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import play.api.libs.functional.syntax._
+import play.api.libs.json.Reads._
+import play.api.libs.json._
+import play.api.libs.ws.WSRequest
+import play.api.mvc.Cookie
+
+import scala.util.{Failure, Success}
+
+object MembersDataAPI {
+  implicit val tierReads = Reads[Tier] {
+    case JsString(s) => Tier.slugMap.get(s.toLowerCase).map(JsSuccess(_)).getOrElse(JsError(s"Unknown tier $s"))
+    case _ => JsError("Expected a string representation of a tier")
+  }
+
+  implicit val attributesReads: Reads[Attributes] = (
+    (JsPath \ "tier").read[Tier] and
+    (JsPath \ "membershipNumber").readNullable[String]
+  )(Attributes.apply _)
+
+  case class Attributes(tier: Tier, membershipNumber: Option[String])
+
+  object Attributes {
+    def fromMember(member: Member) = Attributes(member.tier, member.regNumber)
+  }
+
+  case class ApiError(message: String, details: String) extends RuntimeException(s"$message - $details")
+
+  implicit val errorReads: Reads[ApiError] = (
+    (JsPath \ "message").read[String] and
+    (JsPath \ "details").read[String]
+  )(ApiError)
+
+  case class Helper(cookies: Seq[Cookie]) extends WebServiceHelper[Attributes, ApiError] {
+    override val wsUrl: String = Config.membersDataAPIUrl
+    override def wsPreExecute(req: WSRequest): WSRequest = req.withHeaders(
+      "Cookie" -> cookies.map(c => s"${c.name}=${c.value}").mkString("; ")
+    )
+    override val wsMetrics: StatusMetrics = MembersDataAPIMetrics
+  }
+
+  object Service  {
+    def check(member: Member)(cookies: Seq[Cookie]) = get(cookies).onComplete {
+      case Success(attrs) =>
+        if (attrs != Attributes.fromMember(member)) {
+          Logger.warn(s"Members data API response doesn't match the expected member data. Expected tier: ${member.tier}, number ${member.regNumber}, got tier: ${attrs.tier}, number: ${attrs.membershipNumber}")
+          MembersDataAPIMetrics.put("members-data-api-mismatch", 1)
+        } else {
+          Logger.debug("Members data API response matches the expected member data")
+          MembersDataAPIMetrics.put("members-data-api-match", 1)
+        }
+      case Failure(err) => Logger.error(s"Failed while querying the members-data-api (OK in dev)", err)
+    }
+
+    private def get(cookies: Seq[Cookie]) = Helper(cookies).get[Attributes]("user-attributes/me/membership")(attributesReads, errorReads)
+  }
+}

--- a/frontend/conf/PROD.conf
+++ b/frontend/conf/PROD.conf
@@ -8,3 +8,5 @@ touchpoint.backend.test=UAT
 google.analytics.tracking.id="UA-51507017-1"
 
 stage="PROD"
+
+members-data-api.url="https://members-data-api.theguardian.com"

--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -13,6 +13,8 @@ guardian.host="www.theguardian.com"
 membership.url="https://membership.theguardian.com"
 membership.feedback="membershipfeedback@theguardian.com"
 
+members-data-api.url=""
+
 event.discountMultiplier=0.8
 
 content.api.key=""

--- a/frontend/conf/dev.conf
+++ b/frontend/conf/dev.conf
@@ -46,3 +46,5 @@ zuora.free-event-tickets-allowance = 6
 
 activity.tracking.bcrypt.salt="$2a$10$oL3umggRoHlQuvgoYpWDx."
 activity.tracking.bcrypt.pepper="dummy-pepper"
+
+members-data-api.url="http://members-data-api.thegulocal.com"

--- a/frontend/test/services/MembersDataAPITest.scala
+++ b/frontend/test/services/MembersDataAPITest.scala
@@ -1,0 +1,44 @@
+package services
+
+import com.gu.membership.salesforce.Tier
+import com.gu.membership.salesforce.Tier.Patron
+import org.scalatest.FreeSpec
+import play.api.libs.json._
+import services.MembersDataAPI.Attributes
+
+class MembersDataAPITest extends FreeSpec {
+  "A tier can be deserialized" in {
+    assertResult(JsSuccess(Patron))(
+      Json.parse("\"patron\"").validate[Tier](MembersDataAPI.tierReads)
+    )
+  }
+
+  "Attributes can be deserialized" in {
+    assertResult(
+      JsSuccess(Attributes(Patron, Some("1234567abcdef")))
+    )(
+      Json.parse(
+        """
+          |{
+          |  "membershipNumber": "1234567abcdef",
+          |  "tier": "Patron"
+          |}
+        """.stripMargin).validate[Attributes](MembersDataAPI.attributesReads)
+    )
+  }
+
+  "Errprs can be serialized" in {
+    assertResult(
+      JsSuccess(MembersDataAPI.ApiError("Bad Request", "Detailed error message"))
+    )(
+      Json.parse(
+        """
+          |{
+          |  "message": "Bad Request",
+          |  "details": "Detailed error message"
+          |}
+        """.stripMargin
+      ).validate[MembersDataAPI.ApiError](MembersDataAPI.errorReads)
+    )
+  }
+}


### PR DESCRIPTION
Increment a Cloudwatch metric every time `/user/me` is accessed in order to monitor the API consistency with the data already accessible from membership frontend.

In case of failure, it won't produce an error, but will log the mismatch, and also increment the appropriate Cloudwatch counter.

@rtyley @chrisjowen @afiore 