### PR TITLE
Fix bug getting the latest invoice items

### DIFF
--- a/frontend/app/services/SubscriptionService.scala
+++ b/frontend/app/services/SubscriptionService.scala
@@ -53,16 +53,15 @@ object SubscriptionService {
   }
 
   /**
-   * Given an array of subscription invoice items
-   * return only items corresponding to the last invoice
-   * @param items The incoming list of items with many invoices
+   * Given an array of subscription invoice items, return only items corresponding to the last invoice
+   * @param items The incoming list of items with many invoices, potentially associated to multiple subscription versions
    */
   def latestInvoiceItems(items: Seq[InvoiceItem]): Seq[InvoiceItem] = {
     if(items.isEmpty)
       items
     else {
-      val temp = items.sortBy(_.serviceStartDate)
-      temp.filter(_.id == temp.last.id)
+      val sortedItems = items.sortBy(_.serviceStartDate)
+      sortedItems.filter(_.subscriptionId == sortedItems.last.subscriptionId)
     }
   }
 

--- a/frontend/app/services/SubscriptionService.scala
+++ b/frontend/app/services/SubscriptionService.scala
@@ -53,6 +53,20 @@ object SubscriptionService {
   }
 
   /**
+   * Given an array of subscription invoice items
+   * return only items corresponding to the last invoice
+   * @param items The incoming list of items with many invoices
+   */
+  def latestInvoiceItems(items: Seq[InvoiceItem]): Seq[InvoiceItem] = {
+    if(items.isEmpty)
+      items
+    else {
+      val temp = items.sortBy(_.serviceStartDate)
+      temp.filter(_.id == temp.last.id)
+    }
+  }
+
+  /**
    * @param subscriptions
    * @param amendments which are returned by the Zurora API in an unpredictable order
    * @return amendments which are sorted by the subscription version number they point to (the sub they amended)
@@ -230,8 +244,9 @@ class SubscriptionService(val zuoraSoapClient: soap.ClientWithFeatureSupplier,
   def getPaymentSummary(memberId: MemberId): Future[PaymentSummary] = {
     for {
       subscription <- getSubscriptionStatus(memberId)
-      invoiceItems <- zuoraSoapClient.query[InvoiceItem](SimpleFilter("SubscriptionId", subscription.currentVersionId))
-    } yield PaymentSummary(invoiceItems)
+      invoiceItems <- zuoraSoapClient.query[InvoiceItem](SimpleFilter("SubscriptionNumber", subscription.currentVersion.name))
+      filteredInvoices = latestInvoiceItems(invoiceItems)
+    } yield PaymentSummary(filteredInvoices)
   }
 
   def getMembershipSubscriptionSummary(memberId: MemberId): Future[MembershipSummary] = {

--- a/frontend/test/resources/model/zuora/invoice-result.xml
+++ b/frontend/test/resources/model/zuora/invoice-result.xml
@@ -14,6 +14,7 @@
                     <ns2:ServiceStartDate>2015-02-02T00:00:00.000-08:00</ns2:ServiceStartDate>
                     <ns2:TaxAmount>90</ns2:TaxAmount>
                     <ns2:ProductName>Patron</ns2:ProductName>
+                    <ns2:SubscriptionId>subscription-id-1</ns2:SubscriptionId>
                 </ns1:records>
                 <ns1:records xmlns:ns2="http://object.api.zuora.com/"
                              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ns2:InvoiceItem">
@@ -24,6 +25,7 @@
                     <ns2:ServiceStartDate>2015-02-02T00:00:00.000-08:00</ns2:ServiceStartDate>
                     <ns2:TaxAmount>-22.5</ns2:TaxAmount>
                     <ns2:ProductName>Partner</ns2:ProductName>
+                    <ns2:SubscriptionId>subscription-id-2</ns2:SubscriptionId>
                 </ns1:records>
                 <ns1:size>2</ns1:size>
             </ns1:result>

--- a/frontend/test/services/SubscriptionServiceTest.scala
+++ b/frontend/test/services/SubscriptionServiceTest.scala
@@ -6,8 +6,9 @@ import com.gu.membership.salesforce.Tier.{Supporter, Partner, Patron}
 import com.gu.membership.zuora.soap.models.Queries._
 import com.gu.membership.zuora.soap.models._
 import model.{FreeEventTickets, Books}
+import org.joda.time.format.DateTimeFormatter
 import org.specs2.mutable.Specification
-import org.joda.time.DateTime
+import org.joda.time.{DurationFieldType, ReadableDuration, DateTime}
 import com.github.nscala_time.time.Imports._
 
 class SubscriptionServiceTest extends Specification {
@@ -96,6 +97,39 @@ class SubscriptionServiceTest extends Specification {
         Seq(version(1), version(2)),
         Seq(amend(1, now + 1.month))
       ).currentVersion mustEqual version(1)
+    }
+  }
+
+
+  "filterOutItemsFromPreviousSubscriptionVersions" should {
+
+    import SubscriptionService.latestInvoiceItems
+    val formatter: DateTimeFormatter = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss")
+    val april = formatter.parseDateTime("2015-04-01 09:00:00")
+    val may = formatter.parseDateTime("2015-05-01 09:00:00")
+
+    def invoiceItem(id: String, start: DateTime) = InvoiceItem(id, 1.2f, start, start.withFieldAdded(DurationFieldType.months(), 1), "1", "item")
+
+    "return an empty list when given an empty list" in {
+      latestInvoiceItems(Seq()) mustEqual Seq()
+    }
+
+    "return all those items when given many items with the same id" in {
+      val items = Seq(invoiceItem("a", april), invoiceItem("a", april), invoiceItem("a", april))
+      latestInvoiceItems(items) mustEqual items
+    }
+
+    "return things with the same id as the newest item given items with differing ids" in {
+
+      "items in date order" in {
+        val items = Seq(invoiceItem("a", april), invoiceItem("b", may))
+        latestInvoiceItems(items) mustEqual Seq(invoiceItem("b", may))
+      }
+
+      "items out of order" in {
+        val items = Seq(invoiceItem("b", april), invoiceItem("a", may), invoiceItem("a", april), invoiceItem("c", april))
+        latestInvoiceItems(items) mustEqual Seq(invoiceItem("a", april), invoiceItem("a", may))
+      }
     }
   }
 }

--- a/frontend/test/services/SubscriptionServiceTest.scala
+++ b/frontend/test/services/SubscriptionServiceTest.scala
@@ -101,26 +101,28 @@ class SubscriptionServiceTest extends Specification {
   }
 
 
-  "filterOutItemsFromPreviousSubscriptionVersions" should {
+  "latestInvoiceItems" should {
 
     import SubscriptionService.latestInvoiceItems
     val formatter: DateTimeFormatter = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss")
     val april = formatter.parseDateTime("2015-04-01 09:00:00")
     val may = formatter.parseDateTime("2015-05-01 09:00:00")
 
-    def invoiceItem(id: String, start: DateTime) = InvoiceItem(id, 1.2f, start, start.withFieldAdded(DurationFieldType.months(), 1), "1", "item")
+    def invoiceItem(subscriptionId: String, start: DateTime) =
+      InvoiceItem("item-id", 1.2f, start,
+                  start.withFieldAdded(DurationFieldType.months(), 1),
+                  "1", "item", subscriptionId)
 
     "return an empty list when given an empty list" in {
       latestInvoiceItems(Seq()) mustEqual Seq()
     }
 
-    "return all those items when given many items with the same id" in {
+    "return all those items when given many items with the same subscriptionId" in {
       val items = Seq(invoiceItem("a", april), invoiceItem("a", april), invoiceItem("a", april))
       latestInvoiceItems(items) mustEqual items
     }
 
-    "return things with the same id as the newest item given items with differing ids" in {
-
+    "return items with the same subscriptionId as the newest item when given items with differing subscription ids" in {
       "items in date order" in {
         val items = Seq(invoiceItem("a", april), invoiceItem("b", may))
         latestInvoiceItems(items) mustEqual Seq(invoiceItem("b", may))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "0.4"
   val identityTestUsers = "com.gu" %% "identity-test-users" % "0.5"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.90"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.91"
   val playGoogleAuth = "com.gu" %% "play-googleauth" % "0.3.0"
   val contentAPI = "com.gu" %% "content-api-client" % "6.4"
   val playWS = PlayImport.ws

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
   val snowPlow = "com.snowplowanalytics" % "snowplow-java-tracker" % "0.5.2-SNAPSHOT"
   val bCrypt = "com.github.t3hnar" %% "scala-bcrypt" % "2.4"
   val s3 =  "com.amazonaws" % "aws-java-sdk-s3" % awsClientVersion
-  val scalaTest =  "org.scalatestplus" %% "play" % "1.4.0-M3" % "test"
+  val scalaTest =  "org.scalatestplus" %% "play" % "1.4.0-M4" % "test"
 
   //projects
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "0.4"
   val identityTestUsers = "com.gu" %% "identity-test-users" % "0.5"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.88"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.90"
   val playGoogleAuth = "com.gu" %% "play-googleauth" % "0.3.0"
   val contentAPI = "com.gu" %% "content-api-client" % "6.4"
   val playWS = PlayImport.ws


### PR DESCRIPTION
It is possible to make amendments through the Zuora web UI which change the ID of the subscription, resulting in a subscription ID with no associated invoices.

As such this code alters the query to fetch the payment summary for a given member to instead query on subscription name (number) and then filters the items to return only those associated with the most recent invoice.