### PR TITLE
Don't send members who have entered the 'join' flow to downgrade!

### DIFF
--- a/frontend/app/actions/CommonActions.scala
+++ b/frontend/app/actions/CommonActions.scala
@@ -58,8 +58,6 @@ trait CommonActions {
 
   val AuthenticatedNonMemberAction = AuthenticatedAction andThen onlyNonMemberFilter()
 
-  def AuthenticatedNonMemberWithKnownTierChangeAction(tier: Tier) = AuthenticatedAction andThen onlyNonMemberFilter(onPaidMember = result => tierChangeEnterDetails(tier)(result))
-
   val GoogleAuthAction: ActionBuilder[GoogleAuthRequest] = OAuthActions.AuthAction
 
   val GoogleAuthenticatedStaffAction = NoCacheAction andThen GoogleAuthAction

--- a/frontend/app/actions/Fallbacks.scala
+++ b/frontend/app/actions/Fallbacks.scala
@@ -10,6 +10,9 @@ object Fallbacks {
 
   def changeTier(implicit req: RequestHeader) = redirectTo(controllers.routes.TierController.change())
 
+  def memberHome(implicit request: RequestHeader) =
+    redirectTo(controllers.routes.FrontPage.welcome)
+
   def tierChangeEnterDetails(tier: Tier)(implicit req: RequestHeader) =
     redirectTo(controllers.routes.TierController.upgrade(tier))
 

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -77,7 +77,7 @@ trait Joiner extends Controller with ActivityTracking with LazyLogging {
     }
   }
 
-  def enterDetails(tier: Tier) = AuthenticatedNonMemberWithKnownTierChangeAction(tier).async { implicit request =>
+  def enterDetails(tier: Tier) = (AuthenticatedAction andThen onlyNonMemberFilter(onMember = redirectMemberAttemptingToSignUp(tier))).async { implicit request =>
     for {
       (privateFields, marketingChoices, passwordExists) <- identityDetails(request.user, request)
     } yield {


### PR DESCRIPTION
If a user is already a member (eg Partner), and they click on a link like this:

https://membership.theguardian.com/join/supporter/enter-details

_(which www.theguardian.com might send them to, not knowing the status of the member)_

...then we *don't* want them to be directed to here:

https://membership.theguardian.com/tier/change/supporter

...because that's a downgrade, that they weren't explicitly expressing interest in. We should send them to the members home page, currently:

https://membership.theguardian.com/welcome

If they are hitting 'join' for an _upgrade_ tier (like patron), I think we're ok to redirect them to:

https://membership.theguardian.com/tier/change/patron

If a user _does_ want to downgrade, they can go directly to

https://membership.theguardian.com/tier/change/friend

...and we don't redirect, but allow the user to proceed as we obviously should, because they've expressed an explicit interest in downgrading.

https://trello.com/c/yRJfoWrR/198-don-t-take-existing-members-to-tier-downgrade-if-they-clicked-on-a-join-xxxx-enter-details-link

cc @tomverran @JuliaBellis 