### PR TITLE
Added upgrade message to missing /tier/change page 

### DIFF
--- a/frontend/app/views/joiner/form/payment.scala.html
+++ b/frontend/app/views/joiner/form/payment.scala.html
@@ -18,7 +18,7 @@
 
             <section class="form-header">
                 <h1 class="form-headline">Become a @tier.name.capitalize</h1>
-                <h2> Join as an annual Partner or Patron Member by 31 October and get 3 months free</h2>
+                <p class="page-intro"> Join as an annual Partner or Patron Member by 31 October and get 3 months free</p>
             </section>
 
             <section class="form-section form-section--no-padding">

--- a/frontend/app/views/joiner/tierChooser.scala.html
+++ b/frontend/app/views/joiner/tierChooser.scala.html
@@ -27,7 +27,7 @@
 
     <main role="main" class="page-content l-constrained">
 
-        @fragments.page.pageHeader(pageHeaderTitle, None)
+        @fragments.page.pageHeader(pageHeaderTitle, Some("Join as an annual Partner or Patron Member by 31 October and get 3 months free"), Seq.empty)
 
         <section class="page-section page-section--no-padding">
             <div class="page-section__lead-in">

--- a/frontend/app/views/tier/upgrade/freeToPaid.scala.html
+++ b/frontend/app/views/tier/upgrade/freeToPaid.scala.html
@@ -16,7 +16,7 @@
 
             <section class="page-header">
                 <h1 class="page-headline">Become a @targetTier.name.capitalize</h1>
-                <h2 >Join as an annual Partner or Patron Member by 31 October and get 3 months free</h2>
+                <p class="page-intro"> Join as an annual Partner or Patron Member by 31 October and get 3 months free</p>
             </section>
 
             <section class="form-section form-section--no-padding">


### PR DESCRIPTION
Missing upgreade mesage on the /tier/change page as per https://trello.com/c/vmaUsXmn/186-price-rise-messaging-ahead-of-the-actual-price-rise-on-monday-2nd-november. Additionally changed all pages with the sub menu message to be consistently styled. 