### PR TITLE
Price change message mising for paid-to-paid members

### DIFF
--- a/frontend/app/views/tier/upgrade/paidToPaid.scala.html
+++ b/frontend/app/views/tier/upgrade/paidToPaid.scala.html
@@ -20,7 +20,7 @@
         <form action="@routes.TierController.upgrade(targetTier)" method="POST" class="js-form" id="payment-form">
             @CSRF.formField
 
-            @fragments.page.pageHeader("Great, glad to see you've decided to become a " + targetTier)
+            @fragments.page.pageHeader("Great, glad to see you've decided to become a " + targetTier, Some("Join as an annual Partner or Patron Member by 31 October and get 3 months free"))
 
             @for(flashMsg <- flashMessage) {
                 <section class="page-section page-section--no-padding">


### PR DESCRIPTION
Members upgrading from a paid tier to another paid tier should see the price change message: "Join as an annual Partner or Patron Member by 31 October and get 3 months free" which previously was only visible for the free-to-paid crew. 