### PR TITLE
Improve cta visibility on comparison table

### DIFF
--- a/frontend/assets/stylesheets/components/_comparison-table.scss
+++ b/frontend/assets/stylesheets/components/_comparison-table.scss
@@ -43,7 +43,8 @@ $_background-color: $c-neutral7;
     }
 }
 .comparison-table__trail__action {
-    .is-active & {
+    .is-active &,
+    .is-hover & {
         visibility: visible;
     }
 }

--- a/frontend/assets/stylesheets/components/_comparison-table.scss
+++ b/frontend/assets/stylesheets/components/_comparison-table.scss
@@ -28,18 +28,20 @@ $_background-color: $c-neutral7;
 .comparison-table__tier__name,
 .comparison-table__tier__pricing,
 .comparison-table__trail__inner {
-    transition: background-color 0.3s ease;
-    cursor: pointer;
-    opacity: 0.9;
+    @include mq(desktop) {
+        transition: background-color 0.3s ease;
+        cursor: pointer;
+        opacity: 0.9;
 
-    .is-active & {
-        background-color: $c-neutral5;
-        opacity: 1;
-    }
+        .is-active & {
+            background-color: $c-neutral5;
+            opacity: 1;
+        }
 
-    .is-hover & {
-        background-color: $c-neutral5;
-        opacity: 1;
+        .is-hover & {
+            background-color: $c-neutral5;
+            opacity: 1;
+        }
     }
 }
 .comparison-table__trail__action {
@@ -187,7 +189,9 @@ $_background-color: $c-neutral7;
     border-left: $_table-gutter solid $white;
 }
 .comparison-table__trail__action {
-    visibility: hidden;
+    @include mq(desktop) {
+        visibility: hidden;
+    }
     text-align: center;
     margin: $gs-baseline 0;
 

--- a/frontend/assets/stylesheets/components/_comparison-table.scss
+++ b/frontend/assets/stylesheets/components/_comparison-table.scss
@@ -45,8 +45,7 @@ $_background-color: $c-neutral7;
     }
 }
 .comparison-table__trail__action {
-    .is-active &,
-    .is-hover & {
+    .is-active & {
         visibility: visible;
     }
 }


### PR DESCRIPTION
- On desktop, the 'Join Now' button appears on hover
- On mobile & table the arrow button always appears

**Old mobile:**
![picture 24](https://cloud.githubusercontent.com/assets/5122968/10583969/b9a49d7e-7687-11e5-9e83-cf6716632bca.png)

**New mobile:**
![picture 23](https://cloud.githubusercontent.com/assets/5122968/10583945/8ac18148-7687-11e5-93d8-1eab7b816d6a.png)
