### PR TITLE
Redirect to the identity registration with campaign code

### DIFF
--- a/frontend/app/actions/Fallbacks.scala
+++ b/frontend/app/actions/Fallbacks.scala
@@ -29,7 +29,7 @@ object Fallbacks {
       "errorTemplate" -> errorTemplate.toString
     )
 
-  def redirectTo(call: Call)(implicit req: RequestHeader) = SeeOther(call.absoluteURL)
+  def redirectTo(call: Call)(implicit req: RequestHeader) = SeeOther(call.absoluteURL(secure = true))
 }
 
 

--- a/frontend/app/actions/Fallbacks.scala
+++ b/frontend/app/actions/Fallbacks.scala
@@ -19,8 +19,7 @@ object Fallbacks {
   def notYetAMemberOn(implicit request: RequestHeader) =
     redirectTo(controllers.routes.Joiner.tierChooser()).addingToSession("preJoinReturnUrl" -> request.uri)
 
-  def chooseSigninOrRegister(implicit request: RequestHeader) =
-    redirectTo(controllers.routes.Login.chooseSigninOrRegister(request.uri))
+  def chooseRegister(implicit request: RequestHeader) = SeeOther(RegistrationUri.parse(request))
 
   def joinStaffMembership(implicit request: RequestHeader) =
     redirectTo(controllers.routes.Joiner.staff())
@@ -30,5 +29,7 @@ object Fallbacks {
       "errorTemplate" -> errorTemplate.toString
     )
 
-  def redirectTo(call: Call)(implicit req: RequestHeader) = SeeOther(call.absoluteURL(secure = true))
+  def redirectTo(call: Call)(implicit req: RequestHeader) = SeeOther(call.absoluteURL)
 }
+
+

--- a/frontend/app/actions/Functions.scala
+++ b/frontend/app/actions/Functions.scala
@@ -28,7 +28,7 @@ object Functions extends LazyLogging {
     def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]) = block(request).map(f)
   }
 
-  def authenticated(onUnauthenticated: RequestHeader => Result = chooseSigninOrRegister(_)): ActionBuilder[AuthRequest] =
+  def authenticated(onUnauthenticated: RequestHeader => Result = chooseRegister(_)): ActionBuilder[AuthRequest] =
     new AuthenticatedBuilder(AuthenticationService.authenticatedUserFor(_), onUnauthenticated)
 
   def memberRefiner(onNonMember: RequestHeader => Result = notYetAMemberOn(_)) =

--- a/frontend/app/actions/RegistrationUri.scala
+++ b/frontend/app/actions/RegistrationUri.scala
@@ -1,0 +1,40 @@
+package actions
+
+import com.netaporter.uri.Uri
+import configuration.Config
+import play.api.mvc.RequestHeader
+
+object RegistrationUri {
+  val REFERRER_HEADER: String = "referer"
+  val CAMPAIGN_SOURCE: String = "MEM"
+
+  def parse(request: RequestHeader) = {
+    val redirectUrl: String = Config.idWebAppRegisterUrl(request.uri)
+    extractCampaignCode(request.headers(REFERRER_HEADER), request.path) match {
+      case Some(campaignCode) => redirectUrl.concat(s"&INTCMP=${campaignCode.get}")
+      case _ => redirectUrl
+    }
+  }
+
+  private def extractCampaignCode(referer: String, path: String) = {
+    val refererUrl = Uri.parse(referer)
+
+    val campaignReferer = refererUrl.path match {
+      case "/supporter" => "SUPUK"
+      case "/us/supporter" => "SUPUS"
+      case "/offers-competitions" => "COMP"
+      case "/events" => "EVT"
+      case _ => "HOME"
+    }
+    val campaignTier = path match {
+      case "/join/supporter/enter-details" => Some("SUP")
+      case "/join/partner/enter-details" => Some("PAR")
+      case "/join/patron/enter-details" => Some("PAT")
+      case "/join/friend/enter-details" => Some("FRI")
+      case _ => None
+    }
+    campaignTier.map {
+      tier => Some(Seq(CAMPAIGN_SOURCE, campaignReferer, tier).mkString("_"))
+    }
+  }
+}

--- a/frontend/app/actions/RegistrationUri.scala
+++ b/frontend/app/actions/RegistrationUri.scala
@@ -19,6 +19,9 @@ object RegistrationUri {
   private def extractCampaignCode(referer: String, path: String) = {
     val refererUrl = Uri.parse(referer)
 
+
+//    println(controllers.routes.Joiner.tierChooser())
+
     val campaignReferer = refererUrl.path match {
       case "/supporter" => "SUPUK"
       case "/us/supporter" => "SUPUS"

--- a/frontend/app/actions/RegistrationUri.scala
+++ b/frontend/app/actions/RegistrationUri.scala
@@ -19,14 +19,16 @@ object RegistrationUri {
   private def extractCampaignCode(referer: String, path: String) = {
     val refererUrl = Uri.parse(referer)
 
-
-//    println(controllers.routes.Joiner.tierChooser())
+    val supporter =  controllers.routes.Info.supporter().toString()
+    val supporterUS =  controllers.routes.Info.supporterUSA().toString()
+    val competitions =   controllers.routes.Info.offersAndCompetitions().toString()
+    val events =   controllers.routes.WhatsOn.list().toString()
 
     val campaignReferer = refererUrl.path match {
-      case "/supporter" => "SUPUK"
-      case "/us/supporter" => "SUPUS"
-      case "/offers-competitions" => "COMP"
-      case "/events" => "EVT"
+      case `supporter` => "SUPUK"
+      case `supporterUS` => "SUPUS"
+      case `competitions` => "COMP"
+      case `events` => "EVT"
       case _ => "HOME"
     }
     val campaignTier = path match {

--- a/frontend/app/actions/RegistrationUri.scala
+++ b/frontend/app/actions/RegistrationUri.scala
@@ -1,5 +1,6 @@
 package actions
 
+import com.gu.membership.salesforce.Tier
 import com.netaporter.uri.Uri
 import configuration.Config
 import play.api.mvc.RequestHeader
@@ -18,11 +19,10 @@ object RegistrationUri {
 
   private def extractCampaignCode(referer: String, path: String) = {
     val refererUrl = Uri.parse(referer)
-
-    val supporter =  controllers.routes.Info.supporter().toString()
-    val supporterUS =  controllers.routes.Info.supporterUSA().toString()
-    val competitions =   controllers.routes.Info.offersAndCompetitions().toString()
-    val events =   controllers.routes.WhatsOn.list().toString()
+    val supporter = controllers.routes.Info.supporter().toString()
+    val supporterUS = controllers.routes.Info.supporterUSA().toString()
+    val competitions = controllers.routes.Info.offersAndCompetitions().toString()
+    val events = controllers.routes.WhatsOn.list().toString()
 
     val campaignReferer = refererUrl.path match {
       case `supporter` => "SUPUK"
@@ -31,11 +31,17 @@ object RegistrationUri {
       case `events` => "EVT"
       case _ => "HOME"
     }
+
+    val supporterTier = controllers.routes.Joiner.joinPaid(Tier.Supporter).toString()
+    val partnerTier = controllers.routes.Joiner.joinPaid(Tier.Partner).toString()
+    val patronTier = controllers.routes.Joiner.joinPaid(Tier.Patron).toString()
+    val friendTier = controllers.routes.Joiner.joinPaid(Tier.Friend).toString()
+
     val campaignTier = path match {
-      case "/join/supporter/enter-details" => Some("SUP")
-      case "/join/partner/enter-details" => Some("PAR")
-      case "/join/patron/enter-details" => Some("PAT")
-      case "/join/friend/enter-details" => Some("FRI")
+      case `supporterTier` => Some("SUP")
+      case `partnerTier` => Some("PAR")
+      case `patronTier` => Some("PAT")
+      case `friendTier` => Some("FRI")
       case _ => None
     }
     campaignTier.map {

--- a/frontend/test/actions/RegistrationUriTest.scala
+++ b/frontend/test/actions/RegistrationUriTest.scala
@@ -1,0 +1,55 @@
+package actions
+
+import org.specs2.mutable.Specification
+import play.mvc.Http.RequestBuilder
+
+class RegistrationUriTest extends Specification {
+
+  "from request" should {
+    "contain correct identity tracking code for home page" in {
+      assertCodeFor("MEM_HOME_SUP", "/join/supporter/enter-details", "http://mem.thegulocal.com/")
+      assertCodeFor("MEM_HOME_PAR", "/join/partner/enter-details", "http://mem.thegulocal.com/")
+      assertCodeFor("MEM_HOME_PAT", "/join/patron/enter-details", "http://mem.thegulocal.com/")
+      assertCodeFor("MEM_HOME_FRI", "/join/friend/enter-details", "http://mem.thegulocal.com/")
+    }
+
+    "contain correct identity tracking code for events page" in {
+      assertCodeFor("MEM_EVT_SUP", "/join/supporter/enter-details", "https://membership.theguardian.com/events")
+      assertCodeFor("MEM_EVT_PAR", "/join/partner/enter-details", "https://membership.theguardian.com/events")
+      assertCodeFor("MEM_EVT_PAT", "/join/patron/enter-details", "https://membership.theguardian.com/events")
+      assertCodeFor("MEM_EVT_FRI", "/join/friend/enter-details", "https://membership.theguardian.com/events")
+    }
+
+    "contain correct identity tracking code for event details page" in {
+      assertCodeFor("MEM_COMP_SUP", "/join/supporter/enter-details", "https://membership.theguardian.com/offers-competitions")
+      assertCodeFor("MEM_COMP_PAR", "/join/partner/enter-details", "https://membership.theguardian.com/offers-competitions")
+      assertCodeFor("MEM_COMP_PAT", "/join/patron/enter-details", "https://membership.theguardian.com/offers-competitions")
+      assertCodeFor("MEM_COMP_FRI", "/join/friend/enter-details", "https://membership.theguardian.com/offers-competitions")
+    }
+
+    "contain correct identity tracking code for US supporters" in {
+      assertCodeFor("MEM_SUPUS_SUP", "/join/supporter/enter-details", "https://membership.theguardian.com/us/supporter")
+      assertCodeFor("MEM_SUPUS_PAR", "/join/partner/enter-details", "https://membership.theguardian.com/us/supporter")
+      assertCodeFor("MEM_SUPUS_PAT", "/join/patron/enter-details", "https://membership.theguardian.com/us/supporter")
+      assertCodeFor("MEM_SUPUS_FRI", "/join/friend/enter-details", "https://membership.theguardian.com/us/supporter")
+    }
+
+
+    "contain correct identity tracking code for US supporters" in {
+      assertCodeFor("MEM_SUPUK_SUP", "/join/supporter/enter-details", "https://membership.theguardian.com/supporter")
+      assertCodeFor("MEM_SUPUK_PAR", "/join/partner/enter-details", "https://membership.theguardian.com/supporter")
+      assertCodeFor("MEM_SUPUK_PAT", "/join/patron/enter-details", "https://membership.theguardian.com/supporter")
+      assertCodeFor("MEM_SUPUK_FRI", "/join/friend/enter-details", "https://membership.theguardian.com/supporter")
+    }
+
+  }
+
+
+  private def assertCodeFor(code: String, path: String, referrer: String) =  {
+    val request = new RequestBuilder().path(path).header("referer", referrer).build()._underlyingHeader()
+    val regUri: String = RegistrationUri.parse(request)
+    println(regUri)
+    regUri.contains(code) mustEqual(true)
+  }
+
+}

--- a/frontend/test/actions/RegistrationUriTest.scala
+++ b/frontend/test/actions/RegistrationUriTest.scala
@@ -48,7 +48,6 @@ class RegistrationUriTest extends Specification {
   private def assertCodeFor(code: String, path: String, referrer: String) =  {
     val request = new RequestBuilder().path(path).header("referer", referrer).build()._underlyingHeader()
     val regUri: String = RegistrationUri.parse(request)
-    println(regUri)
     regUri.contains(code) mustEqual(true)
   }
 


### PR DESCRIPTION
Identity need to track better there referers so we now need to pass through a INTCMP query string parameter that will show where they came from and which tier they chose i.e. MEM_{PAGE}_{TIER}. 

See this card for all the permutations:
- https://trello.com/c/ZUTlcWIT/174-enable-identity-to-track-referrals-from-membership