### PR TITLE
Re-instate .aws/config setting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,13 @@ In `~/.aws/credentials` add the following:
 [membership]
 aws_access_key_id = [YOUR_AWS_ACCESS_KEY]
 aws_secret_access_key = [YOUR_AWS_SECRET_ACCESS_KEY]
-region = eu-west-1
+```
 
+Ensure you have the following in `~/.aws/config` (you may already have this from setting up another AWS application):
+
+```
+[default]
+region = eu-west-1
 ```
 
 ### Download private keys


### PR DESCRIPTION
Removed in PR https://github.com/guardian/membership-frontend/pull/678 but it appears it is used by `awscli`. And sometimes `awscli` complains about the `region` setting being inside `credentials` so we shouldn't be putting it in there.

@rtyley 