### PR TITLE
Fix regression in Staff discounted tickets

### DIFF
--- a/frontend/app/controllers/TierController.scala
+++ b/frontend/app/controllers/TierController.scala
@@ -180,7 +180,7 @@ trait CancelTier {
 trait TierController extends Controller with UpgradeTier with DowngradeTier with CancelTier {
   def change() = MemberAction { implicit request =>
     val currentTier = request.member.tier
-    val availableTiers = Tier.all.filter(_ != currentTier)
+    val availableTiers = Tier.allPublic.filter(_ != currentTier)
     Ok(views.html.tier.change(currentTier, availableTiers))
   }
 }

--- a/frontend/app/model/Benefits.scala
+++ b/frontend/app/model/Benefits.scala
@@ -1,12 +1,12 @@
 package model
 
 import com.gu.membership.salesforce.Tier
-import com.gu.membership.salesforce.Tier.{Partner, Patron}
+import com.gu.membership.salesforce.Tier.{Partner, Patron, Staff}
 import configuration.Config.zuoraFreeEventTicketsAllowance
 
 object Benefits {
 
-  val DiscountTicketTiers = Set[Tier](Partner, Patron)
+  val DiscountTicketTiers = Set[Tier](Staff, Partner, Patron)
 
   case class Pricing(
     yearly: Int,

--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -74,7 +74,7 @@ google.directory {
   service_account.cert=""
 }
 
-staff.authorised.emails.groups = "permanent.ftc.staff,all.staff.usa,all.staff.australia,freestaff.membership"
+staff.authorised.emails.groups = "permanent.ftc.staff,all.staff.usa,all.staff.australia,freestaff.membership,membership.dev"
 
 grid.images {
   media.url=""


### PR DESCRIPTION
Since the recent update to membership-commons `0.92`, Staff members are not anymore assigned the `Partner` tier, but a more specific `Staff` tier. This change fixes two recent regression which 1) prevent staff members from accessing events discounts, 2) accidentally include a staff tier in the comparison table. 