### PR TITLE
Avoid hardcoding tier whitelist

### DIFF
--- a/frontend/app/controllers/User.scala
+++ b/frontend/app/controllers/User.scala
@@ -80,9 +80,10 @@ trait User extends Controller {
     "tier" -> member.tier.name,
     "isPaidTier" -> member.tier.isPaid,
     "joinDate" -> member.joinDate,
-    "benefits" -> Json.obj {
-      "discountedEventTickets" -> Benefits.DiscountTicketTiers.contains(member.tier)
-    }
+    "benefits" -> Json.obj(
+      "discountedEventTickets" -> Benefits.DiscountTicketTiers.contains(member.tier),
+      "complimentaryEventTickets" -> Benefits.ComplimenataryTicketTiers.contains(member.tier)
+    )
   )
 
   case class SubCheck(valid: Boolean, msg: Option[String] = None)

--- a/frontend/app/controllers/User.scala
+++ b/frontend/app/controllers/User.scala
@@ -80,7 +80,9 @@ trait User extends Controller {
     "tier" -> member.tier.name,
     "isPaidTier" -> member.tier.isPaid,
     "joinDate" -> member.joinDate,
-    "discountTicketTiers" -> Benefits.DiscountTicketTiers.map(_.name)
+    "benefits" -> Json.obj {
+      "discountedEventTickets" -> Benefits.DiscountTicketTiers.contains(member.tier)
+    }
   )
 
   case class SubCheck(valid: Boolean, msg: Option[String] = None)

--- a/frontend/app/model/Benefits.scala
+++ b/frontend/app/model/Benefits.scala
@@ -7,6 +7,7 @@ import configuration.Config.zuoraFreeEventTicketsAllowance
 object Benefits {
 
   val DiscountTicketTiers = Set[Tier](Staff, Partner, Patron)
+  val ComplimenataryTicketTiers = Set[Tier](Partner, Patron)
 
   case class Pricing(
     yearly: Int,

--- a/frontend/assets/javascripts/src/modules/events/eventPriceEnhance.js
+++ b/frontend/assets/javascripts/src/modules/events/eventPriceEnhance.js
@@ -1,4 +1,4 @@
-define(['$', 'bonzo', 'src/utils/user', 'lodash/collection/contains'], function ($, bonzo, userUtil, contains) {
+define(['$', 'bonzo', 'src/utils/user'], function ($, bonzo, userUtil) {
     'use strict';
 
     var selectors = {
@@ -17,9 +17,7 @@ define(['$', 'bonzo', 'src/utils/user', 'lodash/collection/contains'], function 
     };
 
     var enhanceWithTier = function (memberDetail) {
-        var tier = memberDetail && memberDetail.tier;
-
-        if (tier && contains(memberDetail.discountTicketTiers, tier)) {
+        if (memberDetail && memberDetail.benefits && memberDetail.benefits.discountedEventTickets) {
             events.each(function(el) {
                 updateEventPricing(el);
             });

--- a/frontend/assets/javascripts/src/modules/events/remainingTickets.js
+++ b/frontend/assets/javascripts/src/modules/events/remainingTickets.js
@@ -1,9 +1,8 @@
 define([
     '$',
     'ajax',
-    'lodash/collection/contains',
     'src/utils/user'
-], function ($, ajax, contains, userUtil) {
+], function ($, ajax, userUtil) {
     'use strict';
 
     var ELEM_SELECTOR = '.js-remaining-tickets';
@@ -45,7 +44,7 @@ define([
         }
 
         userUtil.getMemberDetail(function (memberDetail, hasTier) {
-            if (hasTier && contains(['Partner', 'Patron'], memberDetail.tier)) {
+            if (hasTier && memberDetail.benefits && memberDetail.benefits.complimentaryEventTickets) {
                 ajax({
                     url: '/subscription/remaining-tickets',
                     type: 'json'


### PR DESCRIPTION
Avoid listing existing tiers in the `user/me` endpoint. At the same time, prevent potential out-of-sync issues by driving the front-end logic through boolean values produced by the backend.

@rtyley @tomverran 