### PR TITLE
Redirect from 'hidden' events to the replacement events

### DIFF
--- a/frontend/app/controllers/WhatsOn.scala
+++ b/frontend/app/controllers/WhatsOn.scala
@@ -16,17 +16,8 @@ trait WhatsOn extends Controller with ActivityTracking {
   val localEvents: EventbriteService
   val masterclassEvents: EventbriteService
 
-  // This can be deleted once all these events have completed
-  val hiddenEvents = Set(
-    "18862189316",
-    "18882535171",
-    "18882579303",
-    "18882595351",
-    "18882606384"
-  )
-
   private def allEvents = {
-    guLiveEvents.events.filterNot(e => hiddenEvents.contains(e.id)) ++ localEvents.events
+    guLiveEvents.events ++ localEvents.events
   }
 
   private def allEventsByLocation(location: String) = {

--- a/frontend/app/model/Eventbrite.scala
+++ b/frontend/app/model/Eventbrite.scala
@@ -19,6 +19,15 @@ import scala.util.{Failure, Success, Try}
 
 object Eventbrite {
 
+  // This can be deleted once all these events have completed
+  val HiddenEvents = Map(
+    "18862189316" -> "19222944344",
+    "18882535171" -> "19223627387",
+    "18882579303" -> "19223798900",
+    "18882595351" -> "19223835008",
+    "18882606384" -> "19223927284"
+  )
+
   val googleMapsUri = Uri.parse("https://maps.google.com/")
 
   trait EBObject

--- a/frontend/app/services/EventbriteService.scala
+++ b/frontend/app/services/EventbriteService.scala
@@ -13,6 +13,7 @@ import play.api.Play.current
 import play.api.cache.Cache
 import play.api.libs.json.Reads
 import play.api.libs.ws._
+import services.EventbriteService._
 import utils.ScheduledTask
 import utils.StringUtils._
 
@@ -48,7 +49,7 @@ trait EventbriteService extends WebServiceHelper[EBObject, EBError] {
     archivedEventsTask.start(60.seconds)
   }
 
-  def events: Seq[RichEvent] = eventsTask.get()
+  def events: Seq[RichEvent] = eventsTask.get().filterNot(e => HiddenEvents.contains(e.id))
   def eventsDraft: Seq[RichEvent] = draftEventsTask.get()
   def eventsArchive: Seq[RichEvent] = archivedEventsTask.get()
 


### PR DESCRIPTION
Following on from the quick evil hack to hide events with bad EventBrite settings (https://github.com/guardian/membership-frontend/pull/827), this PR addresses a follow-up issue raised by Sophie Davies and Alice James on the Guardian Live Events team - even though we removed the events from the Event listing, they're still linked to on Twitter and from Google- we need to redirect the old pages to the new.

This commit also fixes a problem with the events showing twice on 'filtered' views:

https://membership.theguardian.com/events?location=south-bank

![image](https://cloud.githubusercontent.com/assets/52038/10766869/61d0f57a-7cd1-11e5-8144-4a3e95572f12.png)


```
---------- Forwarded message ----------
From: Sophie Davies
Date: 26 October 2015 at 17:25
Subject:
To: Alice James

hey alice, the old event pages are showing up in google search - e.g.
this https://membership.theguardian.com/event/guardian-live-the-digital-mirror-old-18882606384

do we know if we can delete them completely?
```

cc @tomverran 