### PR TITLE
Javacript disabled causing error logging noise

### DIFF
--- a/frontend/app/views/fragments/form/submit.scala.html
+++ b/frontend/app/views/fragments/form/submit.scala.html
@@ -11,7 +11,6 @@
 
 <fieldset class="fieldset fieldset--simple">
     <div class="fieldset__heading"></div>
-
     <div class="fieldset__fields fieldset__fields--no-padding">
 
     @if(membershipTermsAndConditions){
@@ -20,7 +19,6 @@
             <a href="@Links.guardianPrivacyPolicy" class="text-link" target="_blank">Privacy Policy</a>.
         </p>
     }
-
         <div class="actions">
             <noscript>
                 <a href="http://www.enable-javascript.com/" target="_blank" class="action is-disabled">Enable javascript to proceed</a>.
@@ -33,7 +31,5 @@
             </button>
             <div class="loader js-loader"></div>
         </div>
-
-
     </div>
 </fieldset>

--- a/frontend/app/views/fragments/form/submit.scala.html
+++ b/frontend/app/views/fragments/form/submit.scala.html
@@ -9,7 +9,6 @@
 @import configuration.{Config, Links}
 @import model.Benefits
 
-
 <fieldset class="fieldset fieldset--simple">
     <div class="fieldset__heading"></div>
 

--- a/frontend/app/views/fragments/form/submit.scala.html
+++ b/frontend/app/views/fragments/form/submit.scala.html
@@ -9,6 +9,7 @@
 @import configuration.{Config, Links}
 @import model.Benefits
 
+
 <fieldset class="fieldset fieldset--simple">
     <div class="fieldset__heading"></div>
 
@@ -22,7 +23,10 @@
     }
 
         <div class="actions">
-            <button type="submit" class="action js-submit-input">
+            <noscript>
+                <a href="http://www.enable-javascript.com/" target="_blank" class="action is-disabled">Enable javascript to proceed</a>.
+            </noscript>
+            <button type="button" class="action js-submit-input u-hidden-non-js">
             @Html(tier.fold(ctaTextPrepend)(tier =>
                 ctaTextPrepend + " £<span class=\"js-submit-price-option\">" +
                     Benefits.details(tier).pricing.fold(0)(_.yearly) + "</span> " + ctaTextAppend
@@ -30,6 +34,7 @@
             </button>
             <div class="loader js-loader"></div>
         </div>
+
 
     </div>
 </fieldset>

--- a/frontend/assets/stylesheets/utilities/_util-visibility.scss
+++ b/frontend/assets/stylesheets/utilities/_util-visibility.scss
@@ -1,6 +1,9 @@
 /* ==========================================================================
    State - Responsive Utilities
    ========================================================================== */
+.js-off .u-hidden-non-js {
+    display: none !important;
+}
 
  .js-on .u-hidden-js {
     display: none !important;


### PR DESCRIPTION
When javascript is disabled on submitting the join as a friend form the user is given a 500 error. The fix is to stop the submitting of the form and to display a link to the "enable javascript" help page the same as the header banner shows. 

An example of the error logging is : https://app.getsentry.com/the-guardian/membership/group/90708377/events/3831377884/

A visual of the fix is:

![image](https://cloud.githubusercontent.com/assets/80583/10821770/ff0deed0-7e4b-11e5-9927-c8ba0998d271.png)

 