### PR TITLE
Update mem-common version to 0.94

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "0.4"
   val identityTestUsers = "com.gu" %% "identity-test-users" % "0.5"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.92"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.94"
   val playGoogleAuth = "com.gu" %% "play-googleauth" % "0.3.0"
   val contentAPI = "com.gu" %% "content-api-client" % "6.4"
   val playWS = PlayImport.ws


### PR DESCRIPTION
Add more logging whenever a Zuora call is made. Note that 0.94 does *not* include changes made in 0.93 but is an update of 0.92

@rtyley @chrisjowen @tomverran @joelochlann 