### PR TITLE
Display payment errors against relevant form field

### DIFF
--- a/frontend/assets/javascripts/config/paymentErrorMessages.js
+++ b/frontend/assets/javascripts/config/paymentErrorMessages.js
@@ -1,27 +1,69 @@
 define(function () {
     'use strict';
 
+    var CREDIT_CARD_NUMBER_ELEM = document.querySelector('.js-credit-card-number');
+    var CREDIT_CARD_CVC_ELEM = document.querySelector('.js-credit-card-cvc');
+    var CREDIT_CARD_MONTH_ELEM = document.querySelector('.js-credit-card-exp-month');
+    var CREDIT_CARD_YEAR_ELEM = document.querySelector('.js-credit-card-exp-year');
+
     var paymentErrMsgs = {
         invalid_request_error: {},
         api_error: {
+            elem: CREDIT_CARD_NUMBER_ELEM,
             rate_limit: ''
         },
         card_error: {
-            incorrect_number: 'Sorry, the card number that you have entered is incorrect. Please check and retype.',
-            incorrect_cvc: 'Sorry, the security code that you have entered is incorrect. Please check and retype.',
-            invalid_number: 'Sorry, the card number that you have entered is incorrect. Please check and retype.',
-            invalid_expiry: 'Sorry, the expiry date that you have entered is invalid. Please check and re-enter.',
-            invalid_cvc: 'Sorry, the security code that you have entered is invalid. Please check and retype.',
-            expired_card: 'Sorry, this card has expired. Please try again with another card.',
+            incorrect_number: {
+                elem: CREDIT_CARD_NUMBER_ELEM,
+                msg: 'Sorry, the card number that you have entered is incorrect. Please check and retype.'
+            },
+            incorrect_cvc: {
+                elem: CREDIT_CARD_CVC_ELEM,
+                msg: 'Sorry, the security code that you have entered is incorrect. Please check and retype.'
+            },
+            invalid_number: {
+                elem: CREDIT_CARD_NUMBER_ELEM,
+                msg: 'Sorry, the card number that you have entered is incorrect. Please check and retype.'
+            },
+            invalid_expiry: {
+                elem: CREDIT_CARD_MONTH_ELEM,
+                msg: 'Sorry, the expiry date that you have entered is invalid. Please check and re-enter.'
+            },
+            invalid_expiry_month: {
+                elem: CREDIT_CARD_MONTH_ELEM,
+                msg: 'Sorry, the expiry date that you have entered is invalid. Please check and re-enter.'
+            },
+            invalid_expiry_year: {
+                elem: CREDIT_CARD_YEAR_ELEM,
+                msg: 'Sorry, the expiry date that you have entered is invalid. Please check and re-enter.'
+            },
+            invalid_cvc: {
+                elem: CREDIT_CARD_CVC_ELEM,
+                msg: 'Sorry, the security code that you have entered is invalid. Please check and retype.'
+            },
+            expired_card: {
+                elem: CREDIT_CARD_NUMBER_ELEM,
+                msg: 'Sorry, this card has expired. Please try again with another card.'
+            },
             card_declined: {
+                elem: CREDIT_CARD_NUMBER_ELEM,
                 generic_decline: 'We\'re sorry. Your card has been declined.',
                 card_not_supported: 'We\'re sorry. We can\'t take payment with this type of card. Please try again using Visa, Mastercard or American Express.',
                 try_again_later: 'We can\'t process your payment right now. Please try again later.'
             },
-            processing_error: 'Sorry, we weren\'t able to process your payment this time around. Please try again.',
-            client_validation: 'Sorry, we\'ve found some problems with your details. Please check and retype.'
+            processing_error: {
+                elem: CREDIT_CARD_NUMBER_ELEM,
+                msg: 'Sorry, we weren\'t able to process your payment this time around. Please try again.'
+            },
+            client_validation: {
+                elem: CREDIT_CARD_NUMBER_ELEM,
+                msg: 'Sorry, we\'ve found some problems with your details. Please check and retype.'
+            }
         },
-        generic_error: 'Sorry, we weren\'t able to process your payment this time around. Please try again.'
+        generic_error: {
+            elem: CREDIT_CARD_NUMBER_ELEM,
+            msg: 'Sorry, we weren\'t able to process your payment this time around. Please try again.'
+        }
     };
 
     var getMessage = function (err) {
@@ -31,7 +73,7 @@ define(function () {
         var errMsg;
 
         if (errSection) {
-            errMsg = errSection[errCode];
+            errMsg = errSection[errCode].msg;
 
             if (errCode === 'card_declined') {
                 errMsg = errSection.card_declined[err.decline_code];
@@ -44,7 +86,19 @@ define(function () {
         return errMsg || paymentErrMsgs.generic_error;
     };
 
+    var getElement = function(err) {
+        var errCode = err && err.code;
+        var errType = err && err.type;
+        var errSection = paymentErrMsgs[errType];
+
+        if (errSection) {
+            return errSection.elem || errSection[errCode].elem;
+        }
+        return CREDIT_CARD_NUMBER_ELEM
+    };
+
     return {
-        getMessage: getMessage
+        getMessage: getMessage,
+        getElement: getElement
     };
 });

--- a/frontend/assets/javascripts/src/modules/form/payment/processing.js
+++ b/frontend/assets/javascripts/src/modules/form/payment/processing.js
@@ -51,12 +51,13 @@ define([
      * @param response
      */
     var stripeResponseHandler = function (status, response) {
-        var data, errMsg;
+        var data;
         if (response.error) {
             Raven.captureMessage(response.error.code + ' ' + response.error.message);
-            errMsg = paymentErrorMessages.getMessage(response.error);
-            if (errMsg) {
-                handleError(errMsg);
+            var userMessage = paymentErrorMessages.getMessage(response.error);
+            var errorElement = paymentErrorMessages.getElement(response.error);
+            if (userMessage) {
+                handleError(userMessage, errorElement);
             }
         } else {
             data = serializer(utilsHelper.toArray(form.elem.elements), { 'payment.token': response.id });
@@ -79,7 +80,9 @@ define([
                         Raven.captureException(e);
                     }
 
-                    handleError(paymentErrorMessages.getMessage(paymentErr));
+                    var userMessage = paymentErrorMessages.getMessage(paymentErr);
+                    var errorElement = paymentErrorMessages.getElement(paymentErr);
+                    handleError(userMessage, errorElement);
                 }
             });
 
@@ -93,10 +96,10 @@ define([
      * - enable the submit button
      * @param msg
      */
-    var handleError = function (msg) {
+    var handleError = function (msg, elem) {
         display.toggleErrorState({
             isValid: false,
-            elem: CREDIT_CARD_NUMBER_ELEM,
+            elem: elem,
             msg: msg
         });
 


### PR DESCRIPTION
Previously we displayed all payment errors which come back from Stripe against the card number field. This PR ensures they're displayed against the relevant field, improving the UX.

For example (previously this would have displayed against the card number):

![picture 32](https://cloud.githubusercontent.com/assets/5122968/10827418/bfe6775c-7e66-11e5-9f9a-e804fa1370e9.png)
