### PR TITLE
Better example image url for the Event Comment Builder

### DIFF
--- a/frontend/app/views/eventOverview/fragments/commentBuilder.scala.html
+++ b/frontend/app/views/eventOverview/fragments/commentBuilder.scala.html
@@ -38,8 +38,8 @@
                 <label class="label" for="event-image">Event Image</label>
                 <input class="input-text js-event-image" id="event-image" data-tag="main-image" type="text"/>
                 <div class="form-note">
-                    <i>e.g https://media.gutools.co.uk/images/0816c7b393</i>
-                    <div><a href="https://media.gutools.co.uk/search" target="_blank">Get image url</a></div>
+                    <small><i>e.g https://media.gutools.co.uk/images/dce62a0020049812983a2fd1790ac8442b0f4711?crop=0_0_4194_2515</i></small>
+                    <div>Note you need to use a <strong>crop</strong> created within the <a href="https://media.gutools.co.uk/search" target="_blank">Grid image service</a></div>
                 </div>
             </div>
 


### PR DESCRIPTION
Better example url in the [event comment builder](https://membership.theguardian.com/staff/event-overview/details):

##### Before
![image](https://cloud.githubusercontent.com/assets/52038/10973845/1fdda7e6-83d7-11e5-9eb4-93532780531a.png)
##### After
![image](https://cloud.githubusercontent.com/assets/52038/10974339/8fd21a3a-83d9-11e5-8efe-b0f39c4b5d2e.png)


Alice in the Guardian Live Events team encountered a problem when she created this event:

https://www.eventbrite.co.uk/edit?eid=19419554410

and entered this incorrect url in the metadata:

<!-- main-image: https://media.gutools.co.uk/images/dce62a0020049812983a2fd1790ac8442b0f4711 -->

The image url is incorrect because it doesn't include the 'crop' section: it should be like this:

<!-- main-image: https://media.gutools.co.uk/images/dce62a0020049812983a2fd1790ac8442b0f4711?crop=0_0_4194_2515 -->

...the Grid image service only works with crops, not the raw uploaded image.

cc @joelochlann 


https://trello.com/c/WbMGcAwD/231-give-better-indication-to-event-admins-when-event-image-url-is-entered-incorrectly