### PR TITLE
In generic error fallback case, return message string not object

### DIFF
--- a/frontend/assets/javascripts/config/paymentErrorMessages.js
+++ b/frontend/assets/javascripts/config/paymentErrorMessages.js
@@ -83,7 +83,7 @@ define(function () {
             }
         }
 
-        return errMsg || paymentErrMsgs.generic_error;
+        return errMsg || paymentErrMsgs.generic_error.msg;
     };
 
     var getElement = function(err) {


### PR DESCRIPTION
This fixes a mistake I made in [this piece of work](https://github.com/guardian/membership-frontend/pull/842/files). I refactored things so that you need to drill down into the `.msg` property to get the actual message string. But in the case of a generic error I forgot to do this and was returning the object instead.