### PR TITLE
[WIP] Tell the client when we get a Zuora card decline

### DIFF
--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -9,7 +9,7 @@ import com.gu.identity.play.{IdMinimalUser, StatusFields}
 import com.gu.membership.salesforce.{PaidMember, ScalaforceError, Tier}
 import com.gu.membership.stripe.Stripe
 import com.gu.membership.stripe.Stripe.Serializer._
-import com.gu.membership.zuora.soap.models.errors.ResultError
+import com.gu.membership.zuora.soap.models.errors.{GatewayError, ResultError}
 import com.netaporter.uri.dsl._
 import com.typesafe.scalalogging.LazyLogging
 import configuration.{Config, CopyConfig, Email}
@@ -181,6 +181,7 @@ trait Joiner extends Controller with ActivityTracking with LazyLogging {
           }
           result
         }.recover {
+          case GatewayError(_, _, "Declined") => Forbidden(Json.toJson(Stripe.Error("card_error", "", "card_declined")))
           case error: Stripe.Error => Forbidden(Json.toJson(error))
       	  case error: ResultError => Forbidden
           case error: ScalaforceError => Forbidden


### PR DESCRIPTION
This is linked to [this PR in membership-common](https://github.com/guardian/membership-common/pull/112). We want to pass back some info to the browser when Zuora gets a card decline from its payment gateway.

@afiore 