### PR TITLE
Upgrade to latest version of identity-play-auth

### DIFF
--- a/frontend/app/actions/package.scala
+++ b/frontend/app/actions/package.scala
@@ -1,5 +1,5 @@
 import com.gu.googleauth
-import com.gu.identity.play.IdMinimalUser
+import com.gu.identity.play.{AuthenticatedIdUser, IdMinimalUser}
 import com.gu.membership.salesforce._
 import com.gu.membership.util.Timing
 import play.api.mvc.Security.AuthenticatedRequest
@@ -9,7 +9,7 @@ import services._
 import scala.concurrent.{ExecutionContext, Future}
 
 package object actions {
-  type AuthRequest[A] = AuthenticatedRequest[A, IdMinimalUser]
+  type AuthRequest[A] = AuthenticatedRequest[A, AuthenticatedIdUser]
 
   type GoogleAuthRequest[A] = AuthenticatedRequest[A, googleauth.UserIdentity]
 

--- a/frontend/app/controllers/Info.scala
+++ b/frontend/app/controllers/Info.scala
@@ -171,7 +171,7 @@ trait Info extends Controller {
 
   def submitFeedback = NoCacheAction.async { implicit request =>
 
-    val userOpt = AuthenticationService.authenticatedUserFor(request)
+    val userOpt = AuthenticationService.authenticatedUserFor(request).map(_.user)
     val uaOpt = request.headers.get(USER_AGENT)
 
     def sendFeedback(formData: FeedbackForm) = {

--- a/frontend/app/controllers/TierController.scala
+++ b/frontend/app/controllers/TierController.scala
@@ -54,7 +54,7 @@ trait UpgradeTier {
     def previewUpgrade(subscription: SubscriptionDetails): Future[Result] = {
       if (subscription.inFreePeriodOffer) Future.successful(Ok(views.html.tier.upgrade.unavailable(memberRequest.member.tier, tier)))
       else {
-        val identityUserFieldsF = IdentityService(IdentityApi).getFullUserDetails(memberRequest.user, IdentityRequest(memberRequest)).map(_.privateFields.getOrElse(new PrivateFields))
+        val identityUserFieldsF = IdentityService(IdentityApi).getFullUserDetails(memberRequest.user, IdentityRequest(memberRequest)).map(_.privateFields.getOrElse(PrivateFields()))
 
         val pageInfo = PageInfo.default.copy(stripePublicKey = Some(memberRequest.touchpointBackend.stripeService.publicKey))
 

--- a/frontend/app/controllers/TierController.scala
+++ b/frontend/app/controllers/TierController.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import actions._
+import com.gu.identity.play.PrivateFields
 import com.gu.membership.salesforce._
 import com.gu.membership.stripe.Stripe
 import com.gu.membership.stripe.Stripe.Serializer._
@@ -53,7 +54,7 @@ trait UpgradeTier {
     def previewUpgrade(subscription: SubscriptionDetails): Future[Result] = {
       if (subscription.inFreePeriodOffer) Future.successful(Ok(views.html.tier.upgrade.unavailable(memberRequest.member.tier, tier)))
       else {
-        val identityUserFieldsF = IdentityService(IdentityApi).getFullUserDetails(memberRequest.user, IdentityRequest(memberRequest)).map(_.privateFields)
+        val identityUserFieldsF = IdentityService(IdentityApi).getFullUserDetails(memberRequest.user, IdentityRequest(memberRequest)).map(_.privateFields.getOrElse(new PrivateFields))
 
         val pageInfo = PageInfo.default.copy(stripePublicKey = Some(memberRequest.touchpointBackend.stripeService.publicKey))
 

--- a/frontend/test/services/DestinationServiceTest.scala
+++ b/frontend/test/services/DestinationServiceTest.scala
@@ -3,7 +3,7 @@ package services
 import actions.MemberRequest
 import com.github.nscala_time.time.Imports._
 import com.gu.contentapi.client.parser.JsonParser
-import com.gu.identity.play.IdMinimalUser
+import com.gu.identity.play.{AccessCredentials, AuthenticatedIdUser, IdMinimalUser}
 import com.gu.membership.salesforce.Tier.Friend
 import com.gu.membership.salesforce._
 import model.Eventbrite.EBAccessCode
@@ -38,7 +38,7 @@ class DestinationServiceTest extends PlaySpecification with Mockito with ScalaFu
       val testMember = Contact(ContactDetails("id", Some("fn"), "ln", "email", new DateTime(), "contactId", "accountId"), Member(None, Friend), NoPayment)
       val fakeRequest = FakeRequest().withSession(newSessions: _*)
       val minimalUser: IdMinimalUser = IdMinimalUser("123", None)
-      MemberRequest(testMember, new AuthenticatedRequest(minimalUser, fakeRequest))
+      MemberRequest(testMember, new AuthenticatedRequest(AuthenticatedIdUser(AccessCredentials.Cookies("foo", "bar"), minimalUser), fakeRequest))
 
     }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   //libraries
   val sentryRavenLogback = "net.kencochrane.raven" % "raven-logback" % "6.0.0"
   val identityCookie = "com.gu.identity" %% "identity-cookie" % "3.44"
-  val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "0.4"
+  val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "0.12"
   val identityTestUsers = "com.gu" %% "identity-test-users" % "0.5"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
   val membershipCommon = "com.gu" %% "membership-common" % "0.100"


### PR DESCRIPTION
Most of the changes here are to do with `privateFields` becoming optional, which happened many versions ago: https://github.com/guardian/identity-play-auth/pull/1 - also `AuthRequest` now contains an `AuthenticatedIdUser` rather than a `IdMinimalUser`.

See also guardian/identity-play-auth#4

https://trello.com/c/d7jD8CUW/120-members-data-api-enable-access-by-mobile-access-tokens

cc @tomverran @ostapneko