### PR TITLE
Grant membership.team@guardian.co.uk access to test users

### DIFF
--- a/frontend/app/controllers/Testing.scala
+++ b/frontend/app/controllers/Testing.scala
@@ -18,6 +18,7 @@ object Testing extends Controller with LazyLogging {
   val AuthorisedTester = GoogleAuthenticatedStaffAction andThen isInAuthorisedGroupGoogleAuthReq(
     Set(
       "membership.dev@guardian.co.uk",
+      "membership.team@guardian.co.uk",
       "dig.dev.web-engineers@guardian.co.uk",
       "membership.testusers@guardian.co.uk",
       "touchpoint@guardian.co.uk",


### PR DESCRIPTION
Useful for Anna Chester on Local Events, who recently got caught by the [Staff 'Become a member' bug](https://trello.com/c/XfvVAeno/246-bug-advanced-ticket-sales-for-partners-and-patrons-isn-t-working-https-membership-theguardian-com-event-guardian-local-threecour).

cc @jayceb1 @chrisjowen 