### PR TITLE
Add membership signup bookmarklet

### DIFF
--- a/frontend/app/views/testing/testUsers.scala.html
+++ b/frontend/app/views/testing/testUsers.scala.html
@@ -31,22 +31,35 @@
                 </div>
                 <div class="copy">
                     <p>
-                        Filling out all those registration fields can get tedious.
-                        Here's a bookmarklet to help you:
+                        Here are some bookmarklets to help with the registration process. (In Chrome you can drag a link to the bookmarks bar to bookmark it.)
                     </p>
-                    <p>
-                        <a href="javascript:
+                    <ul>
+                        <li>
+                            <a href="javascript:
                             (function() {
                                 var s = document.createElement('script');
                                 s.src = '@Asset.bookmarklet("identity-signup.js")';
                                 s.type = 'text/javascript';
                                 document.head.appendChild(s);
                             })();">
-                            @if(Config.stageDev){Dev }Identity Signup</a>.
-                        Clicking this on the sign-up page will prompt you for the Test User key, then fill out fields appropriately and submit the form.
-                    </p>
+                                @if(Config.stageDev){Dev }Identity Signup</a>.
+                            Clicking this on the identity sign-up page will prompt you for the Test User key, then fill out fields appropriately and submit the form.
+                        </li>
+                        <li>
+                            <a href="javascript:
+                            (function() {
+                                var s = document.createElement('script');
+                                s.src = '@Asset.bookmarklet("mem-signup.js")';
+                                s.type = 'text/javascript';
+                                document.head.appendChild(s);
+                            })();">
+                                @if(Config.stageDev){Dev }Membership Signup</a>.
+                            Clicking this on the membership sign-up page will fill in the address & card details and submit.
+                            It assumes first name & last name are auto-populated with the test user key
+                            (which will be the case if coming back from identity signup).
+                        </li>
+                    </ul>
                     <p>
-                        In Chrome you can drag a link to the bookmarks bar to bookmark it.
                     </p>
 
                 </div>

--- a/frontend/assets/bookmarklets/mem-signup.js
+++ b/frontend/assets/bookmarklets/mem-signup.js
@@ -1,0 +1,13 @@
+(function() {
+    function id(id) { return document.getElementById(id) };
+    id('address-line-one-deliveryAddress').value = 'Address Line 1';
+    id('address-line-two-deliveryAddress').value = 'Address Line 2';
+    id('town-deliveryAddress').value = 'Town';
+    id('county-or-state-deliveryAddress').value = 'County';
+    id('postCode-deliveryAddress').value = 'Postcode';
+    id('cc-num').value = '4242424242424242';
+    id('cc-cvc').value = '123';
+    id('cc-exp-month').value = '3';
+    id('cc-exp-year').value = '2025';
+    document.querySelector('.js-submit-input').click();
+})();


### PR DESCRIPTION
Added a basic bookmarklet for filling out the membership registration page. It just fills in placeholder data like "Address Line 1", "Address Line 2" etc and valid test card details, and then submits the form. It assumes the first name & last name will be autopopulated because the user is signed in. Obviously it will only work for test users.

See this PR for more history of how we're handling bookmarklets: #850 

@chrisjowen 