### PR TITLE
Sanity check to avoid polluting logs with bookmarklet errors

### DIFF
--- a/frontend/assets/bookmarklets/identity-signup.js
+++ b/frontend/assets/bookmarklets/identity-signup.js
@@ -1,4 +1,8 @@
 (function() {
+    if (!document.getElementById('publicFields_username')) {
+        alert('Element with id publicFields_username not found. Are you on the right page?');
+        return;
+    }
     var username = prompt('Test User key (first name, last name, username and password will be set to this value):');
     if (!username) return;
     ['firstName', 'secondName', 'publicFields_username', 'password', 'primaryEmailAddress'].forEach(function(field) {

--- a/frontend/assets/bookmarklets/mem-signup.js
+++ b/frontend/assets/bookmarklets/mem-signup.js
@@ -1,5 +1,9 @@
 (function() {
     function id(id) { return document.getElementById(id) };
+    if (!id('address-line-one-deliveryAddress')) {
+        alert('Element with id address-line-one-deliveryAddress not found. Are you on the right page?');
+        return;
+    }
     id('address-line-one-deliveryAddress').value = 'Address Line 1';
     id('address-line-two-deliveryAddress').value = 'Address Line 2';
     id('town-deliveryAddress').value = 'Town';


### PR DESCRIPTION
Previously if you fire a bookmarklet on the wrong page, you get JS errors because expected elements are missing. This doesn't do any real harm, but if you're logging clientside errors with Sentry it pollutes the log with these harmless errors. So I've put in a sanity check to bail out early if we think we're on the wrong page.