### PR TITLE
Enable acceptance-tests to run locally

### DIFF
--- a/frontend/conf/acceptance-test.conf
+++ b/frontend/conf/acceptance-test.conf
@@ -1,6 +1,0 @@
-//include "dev"
-include "PROD"
-
-// Defined in Travis CI
-webDriverRemoteUrl = ${?WEBDRIVER_REMOTE_URL}
-identity.test.users.secret=${?IDENTITY_TEST_USERS_SECRET}

--- a/frontend/conf/dev.conf
+++ b/frontend/conf/dev.conf
@@ -16,10 +16,14 @@
 
 include "PROD"
 
-identity.webapp.url="https://profile.thegulocal.com"
-identity.production.keys=false
-identity.api.url="https://idapi.code.dev-theguardian.com"
-identity.api.client.token="membership-dev-client-token"
+identity {
+    api.url="https://idapi.code.dev-theguardian.com"
+    api.client.token="membership-dev-client-token"
+    production.keys=false
+    webapp.url="https://profile.thegulocal.com"
+    test.users.secret="a-non-secure-key-for-our-dev-env-only"
+}
+
 ws.acceptAnyCertificate=true
 
 membership.url="https://mem.thegulocal.com"

--- a/frontend/conf/logback-test.xml
+++ b/frontend/conf/logback-test.xml
@@ -14,7 +14,7 @@
         </layout>
     </appender>
 
-    <root level="info">
+    <root level="WARN">
         <appender-ref ref="CONSOLE"/>
         <appender-ref ref="FILE"/>
     </root>

--- a/frontend/test/acceptance/Config.scala
+++ b/frontend/test/acceptance/Config.scala
@@ -12,7 +12,7 @@ object Config {
 
   def logger = LoggerFactory.getLogger(this.getClass)
 
-  private val conf = ConfigFactory.load("acceptance-test")
+  private val conf = ConfigFactory.load()
 
   val baseUrl = conf.getString("membership.url")
   val profileUrl = conf.getString("identity.webapp.url")

--- a/frontend/test/acceptance/conf/acceptance-test.conf
+++ b/frontend/test/acceptance/conf/acceptance-test.conf
@@ -1,0 +1,10 @@
+include "dev"
+
+// Travis CI environmental variables that override DEV.conf with PROD values
+stage=${?STAGE}
+identity {
+    webapp.url = ${?IDENTITY_WEBAPP_URL}
+    test.users.secret = ${?IDENTITY_TEST_USERS_SECRET}
+}
+membership.url= ${?MEMBERSHIP_URL}
+webDriverRemoteUrl = ${?WEBDRIVER_REMOTE_URL}

--- a/project/Membership.scala
+++ b/project/Membership.scala
@@ -37,7 +37,7 @@ trait Membership {
     publishArtifact in (Compile, packageDoc) := false,
     parallelExecution in Global := false,
     updateOptions := updateOptions.value.withCachedResolution(true),
-    javaOptions in Test += "-Dconfig.resource=dev.conf"
+    javaOptions in Test += "-Dconfig.file=test/acceptance/conf/acceptance-test.conf"
   ) ++ buildInfoPlugin
 
   def lib(name: String) = Project(name, file(name)).enablePlugins(PlayScala).settings(commonSettings: _*)


### PR DESCRIPTION
@joelochlann 

Acceptance tests can now be run locally (`sbt acceptance-test`) provided `membership-frontend` and `frontend` servers have been started locally. 

[Screencast](https://saucelabs.com/tests/871ce50fbb4f4a3997370ebc681ea20f)
[Travis build](https://travis-ci.org/guardian/membership-frontend/builds/95567283)