### PR TITLE
Prevent live-events feed from failing on bad 'main-image' annotations

### DIFF
--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -186,7 +186,7 @@ trait Event extends Controller with ActivityTracking {
   }
 
   def preview(id: String) = GoogleAuthenticatedStaffAction.async { implicit request =>
-   EventbriteService.getPreviewEvent(id).map(eventDetail)
+     EventbriteService.getPreviewEvent(id).map(eventDetail)
   }
 
   def previewLocal(id: String) = GoogleAuthenticatedStaffAction.async { implicit request =>

--- a/frontend/app/model/Eventbrite.scala
+++ b/frontend/app/model/Eventbrite.scala
@@ -12,6 +12,7 @@ import play.api.Logger
 import play.api.data.validation.ValidationError
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
+import services.GridService
 import utils.StringUtils._
 import views.support.Asset
 import views.support.Dates.YearMonthDayHours
@@ -287,6 +288,9 @@ object Eventbrite {
           None
       }
     } yield uri
+
+    val mainImageHasNoCrop: Boolean =
+      mainImageUrl.fold(false)(uri => uri.query.param(GridService.CropQueryParam).isEmpty)
 
     val slug = slugify(name.text) + "-" + id
 

--- a/frontend/app/model/ResponsiveImage.scala
+++ b/frontend/app/model/ResponsiveImage.scala
@@ -13,7 +13,7 @@ object ResponsiveImageGenerator {
 }
 
 object ResponsiveImageGroup {
-  def apply(content: Content): Option[ResponsiveImageGroup] = for {
+  def fromContent(content: Content): Option[ResponsiveImageGroup] = for {
     elements <- content.elements
     element <- elements.find(_.relation == "thumbnail")
   } yield ResponsiveImageGroup(
@@ -26,15 +26,18 @@ object ResponsiveImageGroup {
     } yield ResponsiveImage(file.replace("http://static", "https://static-secure"), width.toInt)
   )
 
-  def apply(image: GridImage): ResponsiveImageGroup = ResponsiveImageGroup(
-    altText = image.metadata.description,
-    metadata = Some(image.metadata),
-    availableImages = image.assets.map { asset =>
-      val path = asset.secureUrl.getOrElse(asset.file)
-      val width = asset.dimensions.width
-      ResponsiveImage(path, width)
-    }
-  )
+  def fromGridImage(image: GridImage): Option[ResponsiveImageGroup] =
+    if (image.assets.nonEmpty)
+      Some(
+        ResponsiveImageGroup(
+        altText = image.metadata.description,
+        metadata = Some(image.metadata),
+        availableImages = image.assets.map { asset =>
+          val path = asset.secureUrl.getOrElse(asset.file)
+          val width = asset.dimensions.width
+          ResponsiveImage(path, width)
+        }))
+    else None
 }
 
 case class ResponsiveImage(path: String, width: Int)

--- a/frontend/app/model/RichContent.scala
+++ b/frontend/app/model/RichContent.scala
@@ -3,7 +3,7 @@ package model
 import com.gu.contentapi.client.model.Content
 
 abstract class RichContent(content: Content) {
-  val imgOpt = ResponsiveImageGroup(content)
+  val imgOpt = ResponsiveImageGroup.fromContent(content)
 }
 
 case class ContentItem(content: Content) extends RichContent(content)

--- a/frontend/app/model/RichEvent.scala
+++ b/frontend/app/model/RichEvent.scala
@@ -51,7 +51,7 @@ object RichEvent {
   }
 
   def getCitiesWithCount(events: Seq[RichEvent]): Seq[(String, Int)] = {
-    val cities = events.map(_.venue.address.flatMap(_.city)).flatten
+    val cities = events.flatMap(_.venue.address.flatMap(_.city))
     cities.groupBy(identity).mapValues(_.size).toSeq.sortBy{ case (name, size) => name }
   }
 
@@ -80,9 +80,9 @@ object RichEvent {
     val detailsUrl = routes.Event.details(event.slug).url
     val hasLargeImage = true
     val canHavePriorityBooking = true
-    val imgOpt = image.map(ResponsiveImageGroup(_))
+    val imgOpt = image.flatMap(ResponsiveImageGroup.fromGridImage)
     val socialImgUrl = imgOpt.map(_.defaultImage)
-    val pastImageOpt = contentOpt.flatMap(ResponsiveImageGroup(_))
+    val pastImageOpt = contentOpt.flatMap(ResponsiveImageGroup.fromContent)
     val schema = EventSchema.from(this)
     val tags = Nil
 

--- a/frontend/app/services/MasterclassDataExtractor.scala
+++ b/frontend/app/services/MasterclassDataExtractor.scala
@@ -20,7 +20,7 @@ object MasterclassDataExtractor {
     val eventbriteIds =
       if (eventbriteIdsFromRefs.nonEmpty) eventbriteIdsFromRefs else scrapeEventbriteIdsFrom(content)
 
-    eventbriteIds.map(eventId => MasterclassData(eventId, content.webUrl, ResponsiveImageGroup(content)))
+    eventbriteIds.map(eventId => MasterclassData(eventId, content.webUrl, ResponsiveImageGroup.fromContent(content)))
   }
 
   def scrapeEventbriteIdsFrom(content: Content): Seq[String] = for {

--- a/frontend/app/views/eventOverview/fragments/overviewSection.scala.html
+++ b/frontend/app/views/eventOverview/fragments/overviewSection.scala.html
@@ -59,6 +59,9 @@
                             </div>
                         </div>
                         <ul class="event-trait-container u-unstyled">
+                        @if(event.mainImageHasNoCrop) {
+                          @eventTrait("main-image URL with no crop parameter", "important")
+                        }
                         @event.ticketing.collect {
                             case ExternalTicketing => {
                                 @eventTrait("Not Sold though Eventbrite", "noteworthy")


### PR DESCRIPTION
Bugfix for https://goo.gl/oPr4K7

Prevents the live events feed to completely fail when an event 'main-image' annotation points to an image with no associated crops/exports.

### Failing example ###

Take this [sample file](https://media.gutools.co.uk/images/7560968d99ed2fcb382a46c19f29a79f1bf42d4d
) uploaded on `media.gutools.co.uk`. Its corresponding JSON representation returned by `https://api.media.gutools.co.uk/images/7560968d99ed2fcb382a46c19f29a79f1bf42d4d` has the following structure:

```json

  "data": {
    "id": "7560968d99ed2fcb382a46c19f29a79f1bf42d4d",
    "uploadTime": "2015-12-08T15:38:36Z",
    "uploadedBy": "andrea.fiore",
    "lastModified": "2015-12-08T15:40:39Z",
    "exports": [],
    "source": {
      "file": "http://media-service-example.com"
   }
``` 

Notice that, as no crops have been created, the `data.exports` attribute is empty. This results in `GridService.getRequestedCrop`  happily returning a blank `Some(GridImage(Nil)...)`, and thus causing a NoSuchElement exception [later down the line](https://github.com/guardian/membership-frontend/blob/43f56ba0fdce3c5b1d59d49e288d429aa6c76c5a/frontend/app/model/ResponsiveImage.scala#L51).

This fix adds additional checks to prevent `GridService` from returning a blank `GridImage` as well as initialising a `ResponsiveImageGroup` from a blank `GridImage`.

### New flag for event-preview dashboard ###

I have also added a new flag for image with no crops (see screenshot below)

![screen shot 2015-12-09 at 11 07 25](https://cloud.githubusercontent.com/assets/63361/11683739/ae8d9e54-9e64-11e5-9976-89b3612a00de.png)