### PR TITLE
Ensure staff can get advanced tickets, like they should

### DIFF
--- a/frontend/app/model/Benefits.scala
+++ b/frontend/app/model/Benefits.scala
@@ -15,6 +15,7 @@ object Benefits {
   }
 
   val DiscountTicketTiers = Set[Tier](Staff, Partner, Patron)
+  val PriorityBookingTiers = DiscountTicketTiers
   val ComplimenataryTicketTiers = Set[Tier](Partner, Patron)
 
   val welcomePack = Benefit("welcome_pack", "Welcome pack, card and gift")

--- a/frontend/app/model/TicketSaleDates.scala
+++ b/frontend/app/model/TicketSaleDates.scala
@@ -2,7 +2,7 @@ package model
 
 import com.github.nscala_time.time.Imports._
 import com.gu.membership.salesforce.Tier
-import com.gu.membership.salesforce.Tier.{Partner, Patron}
+import model.Benefits.PriorityBookingTiers
 import model.Eventbrite.{EBTicketClass, EventTimes}
 import org.joda.time.DateTimeZone.UTC
 import org.joda.time.Instant
@@ -33,7 +33,7 @@ object TicketSaleDates {
    *                             General Release ||---------------------------------------->
    */
   val memberLeadTimeOverGeneralRelease = SortedMap[Duration, Map[Tier, Period]](
-    4.days.standardDuration -> Map(Patron -> 48.hours, Partner -> 48.hours)
+    4.days.standardDuration -> PriorityBookingTiers.map(_ -> 48.hours.toPeriod).toMap
   )
 
   def datesFor(eventTimes: EventTimes, tickets: EBTicketClass): TicketSaleDates = {
@@ -63,9 +63,8 @@ object TicketSaleDates {
     }
   }
 
-  private def maxStartSaleTime(effectiveSaleStart: Instant, tierSaleDate:Instant) = {
+  private def maxStartSaleTime(effectiveSaleStart: Instant, tierSaleDate:Instant) =
     Seq(effectiveSaleStart, toStartOfDay(tierSaleDate)).max
-  }
 
   private def toStartOfDay(instant: Instant) = instant.toDateTime(UTC).withTimeAtStartOfDay().toInstant
 


### PR DESCRIPTION
In conversation with Nick Miller and @AnnaChesters, confirmed that Staff should be getting advanced Event ticket sales too.

Currently, because Staff _aren't_ getting advanced tickets (they get a  'Upgrade Membership' CTA):

![image](https://cloud.githubusercontent.com/assets/52038/11685366/51d22c1e-9e70-11e5-926b-4c2b666f59bc.png)

...but they _are_ already getting 20% discount tickets, because the list of who gets what was defined separately, in `DiscountTicketTiers`. Now `PriorityBookingTiers = DiscountTicketTiers`, and that drives who gets advanced tickets.

cc @tomverran @JuliaBellis 