### PR TITLE
Bugfix: display Zip-code (and not postcode) on US checkout

### DIFF
--- a/frontend/assets/javascripts/src/modules/form/options.js
+++ b/frontend/assets/javascripts/src/modules/form/options.js
@@ -122,6 +122,8 @@ define(['$', 'bean', 'src/modules/form/validation/display'], function ($, bean, 
         if (FRIEND_FORM_EL && checkoutForm) {
             selectCountry(DELIVERY_COUNTRY_EL, checkoutForm.deliveryCountry);
         }
+
+        DELIVERY_COUNTRY_EL.dispatchEvent(new Event('change'));
     };
 
     var addListeners = function () {


### PR DESCRIPTION
When landing on the US supporter checkout form, we currently displayed a form with a "Postcode" field and no dropdown for state:

![screen shot 2015-12-10 at 15 58 04](https://cloud.githubusercontent.com/assets/63361/11720300/8333adaa-9f56-11e5-8cdd-005d1c3e7a98.png)

This fix brings back the correct behaviour:

![screen shot 2015-12-10 at 15 56 34](https://cloud.githubusercontent.com/assets/63361/11720278/724c344e-9f56-11e5-9170-ef9b545d2c06.png)
![screen shot 2015-12-10 at 15 57 00](https://cloud.githubusercontent.com/assets/63361/11720282/77f98144-9f56-11e5-8c1d-a2a380ce63b7.png)
