### PR TITLE
In tablet view, fix content width at 740px and expand margins

### DIFF
--- a/frontend/assets/stylesheets/_mixins.scss
+++ b/frontend/assets/stylesheets/_mixins.scss
@@ -39,8 +39,11 @@ $gs-max-columns: 16;
     @include mq(tablet) {
         max-width: map-get($max-widths, max-tablet) + $offset;
     }
-    @include mq(mem-full) {
+    @include mq(desktop) {
         max-width: map-get($max-widths, max-desktop) + $offset;
+    }
+    @include mq(mem-full) {
+        max-width: map-get($max-widths, max-mem-full) + $offset;
     }
 }
 
@@ -56,8 +59,13 @@ $gs-max-columns: 16;
         #{$property}: -webkit-calc((100% - #{rem($width + $offset)}) / 2);
         #{$property}: calc((100% - #{rem($width + $offset)}) / 2);
     }
-    @include mq(mem-full) {
+    @include mq(desktop) {
         $width: map-get($max-widths, max-desktop);
+        #{$property}: -webkit-calc((100% - #{rem($width + $offset)}) / 2);
+        #{$property}: calc((100% - #{rem($width + $offset)}) / 2);
+    }
+    @include mq(mem-full) {
+        $width: map-get($max-widths, max-mem-full);
         #{$property}: -webkit-calc((100% - #{rem($width + $offset)}) / 2);
         #{$property}: calc((100% - #{rem($width + $offset)}) / 2);
     }

--- a/frontend/assets/stylesheets/_vars.scss
+++ b/frontend/assets/stylesheets/_vars.scss
@@ -169,8 +169,9 @@ $mq-breakpoints: (
 );
 
 $max-widths: (
-    max-tablet: gs-span(12),
-    max-desktop: gs-span(14),
+    max-tablet: gs-span(9),
+    max-desktop: gs-span(12),
+    max-mem-full: gs-span(14),
     max-wide: gs-span(16)
 );
 


### PR DESCRIPTION
This fixes a longstanding discrepancy in the way we adjust the max content width at various breakpoints. We should have fixed width content and variable margins from 740px (tablet) onwards, snapping the content to larger fixed widths at 980px and 1140px. This is how [theguardian.com](http://theguardian.com) works. But for historical reasons we have always had a variable width tablet view.

For example, at 960px we are still in tablet mode but nearing the 980px desktop breakpoint. We should still have the content at 740px but expanded margins, like so:

![picture 59](https://cloud.githubusercontent.com/assets/5122968/11786231/6120fbbc-a27d-11e5-81a0-961922abda3e.png)

Before it was like this:

![picture 60](https://cloud.githubusercontent.com/assets/5122968/11786235/676e3ad4-a27d-11e5-9c3d-ec0db9643143.png)

@tomverran 

