### PR TITLE
Remove obsolete update card endpoint

### DIFF
--- a/frontend/app/controllers/Subscription.scala
+++ b/frontend/app/controllers/Subscription.scala
@@ -1,7 +1,5 @@
 package controllers
 
-import com.gu.membership.stripe.Stripe
-import com.gu.membership.stripe.Stripe.Serializer._
 import model.FreeEventTickets
 import play.api.data.Forms._
 import play.api.data._
@@ -9,20 +7,7 @@ import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json.Json
 import play.api.mvc._
 
-import scala.concurrent.Future
-
 trait Subscription extends Controller with MemberServiceProvider {
-  def updateCard() = AjaxPaidMemberAction.async { implicit request =>
-    updateForm.bindFromRequest
-      .fold(_ => Future.successful(BadRequest), stripeToken =>
-        for {
-          card <- memberService.updateDefaultCard(request.member, stripeToken)
-        } yield Ok(Json.obj("last4" -> card.last4, "cardType" -> card.`type`, "type" -> card.`type`))
-      ).recover {
-        case error: Stripe.Error => Forbidden(Json.toJson(error))
-      }
-  }
-
   def remainingTickets() = AjaxPaidMemberAction.async { implicit request =>
     for {
       subscription <- memberService.currentSubscription(request.member)
@@ -34,8 +19,6 @@ trait Subscription extends Controller with MemberServiceProvider {
       ))
     }
   }
-
-  def updateCardPreflight() = Cors.andThen(CachedAction) { Ok.withHeaders(ACCESS_CONTROL_ALLOW_HEADERS -> "Csrf-Token") }
 
   private val updateForm = Form { single("stripeToken" -> nonEmptyText) }
 }

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -47,8 +47,6 @@ GET            /staff/event-overview/details          controllers.Staff.eventOve
 GET            /staff/catalog                         controllers.Staff.catalogDiagnostics
 
 # Subscription
-POST           /subscription/update-card              controllers.Subscription.updateCard
-OPTIONS        /subscription/update-card              controllers.Subscription.updateCardPreflight
 GET            /subscription/remaining-tickets        controllers.Subscription.remainingTickets
 
 # What's On


### PR DESCRIPTION
This is apparently only used by the MMA page, which is now using the members data API.

@tomverran @afiore 