### PR TITLE
Correct fixed widths for event detail page

### DIFF
--- a/frontend/assets/stylesheets/components/_event-detail.scss
+++ b/frontend/assets/stylesheets/components/_event-detail.scss
@@ -13,14 +13,15 @@
 
     @include mq(tablet) {
         padding: rem($gs-baseline / 2) rem($gs-gutter) rem($gs-baseline * 3);
-    }
-
-    @include mq(desktop) {
         width: rem(map-get($max-widths, max-tablet) + $gs-gutter * 2);
     }
 
-    @include mq(mem-full) {
+    @include mq(desktop) {
         width: rem(map-get($max-widths, max-desktop) + $gs-gutter * 2);
+    }
+
+    @include mq(mem-full) {
+        width: rem(map-get($max-widths, max-mem-full) + $gs-gutter * 2);
     }
 }
 .event-header__container--details {


### PR DESCRIPTION
This fixes some alignment issues on the event detail page caused by PR #891. In #891 I modified the general mechanism which is used (almost) everywhere for handling the variable width margins and snapping of fixed widths at various breakpoints. Unfortunately, the event detail CSS duplicates this mechanism for some reason and it wasn't changed.

For a future PR the event CSS & HTML is in need of cleanup. As well as various visual defects, it seems to duplicate in a custom way lots of general-purpose layout that we use throughout the site. This is an issue for maintainability.

@tomverran 