### PR TITLE
Convert usernames to lower case before comparing

### DIFF
--- a/frontend/test/acceptance/JoinPartnerSpec.scala
+++ b/frontend/test/acceptance/JoinPartnerSpec.scala
@@ -64,7 +64,7 @@ class JoinPartnerSpec extends FeatureSpec
       assert(thankYou.pageHasLoaded())
 
       And("I should be signed in as Partner.")
-      assert(thankYou.userDisplayName == testUser.username.toLowerCase)
+      assert(thankYou.userDisplayName.toLowerCase == testUser.username.toLowerCase)
       assert(thankYou.userTier == "Partner")
     }
   }


### PR DESCRIPTION
@joelochlann 

Solves the following problem with mixed case in usernames: 
```
[info]   Scenario: I join as Partner by clicking 'Become a Partner' button on Membership homepage *** FAILED ***
[info]   "[N3xpEjvKpv9SyaSP]rtb" did not equal "[n3xpejvkpv9syasp]rtb" (JoinPartnerSpec.scala:67)
```
https://travis-ci.org/guardian/membership-frontend/builds/96964352