### PR TITLE
Add missing padding in tablet view of event detail page

### DIFF
--- a/frontend/assets/stylesheets/components/_event-detail.scss
+++ b/frontend/assets/stylesheets/components/_event-detail.scss
@@ -363,8 +363,8 @@
 
     @include mq(tablet) {
         float: left;
-        padding: 0 rem($gs-gutter) 0 0;
-        width: rem(gs-span(5) + $gs-gutter * 3);
+        padding: 0 rem($gs-gutter);
+        width: rem(gs-span(5) + $gs-gutter * 2);
     }
 
     @include mq(desktop) {


### PR DESCRIPTION
Fixes a longstanding issue in the tablet view of the event detail page (we had no left or right padding on the main body of the event).

#### Before
![picture 62](https://cloud.githubusercontent.com/assets/5122968/11815852/9fec12dc-a345-11e5-8b6a-abfad2fec48a.png)

#### After
![picture 63](https://cloud.githubusercontent.com/assets/5122968/11815851/9fe78b9a-a345-11e5-9319-f7b71333d94c.png)