### PR TITLE
Show the default 'Book tickets' message to non-members on Event page

### DIFF
--- a/frontend/assets/javascripts/src/modules/events/cta.js
+++ b/frontend/assets/javascripts/src/modules/events/cta.js
@@ -9,7 +9,6 @@ define([
         buy: {},
         join: {
             id: 'join',
-            label: 'Become a member',
             href: '/choose-tier'
         },
         upgrade: {
@@ -31,7 +30,9 @@ define([
      * @param ctaStatus
      */
     function enhanceCta(elem, ctaStatus) {
-        elem.text(ctaStatus.label);
+        if (ctaStatus.label) {
+            elem.text(ctaStatus.label);
+        }
 
         if (ctaStatus.href) {
             elem.attr('href', ctaStatus.href);


### PR DESCRIPTION
Show non-members a ticket-purchasing button with **'Book tickets'**, rather than **'Become a member'**. @JuliaBellis asked for this change, on the basis that new users on the event page _want to buy a ticket_, and they need a call-to-action that relates to what they want to do.

_NB This is just a text change - the user will still be taken through the Membership sign-up process before being able to purchase the ticket._

**Before:**
![image](https://cloud.githubusercontent.com/assets/52038/11816212/64f944e0-a347-11e5-801f-97aabdde628a.png)

**After:**
![image](https://cloud.githubusercontent.com/assets/52038/11816229/77918d06-a347-11e5-879f-352e92f870e7.png)


cc @joelochlann @davidmcdowell 