### PR TITLE
Use https image url provided by capi

### DIFF
--- a/frontend/app/model/ResponsiveImage.scala
+++ b/frontend/app/model/ResponsiveImage.scala
@@ -21,9 +21,9 @@ object ResponsiveImageGroup {
     metadata = None,
     availableImages = for {
       asset <- element.assets
-      file <- asset.file
+      file <- asset.typeData.get("secureFile")
       width <- asset.typeData.get("width")
-    } yield ResponsiveImage(file.replace("http://static", "https://static-secure"), width.toInt)
+    } yield ResponsiveImage(file, width.toInt)
   )
 
   def fromGridImage(image: GridImage): Option[ResponsiveImageGroup] =

--- a/frontend/app/model/ResponsiveImage.scala
+++ b/frontend/app/model/ResponsiveImage.scala
@@ -51,7 +51,10 @@ case class ResponsiveImageGroup(
 
   private val sortedImages = availableImages.sortBy(_.width)
 
-  val smallestImage = sortedImages.head.path
+  // We expect to have at least one availableImage. In the rare case we don't,
+  // set the path to about:blank, which is still a valid URL whose resource is an empty string.
+  // http://www.w3.org/TR/2011/WD-html5-20110525/fetching-resources.html#about:blank
+  val smallestImage = sortedImages.headOption.map(_.path).getOrElse("about:blank")
   val defaultImage = sortedImages.find(_.width > 300).map(_.path).getOrElse(smallestImage)
 
   val srcset = sortedImages.map { img =>


### PR DESCRIPTION
We have to use secure image URLs because our main site is HTTPS and some browsers won't load non-secure image URLs. Apparently in the past we've achieved this by hacking the insecure URL provided by CAPI in a secure one. But inevitably we have cases where the non-secure URL doesn't match the expected format (e.g. it starts `http://media.guim`) so no replacement happens. The site then attempts to fetch insecure assets which breaks certain images - in our case, some images on [Offers and Competitions](https://membership.theguardian.com/offers-competitions).

But CAPI provides us with a secure URL! This is what we should've been using all along. It's apparently an optional property but should exist for everything added via Composer. If it doesn't exist we skip that image. In the worst case where this happens for all assets returned by CAPI, `availableImages` in `ResponsiveImageGroup` would be an empty list so no image would be displayed for that content, which is fine because with no secure URL we can't display the image anyway.

@rtyley @afiore 