### PR TITLE
Keep event detail image within tablet margins

### DIFF
--- a/frontend/assets/stylesheets/components/_event-detail.scss
+++ b/frontend/assets/stylesheets/components/_event-detail.scss
@@ -251,8 +251,14 @@
 .event-image {
     margin: 0 auto;
 
+    @include mq(tablet) {
+        width: rem(map-get($max-widths, max-tablet) + $gs-gutter * 2);
+    }
+    @include mq(desktop) {
+        width: rem(map-get($max-widths, max-desktop) + $gs-gutter * 2);
+    }
     @include mq(mem-full) {
-        width: rem(gs-span(14) + $gs-gutter * 2);
+        width: rem(map-get($max-widths, max-mem-full) + $gs-gutter * 2);
     }
 
     img {
@@ -264,11 +270,6 @@
     padding: rem(5px) rem($gs-gutter / 2) 0;
 
     @include mq(tablet) {
-        padding-left: 0;
-        margin: 0 auto;
-    }
-
-    @include mq(desktop) {
         padding-left: rem($gs-gutter);
     }
 


### PR DESCRIPTION
... and also add left padding to the caption

#### Before
![picture 64](https://cloud.githubusercontent.com/assets/5122968/11841793/9542c0f8-a3f7-11e5-90b8-57c39a9b9cdd.png)

#### After
![picture 65](https://cloud.githubusercontent.com/assets/5122968/11841800/9a5a89b8-a3f7-11e5-88f0-d6e27090d648.png)
