### PR TITLE
Ensure 'Book Tickets' button on event is wide enough

### DIFF
--- a/frontend/assets/stylesheets/components/_event-detail.scss
+++ b/frontend/assets/stylesheets/components/_event-detail.scss
@@ -189,6 +189,7 @@
 .event-ticket__action {
     padding-top: rem($gs-baseline);
     padding-bottom: rem($gs-baseline);
+    min-width: 169px;
 
     @include mq(tablet) {
         padding-top: 0;


### PR DESCRIPTION
Our px-to-rem plugin allows us to put raw pixel widths in our Sass files - they will later be converted to rem (use of functions like `rem()` elsewhere has been redundant for a while but remain for historical reasons).

The magic number here may come back to bite anyone who stuffs more text into the button later, but it will do for now (no time right now to think of a variable-width solution).

#### Before
![picture 68](https://cloud.githubusercontent.com/assets/5122968/11844231/8527d0d8-a405-11e5-960e-d1d040dc2d6d.png)

#### After
![picture 67](https://cloud.githubusercontent.com/assets/5122968/11844240/89a55c5c-a405-11e5-83f9-26ba82c54382.png)

@tomverran 
