### PR TITLE
Filter benefits by country group

### DIFF
--- a/frontend/app/controllers/Info.scala
+++ b/frontend/app/controllers/Info.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import com.gu.i18n.{GBP, USD}
+import com.gu.i18n.{CountryGroup, GBP}
 import configuration.CopyConfig
 import forms.MemberForm._
 import model._
@@ -14,7 +14,7 @@ import scala.concurrent.Future
 trait Info extends Controller {
 
   def supporter = CachedAction.async { implicit request =>
-    implicit val currency = GBP
+    implicit val countryGroup = CountryGroup.UK
 
     val pageImages = Seq(
       ResponsiveImageGroup(
@@ -69,7 +69,7 @@ trait Info extends Controller {
   }
 
   def supporterUSA = CachedAction.async { implicit request =>
-    implicit val currency = USD
+    implicit val countryGroup = CountryGroup.US
 
     val pageImages = Seq(
       ResponsiveImageGroup(

--- a/frontend/app/model/Benefits.scala
+++ b/frontend/app/model/Benefits.scala
@@ -21,7 +21,7 @@ object Benefits {
   val welcomePack = Benefit("welcome_pack", "Welcome pack, card and gift")
   val accessTicket = Benefit("access_tickets", "Access to tickets")
   val liveStream = Benefit("live_stream", "Access to live stream")
-  val emailUpdates = Benefit("email_updates", "Regular events email")
+  val emailUpdates = Benefit("email_updates", "Regular member emails")
   val offersCompetitions = Benefit("offers_competitions", "Offers and competitions")
   val priorityBooking = Benefit("priority_booking", "48hrs priority booking")
   val noBookingFees = Benefit("no_booking_fees", "No booking fees")
@@ -32,12 +32,14 @@ object Benefits {
   val discount = Benefit("discount", "20% discount for you and a guest")
   val uniqueExperiences = Benefit("unique_experiences", "Exclusive behind-the-scenes functions")
 
+  val marketedOnlyToUK = Set[Benefit](liveStream, accessTicket, offersCompetitions)
+
   val friend = Seq(
     accessTicket,
     offersCompetitions,
     emailUpdates
   )
-  
+
   val supporter = Seq(
     welcomePack,
     liveStream,

--- a/frontend/app/views/fragments/tier/comparisonTable.scala.html
+++ b/frontend/app/views/fragments/tier/comparisonTable.scala.html
@@ -72,7 +72,7 @@
     </div>
     <div class="comparison-table__body">
         <div class="comparison-table__row">
-            @comparisonDetails(catalog.supporter.tier.detailsLimited)
+            @comparisonDetails(catalog.supporter.tier.detailsLimited())
             <div class="comparison-table__checkmarks">
                 @comparisonCheckmark(Supporter, checkmark = true)
                 @comparisonCheckmark(Partner, checkmark = true, isActive = true)
@@ -80,7 +80,7 @@
             </div>
         </div>
         <div class="comparison-table__row">
-            @comparisonDetails(catalog.partner.tier.detailsLimited)
+            @comparisonDetails(catalog.partner.tier.detailsLimited())
             <div class="comparison-table__checkmarks">
                     @comparisonCheckmark(Supporter, checkmark = false)
                     @comparisonCheckmark(Partner, checkmark = true, isActive = true)
@@ -88,7 +88,7 @@
                 </div>
             </div>
             <div class="comparison-table__row">
-            @comparisonDetails(catalog.patron.tier.detailsLimited)
+            @comparisonDetails(catalog.patron.tier.detailsLimited())
             <div class="comparison-table__checkmarks">
                 @comparisonCheckmark(Supporter, checkmark = false)
                 @comparisonCheckmark(Partner, checkmark = false, isActive = true)

--- a/frontend/app/views/fragments/tier/packageFeature.scala.html
+++ b/frontend/app/views/fragments/tier/packageFeature.scala.html
@@ -1,19 +1,19 @@
 @import views.support.DisplayText._
 @import model.PaidTierDetails
-@import com.gu.i18n.Currency
+@import com.gu.i18n.CountryGroup
 
-@(details: PaidTierDetails, currency: Currency, isReversed: Boolean = false)
+@(details: PaidTierDetails, countryGroup: CountryGroup, isReversed: Boolean = false)
 
 <div class="package-feature">
     <div class="package-feature__promo">
-        @fragments.tier.packagePromo(details, currency, isReversed=isReversed, modifierClass=Some("package-promo--always-narrow"))
+        @fragments.tier.packagePromo(details, countryGroup.currency, isReversed=isReversed, modifierClass=Some("package-promo--always-narrow"))
     </div>
     <div class="package-feature__benefits copy">
         <div class="package-feature__leadin tone-border-@details.tier.slug">
             @details.tier.leadin
         </div>
         <ul>
-            @for(benefit <- details.tier.detailsLimited) {
+            @for(benefit <- details.tier.detailsLimited(countryGroup)) {
                 <li>@benefit.title</li>
             }
         </ul>

--- a/frontend/app/views/info/supporter.scala.html
+++ b/frontend/app/views/info/supporter.scala.html
@@ -1,9 +1,9 @@
-@import com.gu.i18n.Currency
 @import model.MembershipCatalog
 @import views.support.PageInfo
+@import com.gu.i18n.CountryGroup
 @(catalog: MembershipCatalog,
   pageInfo: PageInfo,
-  pageImages: Seq[model.ResponsiveImageGroup])(implicit token: play.filters.csrf.CSRF.Token, currency: Currency)
+  pageImages: Seq[model.ResponsiveImageGroup])(implicit token: play.filters.csrf.CSRF.Token, countryGroup: CountryGroup)
 
 @import com.gu.salesforce.Tier.Supporter
 @import configuration.Videos
@@ -19,7 +19,7 @@
                         <span class="text-pale">Plus, join today and £1 will be donated to the Guardian Charity Appeal.</span>
                     </p>
                 </div>
-                @fragments.tier.packagePromo(catalog.supporter, currency, showDescription=false, modifierClass=Some("package-promo--spread"))
+                @fragments.tier.packagePromo(catalog.supporter, countryGroup.currency, showDescription=false, modifierClass=Some("package-promo--spread"))
             }
         </div>
     }
@@ -68,7 +68,7 @@
         <div class="l-constrained">
             <h2 class="page-slice__headline">What's included</h2>
             <div class="page-slice__content">
-                @fragments.tier.packageFeature(catalog.supporter, currency,isReversed=true)
+                @fragments.tier.packageFeature(catalog.supporter, countryGroup, isReversed=true)
             </div>
         </div>
     </div>

--- a/frontend/app/views/info/supporterUSA.scala.html
+++ b/frontend/app/views/info/supporterUSA.scala.html
@@ -77,7 +77,7 @@
         <div class="l-constrained">
             <h2 class="page-slice__headline">What's included</h2>
             <div class="page-slice__content">
-                @fragments.tier.packageFeature(supporterTierDetails, USD, isReversed=true)
+                @fragments.tier.packageFeature(supporterTierDetails, US, isReversed=true)
             </div>
         </div>
     </div>

--- a/frontend/app/views/support/DisplayText.scala
+++ b/frontend/app/views/support/DisplayText.scala
@@ -1,9 +1,10 @@
 package views.support
 
-import com.gu.i18n.GBP
+import com.gu.i18n.CountryGroup
 import com.gu.salesforce.Tier
 import com.gu.salesforce.Tier._
 import configuration.Config.zuoraFreeEventTicketsAllowance
+import model.Benefits.marketedOnlyToUK
 import model.{Benefits, PaidTierDetails}
 import views.support.Pricing._
 
@@ -17,11 +18,13 @@ object DisplayText {
 
     def cta = s"Become a ${tier.slug}"
 
-    def detailsLimited = tier match {
+    def detailsLimited(countryGroup: CountryGroup = CountryGroup.UK) = (tier match {
       case Friend | Supporter => benefits
       case Partner => benefits.filterNot(Benefits.supporter.toSet)
       case Patron => benefits.filterNot(Benefits.partner.toSet)
       case Staff => benefits.filterNot(i => Benefits.partner.toSet.contains(i) || i == Benefits.booksOrTickets)
+    }).filterNot {
+      benefit => marketedOnlyToUK(benefit) && countryGroup != CountryGroup.UK
     }
 
     def leadin = tier match {


### PR DESCRIPTION
Benefits related to events are not supposed to be promoted outside the UK, so we need to filter these by country group when displaying package feature components on the site.

#### US Supporter Page, Before
![picture 87](https://cloud.githubusercontent.com/assets/5122968/11960711/d8035122-a8cb-11e5-98cd-e2fc0d418620.png)

#### US Supporter Page, After
(price difference is just due to touchpoint env differences)
![picture 88](https://cloud.githubusercontent.com/assets/5122968/11960720/e1f792b0-a8cb-11e5-9ad8-b7b1f465475a.png)

@rtyley 

