### PR TITLE
Set friend currencies based on delivery address

### DIFF
--- a/frontend/app/views/staff/catalogDiagnostic.scala.html
+++ b/frontend/app/views/staff/catalogDiagnostic.scala.html
@@ -12,7 +12,7 @@
               <th>RATE PLAN</th>
               <th>ENVIRONMENT</th>
               <th>ID</th>
-              <th>PRICES</th>
+              <th>PRICES/CURRENCIES</th>
             </tr>
           </thead>
           <tbody>
@@ -20,7 +20,7 @@
               <tr>
                 <td>@cat.name</td>
                 <td>@cat.env</td>
-                <td>@cat.productRatePlanId</td>
+                <td>@cat.productRatePlanId.get</td>
                 <td>@cat.prices</td>
               </tr>
             }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "0.13"
   val identityTestUsers = "com.gu" %% "identity-test-users" % "0.5"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.125"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.126"
   val playGoogleAuth = "com.gu" %% "play-googleauth" % "0.3.0"
   val contentAPI = "com.gu" %% "content-api-client" % "6.4"
   val playWS = PlayImport.ws


### PR DESCRIPTION
- Upgrade to membership-common v0.126
- Tweak to the catalog diagnostic page
- display an error in the catalog diagnostics page when the friend rate plan does not contain all possible currencies defined in the catalog (this is required in order to allow downgrade to friend)  

![screen shot 2016-01-07 at 17 46 48](https://cloud.githubusercontent.com/assets/63361/12199726/60c344ec-b612-11e5-9020-3def237f184e.png)

