### PR TITLE
Fix disappearing draft-events 

### DIFF
--- a/frontend/app/model/TicketSaleDates.scala
+++ b/frontend/app/model/TicketSaleDates.scala
@@ -5,7 +5,7 @@ import com.gu.salesforce.Tier
 import model.Benefits.PriorityBookingTiers
 import model.Eventbrite.{EBTicketClass, EventTimes}
 import org.joda.time.DateTimeZone.UTC
-import org.joda.time.Instant
+import org.joda.time.{Duration, Instant}
 
 import scala.collection.immutable.SortedMap
 
@@ -39,7 +39,10 @@ object TicketSaleDates {
   def datesFor(eventTimes: EventTimes, tickets: EBTicketClass): TicketSaleDates = {
     val effectiveSaleStart = tickets.sales_start.getOrElse(eventTimes.created)
 
-    val saleStartLeadTimeOnEvent = (effectiveSaleStart to eventTimes.start).duration
+    val saleStartLeadTimeOnEvent =
+      if (effectiveSaleStart <= eventTimes.start)
+        (effectiveSaleStart to eventTimes.start).duration
+      else Duration.ZERO
 
     memberLeadTimeOverGeneralRelease.until(saleStartLeadTimeOnEvent).values.lastOption match {
       case Some(memberLeadTimes) =>


### PR DESCRIPTION
Avoid constructing invalid interval instances. This prevented the entire draft live event feed from displaying. 

![screen shot 2016-01-11 at 11 17 13](https://cloud.githubusercontent.com/assets/63361/12232298/9e9074d0-b855-11e5-89de-dd6a387e1177.png)
