### PR TITLE
Avoid erroring when a pending amend already exists

### DIFF
--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -49,6 +49,9 @@ object Config {
   def idWebAppSignOutThenInUrl(uri: String): String =
     (idWebAppUrl / "signout") ? ("returnUrl" -> idWebAppSigninUrl(uri)) ? ("skipConfirmation" -> "true")
 
+  def idWebAppProfileUrl =
+    idWebAppUrl / "membership"/ "edit"
+
   val idKeys = if (config.getBoolean("identity.production.keys")) new ProductionKeys else new PreProductionKeys
 
   val idApiUrl = config.getString("identity.api.url")

--- a/frontend/app/views/tier/pendingAmend.scala.html
+++ b/frontend/app/views/tier/pendingAmend.scala.html
@@ -1,0 +1,14 @@
+@import configuration.Config.idWebAppProfileUrl
+@()
+
+@main("Update pending") {
+    <main role="main" class="page-content l-constrained">
+        @fragments.page.pageHeader("Update pending")
+
+        <div class="page-section">
+            <div class="page-section__content copy">
+                <p>Your membership account has an update pending so no further changes are possible right now. Check your <a href="@idWebAppProfileUrl">profile page</a> to find out when your new tier will be active. </p>
+            </div>
+        </div>
+    </main>
+}


### PR DESCRIPTION
As part of the recent effort to clean up Sentry and to reduce the number of noisy exceptions, this handles the pending amends and other `MemberService` error cases as (throwable) values. When a `PendingAmendError ` is returned, we render a specific error page pointing the user to the profile page.

![screen shot 2016-01-12 at 17 13 13](https://cloud.githubusercontent.com/assets/63361/12270665/18af5d0e-b94f-11e5-83a0-3f1b35e47c6c.png)
