### PR TITLE
Dollars without country code

### DIFF
--- a/frontend/app/views/fragments/form/cardDetail.scala.html
+++ b/frontend/app/views/fragments/form/cardDetail.scala.html
@@ -20,7 +20,7 @@
                 <h3 class="credit-card-note__header">Ongoing payments</h3>
                     @for(pricing <- plans.allPricing) {
                         <p class="is-hidden" data-currency="@pricing.currency">
-                            Your card will be charged @pricing.currency.glyph
+                            Your card will be charged @pricing.currency.identifier
                             <span class="js-card-note-pricing-charge"
                                   data-annual="@pricing.yearly.amount"
                                   data-monthly="@pricing.monthly.amount">

--- a/frontend/app/views/fragments/pricing/paidPriceInfo.scala.html
+++ b/frontend/app/views/fragments/pricing/paidPriceInfo.scala.html
@@ -4,12 +4,20 @@
 @import com.gu.memsub.Current
 @import views.support.Pricing._
 
-@(plans: PaidMembershipPlans[Current, PaidTier], currency: Currency, isReversible: Boolean = false, canFlex: Boolean = true)
+@(
+    plans: PaidMembershipPlans[Current, PaidTier],
+    currency: Currency,
+    isReversible: Boolean = false,
+    canFlex: Boolean = true,
+    showCurrencyPrefix: Boolean = true
+)
 <div class="price-info@if(canFlex) { price-info--flex} @if(isReversible) { price-info--@plans.tier.slug}">
     @defining(plans.pricingByCurrencyOrGBP(currency)) { pricing =>
         <div class="price-info__item price-info__item--split">
             <div class="price-info__detail">
-                <strong class="price-info__value">@pricing.yearly.pretty</strong>
+                <strong class="price-info__value">
+                    @if(showCurrencyPrefix) { @pricing.yearly.pretty } else { @pricing.yearly.prettyWithoutCurrencyPrefix }
+                </strong>
                 <span class="price-info__date">/year</span>
             </div>
             @pricing.savingInfo.map { savingMsg =>
@@ -18,7 +26,9 @@
         </div>
         <div class="price-info__item price-info__item--split price-info__item--last">
             <div class="price-info__detail price-info__detail--right">
-                <strong class="price-info__value">@pricing.monthly.pretty</strong>
+                <strong class="price-info__value">
+                    @if(showCurrencyPrefix) { @pricing.monthly.pretty } else { @pricing.monthly.prettyWithoutCurrencyPrefix }
+                </strong>
                 <span class="price-info__date">/month</span>
             </div>
         </div>

--- a/frontend/app/views/fragments/tier/packagePromoUSASupporter.scala.html
+++ b/frontend/app/views/fragments/tier/packagePromoUSASupporter.scala.html
@@ -34,7 +34,7 @@
         </div>
         <div class="package-promo__actions">
             <div class="package-promo__actions__pricing">
-                @fragments.pricing.paidPriceInfo(supporterPlans, US.currency)
+                @fragments.pricing.paidPriceInfo(supporterPlans, US.currency, showCurrencyPrefix = false)
             </div>
             <a class="action action--no-icon u-no-bottom-margin qa-package-@supporter.slug" @actionAttrs>
                 <span class="action__label">

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "0.13"
   val identityTestUsers = "com.gu" %% "identity-test-users" % "0.5"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.126"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.127-SNAPSHOT"
   val playGoogleAuth = "com.gu" %% "play-googleauth" % "0.3.0"
   val contentAPI = "com.gu" %% "content-api-client" % "6.4"
   val playWS = PlayImport.ws

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "0.13"
   val identityTestUsers = "com.gu" %% "identity-test-users" % "0.5"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.127-SNAPSHOT"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.127"
   val playGoogleAuth = "com.gu" %% "play-googleauth" % "0.3.0"
   val contentAPI = "com.gu" %% "content-api-client" % "6.4"
   val playWS = PlayImport.ws


### PR DESCRIPTION
On the US supporter page there's no ambiguity about what $ means, so we don't need to display US$.

#### Before
![picture 115](https://cloud.githubusercontent.com/assets/5122968/12273204/7df02330-b95c-11e5-8506-e84b9967d198.png)

#### After (different prices due to dev env)
![picture 114](https://cloud.githubusercontent.com/assets/5122968/12273210/83cf4d12-b95c-11e5-88c1-91e9138bc8ef.png)

@afiore 

