### PR TITLE
Pull card details from Zuora on the paid to paid upgrade page

### DIFF
--- a/frontend/app/controllers/TierController.scala
+++ b/frontend/app/controllers/TierController.scala
@@ -1,10 +1,10 @@
 package controllers
 
-import _root_.services.{IdentityApi, IdentityService}
+import com.google.gdata.data.docs.Year
 import com.gu.i18n.CountryGroup
 import com.gu.i18n.CountryGroup._
 import com.gu.identity.play.PrivateFields
-import com.gu.memsub._
+import com.gu.memsub.{ProductFamily, Membership, BillingPeriod, PaymentCard}
 import com.gu.memsub.BillingPeriod._
 import com.gu.salesforce._
 import com.gu.stripe.Stripe
@@ -17,6 +17,7 @@ import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json.Json
 import play.api.mvc.{Controller, Result}
 import play.filters.csrf.CSRF.Token.getToken
+import services._
 import tracking.ActivityTracking
 import utils.TierChangeCookies
 import views.support.PageInfo.CheckoutForm

--- a/frontend/app/controllers/package.scala
+++ b/frontend/app/controllers/package.scala
@@ -1,6 +1,6 @@
 import actions._
 import com.gu.membership.MembershipCatalog
-import com.gu.memsub.services.api.SubscriptionService
+import com.gu.memsub.services.api.{PaymentService, SubscriptionService}
 import com.gu.salesforce.{Member, PaidTierMember}
 import com.gu.stripe.StripeService
 import com.gu.zuora.api.ZuoraService
@@ -20,6 +20,11 @@ package object controllers extends CommonActions with LazyLogging{
   trait MemberServiceProvider {
     def memberService(implicit request: BackendProvider): MemberService =
       request.touchpointBackend.memberService
+  }
+
+  trait PaymentServiceProvider {
+    def paymentService(implicit request: BackendProvider): PaymentService =
+      request.touchpointBackend.paymentService
   }
 
   trait CatalogProvider {

--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -230,12 +230,6 @@ class MemberService(identityService: IdentityService,
     }
   }
 
-  override def updateDefaultCard(member: PaidSFMember, token: String): Future[Stripe.Card] =
-    for {
-      customer <- stripeService.Customer.updateCard(member.stripeCustomerId, token)
-      memberId <- salesforceService.updateCardId(member.identityId, customer.card.id)
-    } yield customer.card
-
   override  def getMembershipSubscriptionSummary(contact: GenericSFContact): Future[ThankyouSummary] = {
     val latestSubF = subscriptionService.unsafeGet(contact)
 

--- a/frontend/app/services/TouchpointBackend.scala
+++ b/frontend/app/services/TouchpointBackend.scala
@@ -69,7 +69,8 @@ object TouchpointBackend {
       subscriptionService = subscriptionService,
       catalogService = catalogService,
       zuoraService = zuoraService,
-      membershipRatePlanIds = memRatePlanIds
+      membershipRatePlanIds = memRatePlanIds,
+      paymentService = paymentService
     )
   }
 
@@ -91,7 +92,8 @@ case class TouchpointBackend(salesforceService: api.SalesforceService,
                              subscriptionService: memsubapi.SubscriptionService,
                              catalogService: memsubapi.CatalogService,
                              zuoraService: ZuoraService,
-                             membershipRatePlanIds: MembershipRatePlanIds) extends ActivityTracking {
+                             membershipRatePlanIds: MembershipRatePlanIds,
+                             paymentService: PaymentService) extends ActivityTracking {
 
   def catalog: MembershipCatalog = catalogService.membershipCatalog
 }

--- a/frontend/app/services/api/MemberService.scala
+++ b/frontend/app/services/api/MemberService.scala
@@ -43,8 +43,6 @@ trait MemberService {
 
   def subscriptionUpgradableTo(memberId: SFMember, tier: PaidTier): Future[Option[Subscription]]
 
-  def updateDefaultCard(member: PaidSFMember, token: String): Future[Stripe.Card]
-
   def getMembershipSubscriptionSummary(contact: GenericSFContact): Future[ThankyouSummary]
 
   /*

--- a/frontend/app/views/fragments/user/cardSummary.scala.html
+++ b/frontend/app/views/fragments/user/cardSummary.scala.html
@@ -1,10 +1,11 @@
-@(card: com.gu.stripe.Stripe.Card)
+@import com.gu.memsub.PaymentCard
+@(card: PaymentCard)
 
 <div class="card-summary">
     <div class="card-summary__type">
-        <i class="sprite-card sprite-card--small sprite-card--@(card.issuer)"></i>
+        <i class="sprite-card sprite-card--small sprite-card--@(card.cardType)"></i>
     </div>
     <div class="card-summary__digits">
-        @card.last4
+        @card.lastFourDigits
     </div>
 </div>

--- a/frontend/app/views/support/PaidToPaidUpgradeSummary.scala
+++ b/frontend/app/views/support/PaidToPaidUpgradeSummary.scala
@@ -10,7 +10,7 @@ import model.PaidSubscription
 import model.SubscriptionOps._
 import org.joda.time.{DateTime, LocalDate}
 
-case class CurrentSummary(tier: PaidTier, startDate: LocalDate, payment: Price, card: Card)
+case class CurrentSummary(tier: PaidTier, startDate: LocalDate, payment: Price, card: PaymentCard)
 
 case class TargetSummary(tier: PaidTier, firstPayment: Price, nextPayment: Price, nextPaymentDate: LocalDate)
 
@@ -23,7 +23,7 @@ object PaidToPaidUpgradeSummary {
     override def getMessage = s"Failure while trying to display an upgrade summary for the subscription $subNumber to $targetTier: $msg"
   }
 
-  def apply(invoices: Seq[PreviewInvoiceItem], sub: PaidSubscription, targetId: ProductRatePlanId, card: Card)(implicit catalog: MembershipCatalog): PaidToPaidUpgradeSummary = {
+  def apply(invoices: Seq[PreviewInvoiceItem], sub: PaidSubscription, targetId: ProductRatePlanId, card: PaymentCard)(implicit catalog: MembershipCatalog): PaidToPaidUpgradeSummary = {
     val plan = catalog.unsafeFindPaid(targetId)
     lazy val upgradeError = UpgradeSummaryError(sub.name, plan.tier) _
     val accountCurrency = sub.currency


### PR DESCRIPTION
So essentially to break our dependency on Salesforce for stripe info we need to:

- stop reading any card information from there
- Use a subscription rather than a contact when checking payment status

This PR handles the former, I am tackling the latter on https://github.com/guardian/membership-frontend/tree/subscription-action-refiner