### PR TITLE
Soft-deploy session-cam as a switchable feature

### DIFF
--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -85,6 +85,8 @@ object Config {
 
   val optimizelyEnabled = config.getBoolean("optimizely.enabled")
 
+  val sessionCamCookieName = "sessioncam-on"
+
   val corsAllowOrigin = Set(
     // identity
     "https://profile.thegulocal.com",

--- a/frontend/app/controllers/SessionCam.scala
+++ b/frontend/app/controllers/SessionCam.scala
@@ -1,0 +1,16 @@
+package controllers
+
+import configuration.Config.sessionCamCookieName
+import play.api.mvc.{DiscardingCookie, Cookie, Controller}
+
+object SessionCam extends Controller {
+    // Temporary solution to evaluate SessionCam without actually activating it across the entire site
+  def dropSessionCamCookie = NoCacheAction { implicit request =>
+    Redirect(routes.FrontPage.welcome()).withCookies(
+      Cookie(name = sessionCamCookieName, value = "y", httpOnly = false))
+  }
+
+  def removeSessionCamCookie = NoCacheAction { implicit request =>
+    Redirect(routes.FrontPage.welcome()).discardingCookies(DiscardingCookie(sessionCamCookieName))
+  }
+}

--- a/frontend/app/controllers/Staff.scala
+++ b/frontend/app/controllers/Staff.scala
@@ -4,9 +4,10 @@ import com.gu.memsub.Membership
 import com.gu.memsub.services.CatalogService
 import play.api.libs.concurrent.Akka
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
-import play.api.mvc.Controller
+import play.api.mvc.{DiscardingCookie, Cookie, Controller}
 import services._
 import views.support.Catalog
+import configuration.Config.sessionCamCookieName
 import play.api.Play.current
 
 trait Staff extends Controller {
@@ -28,6 +29,16 @@ trait Staff extends Controller {
 
   def eventOverviewDetails = GoogleAuthenticatedStaffAction { implicit request =>
     Ok(views.html.eventOverview.details(request.path))
+  }
+
+  // Temporary solution to evaluate SessionCam without actually activating it across the entire site
+  def dropSessionCamCookie = GoogleAuthenticatedStaffAction { implicit request =>
+    Redirect(routes.FrontPage.welcome()).withCookies(
+      Cookie(name = sessionCamCookieName, value = "y", httpOnly = false))
+  }
+
+  def removeSessionCamCookie = GoogleAuthenticatedStaffAction { implicit request =>
+    Redirect(routes.FrontPage.welcome()).discardingCookies(DiscardingCookie(sessionCamCookieName))
   }
 
   def catalogDiagnostics = GoogleAuthenticatedStaffAction.async { implicit request =>

--- a/frontend/app/controllers/Staff.scala
+++ b/frontend/app/controllers/Staff.scala
@@ -1,14 +1,12 @@
 package controllers
 
-import com.gu.memsub.Membership
 import com.gu.memsub.services.CatalogService
+import play.api.Play.current
 import play.api.libs.concurrent.Akka
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
-import play.api.mvc.{DiscardingCookie, Cookie, Controller}
+import play.api.mvc.Controller
 import services._
 import views.support.Catalog
-import configuration.Config.sessionCamCookieName
-import play.api.Play.current
 
 trait Staff extends Controller {
   val guLiveEvents = GuardianLiveEventService
@@ -29,16 +27,6 @@ trait Staff extends Controller {
 
   def eventOverviewDetails = GoogleAuthenticatedStaffAction { implicit request =>
     Ok(views.html.eventOverview.details(request.path))
-  }
-
-  // Temporary solution to evaluate SessionCam without actually activating it across the entire site
-  def dropSessionCamCookie = GoogleAuthenticatedStaffAction { implicit request =>
-    Redirect(routes.FrontPage.welcome()).withCookies(
-      Cookie(name = sessionCamCookieName, value = "y", httpOnly = false))
-  }
-
-  def removeSessionCamCookie = GoogleAuthenticatedStaffAction { implicit request =>
-    Redirect(routes.FrontPage.welcome()).discardingCookies(DiscardingCookie(sessionCamCookieName))
   }
 
   def catalogDiagnostics = GoogleAuthenticatedStaffAction.async { implicit request =>

--- a/frontend/app/views/fragments/analytics/sessionCam.scala.html
+++ b/frontend/app/views/fragments/analytics/sessionCam.scala.html
@@ -1,0 +1,18 @@
+@import configuration.Config.sessionCamCookieName
+
+@()
+<!-- SessionCam Client Integration v6.0 -->
+<script type="text/javascript">
+    //<![CDATA[
+    (function (){
+        var cookieNameSubString = '@sessionCamCookieName=';
+        if (document.cookie.indexOf(cookieNameSubString) > -1) {
+            var scRec=document.createElement('SCRIPT');
+            scRec.type='text/javascript';
+            scRec.src="//d2oh4tlt9mrke9.cloudfront.net/Record/js/sessioncam.recorder.js";
+            document.getElementsByTagName('head')[0].appendChild(scRec);
+        }
+    })();
+    //]]>
+</script>
+<!-- End SessionCam -->

--- a/frontend/app/views/main.scala.html
+++ b/frontend/app/views/main.scala.html
@@ -103,6 +103,7 @@
         @fragments.global.footer(pageInfo)
         @fragments.javaScriptRequireJS()
         @fragments.analytics.googleRemarketing()
+        @fragments.analytics.sessionCam()
         <!-- build-commit-id: @app.BuildInfo.gitCommitId -->
     </body>
 </html>

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -44,9 +44,10 @@ GET            /staff/event-overview                  controllers.Staff.eventOve
 GET            /staff/event-overview/local            controllers.Staff.eventOverviewLocal
 GET            /staff/event-overview/masterclasses    controllers.Staff.eventOverviewMasterclasses
 GET            /staff/event-overview/details          controllers.Staff.eventOverviewDetails
-GET            /staff/sessioncam/on                   controllers.Staff.dropSessionCamCookie
-GET            /staff/sessioncam/off                  controllers.Staff.removeSessionCamCookie
 GET            /staff/catalog                         controllers.Staff.catalogDiagnostics
+
+GET            /sessioncam/on                         controllers.SessionCam.dropSessionCamCookie
+GET            /sessioncam/off                        controllers.SessionCam.removeSessionCamCookie
 
 # Subscription
 GET            /subscription/remaining-tickets        controllers.Subscription.remainingTickets

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -44,6 +44,8 @@ GET            /staff/event-overview                  controllers.Staff.eventOve
 GET            /staff/event-overview/local            controllers.Staff.eventOverviewLocal
 GET            /staff/event-overview/masterclasses    controllers.Staff.eventOverviewMasterclasses
 GET            /staff/event-overview/details          controllers.Staff.eventOverviewDetails
+GET            /staff/sessioncam/on                   controllers.Staff.dropSessionCamCookie
+GET            /staff/sessioncam/off                  controllers.Staff.removeSessionCamCookie
 GET            /staff/catalog                         controllers.Staff.catalogDiagnostics
 
 # Subscription


### PR DESCRIPTION
Inclusion of the Sessioncam beacon is triggered by the presence of the `sessioncam-on` cookie. This can be set by staff members by visiting '/staff/sessioncam/on' and unset by visiting '/staff/sessioncam/off'

We are not adding it by default as it does add an extra **~65KB** to our JS build!

**Without Sessioncam**
![screen shot 2016-01-13 at 13 12 14](https://cloud.githubusercontent.com/assets/63361/12295573/cbb39ed8-b9f9-11e5-82eb-1629efb9b267.png)

**With Sessioncam**
![screen shot 2016-01-13 at 13 21 39](https://cloud.githubusercontent.com/assets/63361/12295601/f4fd3132-b9f9-11e5-992d-e04adf3ea7e1.png)