### PR TITLE
Revert "Pull card details from Zuora on the paid to paid upgrade page"

### DIFF
--- a/frontend/app/controllers/TierController.scala
+++ b/frontend/app/controllers/TierController.scala
@@ -4,7 +4,7 @@ import com.google.gdata.data.docs.Year
 import com.gu.i18n.CountryGroup
 import com.gu.i18n.CountryGroup._
 import com.gu.identity.play.PrivateFields
-import com.gu.memsub.{ProductFamily, Membership, BillingPeriod, PaymentCard}
+import com.gu.memsub.{ProductFamily, Membership, Month, BillingPeriod}
 import com.gu.memsub.BillingPeriod._
 import com.gu.salesforce._
 import com.gu.stripe.Stripe
@@ -31,8 +31,7 @@ import scala.language.implicitConversions
 
 trait DowngradeTier extends ActivityTracking with CatalogProvider
                                              with SubscriptionServiceProvider
-                                             with MemberServiceProvider
-                                             with PaymentServiceProvider {
+                                             with MemberServiceProvider {
   self: TierController =>
 
   def downgradeToFriend() = PaidMemberAction.async { implicit request =>
@@ -88,7 +87,7 @@ trait UpgradeTier extends StripeServiceProvider with CatalogProvider {
       PageInfo(initialCheckoutForm = formI18n, stripePublicKey = stripeKey)
     }
 
-    def fromFree(subscription: FreeSubscription, contact: Contact[_, _]): Future[Result] =
+    def fromFree(subscription: FreeSubscription, contact: Contact[FreeTierMember, NoPayment]): Future[Result] =
       for {
         privateFields <- identityUserFieldsF
       } yield {
@@ -101,32 +100,39 @@ trait UpgradeTier extends StripeServiceProvider with CatalogProvider {
         )(getToken, request))
       }
 
-    def fromPaid(subscription: PaidSubscription, contact: Contact[_, _], card: PaymentCard): Future[Result] = {
+    def fromPaid(subscription: PaidSubscription, contact: Contact[PaidTierMember, StripePayment]): Future[Result] = {
+      val stripeCustomerF = stripeService.Customer.read(contact.stripeCustomerId)
       val targetPlanId = targetPlans.get(subscription.plan.billingPeriod).productRatePlanId
 
       for {
-        previewItems <- memberService.previewUpgradeSubscription(subscription, targetPlanId)
+        previewItems <- memberService.previewUpgradeSubscription(
+          subscription, targetPlanId)
+        customer <- stripeCustomerF
         privateFields <- identityUserFieldsF
       } yield {
-        val summary = PaidToPaidUpgradeSummary(previewItems, subscription, targetPlanId, card)
+        val summary = PaidToPaidUpgradeSummary(previewItems, subscription, targetPlanId, customer.card)
         val flashMsgOpt = request.flash.get("error").map(FlashMessage.error)
 
         Ok(views.html.tier.upgrade.paidToPaid(
-        summary,
-        privateFields,
-        pageInfo(privateFields, subscription.plan.billingPeriod),
-        flashMsgOpt
+          summary,
+          privateFields,
+          pageInfo(privateFields, subscription.plan.billingPeriod),
+          flashMsgOpt
         )(getToken, request))
       }
     }
 
-    val paymentCard = paymentService.getPaymentCardByAccount(request.subscription.accountId)
-
-    paymentCard flatMap { p => (request.subscription, p) match {
-      case (s: FreeSubscription, _) => fromFree(s, request.member)
-      case (s: PaidSubscription, Some(a: PaymentCard)) => fromPaid(s, request.member, a)
-      case _ => throw new IllegalStateException(request.subscription.accountId + " is missing a payment status or card")
-    }}
+    (request.subscription, request.member) match {
+      case (sub: FreeSubscription, Contact(d, t: FreeTierMember, p: NoPayment)) =>
+        fromFree(sub, Contact(d, t, p))
+      case (sub: PaidSubscription, Contact(d, t: PaidTierMember, p: StripePayment)) =>
+        fromPaid(sub, Contact(d, t, p))
+      case _ =>
+        Future {
+          val msg = s"Zuora account ${sub.accountId} is inconsistent with its corresponding Salesforce information"
+          throw new IllegalStateException(msg)
+        }
+    }
   }
 
   def upgradeConfirm(target: PaidTier) = ChangeToPaidAction(target).async { implicit request =>

--- a/frontend/app/controllers/package.scala
+++ b/frontend/app/controllers/package.scala
@@ -1,6 +1,6 @@
 import actions._
 import com.gu.membership.MembershipCatalog
-import com.gu.memsub.services.api.{PaymentService, SubscriptionService}
+import com.gu.memsub.services.api.SubscriptionService
 import com.gu.salesforce.{Member, PaidTierMember}
 import com.gu.stripe.StripeService
 import com.gu.zuora.api.ZuoraService
@@ -20,11 +20,6 @@ package object controllers extends CommonActions with LazyLogging{
   trait MemberServiceProvider {
     def memberService(implicit request: BackendProvider): MemberService =
       request.touchpointBackend.memberService
-  }
-
-  trait PaymentServiceProvider {
-    def paymentService(implicit request: BackendProvider): PaymentService =
-      request.touchpointBackend.paymentService
   }
 
   trait CatalogProvider {

--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -230,6 +230,12 @@ class MemberService(identityService: IdentityService,
     }
   }
 
+  override def updateDefaultCard(member: PaidSFMember, token: String): Future[Stripe.Card] =
+    for {
+      customer <- stripeService.Customer.updateCard(member.stripeCustomerId, token)
+      memberId <- salesforceService.updateCardId(member.identityId, customer.card.id)
+    } yield customer.card
+
   override  def getMembershipSubscriptionSummary(contact: GenericSFContact): Future[ThankyouSummary] = {
     val latestSubF = subscriptionService.unsafeGet(contact)
 

--- a/frontend/app/services/TouchpointBackend.scala
+++ b/frontend/app/services/TouchpointBackend.scala
@@ -69,8 +69,7 @@ object TouchpointBackend {
       subscriptionService = subscriptionService,
       catalogService = catalogService,
       zuoraService = zuoraService,
-      membershipRatePlanIds = memRatePlanIds,
-      paymentService = paymentService
+      membershipRatePlanIds = memRatePlanIds
     )
   }
 
@@ -92,8 +91,7 @@ case class TouchpointBackend(salesforceService: api.SalesforceService,
                              subscriptionService: memsubapi.SubscriptionService,
                              catalogService: memsubapi.CatalogService,
                              zuoraService: ZuoraService,
-                             membershipRatePlanIds: MembershipRatePlanIds,
-                             paymentService: PaymentService) extends ActivityTracking {
+                             membershipRatePlanIds: MembershipRatePlanIds) extends ActivityTracking {
 
   def catalog: MembershipCatalog = catalogService.membershipCatalog
 }

--- a/frontend/app/services/api/MemberService.scala
+++ b/frontend/app/services/api/MemberService.scala
@@ -43,6 +43,8 @@ trait MemberService {
 
   def subscriptionUpgradableTo(memberId: SFMember, tier: PaidTier): Future[Option[Subscription]]
 
+  def updateDefaultCard(member: PaidSFMember, token: String): Future[Stripe.Card]
+
   def getMembershipSubscriptionSummary(contact: GenericSFContact): Future[ThankyouSummary]
 
   /*

--- a/frontend/app/views/fragments/user/cardSummary.scala.html
+++ b/frontend/app/views/fragments/user/cardSummary.scala.html
@@ -1,11 +1,10 @@
-@import com.gu.memsub.PaymentCard
-@(card: PaymentCard)
+@(card: com.gu.stripe.Stripe.Card)
 
 <div class="card-summary">
     <div class="card-summary__type">
-        <i class="sprite-card sprite-card--small sprite-card--@(card.cardType)"></i>
+        <i class="sprite-card sprite-card--small sprite-card--@(card.issuer)"></i>
     </div>
     <div class="card-summary__digits">
-        @card.lastFourDigits
+        @card.last4
     </div>
 </div>

--- a/frontend/app/views/support/PaidToPaidUpgradeSummary.scala
+++ b/frontend/app/views/support/PaidToPaidUpgradeSummary.scala
@@ -10,7 +10,7 @@ import model.PaidSubscription
 import model.SubscriptionOps._
 import org.joda.time.{DateTime, LocalDate}
 
-case class CurrentSummary(tier: PaidTier, startDate: LocalDate, payment: Price, card: PaymentCard)
+case class CurrentSummary(tier: PaidTier, startDate: LocalDate, payment: Price, card: Card)
 
 case class TargetSummary(tier: PaidTier, firstPayment: Price, nextPayment: Price, nextPaymentDate: LocalDate)
 
@@ -23,7 +23,7 @@ object PaidToPaidUpgradeSummary {
     override def getMessage = s"Failure while trying to display an upgrade summary for the subscription $subNumber to $targetTier: $msg"
   }
 
-  def apply(invoices: Seq[PreviewInvoiceItem], sub: PaidSubscription, targetId: ProductRatePlanId, card: PaymentCard)(implicit catalog: MembershipCatalog): PaidToPaidUpgradeSummary = {
+  def apply(invoices: Seq[PreviewInvoiceItem], sub: PaidSubscription, targetId: ProductRatePlanId, card: Card)(implicit catalog: MembershipCatalog): PaidToPaidUpgradeSummary = {
     val plan = catalog.unsafeFindPaid(targetId)
     lazy val upgradeError = UpgradeSummaryError(sub.name, plan.tier) _
     val accountCurrency = sub.currency


### PR DESCRIPTION
Reverts guardian/membership-frontend#935

I have come across an issue on live and would like to find out whether this PR is the culprit or not