### PR TITLE
Removal of charity appeal text.

### DIFF
--- a/frontend/app/views/info/supporter.scala.html
+++ b/frontend/app/views/info/supporter.scala.html
@@ -19,7 +19,6 @@
                 <div class="text-feature">
                     <p>
                         Supporters keep our journalism fearless, open and free from interference. For £5 a month.
-                        <span class="text-pale">Plus, join today and £1 will be donated to the Guardian Charity Appeal.</span>
                     </p>
                 </div>
                 @fragments.tier.packagePromo(PaidPlans(supporterPlans), countryGroup, showDescription=false, modifierClass=Some("package-promo--spread"))

--- a/frontend/app/views/info/supporterUSA.scala.html
+++ b/frontend/app/views/info/supporterUSA.scala.html
@@ -56,7 +56,6 @@
         Become a Guardian&nbsp;Supporter
     } {
         Supporters keep our journalism fearless and free to tell the stories other news organizations won’t.
-        <span class="text-pale">Plus, join today and $1 will be donated to the Guardian Charity Appeal.</span>
     }()
 
     @section(hasBorder = false) {

--- a/frontend/assets/stylesheets/objects/_text.scss
+++ b/frontend/assets/stylesheets/objects/_text.scss
@@ -32,10 +32,6 @@
     color: $c-neutral2;
     margin-bottom: rem($gs-baseline / 2);
 }
-.text-pale {
-    color: $c-neutral2;
-}
-
 .o-counter {
     font-weight: bold;
     color: $c-neutral3;


### PR DESCRIPTION
Take the "we will donate £1 to the Guardian Charity Appeal 2015" off our engaged reader banner and revert to the previous message (at 12:00)

@joelochlann 

https://github.com/guardian/membership-frontend/pull/906

https://github.com/guardian/membership-frontend/pull/930

https://trello.com/c/qZ8Rs3TH/274-take-the-we-will-donate-1-to-the-guardian-charity-appeal-2015-off-our-engaged-reader-banner-and-revert-to-the-previous-message-o