### PR TITLE
Improve country/currency detection for new users

### DIFF
--- a/frontend/app/controllers/TierController.scala
+++ b/frontend/app/controllers/TierController.scala
@@ -3,9 +3,8 @@ package controllers
 import com.gu.i18n.CountryGroup
 import com.gu.i18n.CountryGroup._
 import com.gu.identity.play.PrivateFields
-import com.gu.memsub.{ProductFamily, Membership, BillingPeriod, PaymentCard}
 import com.gu.memsub.BillingPeriod._
-import com.gu.memsub.{BillingPeriod, Membership, ProductFamily}
+import com.gu.memsub.{BillingPeriod, Membership, PaymentCard, ProductFamily}
 import com.gu.salesforce._
 import com.gu.stripe.Stripe
 import com.gu.stripe.Stripe.Serializer._
@@ -21,9 +20,8 @@ import play.filters.csrf.CSRF.Token.getToken
 import services._
 import services.api.MemberService.{MemberError, PendingAmendError}
 import tracking.ActivityTracking
-import utils.{CampaignCode, TierChangeCookies}
-import views.support.PageInfo.CheckoutForm
-import views.support.{CountryWithCurrency, PageInfo, PaidToPaidUpgradeSummary}
+import utils.{TierChangeCookies, CampaignCode}
+import views.support.{CheckoutForm, CountryWithCurrency, PageInfo, PaidToPaidUpgradeSummary}
 
 import scala.concurrent.Future
 import scala.language.implicitConversions

--- a/frontend/app/forms/MemberForm.scala
+++ b/frontend/app/forms/MemberForm.scala
@@ -96,7 +96,11 @@ object MemberForm {
   }
 
   private val productFeature = of[Set[FeatureChoice]] as productFeaturesFormatter
-  private val country = of[Country] as countryFormatter
+  private val country: Mapping[String] =
+    text.verifying { code => CountryGroup.countryByCode(code).isDefined }
+      .transform(
+        { code => CountryGroup.countryByCode(code).fold("")(_.name)},
+        { name => CountryGroup.countryByNameOrCode(name).fold("")(_.alpha2)})
 
   val nonPaidAddressMapping: Mapping[Address] = mapping(
     "lineOne" -> text,

--- a/frontend/app/services/IdentityService.scala
+++ b/frontend/app/services/IdentityService.scala
@@ -25,7 +25,7 @@ case class IdentityService(identityApi: IdentityApi) {
     getFullUserDetails(user, identityRequest)
       .zip(doesUserPasswordExist(identityRequest))
       .map { case (fullUser, doesPasswordExist) =>
-        IdentityUser.apply(fullUser, doesPasswordExist)
+        IdentityUser(fullUser, doesPasswordExist)
       }
 
   def getFullUserDetails(user: IdMinimalUser, identityRequest: IdentityRequest): Future[IdUser] =

--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -365,7 +365,7 @@ class MemberService(identityService: IdentityService,
   override def createFreeSubscription(contactId: ContactId,
                                       joinData: JoinForm): Future[SubscribeResult] = {
     val planId = joinData.planChoice.productRatePlanId
-    val currency = catalog.supportedAccountCurrency(joinData.deliveryAddress.country, planId)
+    val currency = catalog.unsafeFindFree(planId).currencyOrGBP(joinData.deliveryAddress.country)
 
     for {
       zuoraFeatures <- zuoraService.getFeatures
@@ -388,10 +388,11 @@ class MemberService(identityService: IdentityService,
     for {
       zuoraFeatures <- zuoraService.getFeatures
       planId = joinData.planChoice.productRatePlanId
+      currency = catalog.unsafeFindPaid(planId).currencyOrGBP(joinData.zuoraAccountAddress.country)
       result <- zuoraService.createSubscription(
         subscribeAccount = SoapSubscribeAccount.stripe(
           contactId = contactId,
-          currency = catalog.supportedAccountCurrency(joinData.zuoraAccountAddress.country, planId),
+          currency = currency,
           autopay = true),
         paymentMethod = Some(CreditCardReferenceTransaction(customer)),
         productRatePlanId = planId,

--- a/frontend/app/views/fragments/form/addressDetail.scala.html
+++ b/frontend/app/views/fragments/form/addressDetail.scala.html
@@ -7,7 +7,6 @@
   town: Option[String],
   postcode: Option[String],
   county: Option[String],
-  userCountry: Option[String],
   addressRequired: Boolean = true,
   heading: String = "",
   note: String = "")

--- a/frontend/app/views/joiner/form/addressWithWelcomePack.scala.html
+++ b/frontend/app/views/joiner/form/addressWithWelcomePack.scala.html
@@ -52,8 +52,7 @@
                         address2 = idUser.privateFields.address2,
                         town = idUser.privateFields.address3,
                         postcode = idUser.privateFields.postcode,
-                        county = idUser.privateFields.address4,
-                        userCountry = idUser.privateFields.country
+                        county = idUser.privateFields.address4
                     )
                     @fragments.form.marketingChoices(
                         idUser.marketingChoices.receiveGnmMarketing,

--- a/frontend/app/views/joiner/form/friendSignup.scala.html
+++ b/frontend/app/views/joiner/form/friendSignup.scala.html
@@ -58,8 +58,7 @@
                             address2 = idUser.privateFields.address2,
                             town = idUser.privateFields.address3,
                             postcode = idUser.privateFields.postcode,
-                            county = idUser.privateFields.address4,
-                            userCountry = idUser.privateFields.country
+                            county = idUser.privateFields.address4
                         )
                         @fragments.form.marketingChoices(idUser.marketingChoices.receiveGnmMarketing, idUser.marketingChoices.receive3rdPartyMarketing)
 

--- a/frontend/app/views/joiner/form/payment.scala.html
+++ b/frontend/app/views/joiner/form/payment.scala.html
@@ -6,9 +6,8 @@
 @import com.gu.membership.PaidMembershipPlans
 @import com.gu.memsub.Current
 @import com.gu.salesforce.PaidTier
-
-@import com.gu.membership.MembershipCatalog
 @import views.support.PaidPlans
+
 @(plans: PaidMembershipPlans[Current, PaidTier],
   countriesWithCurrencies: List[CountryWithCurrency],
   idUser: IdentityUser,
@@ -61,8 +60,7 @@
                             address2 = idUser.privateFields.address2,
                             town = idUser.privateFields.address3,
                             postcode = idUser.privateFields.postcode,
-                            county = idUser.privateFields.address4,
-                            userCountry = idUser.privateFields.country
+                            county = idUser.privateFields.address4
                         )
                         @fragments.form.marketingChoices(idUser.marketingChoices.receiveGnmMarketing, idUser.marketingChoices.receive3rdPartyMarketing)
 
@@ -84,8 +82,7 @@
                             address2 = idUser.privateFields.billingAddress2,
                             town = idUser.privateFields.billingAddress3,
                             postcode = idUser.privateFields.billingPostcode,
-                            county = idUser.privateFields.billingAddress4,
-                            userCountry = idUser.privateFields.billingCountry
+                            county = idUser.privateFields.billingAddress4
                         )
                         @fragments.form.cardDetail(plans)
                     </div>

--- a/frontend/app/views/support/CheckoutForm.scala
+++ b/frontend/app/views/support/CheckoutForm.scala
@@ -1,0 +1,25 @@
+package views.support
+
+import com.gu.i18n._
+import com.gu.memsub.BillingPeriod
+
+case class CheckoutForm(defaultCountry: Option[Country],
+                        currency: Currency,
+                        billingPeriod: BillingPeriod)
+
+object CheckoutForm {
+  def forIdentityUser(idUser: IdentityUser, plans: TierPlans, requestCountryGroup: Option[CountryGroup]): CheckoutForm = {
+    val countryGroup = idUser.countryGroup.orElse(requestCountryGroup).getOrElse(CountryGroup.UK)
+    val country = idUser.country.orElse(countryGroup.defaultCountry)
+
+    val currency =
+      //Get the currency by country
+      country.flatMap(plans.currency)
+        //alternatively, use the countryGroup currency if available in the selected plan
+        .orElse(Some(countryGroup.currency)).filter(plans.currencies)
+        //or fallback to GBP
+        .getOrElse(GBP)
+
+    CheckoutForm(country, currency, BillingPeriod.year)
+  }
+}

--- a/frontend/app/views/support/IdentityUser.scala
+++ b/frontend/app/views/support/IdentityUser.scala
@@ -1,24 +1,24 @@
 package views.support
 
-import com.gu.i18n.CountryGroup
+import com.gu.i18n.{Country, CountryGroup}
 import com.gu.identity.play.{StatusFields, PrivateFields}
 import com.gu.identity.play.IdUser
 
-/**
-  * A Identity user, for view purposes, with default empty private and status fields
-  */
+
 case class IdentityUser(privateFields: PrivateFields, marketingChoices: StatusFields, passwordExists: Boolean) {
-  def withCountryGroup(countryGroup: CountryGroup): IdentityUser = {
-    val country = privateFields.country.orElse(countryGroup.defaultCountry.map(_.alpha2))
-    copy(
-      privateFields = privateFields.copy(
-        billingCountry = country
-      )
-    )
-  }
+  private val countryName: Option[String] = privateFields.billingCountry orElse privateFields.country
+
+  val country: Option[Country] =
+    countryName.flatMap(CountryGroup.countryByNameOrCode)
+
+  val countryGroup: Option[CountryGroup] =
+    countryName.flatMap(CountryGroup.byCountryNameOrCode)
 }
 
 object IdentityUser {
+  /**
+  * An Identity user, for view purposes, with default empty private and status fields
+  */
   def apply(user: IdUser, passwordExists: Boolean): IdentityUser =
     IdentityUser(
       privateFields = user.privateFields.getOrElse(PrivateFields()),

--- a/frontend/app/views/support/PageInfo.scala
+++ b/frontend/app/views/support/PageInfo.scala
@@ -1,13 +1,11 @@
 package views.support
 
-import com.gu.i18n.{Country, CountryGroup, Currency}
+import com.gu.i18n.{Country, CountryGroup, Currency, GBP}
 import com.gu.memsub.BillingPeriod
 import configuration.{Config, CopyConfig}
-import model.EventSchema
-import model.Nav
+import model.{EventSchema, Nav}
 import model.Nav.NavItem
 import play.api.libs.json._
-import views.support.PageInfo.CheckoutForm
 
 case class PageInfo(title: String = CopyConfig.copyTitleDefault,
                     url: String = "/",
@@ -22,9 +20,6 @@ case class PageInfo(title: String = CopyConfig.copyTitleDefault,
                    )
 
 object PageInfo {
-  case class CheckoutForm(defaultCountry: Option[Country],
-                          currency: Currency,
-                          billingPeriod: BillingPeriod)
 
   implicit val bpWrites = new Writes[BillingPeriod] {
     override def writes(bp: BillingPeriod): JsValue = JsString(bp.adjective)

--- a/frontend/app/views/support/TierPlans.scala
+++ b/frontend/app/views/support/TierPlans.scala
@@ -1,5 +1,6 @@
 package views.support
 
+import com.gu.i18n.{Country, Currency}
 import com.gu.membership.{FreeMembershipPlan, PaidMembershipPlans}
 import com.gu.memsub.Current
 import com.gu.salesforce.{FreeTier, PaidTier, Tier}
@@ -11,14 +12,20 @@ import com.gu.salesforce.{FreeTier, PaidTier, Tier}
 
 sealed trait TierPlans {
   def tier: Tier
+  def currencies: Set[Currency]
+  def currency(country: Country): Option[Currency]
 }
 
 case class FreePlan(plan: FreeMembershipPlan[Current, FreeTier]) extends TierPlans {
   override def tier = plan.tier
+  override def currencies = plan.currencies
+  override def currency(country: Country): Option[Currency] = plan.currency(country)
 }
 
 case class PaidPlans(plans: PaidMembershipPlans[Current, PaidTier]) extends TierPlans {
   override def tier = plans.tier
+  override def currencies = plans.currencies
+  override def currency(country: Country): Option[Currency] = plans.month.currency(country)
 }
 
 object TierPlans {

--- a/frontend/app/views/tier/upgrade/freeToPaid.scala.html
+++ b/frontend/app/views/tier/upgrade/freeToPaid.scala.html
@@ -63,8 +63,7 @@
                           address2 = userFields.address2,
                           town = userFields.address3,
                           postcode = userFields.postcode,
-                          county = userFields.address4,
-                          userCountry = userFields.country
+                          county = userFields.address4
                       )
                   </div>
 
@@ -82,8 +81,7 @@
                           address2 = userFields.billingAddress2,
                           town = userFields.billingAddress3,
                           postcode = userFields.billingPostcode,
-                          county = userFields.billingAddress4,
-                          userCountry = userFields.billingCountry
+                          county = userFields.billingAddress4
                       )
                       @fragments.form.cardDetail(targetPlans)
                   </div>

--- a/frontend/test/services/IdentityServiceTest.scala
+++ b/frontend/test/services/IdentityServiceTest.scala
@@ -37,7 +37,7 @@ class IdentityServiceTest extends Specification with Mockito {
 
       val friendForm = FriendJoinForm(
         NameForm("Joe", "Bloggs"),
-        Address("line one", "line 2", "town", "country", "postcode", Country.UK),
+        Address("line one", "line 2", "town", "country", "postcode", Country.UK.name),
         MarketingChoicesForm(Some(false), Some(false)),
         None
       )
@@ -57,8 +57,8 @@ class IdentityServiceTest extends Specification with Mockito {
         partner,
         NameForm("Joe", "Bloggs"),
         PaymentForm(year, "token"),
-        Address("line one", "line 2", "town", "country", "postcode", Country.UK),
-        Some(Address("line one", "line 2", "town", "country", "postcode", Country.UK)),
+        Address("line one", "line 2", "town", "country", "postcode", Country.UK.name),
+        Some(Address("line one", "line 2", "town", "country", "postcode", Country.UK.name)),
         MarketingChoicesForm(Some(false), Some(false)),
         None,
         None,
@@ -78,8 +78,8 @@ class IdentityServiceTest extends Specification with Mockito {
 
     val identityService = new IdentityService(identityAPI)
     val addressDetails = AddressDetails(
-      Address("line one", "line 2", "town", "country", "postcode", Country.UK),
-      Some(Address("line one", "line 2", "town", "country", "postcode", Country.UK))
+      Address("line one", "line 2", "town", "country", "postcode", Country.UK.name),
+      Some(Address("line one", "line 2", "town", "country", "postcode", Country.UK.name))
     )
 
     identityService.updateUserFieldsBasedOnUpgrade(user.id, addressDetails, identityRequest)

--- a/frontend/test/views/support/CheckoutFormTest.scala
+++ b/frontend/test/views/support/CheckoutFormTest.scala
@@ -1,0 +1,90 @@
+package views.support
+
+import com.gu.i18n._
+import com.gu.identity.play.{PrivateFields, StatusFields}
+import com.gu.membership.{PaidMembershipPlan, PaidMembershipPlans}
+import com.gu.memsub.Subscription.ProductRatePlanId
+import com.gu.memsub._
+import com.gu.salesforce.Tier
+import com.gu.salesforce.Tier.Partner
+import org.specs2.mutable.Specification
+import TierPlans._
+
+class CheckoutFormTest extends Specification {
+  val billingAddress = PrivateFields(
+    billingAddress1 = Some("billingAddress1"),
+    billingAddress2 = Some("billingAddress2"),
+    billingAddress3 = Some("billingAddress3"),
+    billingAddress4 = Some("billingAddress4"),
+    billingCountry = CountryGroup.countryByCode("US").map(_.name))
+
+  val idUser =
+    IdentityUser(
+      billingAddress,
+      StatusFields(),
+      passwordExists = false)
+
+  val idUserWithBlankCountry =
+    IdentityUser(
+      billingAddress.copy(billingCountry = None),
+      StatusFields(),
+      passwordExists = false)
+
+  val pricingSummary = PricingSummary(Map(
+    GBP -> Price(1.5f, GBP),
+    USD -> Price(2.5f, USD),
+    EUR -> Price(3.5f, EUR)
+  ))
+
+  val plans = PaidMembershipPlans[Current, Partner](
+    month = PaidMembershipPlan[Current, Partner, Month](Status.current, Tier.partner, BillingPeriod.month, ProductRatePlanId("month"), pricingSummary),
+    year = PaidMembershipPlan[Current, Partner, Year](Status.current, Tier.partner, BillingPeriod.year, ProductRatePlanId("year"), pricingSummary)
+  )
+
+  implicit class checkoutForm2Tuple2(form: CheckoutForm) {
+    def tupled2 = (form.defaultCountry, form.currency)
+  }
+
+  "CheckoutFormTest" should {
+    "forIdentityUser" should {
+      "when a country group is set from the request" should {
+        "set country/currency from the identity user" in {
+          CheckoutForm.forIdentityUser(
+            idUser, plans, Some(CountryGroup.Australia)
+          ).tupled2 === (Some(Country.US), USD)
+        }
+
+        "and the country group currency is available" should {
+          "use the country group for both country and currency" in {
+            CheckoutForm.forIdentityUser(
+              idUserWithBlankCountry, plans, Some(CountryGroup.Europe)
+            ).tupled2 === (None, EUR)
+          }
+        }
+
+        "and the country group currency is not available" should {
+          "fallback to the request country group and set currency to GBP" in {
+            CheckoutForm.forIdentityUser(
+              idUserWithBlankCountry, plans, Some(CountryGroup.Australia)
+            ).tupled2 === (Some(Country.Australia), GBP)
+          }
+        }
+      }
+
+      "when no country group is set" should {
+        "set country/currency from the identity user" in {
+          CheckoutForm.forIdentityUser(
+            idUser, plans, None
+          ).tupled2 === (Some(Country.US), USD)
+        }
+
+        "fallback to the UK country group if the identity user has no address info" in {
+          CheckoutForm.forIdentityUser(
+            idUserWithBlankCountry, plans, None
+          ).tupled2 === (Some(Country.UK), GBP)
+        }
+      }
+    }
+
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "0.13"
   val identityTestUsers = "com.gu" %% "identity-test-users" % "0.5"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.129"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.131"
   val playGoogleAuth = "com.gu" %% "play-googleauth" % "0.3.0"
   val contentAPI = "com.gu" %% "content-api-client" % "6.4"
   val playWS = PlayImport.ws


### PR DESCRIPTION
- Handle the country string coming from identity as either a country code (alpha2) or a country name, improving the likelihood of pre-selecting the user country correctly in the payment form.
- Make the country/currency pre-selection business rules a bit more explicit, by factoring them in the `CheckoutForm.forIdentityUser` method.