### PR TITLE
Remove 'free of charge' from supporter highlight text

### DIFF
--- a/frontend/app/model/Highlights.scala
+++ b/frontend/app/model/Highlights.scala
@@ -19,7 +19,7 @@ object Highlights {
     """Receive regular updates from the membership community,
       | book tickets to Guardian Live and Local events and access the Guardian members area""".stripMargin)
 
-  val support = Highlight("Support our journalism and keep theguardian.com free of charge")
+  val support = Highlight("Support the independence of the Guardian and our award-winning journalism")
   val tickets = Highlight("Get access to tickets and to the live broadcast of events")
   val freeTickets = Highlight(
     s"""Includes $zuoraFreeEventTicketsAllowance tickets to Guardian Live events

--- a/frontend/app/views/fragments/tier/packagePromoSupporter.scala.html
+++ b/frontend/app/views/fragments/tier/packagePromoSupporter.scala.html
@@ -26,7 +26,7 @@
     </div>
     <div class="package-promo__content">
         <div class="package-promo__description copy">
-            <p>Support our journalism and keep theguardian.com free of charge for all</p>
+            <p>Support the independence of the Guardian and our award-winning journalism</p>
             <h4 class="u-margin-top">Benefits:</h4>
             <ul class="o-bulleted-list">
                 <li>Welcome pack, card and gift</li>

--- a/frontend/assets/stylesheets/components/_packages.scss
+++ b/frontend/assets/stylesheets/components/_packages.scss
@@ -113,7 +113,7 @@ $_package-promo__actions_height: 117px;
         @include package-promo-wide();
 
         .package-promo__actions {
-            min-width: 350px;
+            min-width: 270px;
         }
     }
 }


### PR DESCRIPTION
This affects package promos around the site, e.g.

#### Before
<img width="235" alt="picture 120" src="https://cloud.githubusercontent.com/assets/5122968/12447731/7ca57a12-bf69-11e5-92d1-c3d8be8960a0.png">

#### After
<img width="229" alt="picture 119" src="https://cloud.githubusercontent.com/assets/5122968/12447744/90be312e-bf69-11e5-964e-f178c50de1ca.png">

#### Before
<img width="630" alt="picture 122" src="https://cloud.githubusercontent.com/assets/5122968/12447772/b78e03d8-bf69-11e5-9b0b-4025afd8d0bb.png">

#### After
<img width="631" alt="picture 121" src="https://cloud.githubusercontent.com/assets/5122968/12447777/bb70d5e8-bf69-11e5-9db4-b84d3d1677bb.png">

@tomverran 