### PR TITLE
Fixing analytics in Firefox

### DIFF
--- a/frontend/assets/javascripts/src/modules/analytics/setup.js
+++ b/frontend/assets/javascripts/src/modules/analytics/setup.js
@@ -18,9 +18,19 @@ define([
 ) {
     'use strict';
 
+    /*
+     Re: https://bugzilla.mozilla.org/show_bug.cgi?id=1023920#c2
+
+     The landscape at the moment is:
+
+     On navigator [Firefox, Chrome, Opera]
+     On window [IE, Safari]
+     */
+    var isDNT = navigator.doNotTrack == '1' || window.doNotTrack == '1';
+
     var analyticsEnabled = (
         guardian.analyticsEnabled &&
-        !navigator.doNotTrack &&
+        !isDNT &&
         !cookie.getCookie('ANALYTICS_OFF_KEY')
     );
 


### PR DESCRIPTION
Fixing bug where analytics did not work on Firefox, because navigator.doNotTrack === "unspecified" so prefixing ! returned true rather than false. Chrome returns 'null' for that value. Also fixed that IE and Safari use window.doNotTrack rather than navigator.

/cc @rtyley 

Also see https://github.com/guardian/subscriptions-frontend/pull/329