### PR TITLE
Increase Java heap memory to 1024

### DIFF
--- a/frontend/conf/upstart.conf
+++ b/frontend/conf/upstart.conf
@@ -23,5 +23,5 @@ limit nofile 65536 65536
 respawn
 
 script
-  "/membership/frontend-1.0-SNAPSHOT/bin/frontend" -mem 512 -Dconfig.resource=__STAGE.conf > $LOGFILE 2>&1
+  "/membership/frontend-1.0-SNAPSHOT/bin/frontend" -mem 1024 -Dconfig.resource=__STAGE.conf > $LOGFILE 2>&1
 end script


### PR DESCRIPTION
@afiore @rtyley 

Resolves [Sentry event](https://app.getsentry.com/the-guardian/membership/issues/96432625/)

Increased allocated Java heap memory from 512MB to 1024MB to prevent future out of memory crashes.

Note that AWS m3.medium instance on which mem-frontend runs has 3.75 GB RAM available. 
