### PR TITLE
Geocode

### DIFF
--- a/frontend/app/actions/ActionRefiners.scala
+++ b/frontend/app/actions/ActionRefiners.scala
@@ -31,6 +31,7 @@ import scalaz.std.scalaFuture._
  */
 object ActionRefiners extends LazyLogging {
   import model.TierOrdering.upgradeOrdering
+  implicit val pf: ProductFamily = Membership
 
   def resultModifier(f: Result => Result) = new ActionBuilder[Request] {
     def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]) = block(request).map(f)
@@ -48,7 +49,7 @@ object ActionRefiners extends LazyLogging {
   type SubReqWithSub[A] = SubscriptionRequest[A] with Subscriber
 
   private def getSubRequest[A](request: AuthRequest[A]): Future[Option[SubReqWithSub[A]]] = {
-    implicit val pf = ProductFamily.membership
+    implicit val pf = Membership
     val tp = request.touchpointBackend
 
     (for {

--- a/frontend/app/actions/ActionRefiners.scala
+++ b/frontend/app/actions/ActionRefiners.scala
@@ -4,7 +4,7 @@ import services._
 import actions.Fallbacks._
 import com.gu.googleauth.{GoogleGroupChecker, UserIdentity}
 import com.gu.membership.{FreeMembershipPlan, PaidMembershipPlan}
-import com.gu.membership.util.Timing
+import com.gu.memsub.util.Timing
 import com.gu.memsub.Subscriber.{FreeMember, PaidMember}
 import com.gu.memsub.{Subscription => Sub, Status => SubStatus, _}
 import com.gu.monitoring.CloudWatch

--- a/frontend/app/actions/RegistrationUri.scala
+++ b/frontend/app/actions/RegistrationUri.scala
@@ -12,18 +12,20 @@ object RegistrationUri {
   val CAMPAIGN_SOURCE: String = "MEM"
 
   val referingPageCodes = Map(
-    controllers.routes.Info.supporter().toString() -> "SUPUK",
-    controllers.routes.Info.supporterUSA().toString() -> "SUPUS",
-    controllers.routes.Info.offersAndCompetitions().toString()-> "COMP",
-    controllers.routes.WhatsOn.list().toString() -> "EVT",
+    controllers.routes.Info.supporterUK().path -> "SUPUK",
+    controllers.routes.Info.supporterUSA().path -> "SUPUS",
+    controllers.routes.Info.supporterEurope().path -> "SUPEU",
+    controllers.routes.Info.supporterInternational().path -> "SUPIN",
+    controllers.routes.Info.offersAndCompetitions().path-> "COMP",
+    controllers.routes.WhatsOn.list().path -> "EVT",
     "/" -> "HOME"
   )
 
   val campaignTierCodes = Map[String, String](
-    controllers.routes.Joiner.joinPaid(Tier.supporter).toString -> "SUP",
-    controllers.routes.Joiner.joinPaid(Tier.partner).toString -> "PAR",
-    controllers.routes.Joiner.joinPaid(Tier.patron).toString -> "PAT",
-    controllers.routes.Joiner.joinFriend().toString -> "FRI"
+    controllers.routes.Joiner.joinPaid(Tier.supporter).path -> "SUP",
+    controllers.routes.Joiner.joinPaid(Tier.partner).path -> "PAR",
+    controllers.routes.Joiner.joinPaid(Tier.patron).path -> "PAT",
+    controllers.routes.Joiner.joinFriend().path -> "FRI"
   )
 
   def parse(request: RequestHeader) = {

--- a/frontend/app/actions/package.scala
+++ b/frontend/app/actions/package.scala
@@ -2,7 +2,7 @@ import com.gu.googleauth
 import com.gu.identity.play.AuthenticatedIdUser
 import com.gu.memsub.Subscriber.{Member, FreeMember, PaidMember}
 import com.gu.salesforce._
-import com.gu.membership.util.Timing
+import com.gu.memsub.util.Timing
 import monitoring.MemberAuthenticationMetrics
 import play.api.mvc.Security.AuthenticatedRequest
 import play.api.mvc.{Cookie, WrappedRequest}

--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -5,7 +5,7 @@ import actions.Fallbacks._
 import actions.ActionRefiners._
 import com.gu.memsub.Subscriber.Member
 import com.gu.salesforce.Tier
-import com.gu.membership.util.Timing
+import com.gu.memsub.util.Timing
 import com.netaporter.uri.Uri
 import com.netaporter.uri.dsl._
 import model.EmbedSerializer._

--- a/frontend/app/controllers/Info.scala
+++ b/frontend/app/controllers/Info.scala
@@ -1,7 +1,9 @@
 package controllers
 
+import com.gu.i18n.CountryGroup
 import com.gu.i18n.CountryGroup._
 import configuration.CopyConfig
+import controllers.Redirects.redirectToSupporterPage
 import forms.MemberForm._
 import model._
 import play.api.mvc.Controller
@@ -11,8 +13,17 @@ import views.support.{Asset, PageInfo}
 import scala.concurrent.Future
 
 trait Info extends Controller {
+  def supporterRedirect = NoCacheAction { implicit request =>
+    val countryGroup =
+      request.headers
+        .get("X-Fastly-Country-Code")
+        .flatMap(CountryGroup.byFastlyCountryCode)
+        .getOrElse(CountryGroup.RestOfTheWorld)
 
-  def supporter = CachedAction { implicit request =>
+    Redirect(redirectToSupporterPage(countryGroup))
+  }
+
+  def supporterUK = CachedAction { implicit request =>
     implicit val countryGroup = UK
 
     val pageImages = Seq(

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -5,7 +5,7 @@ import actions.{RichAuthRequest, _}
 import com.github.nscala_time.time.Imports._
 import com.gu.i18n.CountryGroup.UK
 import com.gu.i18n.{CountryGroup, GBP}
-import com.gu.memsub.ProductFamily
+import com.gu.memsub.{Membership, ProductFamily}
 import com.gu.salesforce._
 import com.gu.stripe.Stripe
 import com.gu.stripe.Stripe.Serializer._
@@ -186,7 +186,7 @@ object Joiner extends Controller with ActivityTracking
   def thankyou(tier: Tier, upgrade: Boolean = false) = SubscriptionAction.async { implicit request =>
 
     val paymentCard = (for {
-      sub <- OptionT(subscriptionService.get(request.subscriber.contact)(ProductFamily.membership))
+      sub <- OptionT(subscriptionService.get(request.subscriber.contact)(Membership))
       card <- OptionT(paymentService.getPaymentCardByAccount(sub.accountId))
     } yield card).run
 

--- a/frontend/app/controllers/Redirects.scala
+++ b/frontend/app/controllers/Redirects.scala
@@ -1,15 +1,24 @@
 package controllers
 
-import play.api.mvc.Controller
+import com.gu.i18n.CountryGroup
+import play.api.mvc.{Result, Call, Controller}
 
 trait Redirects extends Controller {
 
   def homepageRedirect = CachedAction(MovedPermanently("/"))
 
   def supporterRedirect = CachedAction {
-    MovedPermanently(routes.Info.supporter.toString)
+    MovedPermanently(routes.Info.supporterRedirect.path)
   }
 
+  def redirectToSupporterPage(countryGroup: CountryGroup): Call = {
+    countryGroup match {
+      case CountryGroup.UK => routes.Info.supporterUK()
+      case CountryGroup.US => routes.Info.supporterUSA()
+      case CountryGroup.Europe => routes.Info.supporterEurope()
+      case _ => routes.Info.supporterInternational()
+    }
+  }
 }
 
 object Redirects extends Redirects

--- a/frontend/app/controllers/TierController.scala
+++ b/frontend/app/controllers/TierController.scala
@@ -197,7 +197,7 @@ trait CancelTier extends CatalogProvider {
 }
 
 trait TierController extends Controller with UpgradeTier with DowngradeTier with CancelTier {
-  implicit def productFamily: ProductFamily = Membership()
+  implicit def productFamily: ProductFamily = Membership
 
   def change() = SubscriptionAction { implicit request =>
     implicit val countryGroup = UK

--- a/frontend/app/services/EventbriteService.scala
+++ b/frontend/app/services/EventbriteService.scala
@@ -1,7 +1,7 @@
 package services
 
 import com.github.nscala_time.time.OrderingImplicits._
-import com.gu.membership.util.WebServiceHelper
+import com.gu.memsub.util.WebServiceHelper
 import com.squareup.okhttp.Request
 import configuration.Config
 import model.Eventbrite._

--- a/frontend/app/services/GridService.scala
+++ b/frontend/app/services/GridService.scala
@@ -1,7 +1,7 @@
 package services
 
 import akka.agent.Agent
-import com.gu.membership.util.WebServiceHelper
+import com.gu.memsub.util.WebServiceHelper
 import com.gu.monitoring.StatusMetrics
 import com.netaporter.uri.Uri
 import com.squareup.okhttp.Request

--- a/frontend/app/services/IdentityService.scala
+++ b/frontend/app/services/IdentityService.scala
@@ -1,7 +1,7 @@
 package services
 
 import com.gu.identity.play.{IdMinimalUser, IdUser}
-import com.gu.membership.util.Timing
+import com.gu.memsub.util.Timing
 import com.gu.memsub.Address
 import configuration.Config
 import controllers.IdentityRequest

--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -1,13 +1,12 @@
 package services
 
-import api.MemberService.{PendingAmendError, PaidSubscriptionExpected, MemberError}
 import com.gu.i18n.Currency
 import com.gu.identity.play.IdMinimalUser
-import com.gu.membership.{FreeMembershipPlan, PaidMembershipPlan, MembershipPlan}
-import com.gu.membership.util.Timing
 import com.gu.memsub.BillingPeriod.year
-import com.gu.memsub.Subscriber.{PaidMember, FreeMember}
-import com.gu.memsub.Subscription.{MembershipSub, Paid, Plan, ProductRatePlanId}
+import com.gu.memsub.Subscriber.{FreeMember, PaidMember}
+import com.gu.memsub.Subscription.{MembershipSub, Plan, ProductRatePlanId}
+import com.gu.memsub.util.Timing
+import services.api.MemberService.{MemberError, PendingAmendError}
 import com.gu.memsub._
 import com.gu.memsub.services.api.{CatalogService, PaymentService, SubscriptionService}
 import com.gu.salesforce.Tier.{Partner, Patron}
@@ -35,10 +34,10 @@ import views.support.ThankyouSummary.NextPayment
 
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
-import scalaz.{MonadTrans, EitherT, \/}
-import scalaz.syntax.either._
 import scalaz.std.scalaFuture._
+import scalaz.syntax.either._
 import scalaz.syntax.monad._
+import scalaz.{EitherT, MonadTrans, \/}
 
 object MemberService {
   import api.MemberService.MemberError

--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -71,7 +71,7 @@ class MemberService(identityService: IdentityService,
   import MemberService._
 
   implicit val catalog = catalogService.membershipCatalog
-  implicit val productFamily = Membership()
+  implicit val productFamily = Membership
 
   private val logger = Logger(getClass)
 
@@ -276,7 +276,7 @@ class MemberService(identityService: IdentityService,
     def getSummaryViaPreview =
       for {
         sub <- latestSubF
-        paymentDetails <- paymentService.paymentDetails(contact)(Membership())
+        paymentDetails <- paymentService.paymentDetails(contact)(Membership)
       } yield {
         implicit val currency = sub.currency
         val (planAmount, bp) = plan(sub)

--- a/frontend/app/services/MembersDataAPI.scala
+++ b/frontend/app/services/MembersDataAPI.scala
@@ -2,7 +2,7 @@ package services
 
 import com.gu.memsub.Subscriber.Member
 import com.gu.salesforce.Tier
-import com.gu.membership.util.WebServiceHelper
+import com.gu.memsub.util.WebServiceHelper
 import com.gu.monitoring.StatusMetrics
 import com.squareup.okhttp.Request
 import configuration.Config

--- a/frontend/app/services/SalesforceService.scala
+++ b/frontend/app/services/SalesforceService.scala
@@ -4,10 +4,10 @@ import com.gu.identity.play.{IdMinimalUser, IdUser}
 import com.gu.salesforce.ContactDeserializer.Keys
 import com.gu.salesforce._
 import com.gu.stripe.Stripe.Customer
-import com.gu.membership.util.FutureSupplier
+import com.gu.memsub.util.FutureSupplier
 import configuration.Config
 import forms.MemberForm.JoinForm
-import model.{GenericSFContact}
+import model.GenericSFContact
 import monitoring.MemberMetrics
 import play.api.Play.current
 import play.api.libs.concurrent.Akka

--- a/frontend/app/services/TouchpointBackend.scala
+++ b/frontend/app/services/TouchpointBackend.scala
@@ -47,7 +47,7 @@ object TouchpointBackend {
 
     val restBackendConfig = backend.zuoraRest.copy(url = Uri.parse(backend.zuoraRestUrl(Config.config)))
 
-    val zuoraSoapClient = new ClientWithFeatureSupplier(FeatureChoice.codes, backend.zuoraSoap, backend.zuoraMetrics("zuora-soap-client"), Akka.system())
+    val zuoraSoapClient = new ClientWithFeatureSupplier(FeatureChoice.codes, backend.zuoraSoap, backend.zuoraMetrics("zuora-soap-client"))
     val zuoraRestClient = new rest.Client(restBackendConfig, backend.zuoraMetrics("zuora-rest-client"))
     val memRatePlanIds = Config.membershipRatePlanIds(restBackendConfig.envName)
     val digipackRatePlanIds = Config.digipackRatePlanIds(restBackendConfig.envName)

--- a/frontend/app/views/fragments/global/controlNavigation.scala.html
+++ b/frontend/app/views/fragments/global/controlNavigation.scala.html
@@ -66,7 +66,7 @@
             <nav id="js-country-switcher" role="navigation" class="js-dropdown-menu nav-popup is-hidden" aria-label="Country switcher">
                 <ul class="nav-popup__list">
                     <li class="nav-popup__item">
-                        <a href="@routes.Info.supporter" class="nav-popup__link">@UK.name (@UK.currency.identifier)</a>
+                        <a href="@routes.Info.supporterUK" class="nav-popup__link">@UK.name (@UK.currency.identifier)</a>
                     </li>
                     <li class="nav-popup__item">
                         <a href="@routes.Info.supporterUSA" class="nav-popup__link">@US.name (@US.currency.identifier)</a>

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -88,7 +88,8 @@ GET            /tier/change/:tier/summary             controllers.TierController
 
 # Information
 GET            /patrons                               controllers.Info.patron
-GET            /supporter                             controllers.Info.supporter
+GET            /supporter                             controllers.Info.supporterRedirect
+GET            /uk/supporter                          controllers.Info.supporterUK
 GET            /us/supporter                          controllers.Info.supporterUSA
 GET            /eu/supporter                          controllers.Info.supporterEurope
 GET            /int/supporter                         controllers.Info.supporterInternational

--- a/frontend/test/actions/RegistrationUriTest.scala
+++ b/frontend/test/actions/RegistrationUriTest.scala
@@ -36,10 +36,10 @@ class RegistrationUriTest extends Specification {
 
 
     "contain correct identity tracking code for US supporters" in {
-      assertCodeFor("MEM_SUPUK_SUP", "/join/supporter/enter-details", "https://membership.theguardian.com/supporter")
-      assertCodeFor("MEM_SUPUK_PAR", "/join/partner/enter-details", "https://membership.theguardian.com/supporter")
-      assertCodeFor("MEM_SUPUK_PAT", "/join/patron/enter-details", "https://membership.theguardian.com/supporter")
-      assertCodeFor("MEM_SUPUK_FRI", "/join/friend/enter-details", "https://membership.theguardian.com/supporter")
+      assertCodeFor("MEM_SUPUK_SUP", "/join/supporter/enter-details", "https://membership.theguardian.com/uk/supporter")
+      assertCodeFor("MEM_SUPUK_PAR", "/join/partner/enter-details", "https://membership.theguardian.com/uk/supporter")
+      assertCodeFor("MEM_SUPUK_PAT", "/join/patron/enter-details", "https://membership.theguardian.com/uk/supporter")
+      assertCodeFor("MEM_SUPUK_FRI", "/join/friend/enter-details", "https://membership.theguardian.com/uk/supporter")
     }
 
 

--- a/frontend/test/controllers/RedirectsTest.scala
+++ b/frontend/test/controllers/RedirectsTest.scala
@@ -1,0 +1,15 @@
+package controllers
+
+import com.gu.i18n.CountryGroup
+import org.specs2.mutable.Specification
+import Redirects._
+
+class RedirectsTest extends Specification {
+  "redirectToSupporterPage" in {
+    redirectToSupporterPage(CountryGroup.UK) must_=== routes.Info.supporterUK()
+    redirectToSupporterPage(CountryGroup.US) must_=== routes.Info.supporterUSA()
+    redirectToSupporterPage(CountryGroup.Europe) must_=== routes.Info.supporterEurope()
+    redirectToSupporterPage(CountryGroup.Australia) must_=== routes.Info.supporterInternational()
+    redirectToSupporterPage(CountryGroup.RestOfTheWorld) must_=== routes.Info.supporterInternational()
+  }
+}

--- a/nginx/membership.conf
+++ b/nginx/membership.conf
@@ -9,6 +9,7 @@ server {
 
 server {
     server_name members.thegulocal.com;
+    proxy_pass_request_headers      on;
 
     location / {
         proxy_pass http://localhost:9100/;

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "0.13"
   val identityTestUsers = "com.gu" %% "identity-test-users" % "0.5"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.140-SNAPSHOT"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.141"
   val playGoogleAuth = "com.gu" %% "play-googleauth" % "0.3.3"
   val contentAPI = "com.gu" %% "content-api-client" % "6.4"
   val playWS = PlayImport.ws

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "0.13"
   val identityTestUsers = "com.gu" %% "identity-test-users" % "0.5"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.133"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.140-SNAPSHOT"
   val playGoogleAuth = "com.gu" %% "play-googleauth" % "0.3.3"
   val contentAPI = "com.gu" %% "content-api-client" % "6.4"
   val playWS = PlayImport.ws

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "0.13"
   val identityTestUsers = "com.gu" %% "identity-test-users" % "0.5"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.141"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.144"
   val playGoogleAuth = "com.gu" %% "play-googleauth" % "0.3.3"
   val contentAPI = "com.gu" %% "content-api-client" % "6.4"
   val playWS = PlayImport.ws


### PR DESCRIPTION
redirect users heading to the `/supporter` path to a country-specific supporter page based on the `X-Fastly-Country-Code` value