### PR TITLE
Updated twitter hashtag

### DIFF
--- a/frontend/app/configuration/Social.scala
+++ b/frontend/app/configuration/Social.scala
@@ -2,7 +2,7 @@ package configuration
 
 object Social {
   val twitterUsername = "gdnmembership"
-  val twitterHashtag = "#guardianmembership"
+  val twitterHashtag = "#guardianmembers"
   val youtube = "https://www.youtube.com/user/guardianmembership"
   val googleplus = "https://plus.google.com/+guardianmembership/"
   val twitter = "https://www.twitter.com/" + twitterUsername


### PR DESCRIPTION
We were tweeting with a #GuardianMembership hashtag which is not in line with the 'new' branding.

@rtyley 