### PR TITLE
Tweak members-data-api-check-logging to record affected user

### DIFF
--- a/frontend/app/actions/package.scala
+++ b/frontend/app/actions/package.scala
@@ -34,11 +34,6 @@ package object actions {
   case class SubscriptionRequest[A](touchpointBackend: TouchpointBackend,
                                     request: AuthRequest[A]) extends AuthRequest(request.user, request) with BackendProvider {
 
-    def idCookies: Option[Seq[Cookie]] = for {
-      guu <- request.cookies.get("GU_U")
-      scguu <- request.cookies.get("SC_GU_U")
-    } yield Seq(guu, scguu)
-
     def this(other: SubscriptionRequest[A]) =
       this(other.touchpointBackend, other.request)
   }

--- a/frontend/app/controllers/User.scala
+++ b/frontend/app/controllers/User.scala
@@ -1,10 +1,8 @@
 package controllers
 
-import com.gu.membership.MembershipPlan
-import com.gu.memsub.{Subscriber, PaymentStatus, PaidPS}
-import com.gu.salesforce._
+import com.gu.memsub.Subscriber
 import model.Benefits
-import org.joda.time.{DateTime, Instant}
+import org.joda.time.Instant
 import org.joda.time.format.ISODateTimeFormat
 import play.api.libs.json._
 import play.api.mvc.Controller
@@ -17,7 +15,7 @@ trait User extends Controller {
 
   def me = AjaxSubscriptionAction { implicit request =>
     val json = basicDetails(request.subscriber)
-    request.idCookies.foreach(MembersDataAPI.Service.check(request.subscriber))
+    MembersDataAPI.Service.checkMatchesResolvedMemberIn(request)
     Ok(json).withCookies(GuMemCookie.getAdditionCookie(json))
   }
 


### PR DESCRIPTION
We're seeing some peaks of about 30 mismatches a day between `members-data-api`, and the data we get directly from the Touchpoint backend:

https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#metrics:graph=!D06-2!D17-2!E03-2!E15-2!ET4!MN10~9!NS2-2!PD1-2!SS8-2!ST0!VA-P14D~86400~Frontend~Members%2BData%2BAPI~P0D~PROD~Services~Stage~Sum~members-data-api-match~members-data-api-mismatch

In the logs we see this:

```
WARN application - Members data API response doesn't match the expected member data. Expected Attributes(Staff(),None), got Attributes(Staff(),Some(123456))
```

This tweaks the logging so we get the user id as well, makes it easier to work out what's going on and check up on reported mismatches. It also logs at **error** level if the _tier_ mismatches (which happens much less frequently).

cc @ostapneko 