### PR TITLE
Fix the eventbrite banner

### DIFF
--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -23,7 +23,7 @@ import forms.MemberForm._
 import model.Eventbrite.{EBCode, EBOrder, EBTicketClass}
 import model.RichEvent.RichEvent
 import model.{PaidSubscription, _}
-import org.joda.time.DateTime
+import org.joda.time.{DateTimeZone, DateTime}
 import play.api.Logger
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import tracking._
@@ -305,7 +305,7 @@ class MemberService(identityService: IdentityService,
 
   override def getUsageCountWithinTerm(subscription: Subscription, unitOfMeasure: String): Future[Option[Int]] = {
     val features = subscription.features
-    val startDate = subscription.startDate.toDateTimeAtCurrentTime()
+    val startDate = subscription.startDate.toDateTimeAtStartOfDay(DateTimeZone.forID("America/Los_Angeles"))
     zuoraService.getUsages(subscription.name, unitOfMeasure, startDate).map { usages =>
       val hasComplimentaryTickets = features.map(_.code).contains(FreeEventTickets.zuoraCode)
       if (!hasComplimentaryTickets) None else Some(usages.size)

--- a/frontend/test/services/DestinationServiceTest.scala
+++ b/frontend/test/services/DestinationServiceTest.scala
@@ -52,6 +52,7 @@ class DestinationServiceTest extends PlaySpecification with Mockito with ScalaFu
         productRatePlanId = Subscription.ProductRatePlanId(""),
         productName = "productName",
         startDate = new LocalDate("2015-01-01"),
+        termStartDate = new LocalDate("2015-01-01"),
         termEndDate = new LocalDate("2016-01-01"),
         features = Nil,
         casActivationDate = None,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "0.13"
   val identityTestUsers = "com.gu" %% "identity-test-users" % "0.5"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.152"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.154"
   val playGoogleAuth = "com.gu" %% "play-googleauth" % "0.3.3"
   val contentAPI = "com.gu" %% "content-api-client" % "6.4"
   val playWS = PlayImport.ws


### PR DESCRIPTION
So two problems fixed here

- We were only fetching tickets you managed to buy at the exact same time you signed up
-  By using the _subscription_ start date rather than the _term_ start date we would not have reset allocations each year, had we been picking them up at all

![image](https://cloud.githubusercontent.com/assets/1388226/12850090/e765995a-cc1a-11e5-8595-3ddee6eb7671.png)
