### PR TITLE
Use memsub-common-play-auth, remove google-auth config from Membership

### DIFF
--- a/frontend/app/actions/GuardianDomains.scala
+++ b/frontend/app/actions/GuardianDomains.scala
@@ -1,12 +1,12 @@
 package actions
 
-import configuration.Config.GuardianGoogleAppsDomain
+import com.gu.memsub.auth.common.MemSub.Google.GuardianAppsDomain
 
 object GuardianDomains {
 
   def emailsMatch(guardianEmail: String, email: String) = {
     val emailName = guardianEmail.split("@").head.toLowerCase
-    val validGuardianEmails = Seq(GuardianGoogleAppsDomain, "theguardian.com").map(domain => s"$emailName@$domain")
+    val validGuardianEmails = Seq(GuardianAppsDomain, "theguardian.com").map(domain => s"$emailName@$domain")
     validGuardianEmails.contains(email)
   }
 }

--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -1,12 +1,10 @@
 package configuration
 
-import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.amazonaws.auth.{AWSCredentialsProviderChain, InstanceProfileCredentialsProvider}
 import com.github.nscala_time.time.Imports._
 import com.gu.config.{DigitalPackRatePlanIds, MembershipRatePlanIds}
-import com.gu.googleauth.{GoogleAuthConfig, GoogleServiceAccount}
 import com.gu.identity.cookie.{PreProductionKeys, ProductionKeys}
-import com.gu.memsub.promo.{EnglishHeritageOffer, AppliesTo, PromoCode, Promotion}
+import com.gu.memsub.auth.common.MemSub.Google._
+import com.gu.memsub.promo.{AppliesTo, EnglishHeritageOffer, PromoCode, Promotion}
 import com.gu.salesforce.Tier
 import com.netaporter.uri.Uri
 import com.netaporter.uri.dsl._
@@ -14,10 +12,11 @@ import com.typesafe.config.ConfigFactory
 import model.Eventbrite.EBEvent
 import net.kencochrane.raven.dsn.Dsn
 import play.api.Logger
-import services._
-import scala.util.Try
-import play.api.libs.concurrent.Akka
 import play.api.Play.current
+import play.api.libs.concurrent.Akka
+import services._
+
+import scala.util.Try
 
 object Config {
   val logger = Logger(this.getClass)
@@ -118,48 +117,11 @@ object Config {
   val stageProd: Boolean = stage == "PROD"
   val stageDev: Boolean = stage == "DEV"
 
-  val GuardianGoogleAppsDomain = "guardian.co.uk"
+  val googleGroupChecker = googleGroupCheckerFor(config)
 
-  val googleAuthConfig = {
-    val con = config.getConfig("google.oauth")
-    GoogleAuthConfig(
-      con.getString("client.id"),
-      con.getString("client.secret"),
-      con.getString("callback"),
-      Some(GuardianGoogleAppsDomain)        // Google App domain to restrict login
-    )
-  }
+  lazy val googleAuthConfig = googleAuthConfigFor(config)
 
-  val awsProfileName = "membership"
-  val awsS3PrivateBucketName = "membership-private"
-
-  lazy val awsCredentialsProvider = new AWSCredentialsProviderChain(new ProfileCredentialsProvider(awsProfileName), new InstanceProfileCredentialsProvider())
-  lazy val s3PrivateKeyService = new S3PrivateKeyService(awsS3PrivateBucketName, awsCredentialsProvider)
-
-  val privateKeyStorePass = "notasecret"
-  val privateKeyAlias = "privatekey"
-  val privateKeyPass = "notasecret"
-  val certPath = config.getString("google.directory.service_account.cert")
-
-  lazy val privateKey = {
-    s3PrivateKeyService.loadPrivateKey(
-      certPath,
-      privateKeyStorePass,
-      privateKeyAlias,
-      privateKeyPass
-    )
-  }
-
-  lazy val googleDirectoryConfig = {
-    val con = config.getConfig("google.directory")
-    GoogleServiceAccount(
-      con.getString("service_account.id"),
-      privateKey,
-      con.getString("service_account.email")
-    )
-  }
-
-  val staffAuthorisedEmailGroups = config.getString("staff.authorised.emails.groups").split(",").map(group => s"$group@$GuardianGoogleAppsDomain").toSet
+  val staffAuthorisedEmailGroups = config.getString("staff.authorised.emails.groups").split(",").map(group => s"$group@$GuardianAppsDomain").toSet
 
   val contentApiKey = config.getString("content.api.key")
 

--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -117,7 +117,7 @@ object Config {
   val stageProd: Boolean = stage == "PROD"
   val stageDev: Boolean = stage == "DEV"
 
-  val googleGroupChecker = googleGroupCheckerFor(config)
+  lazy val googleGroupChecker = googleGroupCheckerFor(config)
 
   lazy val googleAuthConfig = googleAuthConfigFor(config)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,29 +7,25 @@ object Dependencies {
   val awsClientVersion = "1.10.50"
   //libraries
   val sentryRavenLogback = "net.kencochrane.raven" % "raven-logback" % "6.0.0"
-  val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "0.13"
-  val identityTestUsers = "com.gu" %% "identity-test-users" % "0.5"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
   val membershipCommon = "com.gu" %% "membership-common" % "0.156"
-  val playGoogleAuth = "com.gu" %% "play-googleauth" % "0.3.3"
+  val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.1"
   val contentAPI = "com.gu" %% "content-api-client" % "6.4"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache
-  val playFilters = PlayImport.filters
   val awsSimpleEmail = "com.amazonaws" % "aws-java-sdk-ses" % awsClientVersion
   val snowPlow = "com.snowplowanalytics" % "snowplow-java-tracker" % "0.5.2-SNAPSHOT"
   val bCrypt = "com.github.t3hnar" %% "scala-bcrypt" % "2.4"
-  val s3 =  "com.amazonaws" % "aws-java-sdk-s3" % awsClientVersion
   val scalaTest =  "org.scalatestplus" %% "play" % "1.4.0-M4" % "test"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.1"
   val selenium = "org.seleniumhq.selenium" % "selenium-java" % "2.48.2" % "test"
 
   //projects
 
-  val frontendDependencies = Seq(identityPlayAuth, playGoogleAuth, identityTestUsers, scalaUri, membershipCommon,
-    contentAPI, playWS, playCache, playFilters,sentryRavenLogback, awsSimpleEmail, snowPlow, bCrypt, s3, scalaz,
+  val frontendDependencies = Seq(memsubCommonPlayAuth, scalaUri, membershipCommon,
+    contentAPI, playWS, playCache, sentryRavenLogback, awsSimpleEmail, snowPlow, bCrypt, scalaz,
     PlayImport.specs2 % "test")
 
-  val acceptanceTestDependencies = Seq(scalaTest, selenium, identityTestUsers)
+  val acceptanceTestDependencies = Seq(scalaTest, selenium, memsubCommonPlayAuth)
 
 }


### PR DESCRIPTION
The releveant code is now in:

https://github.com/guardian/memsub-common-play-auth

This is working towards having common code for Membership and Subscriptions
with Google-Group based restrictions:

https://trello.com/c/boSbvE9P/356-user-authentication-google-groups-for-new-subscription-checker-tool-that-works-with-zuora-as-well-as-legacy-cas

cc @AWare 