### PR TITLE
Added a campaign code to the members -> membership redirect

### DIFF
--- a/frontend/app/filters/RedirectMembersFilter.scala
+++ b/frontend/app/filters/RedirectMembersFilter.scala
@@ -14,7 +14,11 @@ object RedirectMembersFilter extends Filter {
   def apply(nextFilter: RequestHeader => Future[Result])(requestHeader: RequestHeader): Future[Result] = {
     if (requestHeader.host.toLowerCase.startsWith("members.")) {
       val requestUri = Uri.parse(requestHeader.uri)
-      Future.successful(Redirect(requestUri.withScheme("https").withHost(Config.membershipHost).toString, FOUND))
+      val redirectUri = requestUri.query.param("INTCMP") match {
+        case None => requestUri.addParam("INTCMP", "MEMBERS_DOMAIN_REDIRECT")
+        case _ => requestUri
+      }
+      Future.successful(Redirect(redirectUri.withScheme("https").withHost(Config.membershipHost).toString, FOUND))
     } else nextFilter(requestHeader)
   }
 }


### PR DESCRIPTION
Added a campaign code to the members -> membership redirect if there isn't one in the URL already. This will let us track customers who go to members.theguardian.com after listening to the podcast adverts, etc.

/cc @tomverran 