### PR TITLE
Display the ticket sale times if any of them are not midnight. 

### DIFF
--- a/frontend/app/model/TicketSaleDates.scala
+++ b/frontend/app/model/TicketSaleDates.scala
@@ -73,8 +73,6 @@ object TicketSaleDates {
 
   private def needToDistinguishTimes(generalAvailability: Instant, memberAdvanceTicketSales: Option[Map[Tier, Instant]] = None) = {
     val allDistinctDates: Set[Instant] = Set(generalAvailability) ++ memberAdvanceTicketSales.map(_.values).toSeq.flatten
-    val smallestGapBetweenDates = allDistinctDates.toSeq.sorted.sliding(2).map(ds => (ds.head to ds.last).duration).toSeq.sorted.headOption
-
-    smallestGapBetweenDates.exists(_ < 24.hours)
+    allDistinctDates.exists(_.toDateTime().millisOfDay()!=0)
   }
 }


### PR DESCRIPTION
https://trello.com/c/AX2t2vRV/86-show-time-on-the-ticket-availability-panel-on-the-event-page

[![selfie-0](http://i.imgur.com/DqhzE8P.gif)](https://github.com/thieman/github-selfies/)
