### PR TITLE
Updating membership-frontend to the latest membership-common

### DIFF
--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -4,7 +4,7 @@ import com.github.nscala_time.time.Imports._
 import com.gu.config.{DigitalPackRatePlanIds, MembershipRatePlanIds}
 import com.gu.identity.cookie.{PreProductionKeys, ProductionKeys}
 import com.gu.memsub.auth.common.MemSub.Google._
-import com.gu.memsub.promo.{AppliesTo, EnglishHeritageOffer, PromoCode, Promotion}
+import com.gu.memsub.promo._
 import com.gu.salesforce.Tier
 import com.netaporter.uri.Uri
 import com.netaporter.uri.dsl._
@@ -151,16 +151,20 @@ object Config {
   def demoPromo(env: String) = {
     val prpIds = membershipRatePlanIds(env)
     Promotion(
-      landingPageTemplate = EnglishHeritageOffer,
-      codes = Set(PromoCode("EH2016")),
       appliesTo = AppliesTo.ukOnly(Set(
         prpIds.partnerMonthly,
         prpIds.partnerYearly
       )),
-      thumbnailUrl = "http://lorempixel.com/400/200/abstract",
+      campaignName = "English Heritage Offer - Q4 FY2016",
+      codes = PromoCodeSet(PromoCode("EH2016")),
       description = "Free English Heritage membership worth £88 when you become a Partner or Patron Member",
+      expires = DateTime.parse("2016-04-01T01:00:00Z"),
+      imageUrl = "http://lorempixel.com/400/200/abstract",
+      promotionType = Incentive,
       redemptionInstructions = "We'll send you an email with instructions on redeeming your English Heritage offer within 35 days.",
-      expires = DateTime.parse("2016-04-01T00:00:00Z")
+      roundelHtml = "<h1 class=\"roundel__title\">Free annual English Heritage membership</h1>\n<p class=\"roundel__description\">when you join as a Partner or Patron by 31 March</p>",
+      thumbnailUrl = "http://lorempixel.com/40/20/abstract",
+      title = "Free English Heritage membership worth £88"
     )
   }
 

--- a/frontend/app/controllers/Promotions.scala
+++ b/frontend/app/controllers/Promotions.scala
@@ -4,8 +4,8 @@ import actions.RichAuthRequest
 import com.gu.i18n.Country
 import com.gu.i18n.CountryGroup._
 import com.gu.memsub.BillingPeriod
-import com.gu.memsub.promo._
 import com.gu.memsub.promo.Writers._
+import com.gu.memsub.promo._
 import com.gu.salesforce.{FreeTier, PaidTier, Tier}
 import model._
 import play.api.libs.json._
@@ -47,16 +47,16 @@ object Promotions extends Controller {
   def promotionPage(promoCodeStr: String) = GoogleAuthenticatedStaffAction { implicit request =>
 
     def findTemplateForPromotion(promoCode: PromoCode, promotion: Promotion, url: String) =
-      promotion.landingPageTemplate match {
-        case EnglishHeritageOffer =>
+      promotion.promotionType match {
+        case Incentive =>
           implicit val countryGroup = UK
 
           Some(views.html.promotions.englishHeritageOffer(
             TouchpointBackend.Normal.catalog.partner,
             PageInfo(
-              title = "Free English Heritage membership worth £88",
+              title = promotion.title,
               url = url,
-              description = Some("LOREM IPSUM")
+              description = Some(promotion.description)
             ),
             pageImages
           ))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,5 +1,5 @@
-import sbt._
 import play.sbt.PlayImport
+import sbt._
 
 object Dependencies {
 
@@ -8,7 +8,7 @@ object Dependencies {
   //libraries
   val sentryRavenLogback = "net.kencochrane.raven" % "raven-logback" % "6.0.0"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.156"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.159"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.1"
   val contentAPI = "com.gu" %% "content-api-client" % "6.4"
   val playWS = PlayImport.ws


### PR DESCRIPTION
I haven't wired the roundelHtml from the model into the view yet - it's still using the homepage's template. We can generalise the roundel next sprint when we work on price-reducing promotions.

/cc @AWare @tomverran 