### PR TITLE
Disable integration tests until new id frontend launched.

### DIFF
--- a/.prout.json
+++ b/.prout.json
@@ -3,14 +3,6 @@
         "PROD": {
             "url": "https://membership.theguardian.com/",
             "overdue": "14M",
-            "afterSeen": {
-                "travis": {
-                    "config": {
-                        "script": "sbt ++$TRAVIS_SCALA_VERSION acceptance-test",
-                        "after_script": "./test_feedback.sh"
-                    }
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
PR to disable post deploy integration tests. To be reverted when the new id frontend is released. @rtyley 