### PR TITLE
Use play-googleauth library's new Google-Group filtering

### DIFF
--- a/frontend/app/actions/CommonActions.scala
+++ b/frontend/app/actions/CommonActions.scala
@@ -1,7 +1,7 @@
 package actions
 
-import actions.Fallbacks._
 import actions.ActionRefiners._
+import actions.Fallbacks._
 import com.gu.googleauth
 import com.gu.salesforce.PaidTier
 import configuration.Config
@@ -18,6 +18,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 trait CommonActions {
+  import OAuthActions._
 
   val AddUserInfoToResponse = new ActionBuilder[Request] {
     def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]) =
@@ -57,25 +58,24 @@ trait CommonActions {
 
   val AuthenticatedNonMemberAction = AuthenticatedAction andThen onlyNonMemberFilter()
 
-  val GoogleAuthAction: ActionBuilder[GoogleAuthRequest] = OAuthActions.AuthAction
+  val GoogleAuthAction: ActionBuilder[GoogleAuthRequest] = AuthAction
 
   val GoogleAuthenticatedStaffAction = NoCacheAction andThen GoogleAuthAction
 
   val permanentStaffGroups = Config.staffAuthorisedEmailGroups
 
   val PermanentStaffNonMemberAction =
-    GoogleAuthenticatedStaffAction andThen
-    isInAuthorisedGroupGoogleAuthReq(permanentStaffGroups, views.html.fragments.oauth.staffUnauthorisedError())
+    GoogleAuthenticatedStaffAction andThen requireGroup[GoogleAuthRequest](permanentStaffGroups, unauthorisedStaff(views.html.fragments.oauth.staffUnauthorisedError())(_))
 
   val AuthorisedStaff =
     GoogleAuthenticatedStaffAction andThen
-    isInAuthorisedGroupGoogleAuthReq(permanentStaffGroups, views.html.fragments.oauth.staffWrongGroup())
+      requireGroup[GoogleAuthRequest](permanentStaffGroups, unauthorisedStaff(views.html.fragments.oauth.staffWrongGroup())(_))
 
   val AuthenticatedStaffNonMemberAction =
     AuthenticatedAction andThen
     onlyNonMemberFilter() andThen
     googleAuthenticationRefiner() andThen
-    isInAuthorisedGroupIdentityGoogleAuthReq(permanentStaffGroups, views.html.fragments.oauth.staffUnauthorisedError())
+      requireGroup[IdentityGoogleAuthRequest](permanentStaffGroups, unauthorisedStaff(views.html.fragments.oauth.staffUnauthorisedError())(_))
 
   val SubscriptionAction = AuthenticatedAction andThen subscriptionRefiner()
 
@@ -102,10 +102,12 @@ trait CommonActions {
   def ChangeToPaidAction(targetTier: PaidTier) = SubscriptionAction andThen checkTierChangeTo(targetTier)
 }
 
-trait OAuthActions extends googleauth.Actions {
+trait OAuthActions extends googleauth.Actions with googleauth.Filters {
   val authConfig = Config.googleAuthConfig
 
   val loginTarget = routes.OAuth.loginAction()
+
+  lazy val groupChecker = Config.googleGroupChecker
 }
 
 object OAuthActions extends OAuthActions

--- a/frontend/app/controllers/Testing.scala
+++ b/frontend/app/controllers/Testing.scala
@@ -1,10 +1,12 @@
 package controllers
 
+import actions.Fallbacks._
+import actions._
 import com.typesafe.scalalogging.LazyLogging
 import play.api.mvc.{Controller, Cookie}
-import play.twirl.api.Html
 import utils.TestUsers.testUsers
-import actions.ActionRefiners._
+
+import scala.concurrent.ExecutionContext.Implicits.global
 
 object Testing extends Controller with LazyLogging {
 
@@ -13,19 +15,16 @@ object Testing extends Controller with LazyLogging {
   val analyticsOffCookie = Cookie(AnalyticsCookieName, "true", httpOnly = false)
 
   /**
-   * Make sure to use cannonical @guardian.co.uk for addresses
+   * Make sure to use canonical @guardian.co.uk for addresses
    */
-  val AuthorisedTester = GoogleAuthenticatedStaffAction andThen isInAuthorisedGroupGoogleAuthReq(
-    Set(
+  val AuthorisedTester = GoogleAuthenticatedStaffAction andThen OAuthActions.requireGroup[GoogleAuthRequest](Set(
       "membership.dev@guardian.co.uk",
       "membership.team@guardian.co.uk",
       "dig.dev.web-engineers@guardian.co.uk",
       "membership.testusers@guardian.co.uk",
       "touchpoint@guardian.co.uk",
       "crm@guardian.co.uk"
-    ),
-    views.html.fragments.oauth.staffWrongGroup()
-  )
+    ), unauthorisedStaff(views.html.fragments.oauth.staffWrongGroup())(_))
 
   def testUser = AuthorisedTester { implicit request =>
     val testUserString = testUsers.generate()

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "net.kencochrane.raven" % "raven-logback" % "6.0.0"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
   val membershipCommon = "com.gu" %% "membership-common" % "0.159"
-  val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.1"
+  val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.2"
   val contentAPI = "com.gu" %% "content-api-client" % "6.4"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache


### PR DESCRIPTION
Deleting lots of code!

https://github.com/guardian/play-googleauth/pull/36

Part of https://trello.com/c/boSbvE9P/356-user-authentication-google-groups-for-new-subscription-checker-tool-that-works-with-zuora-as-well-as-legacy-cas

cc @AWare 