### PR TITLE
Increase uses-per-access-code to 4 for Guardian Live Events

### DIFF
--- a/frontend/app/services/EventbriteService.scala
+++ b/frontend/app/services/EventbriteService.scala
@@ -133,7 +133,7 @@ object GuardianLiveEventService extends LiveService {
   // maximum number of tickets that can be purchased with a given code).
   //
   // see https://www.eventbrite.com/developer/v3/formats/event/#ebapi-access-code
-  val maxDiscountQuantityAvailable = 3
+  val maxDiscountQuantityAvailable = 4
   val wsMetrics = new EventbriteMetrics("Guardian Live")
 
   val refreshTimePriorityEvents = new FiniteDuration(Config.eventbriteRefreshTimeForPriorityEvents, SECONDS)


### PR DESCRIPTION
The intention here is to allow users to be able to use **2** 'no-extra-cost' tickets per event instead of 1, which Graham Page asked if we could do. The code change is really a bit of a corner-case, the real unlocking of 2 'no-extra-cost' tickets per event is in the Eventbrite admin console, setting the 'Tickets allowed per order' maximum to `2` instead of `1` for each event - the Guardian Live Events team will have to pick that up.

![image](https://cloud.githubusercontent.com/assets/52038/13178626/d3783d5a-d717-11e5-9a7f-69a8bd160377.png)


The way access codes work is quite subtle. For a given access code:

* The code will unlock specified ticket classes, but does not directly allow us to say how many times a ticket in a given class can be used with this access code.
* However, the access code does have a "Uses per Offer" (a.k.a  "quantity_available") attribute, which says how many tickets may be bought with it in total.

So, if we want to allow 2 _20% discount_ tickets  as well as possibly 2 _no-extra-cost_ tickets, the simplest thing to do is just specify a "quantity_available" value of 4. There is a potential for some bending-of-the-rules abuse here, which increases as we allow an additional 'no-extra-cost' ticket to be unlocked, but Graham argues that the improved user experience is worth it.

Note that there is also some accompanying messaging that can be tweaked in [remainingTickets.js](https://github.com/guardian/membership-frontend/blob/383bc16b/frontend/assets/javascripts/src/modules/events/remainingTickets.js#L16-L30) as it currently says, eg, "You can use _one_ of your 6 allocated member tickets for this event." - this could be refined, but the code will be a bit more complicated so skipping that for now!

![image](https://cloud.githubusercontent.com/assets/52038/13178646/f4f59310-d717-11e5-8f80-b867d25bed9a.png)

cc @paulbrown1982