### PR TITLE
Add a basic 'Canada' supporter landing page

### DIFF
--- a/frontend/app/actions/RegistrationUri.scala
+++ b/frontend/app/actions/RegistrationUri.scala
@@ -1,5 +1,7 @@
 package actions
 
+import com.gu.i18n.CountryGroup
+import com.gu.i18n.CountryGroup.RestOfTheWorld
 import com.gu.salesforce.Tier
 import com.netaporter.uri.Uri
 import configuration.Config
@@ -11,11 +13,14 @@ object RegistrationUri {
   val REFERRER_HEADER: String = "referer"
   val CAMPAIGN_SOURCE: String = "MEM"
 
-  val referingPageCodes = Map(
-    controllers.routes.Info.supporterUK().path -> "SUPUK",
-    controllers.routes.Info.supporterUSA().path -> "SUPUS",
-    controllers.routes.Info.supporterEurope().path -> "SUPEU",
-    controllers.routes.Info.supporterInternational().path -> "SUPIN",
+  val supporterReferingPageCodes =  Map(CountryGroup.allGroups.map { countryGroup =>
+    // sadly 'SUPIN' is the refering page code in use - but our country-group code is 'int'
+    val suffix = if (countryGroup == RestOfTheWorld) "IN" else countryGroup.id.toUpperCase
+
+    controllers.routes.Info.supporterFor(countryGroup).path -> s"SUP$suffix"
+  }: _*)
+
+  val referingPageCodes = supporterReferingPageCodes ++ Map(
     controllers.routes.Info.offersAndCompetitions().path-> "COMP",
     controllers.routes.WhatsOn.list().path -> "EVT",
     "/" -> "HOME"

--- a/frontend/app/controllers/Binders.scala
+++ b/frontend/app/controllers/Binders.scala
@@ -34,7 +34,11 @@ object Binders {
     FreeTier.slugMap, _.slug, (key: String, e: Exception) => s"Cannot parse parameter $key as a FreeTier: ${e.getMessage}"
   )
 
-  implicit object bindableCountryGroup extends QueryParsing[CountryGroup](
+  implicit object bindableCountryGroupPathParser extends PathParsing[CountryGroup](
+    id => CountryGroup.byId(id).get, _.id, (key: String, _: Exception) => s"Cannot parse path parameter $key as a CountryGroup"
+  )
+
+  implicit object bindableCountryGroupQueryParser extends QueryParsing[CountryGroup](
     id => CountryGroup.byId(id).get, _.id, (key: String, _: Exception) => s"Cannot parse parameter $key as a CountryGroup"
   )
 

--- a/frontend/app/controllers/Info.scala
+++ b/frontend/app/controllers/Info.scala
@@ -139,9 +139,7 @@ trait Info extends Controller {
     )
   }
 
-  def supporterInternational = CachedAction { implicit request =>
-    implicit val countryGroup = RestOfTheWorld
-
+  def supporterFor(implicit countryGroup: CountryGroup) = CachedAction { implicit request =>
     val pageImages = Seq(
       ResponsiveImageGroup(
         name=Some("fearless"),

--- a/frontend/app/controllers/Redirects.scala
+++ b/frontend/app/controllers/Redirects.scala
@@ -16,7 +16,7 @@ trait Redirects extends Controller {
       case CountryGroup.UK => routes.Info.supporterUK()
       case CountryGroup.US => routes.Info.supporterUSA()
       case CountryGroup.Europe => routes.Info.supporterEurope()
-      case _ => routes.Info.supporterInternational()
+      case _ => routes.Info.supporterFor(countryGroup)
     }
   }
 }

--- a/frontend/app/views/fragments/global/controlNavigation.scala.html
+++ b/frontend/app/views/fragments/global/controlNavigation.scala.html
@@ -65,18 +65,11 @@
             </a>
             <nav id="js-country-switcher" role="navigation" class="js-dropdown-menu nav-popup is-hidden" aria-label="Country switcher">
                 <ul class="nav-popup__list">
-                    <li class="nav-popup__item">
-                        <a href="@routes.Info.supporterUK" class="nav-popup__link">@UK.name (@UK.currency.identifier)</a>
-                    </li>
-                    <li class="nav-popup__item">
-                        <a href="@routes.Info.supporterUSA" class="nav-popup__link">@US.name (@US.currency.identifier)</a>
-                    </li>
-                    <li class="nav-popup__item">
-                        <a href="@routes.Info.supporterEurope" class="nav-popup__link">@Europe.name (@Europe.currency.identifier)</a>
-                    </li>
-                    <li class="nav-popup__item">
-                        <a href="@routes.Info.supporterInternational" class="nav-popup__link">@RestOfTheWorld.name (@RestOfTheWorld.currency.identifier)</a>
-                    </li>
+                    @for(countryGroup <- Seq(UK, Europe, US, Canada, RestOfTheWorld)) {
+                        <li class="nav-popup__item">
+                            <a href="@routes.Info.supporterFor(countryGroup)" class="nav-popup__link">@countryGroup.name (@countryGroup.currency.identifier)</a>
+                        </li>
+                    }
                 </ul>
             </nav>
         </li>

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -90,7 +90,7 @@ GET            /supporter                             controllers.Info.supporter
 GET            /uk/supporter                          controllers.Info.supporterUK
 GET            /us/supporter                          controllers.Info.supporterUSA
 GET            /eu/supporter                          controllers.Info.supporterEurope
-GET            /int/supporter                         controllers.Info.supporterInternational
+GET            /:countryGroup/supporter               controllers.Info.supporterFor(countryGroup: CountryGroup)
 GET            /help                                  controllers.Info.help
 GET            /feedback                              controllers.Info.feedback
 POST           /feedback                              controllers.Info.submitFeedback

--- a/frontend/test/controllers/RedirectsTest.scala
+++ b/frontend/test/controllers/RedirectsTest.scala
@@ -9,7 +9,8 @@ class RedirectsTest extends Specification {
     redirectToSupporterPage(CountryGroup.UK) must_=== routes.Info.supporterUK()
     redirectToSupporterPage(CountryGroup.US) must_=== routes.Info.supporterUSA()
     redirectToSupporterPage(CountryGroup.Europe) must_=== routes.Info.supporterEurope()
-    redirectToSupporterPage(CountryGroup.Australia) must_=== routes.Info.supporterInternational()
-    redirectToSupporterPage(CountryGroup.RestOfTheWorld) must_=== routes.Info.supporterInternational()
+    redirectToSupporterPage(CountryGroup.Australia) must_=== routes.Info.supporterFor(CountryGroup.Australia)
+    redirectToSupporterPage(CountryGroup.Canada) must_=== routes.Info.supporterFor(CountryGroup.Canada)
+    redirectToSupporterPage(CountryGroup.RestOfTheWorld) must_=== routes.Info.supporterFor(CountryGroup.RestOfTheWorld)
   }
 }


### PR DESCRIPTION
This is based off the 'International' supporter landing page, but will show the appropriate currency of Canadian Dollars.

So...

https://membership.theguardian.com/ca/supporter

...will look a lot like:

https://membership.theguardian.com/int/supporter

The drop down used to look like this:
![image](https://cloud.githubusercontent.com/assets/52038/13294633/c138fe0a-db1c-11e5-9d27-53b10184e2c5.png)

...now it looks like this:

![image](https://cloud.githubusercontent.com/assets/52038/13294619/b347dc94-db1c-11e5-9d5c-7279caa73f30.png)



This work is further to....

---------- Forwarded message ----------
From: Roberto Tyley
Date: 23 February 2016 at 17:27
Subject: Membership: Canadians can now pay in Canadian Dollars

After discussion with Graham Page and Charles Minty, I've enabled CAD as the payment currency for Canada:

![image](https://cloud.githubusercontent.com/assets/52038/13294554/734a8ca4-db1c-11e5-8a23-4ed4eee3bea9.png)


cc @paulbrown1982 