### PR TITLE
Fix guava-jdk5 dependency introduced by Google Directory API client

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "net.kencochrane.raven" % "raven-logback" % "6.0.0"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
   val membershipCommon = "com.gu" %% "membership-common" % "0.161"
-  val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.2"
+  val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.3"
   val contentAPI = "com.gu" %% "content-api-client" % "6.4"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache


### PR DESCRIPTION
We don't currently use DirectDebit/Go-Cardless on Membership, but the Google Groups library was still pulling in the awful `guava-jdk5` dependency, leading to hidden classpath collisions.

https://github.com/guardian/play-googleauth/pull/37
https://github.com/guardian/subscriptions-frontend/pull/363#issuecomment-186190081
https://github.com/guardian/subscriptions-frontend/pull/366

cc @paulbrown1982 