### PR TITLE
Forward the GU-IdentityToken or the SC_GU_U cookie to identity

### DIFF
--- a/frontend/app/actions/ActionRefiners.scala
+++ b/frontend/app/actions/ActionRefiners.scala
@@ -38,7 +38,7 @@ object ActionRefiners extends LazyLogging {
   }
 
   def authenticated(onUnauthenticated: RequestHeader => Result = chooseRegister(_)): ActionBuilder[AuthRequest] =
-    new AuthenticatedBuilder(AuthenticationService.authenticatedUserFor, onUnauthenticated)
+    new AuthenticatedBuilder(AuthenticationService.authenticatedIdUserProvider("members-data-api"), onUnauthenticated)
 
   type SubRequestOrResult[A] = Future[Either[Result, SubReqWithSub[A]]]
   type PaidSubRequestOrResult[A] = Future[Either[Result, SubscriptionRequest[A] with PaidSubscriber]]

--- a/frontend/app/actions/ActionRefiners.scala
+++ b/frontend/app/actions/ActionRefiners.scala
@@ -38,7 +38,7 @@ object ActionRefiners extends LazyLogging {
   }
 
   def authenticated(onUnauthenticated: RequestHeader => Result = chooseRegister(_)): ActionBuilder[AuthRequest] =
-    new AuthenticatedBuilder(AuthenticationService.authenticatedIdUserProvider("members-data-api"), onUnauthenticated)
+    new AuthenticatedBuilder(AuthenticationService.authenticatedIdUserProvider, onUnauthenticated)
 
   type SubRequestOrResult[A] = Future[Either[Result, SubReqWithSub[A]]]
   type PaidSubRequestOrResult[A] = Future[Either[Result, SubscriptionRequest[A] with PaidSubscriber]]

--- a/frontend/app/controllers/IdentityRequest.scala
+++ b/frontend/app/controllers/IdentityRequest.scala
@@ -7,16 +7,16 @@ case class IdentityRequest(headers: List[(String, String)], trackingParameters: 
 
 object IdentityRequest extends RemoteAddress {
   def apply(request: Request[_]): IdentityRequest = {
-    val cookie = request.cookies.get("SC_GU_U")
     val ipAddress = clientIp(request)
 
-    val headers = List(("X-GU-ID-Client-Access-Token" -> s"Bearer ${Config.idApiClientToken}")) ++
-      cookie.map("X-GU-ID-FOWARDED-SC-GU-U" -> _.value)
+    val headers = List("X-GU-ID-Client-Access-Token" -> s"Bearer ${Config.idApiClientToken}") ++
+      request.cookies.get("SC_GU_U").map(_.value).map("X-GU-ID-FOWARDED-SC-GU-U" -> _) ++
+      request.headers.get("GU-IdentityToken").map("Authorization" -> _)
 
     val trackingParameters = List() ++
-      request.headers.get("Referer").map(("trackingReferer" -> _)) ++
-      request.headers.get("User-Agent").map(("trackingUserAgent" -> _)) ++
-      ipAddress.map(("trackingIpAddress" -> _))
+      request.headers.get("Referer").map("trackingReferer" -> _) ++
+      request.headers.get("User-Agent").map("trackingUserAgent" -> _) ++
+      ipAddress.map("trackingIpAddress" -> _)
 
     IdentityRequest(headers, trackingParameters)
 

--- a/frontend/app/services/AuthenticationService.scala
+++ b/frontend/app/services/AuthenticationService.scala
@@ -9,9 +9,9 @@ object AuthenticationService extends com.gu.identity.play.AuthenticationService 
 
   val identityKeys = Config.idKeys
 
-  def authenticatedIdUserProvider(targetClientId: String): (RequestHeader) => Option[AuthenticatedIdUser] = AuthenticatedIdUser.provider(
+  override lazy val authenticatedIdUserProvider: (RequestHeader) => Option[AuthenticatedIdUser] = AuthenticatedIdUser.provider(
     AccessCredentials.Cookies.authProvider(identityKeys),
-    AccessCredentials.Token.authProvider(identityKeys, targetClientId)
+    AccessCredentials.Token.authProvider(identityKeys, "members-data-api")
   )
 
 }

--- a/frontend/app/services/AuthenticationService.scala
+++ b/frontend/app/services/AuthenticationService.scala
@@ -11,7 +11,7 @@ object AuthenticationService extends com.gu.identity.play.AuthenticationService 
 
   override lazy val authenticatedIdUserProvider: (RequestHeader) => Option[AuthenticatedIdUser] = AuthenticatedIdUser.provider(
     AccessCredentials.Cookies.authProvider(identityKeys),
-    AccessCredentials.Token.authProvider(identityKeys, "members-data-api")
+    AccessCredentials.Token.authProvider(identityKeys, "membership")
   )
 
 }

--- a/frontend/app/services/AuthenticationService.scala
+++ b/frontend/app/services/AuthenticationService.scala
@@ -1,9 +1,17 @@
 package services
 
+import com.gu.identity.play.{AccessCredentials, AuthenticatedIdUser}
 import configuration.Config
+import play.api.mvc.RequestHeader
 
 object AuthenticationService extends com.gu.identity.play.AuthenticationService {
   def idWebAppSigninUrl(returnUrl: String) = Config.idWebAppSigninUrl(returnUrl)
 
   val identityKeys = Config.idKeys
+
+  def authenticatedIdUserProvider(targetClientId: String): (RequestHeader) => Option[AuthenticatedIdUser] = AuthenticatedIdUser.provider(
+    AccessCredentials.Cookies.authProvider(identityKeys),
+    AccessCredentials.Token.authProvider(identityKeys, targetClientId)
+  )
+
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "net.kencochrane.raven" % "raven-logback" % "6.0.0"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
   val membershipCommon = "com.gu" %% "membership-common" % "0.159"
-  val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.2"
+  val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.4"
   val contentAPI = "com.gu" %% "content-api-client" % "6.4"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache


### PR DESCRIPTION
Makes Membership frontend use the SC_GU_U cookie or the GU-IdentityToken header containing the identity app specific.
It passes all authentication mechanics to the id api and upgrade identity-play-auth with a fix for a null pointer exception.