### PR TITLE
New identity branding query param

### DIFF
--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -42,14 +42,18 @@ object Config {
 
   val idWebAppUrl = config.getString("identity.webapp.url")
 
+  val idMember = "clientId" -> "members"
+
+  private val idSkipConfirmation: (String, String) = "skipConfirmation" -> "true"
+
   def idWebAppSigninUrl(uri: String): String =
-    (idWebAppUrl / "signin") ? ("returnUrl" -> s"$membershipUrl$uri") ? ("skipConfirmation" -> "true")
+    (idWebAppUrl / "signin") ? ("returnUrl" -> s"$membershipUrl$uri") & idSkipConfirmation & idMember
 
   def idWebAppRegisterUrl(uri: String): String =
-    (idWebAppUrl / "register") ? ("returnUrl" -> s"$membershipUrl$uri") ? ("skipConfirmation" -> "true")
+    (idWebAppUrl / "register") ? ("returnUrl" -> s"$membershipUrl$uri") & idSkipConfirmation & idMember
 
   def idWebAppSignOutThenInUrl(uri: String): String =
-    (idWebAppUrl / "signout") ? ("returnUrl" -> idWebAppSigninUrl(uri)) ? ("skipConfirmation" -> "true")
+    (idWebAppUrl / "signout") ? ("returnUrl" -> idWebAppSigninUrl(uri)) & idSkipConfirmation & idMember
 
   def idWebAppProfileUrl =
     idWebAppUrl / "membership"/ "edit"

--- a/frontend/app/configuration/Links.scala
+++ b/frontend/app/configuration/Links.scala
@@ -1,6 +1,7 @@
 package configuration
 
 import controllers.routes
+import com.netaporter.uri.dsl._
 
 object Links {
   val guardianCookiePolicy = "http://www.theguardian.com/info/cookies"
@@ -19,15 +20,15 @@ object Links {
 
 object ProfileLinks {
 
-  val commentActivity = s"${Config.idWebAppUrl}/user/id/"
+  val commentActivity =  Config.idWebAppUrl /  "/user/id/"
 
-  val editProfile = s"${Config.idWebAppUrl}/public/edit"
+  val editProfile =  Config.idWebAppUrl / "/public/edit" ? Config.idMember
 
-  val editProfileMembership = s"${Config.idWebAppUrl}/membership/edit"
+  val editProfileMembership =  Config.idWebAppUrl / "/membership/edit" ? Config.idMember
 
-  val emailPreferences = s"${Config.idWebAppUrl}/email-prefs"
+  val emailPreferences =  Config.idWebAppUrl / "/email-prefs" ? Config.idMember
 
-  val changePassword = s"${Config.idWebAppUrl}/password/change"
+  val changePassword =  Config.idWebAppUrl / "/password/change" ? Config.idMember
 
   def signOut(path: String) = {
 
@@ -37,7 +38,7 @@ object ProfileLinks {
     )
 
     if(exclusions.contains(path)) {
-      s"$baseUrl?returnUrl=${Config.membershipUrl}"
+      s"$baseUrl?returnUrl=${Config.membershipUrl}&clientId=members"
     } else baseUrl
 
   }

--- a/frontend/app/configuration/Links.scala
+++ b/frontend/app/configuration/Links.scala
@@ -20,25 +20,25 @@ object Links {
 
 object ProfileLinks {
 
-  val commentActivity =  Config.idWebAppUrl /  "/user/id/"
+  val commentActivity =  Config.idWebAppUrl /  "user/id/"
 
-  val editProfile =  Config.idWebAppUrl / "/public/edit" ? Config.idMember
+  val editProfile =  Config.idWebAppUrl / "public/edit" ? Config.idMember
 
-  val editProfileMembership =  Config.idWebAppUrl / "/membership/edit" ? Config.idMember
+  val editProfileMembership =  Config.idWebAppUrl / "membership/edit" ? Config.idMember
 
-  val emailPreferences =  Config.idWebAppUrl / "/email-prefs" ? Config.idMember
+  val emailPreferences =  Config.idWebAppUrl / "email-prefs" ? Config.idMember
 
-  val changePassword =  Config.idWebAppUrl / "/password/change" ? Config.idMember
+  val changePassword =  Config.idWebAppUrl / "password/change" ? Config.idMember
 
   def signOut(path: String) = {
 
-    val baseUrl = s"${Config.idWebAppUrl}/signout"
+    val baseUrl = Config.idWebAppUrl / "signout" ? Config.idMember
     val exclusions = Seq(
       routes.FrontPage.welcome.url
     )
 
     if(exclusions.contains(path)) {
-      s"$baseUrl?returnUrl=${Config.membershipUrl}&clientId=members"
+      baseUrl ? ("returnUrl" -> Config.membershipUrl)
     } else baseUrl
 
   }


### PR DESCRIPTION
Give the identity links a clientId=members query param to load the membership branding. Leaving comment activity until we update lodash and identity implement that endpoint in their new frontend