### PR TITLE
Align landing page cta with heatmap of user mouse movement

### DIFF
--- a/frontend/app/controllers/User.scala
+++ b/frontend/app/controllers/User.scala
@@ -28,7 +28,7 @@ trait User extends Controller {
     "joinDate" -> subscriber.contact.joinDate,
     "benefits" -> Json.obj(
       "discountedEventTickets" -> Benefits.DiscountTicketTiers.contains(subscriber.subscription.plan.tier),
-      "complimentaryEventTickets" -> Benefits.ComplimenataryTicketTiers.contains(subscriber.subscription.plan.tier)
+      "complimentaryEventTickets" -> Benefits.ComplimentaryTicketTiers.contains(subscriber.subscription.plan.tier)
     )
   )
 }

--- a/frontend/app/model/Benefits.scala
+++ b/frontend/app/model/Benefits.scala
@@ -16,7 +16,7 @@ object Benefits {
 
   val DiscountTicketTiers = Set[Tier](Staff(), Partner(), Patron())
   val PriorityBookingTiers = DiscountTicketTiers
-  val ComplimenataryTicketTiers = Set[Tier](Partner(), Patron())
+  val ComplimentaryTicketTiers = Set[Tier](Partner(), Patron())
 
   val welcomePack = Benefit("welcome_pack", "Welcome pack, card and gift")
   val accessTicket = Benefit("access_tickets", "Access to tickets")
@@ -80,11 +80,4 @@ object Benefits {
   )
 
   val staff = (partner ++ supporter).filterNot(_ == booksOrTickets).distinct
-
-  val comparisonHiglightsList = Seq(
-    booksOrTickets,
-    priorityBooking,
-    discount,
-    uniqueExperiences
-  )
 }

--- a/frontend/app/views/fragments/tier/packagePromo.scala.html
+++ b/frontend/app/views/fragments/tier/packagePromo.scala.html
@@ -63,10 +63,10 @@
                }
             </div>
             <a class="action action--no-icon u-no-bottom-margin qa-package-@plans.tier.slug" @actionAttrs>
-                <span class="action__label">
-                    Become a @plans.tier.name
-                </span>
-                @fragments.actionIcon("arrow-right")
+                Become a @plans.tier.name
+                <svg class="icon-inline action__icon action__icon--right u-no-float">
+                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow-right"></use>
+                </svg>
             </a>
         </div>
     </div>

--- a/frontend/app/views/fragments/tier/packagePromoSupporter.scala.html
+++ b/frontend/app/views/fragments/tier/packagePromoSupporter.scala.html
@@ -14,7 +14,7 @@
     data-metric-action="@Supporter.toString.toLowerCase"
 }
 
-<div class="package-promo package-promo--homepage tone-border-supporter">
+<div class="package-promo package-promo--landing-page tone-border-supporter">
     <div class="package-promo__header">
         <a class="no-underline minimal-link" @actionAttrs>
             <div class="package-promo__tier">
@@ -38,10 +38,10 @@
                 @fragments.pricing.paidPriceInfo(supporterPlans, cg.currency, showCurrencyPrefix = false)
             </div>
             <a class="action action--no-icon u-no-bottom-margin qa-package-@supporter.slug" @actionAttrs>
-                <span class="action__label">
-                    Become a Supporter
-                </span>
-                @fragments.actionIcon("arrow-right")
+                Become a Supporter
+                <svg class="icon-inline action__icon action__icon--right u-no-float">
+                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow-right"></use>
+                </svg>
             </a>
         </div>
     </div>

--- a/frontend/app/views/info/supporterEurope.scala.html
+++ b/frontend/app/views/info/supporterEurope.scala.html
@@ -13,7 +13,7 @@
     @fragments.page.heroBanner("hero-banner--eu-supporter") {
         Become a Guardian&nbsp;Supporter
     } {
-        Supporters keep our journalism fearless and free from interference.
+        Supporters keep our journalism fearless and free from interference
     }()
 
     @fragments.page.section(hasBorder = false) {

--- a/frontend/app/views/info/supporterInternational.scala.html
+++ b/frontend/app/views/info/supporterInternational.scala.html
@@ -13,7 +13,7 @@
     @fragments.page.heroBanner("hero-banner--row-supporter") {
         Become a Guardian&nbsp;Supporter
     } {
-        Supporters keep our journalism fearless and free from interference.
+        Supporters keep our journalism fearless and free from interference
     }()
 
     @fragments.page.section(hasBorder = false) {

--- a/frontend/app/views/info/supporterUSA.scala.html
+++ b/frontend/app/views/info/supporterUSA.scala.html
@@ -13,7 +13,7 @@
     @fragments.page.heroBanner("hero-banner--us-supporter") {
         Become a Guardian&nbsp;Supporter
     } {
-        Supporters keep our journalism fearless and free to tell the stories other news organizations won’t.
+        Supporters keep our journalism fearless and free to tell the stories other news organizations won’t
     }()
 
     @fragments.page.section(hasBorder = false) {

--- a/frontend/app/views/promotions/englishHeritageOffer.scala.html
+++ b/frontend/app/views/promotions/englishHeritageOffer.scala.html
@@ -14,11 +14,11 @@
         Become a Guardian Partner
     } {
 
-        Support the independence of the Guardian and our award-winning journalism, plus enjoy a host of benefits.
+        Support the independence of the Guardian and our award-winning journalism, plus enjoy a host of benefits
     }()
 
     @fragments.page.section(hasBorder = false) {
-        @fragments.tier.packagePromo(partnerPlans, countryGroup, promoCode = Some("EH2016"))
+        @fragments.tier.packagePromo(partnerPlans, countryGroup, promoCode = Some("EH2016"), modifierClass = Some("package-promo--landing-page"))
     }
 
     @for(img <- pageImages.find(_.name.contains("stonehenge"))) {
@@ -52,6 +52,6 @@
     }
 
     @fragments.page.section("What's included") {
-        @fragments.tier.packagePromo(partnerPlans, countryGroup, promoCode = Some("EH2016"))
+        @fragments.tier.packagePromo(partnerPlans, countryGroup, promoCode = Some("EH2016"), modifierClass = Some("package-promo--landing-page"))
     }
 }

--- a/frontend/assets/stylesheets/components/_packages.scss
+++ b/frontend/assets/stylesheets/components/_packages.scss
@@ -27,6 +27,7 @@ $_package-promo__actions_height: 117px;
         p { margin-bottom: 0; }
     }
     .package-promo__actions {
+        white-space: nowrap;
         margin: rem($gs-gutter / 2) 0;
     }
     .package-promo__actions__pricing {
@@ -82,7 +83,6 @@ $_package-promo__actions_height: 117px;
         vertical-align: top;
         width: auto;
         min-width: 205px;
-        max-width: 350px;
     }
 }
 
@@ -96,6 +96,16 @@ $_package-promo__actions_height: 117px;
     }
     @include mq($from: desktop) {
         @include package-promo-narrow();
+    }
+}
+
+// Narrow -> wide -> wide
+.package-promo--landing-page {
+    @include mq($from: mobile, $until: tablet) {
+        @include package-promo-narrow();
+    }
+    @include mq($from: tablet) {
+        @include package-promo-wide();
     }
 }
 

--- a/frontend/assets/stylesheets/components/_pricing.scss
+++ b/frontend/assets/stylesheets/components/_pricing.scss
@@ -78,8 +78,6 @@
         text-align: left;
         width: 50%;
         height: 100%;
-        padding-right: $gutter-width-fluid;
-
     }
     .price-info__item--single {
         padding-right: 0;

--- a/frontend/assets/stylesheets/utilities/_util-layout.scss
+++ b/frontend/assets/stylesheets/utilities/_util-layout.scss
@@ -70,6 +70,9 @@
 .u-align-middle {
     vertical-align: middle;
 }
+.u-no-float {
+    float: none !important;
+}
 
 /**
  * Spacing


### PR DESCRIPTION
The main change is this (on https://membership.theguardian.com/english-heritage, desktop view):

#### Before
![picture 133](https://cloud.githubusercontent.com/assets/5122968/13395981/eec827da-dee9-11e5-979c-9779a15f512d.png)

#### After
![picture 132](https://cloud.githubusercontent.com/assets/5122968/13395982/eec9702c-dee9-11e5-9acb-f3c66db77e09.png)

And the main motivation for it is this heatmap from Session Cam:

![screenshot_at_feb_29_11-14-35](https://cloud.githubusercontent.com/assets/5122968/13396013/223efdb4-deea-11e5-8aa8-b87f020a2285.png)

I've also included some cosmetic copy tweaks (removing full stops) and tweaking the styling for the price component in the promo to ensure that it never wraps

@AWare 
