### PR TITLE
Remove PATH modification from pre-commit hook

### DIFF
--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -2,8 +2,6 @@
 #
 # Pre-commit hooks
 
-PATH="/usr/local/bin:$PATH"
-
 # Allows us to change directory in this script
 unset GIT_DIR
 


### PR DESCRIPTION
@tomverran @rtyley 

Having ```/usr/local/bin``` as the first entry in `PATH` confuses NVM.