### PR TITLE
Basic read-only API endpoint to read event image data

### DIFF
--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -132,7 +132,6 @@ object Config {
   val gridConfig = {
     val con = config.getConfig("grid.images")
     GridConfig(
-      con.getString("media.url"),
       con.getString("api.url"),
       con.getString("api.key")
     )

--- a/frontend/app/controllers/EventApi.scala
+++ b/frontend/app/controllers/EventApi.scala
@@ -1,0 +1,36 @@
+package controllers
+
+import com.typesafe.scalalogging.LazyLogging
+import model.RichEvent.RichEvent
+import play.api.libs.json.Json
+import play.api.libs.json.Json.toJson
+import play.api.mvc.Controller
+import services.GridService.ImageIdWithCrop
+
+object EventApi extends Controller with LazyLogging {
+  case class Event(
+    id: String,
+    url: String,
+    mainImage: Option[ImageIdWithCrop]
+  )
+
+  object Event {
+    implicit val writesEvent = Json.writes[Event]
+
+    def forRichEvent(e: RichEvent) = Event(e.id, e.memUrl, e.mainImageGridId)
+  }
+
+  case class EventsResponse(events: Seq[Event])
+
+  object EventsResponse {
+    implicit val writesEventsData = Json.writes[EventsResponse]
+  }
+
+  /**
+    * @return for now, only Guardian Live Events - other types may be added in the future
+    */
+  def events = CachedAction {
+    Ok(toJson(EventsResponse(controllers.Event.guLiveEvents.events.map(Event.forRichEvent))))
+  }
+
+}

--- a/frontend/app/model/Eventbrite.scala
+++ b/frontend/app/model/Eventbrite.scala
@@ -13,6 +13,7 @@ import play.api.data.validation.ValidationError
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import services.GridService
+import services.GridService.{CropQueryParam, ImageIdWithCrop}
 import utils.StringUtils._
 import views.support.Asset
 import views.support.Dates.YearMonthDayHours
@@ -289,8 +290,9 @@ object Eventbrite {
       }
     } yield uri
 
-    val mainImageHasNoCrop: Boolean =
-      mainImageUrl.fold(false)(uri => uri.query.param(GridService.CropQueryParam).isEmpty)
+    val mainImageHasNoCrop: Boolean = mainImageUrl.exists(!_.query.params.contains(CropQueryParam))
+
+    val mainImageGridId: Option[ImageIdWithCrop] = mainImageUrl.flatMap(ImageIdWithCrop.fromGuToolsUri)
 
     val slug = slugify(name.text) + "-" + id
 

--- a/frontend/app/services/EventbriteService.scala
+++ b/frontend/app/services/EventbriteService.scala
@@ -118,11 +118,11 @@ trait EventbriteService extends WebServiceHelper[EBObject, EBError] {
 }
 
 abstract class LiveService extends EventbriteService {
-  val gridService = GridService(Config.gridConfig.url)
+
   val contentApiService = GuardianContentService
 
   def gridImageFor(event: EBEvent) =
-    event.mainImageUrl.fold[Future[Option[GridImage]]](Future.successful(None))(gridService.getRequestedCrop)
+    event.mainImageGridId.fold[Future[Option[GridImage]]](Future.successful(None))(GridService.getRequestedCrop)
 }
 
 object GuardianLiveEventService extends LiveService {

--- a/frontend/app/services/GridService.scala
+++ b/frontend/app/services/GridService.scala
@@ -11,45 +11,47 @@ import model.Grid._
 import model.GridDeserializer._
 import model.RichEvent.GridImage
 import monitoring.GridApiMetrics
+import play.api.libs.json.Json
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-object GridService {
+object GridService extends WebServiceHelper[GridObject, Error] with LazyLogging{
+
+  val gridUrl: String = "https://media.gutools.co.uk/images/"
   val CropQueryParam = "crop"
   def cropParam(url: Uri) = url.query.param(CropQueryParam)
 
   case class ImageIdWithCrop(id: String, crop: String)
   object ImageIdWithCrop {
-    def fromGuToolsUri(gridUrl: String)(uri: Uri): Option[ImageIdWithCrop] =
+    implicit val writesImageIdWithCrop = Json.writes[ImageIdWithCrop]
+
+
+    def fromGuToolsUri(uri: Uri): Option[ImageIdWithCrop] =
       for {
         imageId <- uri.path.split("/").lastOption
         crop <-  uri.query.param(CropQueryParam)
         if uri.toString().startsWith(gridUrl)
       } yield ImageIdWithCrop(imageId, crop)
   }
-}
-case class GridService(gridUrl: String) extends WebServiceHelper[GridObject, Error] with LazyLogging{
-  import GridService._
 
-  lazy val agent = Agent[Map[Uri, GridImage]](Map.empty)
+  lazy val agent = Agent[Map[ImageIdWithCrop, GridImage]](Map.empty)
 
-  def getRequestedCrop(url: Uri) : Future[Option[GridImage]] = {
+  def getRequestedCrop(gridId: ImageIdWithCrop) : Future[Option[GridImage]] = {
     val currentImageData = agent.get()
-    if(currentImageData.contains(url)) Future.successful(currentImageData.get(url))
+    if(currentImageData.contains(gridId)) Future.successful(currentImageData.get(gridId))
     else {
-      getGrid(url).map { gridOpt =>
+      getGrid(gridId).map { grid =>
         for {
-          grid <- gridOpt
           exports <- grid.data.exports
-          assets = findAssets(exports, cropParam(url))
+          assets = findAssets(exports, gridId.crop)
           if assets.nonEmpty
         } yield {
           val image = GridImage(assets, grid.data.metadata)
           agent send {
             oldImageData =>
-              val newImageData = oldImageData + (url -> image)
-              logger.trace(s"Adding image $url to the event image map")
+              val newImageData = oldImageData + (gridId -> image)
+              logger.trace(s"Adding image $gridId to the event image map")
               newImageData
           }
           image
@@ -57,17 +59,15 @@ case class GridService(gridUrl: String) extends WebServiceHelper[GridObject, Err
       }
     }
   }.recover { case e =>
-    logger.error(s"Error getting crop for $url", e)
+    logger.error(s"Error getting crop for $gridId", e)
     None
   } // We should return no image, rather than die
 
-  def getGrid(url: Uri): Future[Option[GridResult]] =
-    ImageIdWithCrop.fromGuToolsUri(gridUrl)(url).map { case ImageIdWithCrop(id, cropId) =>
-      get[GridResult](id, CropQueryParam -> cropId).map(Some(_))
-    } getOrElse Future.successful(None)
+  def getGrid(gridId: ImageIdWithCrop): Future[GridResult] =
+    get[GridResult](gridId.id, CropQueryParam -> gridId.crop)
 
-  def findAssets(exports: List[Export], cropParameter: Option[String]) = {
-    val requestedExport = cropParameter.flatMap(cr => exports.find(_.id == cr)).orElse(exports.headOption)
+  def findAssets(exports: List[Export], cropId: String) = {
+    val requestedExport = exports.find(_.id == cropId)
     requestedExport.map(_.assets).getOrElse(Nil)
   }
 
@@ -78,5 +78,5 @@ case class GridService(gridUrl: String) extends WebServiceHelper[GridObject, Err
   override val wsMetrics: StatusMetrics = GridApiMetrics
 }
 
-case class GridConfig(url: String, apiUrl: String, key: String)
+case class GridConfig(apiUrl: String, key: String)
 

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -52,6 +52,8 @@ GET            /subscription/remaining-tickets        controllers.Subscription.r
 
 # What's On
 GET            /events                                controllers.WhatsOn.list
+GET            /events.json                           controllers.EventApi.events
+
 GET            /events/archive                        controllers.WhatsOn.listArchive
 GET            /events/calendar                       controllers.WhatsOn.calendar
 GET            /masterclasses                         controllers.WhatsOn.masterclassesList

--- a/frontend/test/services/GridServiceTest.scala
+++ b/frontend/test/services/GridServiceTest.scala
@@ -1,29 +1,26 @@
 package services
 
-import model.Grid.GridResult
-import org.specs2.mutable.Specification
-import utils.Resource
-import model.GridDeserializer._
+import com.netaporter.uri.Uri
 import com.netaporter.uri.dsl._
+import model.Grid.GridResult
+import model.GridDeserializer._
+import org.specs2.mutable.Specification
+import services.GridService.ImageIdWithCrop.fromGuToolsUri
+import utils.Resource
 
 class GridServiceTest extends Specification {
   import GridService.ImageIdWithCrop
 
-  val configUrl = "https://valid-media-tool-url/images/"
-  val validGridUrl = "https://valid-media-tool-url/images/aef2fb1db22f7cd20683548719a2849b3c9962ec?crop=0_19_480_288"
-  val invalidGridUrl = "https://invalid-media-tool-url/images/aef2fb1db22f7cd20683548719a2849b3c9962ec?crop=0_19_480_288"
+  val validGridUrl: Uri = "https://media.gutools.co.uk/images/aef2fb1db22f7cd20683548719a2849b3c9962ec?crop=0_19_480_288"
 
   "ImageIdWithCrop" should {
     "build only from valid urls" in {
-      val imageIdWithCrop = ImageIdWithCrop.fromGuToolsUri(configUrl) _
-      imageIdWithCrop(validGridUrl) mustEqual Some(ImageIdWithCrop("aef2fb1db22f7cd20683548719a2849b3c9962ec", "0_19_480_288"))
-      imageIdWithCrop(invalidGridUrl) mustEqual None
+      fromGuToolsUri(validGridUrl) must beSome(ImageIdWithCrop("aef2fb1db22f7cd20683548719a2849b3c9962ec", "0_19_480_288"))
+      fromGuToolsUri("https://twitter.com/rtyley") must beNone
     }
   }
 
   "GridService" should {
-    val service = new GridService(configUrl)
-
     "cropParam" in {
       GridService.cropParam(validGridUrl) mustEqual Some("0_19_480_288")
       GridService.cropParam("http://example.com?q=v") mustEqual None
@@ -32,21 +29,11 @@ class GridServiceTest extends Specification {
       val grid = Resource.getJson("model/grid/api-image.json")
       val gridResponse = grid.as[GridResult]
       val exports = gridResponse.data.exports.get
-      val requestedCrop = Some("0_130_1703_1022")
-      val assets = service.findAssets(exports, requestedCrop)
+      val requestedCrop = "0_130_1703_1022"
+      val assets = GridService.findAssets(exports, requestedCrop)
 
       assets.size mustEqual(3)
       assets.map(_.dimensions.width) mustEqual(List(1000, 500, 140))
-    }
-    "must return first crop when requested crop is not defined" in {
-      val grid = Resource.getJson("model/grid/api-image.json")
-      val gridResponse = grid.as[GridResult]
-      val exports = gridResponse.data.exports.get
-
-      val assets = service.findAssets(exports, None)
-
-      assets.size mustEqual(2)
-      assets.map(_.dimensions.width) mustEqual(List(1000, 500))
     }
   }
 }


### PR DESCRIPTION
This is to assist a proposed commercial component for dotcom that will show Guardian Live events - thus encouraging them to join Membership!

Only returns Guardian Live Events, because for the moment that is all @regiskuckaertz & @JonNorman needs - other event types may be added in the future.

The endpoint is **https://membership.theguardian.com/events.json** - once this PR is merged, you'll get a response like:

```
{
"events": [
{
  "id": "20940795483",
  "url": "https://membership.theguardian.com/event/guardian-live-a-nations-theatre-conversation-farnham-i-liked-it-but-i-couldnt-book-it-20940795483",
  "mainImage": {
    "id": "ecf6ea115a9c1286865fc792208f514b05e4026b",
    "crop": "0_0_3500_2101"
  }
},
...
```

I've deliberately restricted the information returned at this point - we can add more when it's required. 

The image information is given as [Grid](https://github.com/guardian/grid) identifiers - I would probably have just given a url, but a quirk of the Grid API is that AFAICT there's actually no API url for the crop of image (see https://github.com/guardian/grid/issues/1793)

To get the Grid ImageIdWithCrop into the API, I had to refactor GridService a bit. The value of `grid.images.media.url` was in the private config file, but it's a value that's publicly exposed in lots of other places, so we might as well just have it as a constant - the address of the grid admin tool is not a secret: "https://media.gutools.co.uk/images/"

cc @tomverran 