### PR TITLE
Display price correctly on event thank you page

### DIFF
--- a/frontend/app/views/fragments/event/itemSnapshotOrder.scala.html
+++ b/frontend/app/views/fragments/event/itemSnapshotOrder.scala.html
@@ -1,5 +1,7 @@
 @import configuration.Config
 @import views.support.Asset
+@import com.gu.i18n.GBP
+@import com.gu.memsub.Price
 
 @(event: model.RichEvent.RichEvent, order: model.Eventbrite.EBOrder)
 
@@ -27,7 +29,7 @@
                         <div class="order-summary__id">Order no. @order.id</div>
                         <div class="order-summary__ticket">
                             @order.ticketCount ticket@if(order.ticketCount > 1){s}
-                            @if(order.totalCost > 0) { Pricing.pretty(@order.totalCost, GBP) } else { free }
+                            @if(order.totalCost > 0) { @Price(order.totalCost, GBP).pretty } else { free }
                         </div>
                         <div class="order-summary__reference copy">The order has been saved in <a href="@(Config.eventbriteUrl + "/gettickets")">MyTickets</a> on Eventbrite. We've also sent confirmation to your registered EventBrite email address.</div>
                         <img class="u-margin-top" src="@Asset.at("images/logos/eventbrite.svg")">


### PR DESCRIPTION
Think this went awry during Andrea & Tom's big refactoring for international prices.

#### Before:

<img width="874" alt="screen shot 2016-03-01 at 11 32 26" src="https://cloud.githubusercontent.com/assets/5122968/13432409/5e788f1c-dfc5-11e5-928b-986c7c83b977.png">

#### After:
<img width="867" alt="picture 134" src="https://cloud.githubusercontent.com/assets/5122968/13432448/8edd03f4-dfc5-11e5-9648-6eda4e0d855e.png">

@rtyley 

