### PR TITLE
Support custom ticket price descriptions on Events

### DIFF
--- a/frontend/app/model/Eventbrite.scala
+++ b/frontend/app/model/Eventbrite.scala
@@ -111,6 +111,7 @@ object Eventbrite {
    */
   case class EBTicketClass(id: String,
                            name: String,
+                           description: Option[String],
                            free: Boolean,
                            quantity_total: Int,
                            quantity_sold: Int,

--- a/frontend/app/views/fragments/pricing/priceInfoEvent.scala.html
+++ b/frontend/app/views/fragments/pricing/priceInfoEvent.scala.html
@@ -8,7 +8,12 @@
         } else {
             @ticketing.memberDiscountOpt.fold {
                 <div class="price-info-inline__value qa-event-detail-price">
-                    @ticketing.generalReleaseTicketOpt.map(_.priceText)
+                    @for(generalReleaseTicket <- ticketing.generalReleaseTicketOpt) {
+                        @generalReleaseTicket.priceText
+                        @for(description <- generalReleaseTicket.description) {
+                            <div class="price-info-inline__trail">@description</div>
+                        }
+                    }
                 </div>
 	        } { discountTicketing =>
                 <div class="js-event-price">
@@ -27,6 +32,9 @@
                         <div class="price-info-inline__trail price-info-inline__limited">
                             @event.limitedAvailabilityText
                         </div>
+                    }
+                    @for(description <- discountTicketing.generalRelease.description) {
+                        <div class="price-info-inline__trail">@description</div>
                     }
                 </div>
             }

--- a/frontend/test/model/EventbriteTestObjects.scala
+++ b/frontend/test/model/EventbriteTestObjects.scala
@@ -13,7 +13,7 @@ object EventbriteTestObjects {
   def eventLocation = new EBAddress(None, None, None, None, None, None)
   def eventVenue = new EBVenue(Option(eventLocation), None)
   def eventWithName(name: String = "") = EBEvent(eventName(name), Option(eventDescription()), "", name, eventTime, eventTime + 2.hours, (eventTime - 1.month).toInstant, eventVenue, 0, Seq.empty, "live")
-  def eventTicketClass = EBTicketClass("", "", false, 0, 0, None, None, None, eventTime.toInstant, None, None)
+  def eventTicketClass = EBTicketClass("", "", None, false, 0, 0, None, None, None, eventTime.toInstant, None, None)
 
   case class TestRichEvent(event: EBEvent) extends RichEvent {
     val detailsUrl = ""


### PR DESCRIPTION
Tina asked if it would be possible to add more explanatory text next to the ticket price (because the price on [one of their new events](https://membership.theguardian.com/preview-event/22493299063) is quite high due to it including a book). Eventbrite does allow a 'description' field on tickets:

https://www.eventbrite.co.uk/developer/v3/endpoints/events/#ebapi-post-events-id-ticket-classes

So long as this description field isn't being used for any other purpose, I think we should be fine to add it as extra descriptive text. Note that the info must be added to the 'general release' ticket (ie the
first non-hidden ticket). It'll look like this (the descriptive text is _'Price includes signed book'_):

![image](https://cloud.githubusercontent.com/assets/52038/13470804/b4e79204-e0a5-11e5-8d79-d606648ba677.png)

It's configured like this in the EventBrite event editor: ![image](https://cloud.githubusercontent.com/assets/52038/13470919/37ecc930-e0a6-11e5-9196-5be36e166018.png)


Request from Tina on the Guardian Live Events team:

```
---------- Forwarded message ----------
From: Tina Moynihan
Date: 2 March 2016 at 17:08
Subject: Adding text?

This event price of £23 and includes a signed book. Can we say this where
I have positioned the yellow arrow? Otherwise the high price point might
put people off from clicking through to the event.

Thanks,
Tina

https://membership.theguardian.com/preview-event/22493299063
```

cc @JuliaBellis @joelochlann  