### PR TITLE
Use serverside redirect not JavaScript for ticket join flow

### DIFF
--- a/frontend/app/model/RichEvent.scala
+++ b/frontend/app/model/RichEvent.scala
@@ -88,7 +88,7 @@ object RichEvent {
       tickets.getOrElse(Seq[EBTicketClass]())
     }
 
-    def isBookableByTier(tier: Tier): Boolean = this.internalTicketing.exists(_.salesDates.tierCanBuyTicket(tier))
+    def isBookableByTier(tier: Tier): Boolean = event.internalTicketing.exists(_.salesDates.tierCanBuyTicket(tier))
   }
 
   abstract class LiveEvent(

--- a/frontend/app/model/RichEvent.scala
+++ b/frontend/app/model/RichEvent.scala
@@ -87,6 +87,8 @@ object RichEvent {
 
       tickets.getOrElse(Seq[EBTicketClass]())
     }
+
+    def isBookableByTier(tier: Tier): Boolean = this.internalTicketing.exists(_.salesDates.tierCanBuyTicket(tier))
   }
 
   abstract class LiveEvent(

--- a/frontend/assets/javascripts/src/modules/events/cta.js
+++ b/frontend/assets/javascripts/src/modules/events/cta.js
@@ -8,13 +8,11 @@ define([
     var CTA_ACTIONS = {
         buy: {},
         join: {
-            id: 'join',
-            href: '/choose-tier'
+            id: 'join'
         },
         upgrade: {
             id: 'upgrade',
-            label: 'Upgrade membership',
-            href: '/tier/change'
+            label: 'Upgrade membership'
         },
         unavailable: {
             id: 'unavailable',
@@ -32,10 +30,6 @@ define([
     function enhanceCta(elem, ctaStatus) {
         if (ctaStatus.label) {
             elem.text(ctaStatus.label);
-        }
-
-        if (ctaStatus.href) {
-            elem.attr('href', ctaStatus.href);
         }
 
         if (ctaStatus.disable) {

--- a/frontend/test/model/EventbriteTestObjects.scala
+++ b/frontend/test/model/EventbriteTestObjects.scala
@@ -12,8 +12,8 @@ object EventbriteTestObjects {
   def eventDescription(description: String = "Event Description") = new EBRichText(description, "")
   def eventLocation = new EBAddress(None, None, None, None, None, None)
   def eventVenue = new EBVenue(Option(eventLocation), None)
-  def eventWithName(name: String = "") = EBEvent(eventName(name), Option(eventDescription()), "", name, eventTime, eventTime + 2.hours, (eventTime - 1.month).toInstant, eventVenue, 0, Seq.empty, "live")
   def eventTicketClass = EBTicketClass("", "", None, false, 0, 0, None, None, None, eventTime.toInstant, None, None)
+  def eventWithName(name: String = "") = EBEvent(eventName(name), Option(eventDescription()), "", name, eventTime, eventTime + 2.hours, (eventTime - 1.month).toInstant, eventVenue, 0, Seq(eventTicketClass), "live")
 
   case class TestRichEvent(event: EBEvent) extends RichEvent {
     val detailsUrl = ""


### PR DESCRIPTION
This fixes a bug in the join/upgrade flow when purchasing tickets. If you entered the join/upgrade flow by clicking on the "Book Tickets" button, you should see a link to Eventbrite on the thank you page, as below:

![picture 143](https://cloud.githubusercontent.com/assets/5122968/13534217/f505c022-e22b-11e5-9359-cccefff35d0f.png)

The serverside logic was (mostly) in place to do this, but because the link href was being changed by JavaScript it was never going via the redirect code path so the `preJoinReturnUrl` was not being set. Also the cookie was never being dropped on the upgrade path, only the join path, so I added that. And I also had to add a condition to prevent this backdoor to priority tickets:

1. non-member, try to book tickets during partner/patron priority period
2. get directed to join flow, choose supporter tier
3. on thank you page, you get the eventbrite link (which should only be available to partners & patrons)

@tomverran @paulbrown1982 


