### PR TITLE
Add ability to modify the button in the packagePromo view fragment

### DIFF
--- a/frontend/app/model/Highlights.scala
+++ b/frontend/app/model/Highlights.scala
@@ -4,6 +4,7 @@ import com.gu.salesforce.Tier
 import com.gu.salesforce.Tier._
 import views.support.DisplayText.Highlight
 import configuration.Config.zuoraFreeEventTicketsAllowance
+import scalaz.NonEmptyList
 
 
 object Highlights {
@@ -42,4 +43,10 @@ object Highlights {
   val patron = Seq(ehPatron, deepSupport, behindTheScenes)
 
   val marketedOnlyToUK = Set[Highlight](tickets, freeTickets, priorityBooking, ehPartner, ehPatron)
+
+  val ehLandingPage = NonEmptyList(
+    Highlight("Support Guardian journalism and our coverage of critical, under-reported stories from around the world."),
+    Highlight("Enjoy a host of benefits, from Guardian Live tickets to the best Guardian books."),
+    Highlight("Receive a free English Heritage membership worth £88 when you become a Guardian Partner by 31 March")
+  )
 }

--- a/frontend/app/model/PackagePromo.scala
+++ b/frontend/app/model/PackagePromo.scala
@@ -1,0 +1,8 @@
+package model
+import com.netaporter.uri.Uri
+
+object PackagePromo {
+
+  // the call-to-action button on the package promo view element
+  case class CtaButton(text: String, to: Uri, attributes: Map[String, String])
+}

--- a/frontend/app/views/fragments/tier/packagePromo.scala.html
+++ b/frontend/app/views/fragments/tier/packagePromo.scala.html
@@ -2,34 +2,30 @@
 @import views.support.DisplayText._
 @import views.support.{FreePlan, PaidPlans, TierPlans}
 @import com.gu.i18n.CountryGroup
+@import scalaz.NonEmptyList
+@import views.support.PackagePromo._
 
+@import model.PackagePromo.CtaButton
+@import model.PackagePromo
 @(plans: TierPlans,
   cg: CountryGroup,
   showDescription: Boolean = true,
   descriptionAnchor: Option[String] = None,
   modifierClass: Option[String] = None,
   extraClasses: Seq[String] = Seq.empty,
+  highlightOverrides: Option[NonEmptyList[Highlight]] = None,
   isReversed: Boolean = false,
   chooseTier: Boolean = false,
-  promoCode: Option[String] = None)
+  promoCode: Option[String] = None,
+  button: Option[CtaButton] = None)
 
-@link(tier: Tier) = {
-    @tier match {
-        case paid: PaidTier => {@routes.Joiner.enterPaidDetails(paid)}
-        case _: FreeTier => {@routes.Joiner.enterFriendDetails()}
-    }
-}
-
-@actionAttrs = {
-    href="@link(plans.tier)?countryGroup=@{cg.id}@promoCode.map("&promoCode=" + _).mkString"
-    data-metric-trigger="click"
-    data-metric-category="join"
-    data-metric-action="@plans.tier.slug"
+@promoButton = @{
+    button.getOrElse(forCountryTier(plans.tier, cg, promoCode))
 }
 
 <div class="@if(isReversed){ package-promo--reversed} @modifierClass.getOrElse("package-promo--default") @extraClasses.mkString("") tone-border-@plans.tier.slug">
     <div class="package-promo__header">
-        <a class="no-underline minimal-link" @actionAttrs>
+        <a class="no-underline minimal-link" href="@promoButton.to" @promoButton.attributes.html>
             <div class="package-promo__tier">
                 <div class="package-promo__tier__title">
                     @fragments.tier.tierTrail(plans.tier, showCaption=false)
@@ -41,7 +37,7 @@
         @if(showDescription) {
             <div class="package-promo__description copy">
                 <ul class="o-bulleted-list">
-                    @for(highlight <- if(chooseTier && plans.tier == Tier.patron) plans.tier.chooseTierPatron else plans.tier.highlights(cg)) {
+                    @for(highlight <- if(chooseTier && plans.tier == Tier.patron) plans.tier.chooseTierPatron else highlightOverrides.fold(plans.tier.highlights(cg))(_.list) ) {
                         <li>
                             @if(highlight.isNew) {
                                 @fragments.inlineIcon("new-arrow", List("icon-inline--badge", "icon-inline--brand"))
@@ -62,8 +58,8 @@
                    case PaidPlans(p) => { @fragments.pricing.paidPriceInfo(p, cg.currency) }
                }
             </div>
-            <a class="action action--no-icon u-no-bottom-margin qa-package-@plans.tier.slug" @actionAttrs>
-                Become a @plans.tier.name
+            <a class="action action--no-icon u-no-bottom-margin qa-package-@plans.tier.slug" href="@promoButton.to" @promoButton.attributes.html>
+                @promoButton.text
                 <svg class="icon-inline action__icon action__icon--right u-no-float">
                     <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow-right"></use>
                 </svg>

--- a/frontend/app/views/index.scala.html
+++ b/frontend/app/views/index.scala.html
@@ -3,6 +3,7 @@
 @import com.gu.membership.MembershipCatalog
 @import views.support.PaidPlans
 @import com.gu.salesforce.PaidTier
+@import model.PackagePromo
 @(
   catalog: MembershipCatalog,
   pageImages: Seq[model.ResponsiveImageGroup],

--- a/frontend/app/views/promotions/englishHeritageOffer.scala.html
+++ b/frontend/app/views/promotions/englishHeritageOffer.scala.html
@@ -3,11 +3,19 @@
 @import com.gu.salesforce.Tier.Partner
 @import com.gu.membership.PaidMembershipPlans
 @import views.support.PageInfo
+@import model.Highlights
+@import model.PackagePromo.CtaButton
+@import com.netaporter.uri.dsl._
+
 @(partnerPlans: PaidMembershipPlans[Current, Partner],
     pageInfo: PageInfo,
     pageImages: Seq[model.ResponsiveImageGroup])(implicit token: play.filters.csrf.CSRF.Token, countryGroup: CountryGroup)
 
 @import views.support.Asset
+@buttonCta = @{
+    Some(CtaButton("Find out more", "/", Map.empty))
+}
+
 @main("English Heritage Promotion", pageInfo=pageInfo, countryGroup=Some(countryGroup)) {
     @fragments.promos.englishHeritageRoundel()
     @fragments.page.heroBanner("hero-banner--eng-heritage") {
@@ -18,7 +26,13 @@
     }()
 
     @fragments.page.section(hasBorder = false) {
-        @fragments.tier.packagePromo(partnerPlans, countryGroup, promoCode = Some("EH2016"), modifierClass = Some("package-promo--landing-page"))
+        @fragments.tier.packagePromo(
+            partnerPlans,
+            countryGroup,
+            promoCode = Some("EH2016"),
+            modifierClass = Some("package-promo--landing-page"),
+            highlightOverrides = Some(Highlights.ehLandingPage),
+            button = buttonCta)
     }
 
     @for(img <- pageImages.find(_.name.contains("stonehenge"))) {
@@ -52,6 +66,12 @@
     }
 
     @fragments.page.section("What's included") {
-        @fragments.tier.packagePromo(partnerPlans, countryGroup, promoCode = Some("EH2016"), modifierClass = Some("package-promo--landing-page"))
+        @fragments.tier.packagePromo(
+            partnerPlans,
+            countryGroup,
+            promoCode = Some("EH2016"),
+            modifierClass = Some("package-promo--landing-page"),
+            button = buttonCta,
+            highlightOverrides = Some(Highlights.ehLandingPage))
     }
 }

--- a/frontend/app/views/support/PackagePromo.scala
+++ b/frontend/app/views/support/PackagePromo.scala
@@ -1,0 +1,37 @@
+package views.support
+
+import com.gu.i18n.CountryGroup
+import com.gu.salesforce.{FreeTier, PaidTier, Tier}
+import com.netaporter.uri.Uri
+import com.netaporter.uri.dsl._
+import controllers.routes
+import model.PackagePromo.CtaButton
+import play.twirl.api.Html
+
+
+object PackagePromo {
+
+  /**
+    * A default CTA button for a country & tier which goes to enter details
+    */
+  def forCountryTier(t: Tier, cg: CountryGroup, promoCode: Option[String]) = {
+
+    val link = (t match {
+      case p: PaidTier => Uri.parse(routes.Joiner.enterPaidDetails(p).url)
+      case _: FreeTier => Uri.parse(routes.Joiner.enterFriendDetails().url)
+    }) ? ("countryGroup" -> cg.id) & ("promoCode" -> promoCode)
+
+    val attrs = Map[String, String](
+      "data-metric-trigger" -> "click",
+      "data-metric-category" -> "join",
+      "data-metric-action" -> t.slug
+    )
+
+    CtaButton("Become a " + t.slug, to = link, attributes = attrs)
+  }
+
+  implicit class AttrsToHtml(attrs: Map[String, String]) {
+    // no escaping of the attribute values happens here as twirl does it
+    def html: String = attrs.map { case (k, v) => s"""$k=$v""" }.mkString(" ")
+  }
+}


### PR DESCRIPTION
So the brief is/was to modify the EH landing page to change the partner highlights text and also to change "Become a partner" to "Find out more" and make it point to the homepage.

I think we should move towards modelling the package promo container contents with objects rather than lots and lots of parameters, so to advance us towards that goal I've modelled the CTA button, the eventual aim being to have one big PackagePromo object we can tweak for any variants