### PR TITLE
Remove the "and no fees" bit of copy where necessary

### DIFF
--- a/frontend/app/views/fragments/pricing/priceInfoEvent.scala.html
+++ b/frontend/app/views/fragments/pricing/priceInfoEvent.scala.html
@@ -24,8 +24,8 @@
                         }
                     </div>
                     <div class="price-info-inline__trail">
-                        <span class="js-event-price-saving" data-discount-text="You save @discountTicketing.savingText (@discountTicketing.roundedSavingPercentageExcludingFee% off and no fees)">
-                            Partners/Patrons save @discountTicketing.savingText (@discountTicketing.roundedSavingPercentageExcludingFee% off and no fees)
+                        <span class="js-event-price-saving" data-discount-text="You save @discountTicketing.savingText (@discountTicketing.roundedSavingPercentageExcludingFee% off@if(discountTicketing.generalRelease.feeText.isDefined){ and no fees})">
+                            Partners/Patrons save @discountTicketing.savingText (@discountTicketing.roundedSavingPercentageExcludingFee% off@if(discountTicketing.generalRelease.feeText.isDefined){ and no fees})
                         </span>
                     </div>
                     @if(showLimited && event.isBookable && event.isLimitedAvailability) {


### PR DESCRIPTION
Remove the "and no fees" bit of copy iff there are no fees on the Event/Masterclass's general release ticket.

https://trello.com/c/VSH1ZruW/260-we-are-displaying-the-booking-fees-message-on-masterclasses

cc @joelochlann 
