### PR TITLE
Add event brand text

### DIFF
--- a/frontend/app/model/EventMetadata.scala
+++ b/frontend/app/model/EventMetadata.scala
@@ -42,7 +42,7 @@ object EventMetadata {
 
   val localMetadata = Metadata(
     identifier="local",
-    title="Guardian Local events",
+    title="Guardian Local",
     shortTitle="Events",
     pluralTitle="Local events",
     description=Some("Guardian Local is a programme of events, specially selected to give our members the chance to " +

--- a/frontend/app/model/EventMetadata.scala
+++ b/frontend/app/model/EventMetadata.scala
@@ -14,7 +14,8 @@ object EventMetadata {
     eventListUrl: String,
     termsUrl: String,
     highlightsOpt: Option[HighlightsMetadata] = None,
-    chooseTier: ChooseTierMetadata
+    chooseTier: ChooseTierMetadata,
+    brand: String
   )
 
   case class ChooseTierMetadata(title: String, sectionTitle: String)
@@ -35,12 +36,13 @@ object EventMetadata {
     chooseTier=ChooseTierMetadata(
       "Guardian Live events are exclusively for Guardian members",
       "Choose a membership tier to continue with your booking"
-    )
+    ),
+    brand = "A Guardian Live event"
   )
 
   val localMetadata = Metadata(
     identifier="local",
-    title="Guardian Local",
+    title="Guardian Local events",
     shortTitle="Events",
     pluralTitle="Local events",
     description=Some("Guardian Local is a programme of events, specially selected to give our members the chance to " +
@@ -51,7 +53,8 @@ object EventMetadata {
     chooseTier=ChooseTierMetadata(
       "Guardian Local events are exclusively for Guardian members",
       "Choose a membership tier to continue with your booking"
-    )
+    ),
+    brand = "A Guardian Local event"
   )
 
   val masterclassMetadata = Metadata(
@@ -69,7 +72,8 @@ object EventMetadata {
     chooseTier=ChooseTierMetadata(
       "Choose a membership tier to continue with your booking",
       "Become a Partner or Patron to save 20% on your masterclass"
-    )
+    ),
+    brand = ""
   )
 
 }

--- a/frontend/app/views/eventOverview/fragments/overviewSection.scala.html
+++ b/frontend/app/views/eventOverview/fragments/overviewSection.scala.html
@@ -12,12 +12,10 @@
 }
 
 @previewUrlSubCategory(eventOpt: Option[model.RichEvent.RichEvent]) = @{
-    eventOpt.fold("") { event =>
-        event match {
-            case _: GuLiveEvent => "event"
-            case _: MasterclassEvent => "masterclass"
-            case _: LocalEvent => "local"
-        }
+    eventOpt.fold("") {
+        case _: GuLiveEvent => "event"
+        case _: MasterclassEvent => "masterclass"
+        case _: LocalEvent => "local"
     }
 }
 
@@ -41,7 +39,7 @@
                                             alt="@event.name.text" class="responsive-img"
                                         />
                                     } { img =>
-                                        <img src="@img.defaultImage"" alt="@event.name.text" class="responsive-img"/>
+                                        <img src="@img.defaultImage" alt="@event.name.text" class="responsive-img"/>
                                     }
                                     <span class="pseudo-link event-detail-title">@event.name.text</span>
                                 </a>

--- a/frontend/app/views/fragments/event/item.scala.html
+++ b/frontend/app/views/fragments/event/item.scala.html
@@ -29,6 +29,7 @@
                     @desc.blurb
                 </div>
             }
+            <div class="event-item__brand">@event.metadata.brand</div>
         </div>
     </div>
 }

--- a/frontend/app/views/fragments/event/itemList.scala.html
+++ b/frontend/app/views/fragments/event/itemList.scala.html
@@ -16,5 +16,6 @@
                 </div>
             </div>
         }
+        <div class="event-item__brand">@event.metadata.brand</div>
     </div>
 </a>

--- a/frontend/assets/stylesheets/components/_event-items.scss
+++ b/frontend/assets/stylesheets/components/_event-items.scss
@@ -69,7 +69,8 @@
     }
 }
 .event-item__time,
-.event-item__location, {
+.event-item__location,
+.event-item__brand {
     @include fs-data(3);
 
     @include mq(tablet) {
@@ -87,6 +88,9 @@
         @include fs-headline(2, $size-only: true);
         padding-top: $gs-baseline;
     }
+}
+.event-item__brand {
+    color: $c-neutral2;
 }
 
 .event-item--clippath-0,

--- a/frontend/test/model/EventbriteTestObjects.scala
+++ b/frontend/test/model/EventbriteTestObjects.scala
@@ -38,7 +38,8 @@ object EventbriteTestObjects {
       eventListUrl="",
       termsUrl="",
       highlightsOpt=None,
-      chooseTier=ChooseTierMetadata("", "")
+      chooseTier=ChooseTierMetadata("", ""),
+      brand=""
     )
 
     def deficientGuardianMembersTickets: Boolean = false


### PR DESCRIPTION
Adding the event's branding below the location text on a grid item. This will allow us to remove the branding from the event's name in EventBrite.

https://trello.com/c/oVKYarCL/144-don-t-display-events-brand-in-event-title-on-list-page-display-brand-in-design-instead

cc @rtyley