### PR TITLE
Promo code redirect 

### DIFF
--- a/frontend/app/controllers/Promotions.scala
+++ b/frontend/app/controllers/Promotions.scala
@@ -1,5 +1,6 @@
 package controllers
 
+
 import actions.RichAuthRequest
 
 import com.gu.i18n.Country
@@ -70,10 +71,12 @@ object Promotions extends Controller {
     val promoCode = PromoCode(promoCodeStr)
     val notFound = NotFound(views.html.error404())
 
+
     (for {
       promotion <- TouchpointBackend.Normal.promoService.findPromotion(promoCode) \/> notFound
-      _ <- if(promoCodeStr.toUpperCase != promoCodeStr) \/.left(Redirect("/p/" + promoCodeStr.toUpperCase))
-      html <- if (promotion.expires.isBeforeNow) \/.left(notFound) else findTemplateForPromotion(promoCode, promotion, request.path) \/> notFound
+      _ <- if(promoCodeStr.toUpperCase != promoCodeStr) \/.left(Redirect("/p/" + promoCodeStr.toUpperCase)) else \/.right(Unit)
+      _ <- if(promotion.expires.isBeforeNow) \/.left(notFound) else \/.right(Unit)
+      html <- findTemplateForPromotion(promoCode, promotion, request.path) \/> notFound
     } yield Ok(html).withCookies(sessionCookieFromCode(promoCode))).fold(identity, identity)
 
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,8 +8,8 @@ object Dependencies {
   //libraries
   val sentryRavenLogback = "net.kencochrane.raven" % "raven-logback" % "6.0.0"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.171"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.5"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.171"
   val contentAPI = "com.gu" %% "content-api-client" % "6.4"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache


### PR DESCRIPTION
Redirect lower case promo codes to upper case promo codes.
Ignore other strings.

Depends on https://github.com/guardian/membership-common/pull/197 