### PR TITLE
[MMF-37] More data about event 

### DIFF
--- a/frontend/app/controllers/rest/Event.scala
+++ b/frontend/app/controllers/rest/Event.scala
@@ -1,0 +1,45 @@
+package controllers.rest
+
+import model.Eventbrite.EBVenue
+import model.RichEvent.RichEvent
+import org.joda.time.DateTime
+import play.api.libs.json.Json
+
+case class Event(
+  id: String,
+  url: String,
+  mainImageUrl: Option[String],
+  start: DateTime,
+  end: DateTime,
+  venue: Venue,
+  title: String
+)
+
+case class Venue(name: Option[String], address: Option[Address])
+case class Address(city: Option[String], postCode: Option[String], country: Option[String])
+
+object Venue {
+  implicit val addressWrites = Json.writes[Address]
+  implicit val venueWrites = Json.writes[Venue]
+
+  def forEventVenue(ebVenue: EBVenue): Venue = {
+    val address = ebVenue.address map { a => Address(a.city, a.postal_code, a.country) }
+    Venue(ebVenue.name, address)
+  }
+}
+
+
+object Event {
+  implicit val writesEvent = Json.writes[Event]
+
+  def forRichEvent(e: RichEvent) = Event(
+    id = e.id,
+    url = e.memUrl,
+    mainImageUrl = e.gridImgUrl,
+    start = e.start,
+    end = e.end,
+    venue = Venue.forEventVenue(e.venue),
+    title = e.name.text
+  )
+}
+

--- a/frontend/app/controllers/rest/EventApi.scala
+++ b/frontend/app/controllers/rest/EventApi.scala
@@ -1,25 +1,12 @@
-package controllers
+package controllers.rest
 
+import controllers._
 import com.typesafe.scalalogging.LazyLogging
-import model.RichEvent.RichEvent
 import play.api.libs.json.Json
 import play.api.libs.json.Json.toJson
 import play.api.mvc.Controller
-import services.GridService.ImageIdWithCrop
 
 object EventApi extends Controller with LazyLogging {
-  case class Event(
-    id: String,
-    url: String,
-    mainImage: Option[ImageIdWithCrop]
-  )
-
-  object Event {
-    implicit val writesEvent = Json.writes[Event]
-
-    def forRichEvent(e: RichEvent) = Event(e.id, e.memUrl, e.mainImageGridId)
-  }
-
   case class EventsResponse(events: Seq[Event])
 
   object EventsResponse {
@@ -32,5 +19,4 @@ object EventApi extends Controller with LazyLogging {
   def events = CachedAction {
     Ok(toJson(EventsResponse(controllers.Event.guLiveEvents.events.map(Event.forRichEvent))))
   }
-
 }

--- a/frontend/app/controllers/rest/package.scala
+++ b/frontend/app/controllers/rest/package.scala
@@ -1,0 +1,20 @@
+package controllers
+
+import com.netaporter.uri.Uri
+import org.joda.time.DateTimeZone.UTC
+import org.joda.time.format.ISODateTimeFormat.dateTimeNoMillis
+import org.joda.time.DateTime
+import play.api.libs.json.{Json, JsString, JsValue, Writes}
+
+package object rest {
+  implicit val uriWrites = new Writes[Uri] {
+    override def writes(uri: Uri): JsValue = JsString(uri.toString)
+  }
+
+  implicit val dateTimeWrites = new Writes[DateTime] {
+    override def writes(dt: DateTime): JsValue = Json.obj(
+      "time" -> dt.withZone(UTC).toString(dateTimeNoMillis),
+      "zone" -> dt.getZone.getID
+    )
+  }
+}

--- a/frontend/app/model/Grid.scala
+++ b/frontend/app/model/Grid.scala
@@ -12,13 +12,14 @@ object Grid {
   case class Data(id: String, metadata: Metadata, exports: Option[List[Export]])
 
   case class Metadata(description: Option[String], credit: Option[String], byline: Option[String]) {
-
     val photographer = (byline ++ credit).mkString("/")
   }
 
-  case class Export(id: String, assets: List[Asset])
+  case class Export(id: String, assets: List[Asset], master: Option[Asset])
 
-  case class Asset(file: String, secureUrl: Option[String], dimensions: Dimensions)
+  case class Asset(file: String, secureUrl: Option[String], dimensions: Dimensions) {
+    lazy val pixels = dimensions.width * dimensions.height
+  }
 
   case class Dimensions(height: Int, width: Int)
 

--- a/frontend/app/services/GridService.scala
+++ b/frontend/app/services/GridService.scala
@@ -16,7 +16,7 @@ import play.api.libs.json.Json
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-object GridService extends WebServiceHelper[GridObject, Error] with LazyLogging{
+object GridService extends WebServiceHelper[GridObject, Error] with LazyLogging {
 
   val gridUrl: String = "https://media.gutools.co.uk/images/"
   val CropQueryParam = "crop"
@@ -33,7 +33,7 @@ object GridService extends WebServiceHelper[GridObject, Error] with LazyLogging{
       } yield ImageIdWithCrop(imageId, crop)
   }
 
-  lazy val agent = Agent[Map[ImageIdWithCrop, GridImage]](Map.empty)
+  private lazy val agent = Agent[Map[ImageIdWithCrop, GridImage]](Map.empty)
 
   def getRequestedCrop(gridId: ImageIdWithCrop) : Future[Option[GridImage]] = {
     val currentImageData = agent.get()
@@ -61,10 +61,10 @@ object GridService extends WebServiceHelper[GridObject, Error] with LazyLogging{
     None
   } // We should return no image, rather than die
 
-  def getGrid(gridId: ImageIdWithCrop): Future[GridResult] =
+  private [services] def getGrid(gridId: ImageIdWithCrop): Future[GridResult] =
     get[GridResult](gridId.id, CropQueryParam -> gridId.crop)
 
-  def findExport(exports: List[Export], cropId: String): Option[Export] = exports.find(_.id == cropId)
+  private [services] def findExport(exports: List[Export], cropId: String): Option[Export] = exports.find(_.id == cropId)
 
   override val wsUrl: String = Config.gridConfig.apiUrl
 

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -52,7 +52,7 @@ GET            /subscription/remaining-tickets        controllers.Subscription.r
 
 # What's On
 GET            /events                                controllers.WhatsOn.list
-GET            /events.json                           controllers.EventApi.events
+GET            /events.json                           controllers.rest.EventApi.events
 
 GET            /events/archive                        controllers.WhatsOn.listArchive
 GET            /events/calendar                       controllers.WhatsOn.calendar

--- a/frontend/test/controllers/rest/EventsResponseTest.scala
+++ b/frontend/test/controllers/rest/EventsResponseTest.scala
@@ -1,0 +1,113 @@
+package controllers.rest
+
+import EventApi.EventsResponse
+import model.Eventbrite.{EBAddress, EBEvent, EBRichText, EBVenue}
+import model.Grid
+import model.Grid.{Dimensions, Asset}
+import model.RichEvent.{GridImage, GuLiveEvent}
+import org.joda.time.DateTimeUtils._
+import org.joda.time.DateTimeZone.UTC
+import org.joda.time.format.ISODateTimeFormat.dateTimeNoMillis
+import org.joda.time.{DateTime, Instant}
+import org.specs2.execute.{Result, AsResult}
+import org.specs2.matcher.JsonMatchers
+import org.specs2.mutable.Specification
+import org.specs2.specification.AroundEach
+import play.api.libs.json.Json
+
+class EventsResponseTest extends Specification with JsonMatchers with EventFixtures with DateTimeFixed {
+  "Event response JSON created from RichEvent" should {
+    "have event id" in {
+      val response = EventsResponse(events = Seq(Event.forRichEvent(defaultLiveEvent)))
+
+      asJsonString(response) must /("events") /# 0 / ("id" -> defaultLiveEvent.id)
+    }
+
+    "have url" in {
+      val response = EventsResponse(events = Seq(Event.forRichEvent(defaultLiveEvent)))
+
+      asJsonString(response) must /("events") /# 0 / ("url" -> contain("/event/"))
+    }
+
+    "have title" in {
+      val response = EventsResponse(events = Seq(Event.forRichEvent(defaultLiveEvent)))
+
+      asJsonString(response) must /("events") /# 0 / ("title" -> defaultLiveEvent.name.text)
+    }
+
+    "have start and dates in utc with timezone" in {
+      val response = EventsResponse(events = Seq(Event.forRichEvent(defaultLiveEvent)))
+
+      val expectedStartTime = defaultLiveEvent.start
+        .toDateTime(UTC)
+        .toString(dateTimeNoMillis())
+
+      asJsonString(response) must /("events") /# 0 / "start" / ("time" -> expectedStartTime)
+    }
+
+    "have venue" in {
+      val venue = EBVenue(
+        address = Some(EBAddress(
+          city = Some("London"),
+          postal_code = Some("N1 6GU"),
+          country = Some("GB"),
+          region = None, address_1 = None, address_2 = None)
+        ),
+        name = Some("Kings Cross")
+      )
+
+      val response = EventsResponse(events = Seq(Event.forRichEvent(liveEvent(venue))))
+
+      asJsonString(response) must /("events") /# 0 / "venue" / "address" / ("city" -> "London")
+      asJsonString(response) must /("events") /# 0 / "venue" / "address" / ("postCode" -> "N1 6GU")
+      asJsonString(response) must /("events") /# 0 / "venue" / "address" / ("country" -> "GB")
+    }
+
+    "have masterImageUrl" in {
+      val response = EventsResponse(events = Seq(Event.forRichEvent(defaultLiveEvent)))
+
+      asJsonString(response) must /("events") /# 0 / ("mainImageUrl" -> "https://media.guim.co.uk/b7c830bff5104b9ce9951928238fb09004d50335/0_0_1280_768/master/1280.jpg")
+    }
+  }
+
+  def asJsonString(response: EventsResponse): String = Json.stringify(Json.toJson(response))
+}
+
+trait DateTimeFixed extends AroundEach {
+  override def around[R: AsResult](r: => R): Result = {
+    setCurrentMillisFixed(currentTimeMillis())
+    try
+      AsResult(r)
+    finally
+      setCurrentMillisSystem()
+  }
+}
+
+trait EventFixtures {
+  def liveEvent(venue: EBVenue = EBVenue(None, None)) = GuLiveEvent(
+    event = EBEvent(
+      name = EBRichText(text = "The ten (food) commandments with Jay Rayner", html = "The ten (food) commandments with Jay Rayner"),
+      description = None,
+      url = "https://membership.theguardian.com/event/guardian-live-the-ten-food-commandments-with-jay-rayner-22576715564",
+      id = "22576715564",
+      start = DateTime.now(),
+      end = DateTime.now().plusMonths(1),
+      created = Instant.now(),
+      venue = venue,
+      capacity = 200,
+      ticket_classes = Seq.empty,
+      status = "live"),
+    image = Option(GridImage(
+      assets = List.empty,
+      metadata = Grid.Metadata(None, None, None),
+      master = Some(Asset(
+        "http://media.guim.co.uk/b7c830bff5104b9ce9951928238fb09004d50335/0_0_1280_768/master/1280.jpg",
+        Some("https://media.guim.co.uk/b7c830bff5104b9ce9951928238fb09004d50335/0_0_1280_768/master/1280.jpg"),
+        Dimensions(1280, 768)
+      ))
+    )),
+    contentOpt = None
+  )
+
+  val defaultLiveEvent = liveEvent()
+}

--- a/frontend/test/controllers/rest/EventsResponseTest.scala
+++ b/frontend/test/controllers/rest/EventsResponseTest.scala
@@ -15,7 +15,7 @@ import org.specs2.mutable.Specification
 import org.specs2.specification.AroundEach
 import play.api.libs.json.Json
 
-class EventsResponseTest extends Specification with JsonMatchers with EventFixtures with DateTimeFixed {
+class EventsResponseTest extends Specification with JsonMatchers with EventFixtures {
   "Event response JSON created from RichEvent" should {
     "have event id" in {
       val response = EventsResponse(events = Seq(Event.forRichEvent(defaultLiveEvent)))
@@ -71,16 +71,6 @@ class EventsResponseTest extends Specification with JsonMatchers with EventFixtu
   }
 
   def asJsonString(response: EventsResponse): String = Json.stringify(Json.toJson(response))
-}
-
-trait DateTimeFixed extends AroundEach {
-  override def around[R: AsResult](r: => R): Result = {
-    setCurrentMillisFixed(currentTimeMillis())
-    try
-      AsResult(r)
-    finally
-      setCurrentMillisSystem()
-  }
 }
 
 trait EventFixtures {

--- a/frontend/test/model/EventbriteTestObjects.scala
+++ b/frontend/test/model/EventbriteTestObjects.scala
@@ -27,6 +27,7 @@ object EventbriteTestObjects {
     val pastImageOpt = None
     val hasLargeImage = true
     val canHavePriorityBooking = true
+    val gridImgUrl = None
 
     val metadata = Metadata(
       identifier="",

--- a/frontend/test/model/GuLiveEventTest.scala
+++ b/frontend/test/model/GuLiveEventTest.scala
@@ -18,7 +18,8 @@ class GuLiveEventTest extends PlaySpecification with Mockito {
 
     "contain metadata and socialUrl for an event image" in {
 
-      val image = GridImage(gridResponse.data.exports.get(1).assets, gridResponse.data.metadata)
+      val firstExport = gridResponse.data.exports.get(1)
+      val image = GridImage(firstExport.assets, gridResponse.data.metadata, firstExport.master)
       val guEvent = GuLiveEvent(event, Some(image), None)
 
       guEvent.imgOpt.flatMap(_.metadata.flatMap(_.description)) mustEqual Some("It's Chris!")

--- a/frontend/test/services/GridServiceTest.scala
+++ b/frontend/test/services/GridServiceTest.scala
@@ -21,19 +21,16 @@ class GridServiceTest extends Specification {
   }
 
   "GridService" should {
-    "cropParam" in {
-      GridService.cropParam(validGridUrl) mustEqual Some("0_19_480_288")
-      GridService.cropParam("http://example.com?q=v") mustEqual None
-    }
     "must return requested crop with dimensions" in {
       val grid = Resource.getJson("model/grid/api-image.json")
       val gridResponse = grid.as[GridResult]
       val exports = gridResponse.data.exports.get
       val requestedCrop = "0_130_1703_1022"
-      val assets = GridService.findAssets(exports, requestedCrop)
+      val export = GridService.findExport(exports, requestedCrop)
 
-      assets.size mustEqual(3)
-      assets.map(_.dimensions.width) mustEqual(List(1000, 500, 140))
+      export must beSome
+      export.get.assets.size mustEqual(3)
+      export.get.assets.map(_.dimensions.width) mustEqual(List(1000, 500, 140))
     }
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,12 +19,13 @@ object Dependencies {
   val scalaTest =  "org.scalatestplus" %% "play" % "1.4.0-M4" % "test"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.1"
   val selenium = "org.seleniumhq.selenium" % "selenium-java" % "2.48.2" % "test"
+  val specs2Extra = "org.specs2" % "specs2-matcher-extra_2.11" % "3.6" % "test"
 
   //projects
 
   val frontendDependencies = Seq(memsubCommonPlayAuth, scalaUri, membershipCommon,
     contentAPI, playWS, playCache, sentryRavenLogback, awsSimpleEmail, snowPlow, bCrypt, scalaz,
-    PlayImport.specs2 % "test")
+    PlayImport.specs2 % "test", specs2Extra)
 
   val acceptanceTestDependencies = Seq(scalaTest, selenium, memsubCommonPlayAuth)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
   val scalaTest =  "org.scalatestplus" %% "play" % "1.4.0-M4" % "test"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.1"
   val selenium = "org.seleniumhq.selenium" % "selenium-java" % "2.48.2" % "test"
-  val specs2Extra = "org.specs2" % "specs2-matcher-extra_2.11" % "3.6" % "test"
+  val specs2Extra = "org.specs2" %% "specs2-matcher-extra" % "3.6" % "test"
 
   //projects
 


### PR DESCRIPTION
Mobile apps need to have more data about live events. 
I moved REST-specific controllers to separate package so that it does not collide with namespace introduced by old controllers.

Url returned in mainImageUrl is selected from assets provided by Media API. Firstly master image is being probed, then we're falling back to best (in terms of resolution) asset.

New test-scoped dependency added for specs2 JsonMatchers.

I did small refactoring of `GridService`, but it still needs some refactoring towards usage of new Media API endpoint already introduced in https://github.com/guardian/grid/pull/1794.

cc @rtyley, @JonNorman, @regiskuckaertz

Shape of JSON:

```
{
    "events": [
    {
        "id": "21081001844",
            "url": "https://mem.thegulocal.com/event/guardian-live-how-can-we-get-more-people-cycling-in-london-chris-boardman-andrew-gilligan-and-guests-discuss-21081001844",
            "mainImageUrl": "https://media.guim.co.uk/4c3a44853ff4e41c81d7ba15760657caf8219757/0_0_1920_1152/master/1920.jpg",
            "start": {
                "time": "2016-03-10T19:00:00Z",
                "zone": "Europe/London"
            },
            "end": {
                "time": "2016-03-10T20:30:00Z",
                "zone": "Europe/London"
            },
            "venue": {
                "name": "The Guardian",
                "address": {
                    "city": "London",
                    "postCode": "N1 9GU",
                    "country": "GB"
                }
            },
            "title": "Guardian Live | How can we get more people cycling in London? Chris Boardman, Andrew Gilligan and guests discuss"
    },
   ...
```