### PR TITLE
Moving the event brand text above the description

### DIFF
--- a/frontend/app/views/fragments/event/item.scala.html
+++ b/frontend/app/views/fragments/event/item.scala.html
@@ -24,12 +24,12 @@
                     @addressShortLine
                 </div>
             }
+            <div class="event-item__brand">@event.metadata.brand</div>
             @for(desc <- event.description if isFeatured) {
                 <div class="event-item__description">
                     @desc.blurb
                 </div>
             }
-            <div class="event-item__brand">@event.metadata.brand</div>
         </div>
     </div>
 }


### PR DESCRIPTION
Because it doesn't quite look right on the big event image:

![picture 40](https://cloud.githubusercontent.com/assets/1515970/13671678/306a23f0-e6c9-11e5-8684-bcc57ff89ca1.png)