### PR TITLE
Support Mobile apps authenticating using a SC_GU_U + access-token combo

### DIFF
--- a/frontend/test/services/DestinationServiceTest.scala
+++ b/frontend/test/services/DestinationServiceTest.scala
@@ -72,7 +72,7 @@ class DestinationServiceTest extends PlaySpecification with Mockito with ScalaFu
 
       val minimalUser: IdMinimalUser = IdMinimalUser("123", None)
       val fakeRequest = FakeRequest().withSession(newSessions: _*)
-      val ar = new AuthenticatedRequest(AuthenticatedIdUser(AccessCredentials.Cookies("foo", "bar"), minimalUser), fakeRequest)
+      val ar = new AuthenticatedRequest(AuthenticatedIdUser(AccessCredentials.Cookies("foo"), minimalUser), fakeRequest)
 
       new SubscriptionRequest(mock[TouchpointBackend],ar) with Subscriber {
         override def subscriber = Subscriber(testSub, testMember)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   //libraries
   val sentryRavenLogback = "net.kencochrane.raven" % "raven-logback" % "6.0.0"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
-  val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.5"
+  val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.6"
   val membershipCommon = "com.gu" %% "membership-common" % "0.171"
   val contentAPI = "com.gu" %% "content-api-client" % "6.4"
   val playWS = PlayImport.ws


### PR DESCRIPTION
https://github.com/guardian/identity-play-auth/pull/12

cc @DiegoVazquezNanini 