### PR TITLE
Fixing missing Masterclass images

### DIFF
--- a/frontend/app/services/MasterclassDataExtractor.scala
+++ b/frontend/app/services/MasterclassDataExtractor.scala
@@ -17,8 +17,7 @@ object MasterclassDataExtractor {
     val eventbriteIdsFromRefs =
       content.references.filter(_.`type` == "eventbrite").map(_.id.stripPrefix("eventbrite/"))
 
-    val eventbriteIds =
-      if (eventbriteIdsFromRefs.nonEmpty) eventbriteIdsFromRefs else scrapeEventbriteIdsFrom(content)
+    val eventbriteIds = (eventbriteIdsFromRefs ++ scrapeEventbriteIdsFrom(content)).distinct
 
     eventbriteIds.map(eventId => MasterclassData(eventId, content.webUrl, ResponsiveImageGroup.fromContent(content)))
   }

--- a/frontend/test/services/MasterclassDataExtractorTest.scala
+++ b/frontend/test/services/MasterclassDataExtractorTest.scala
@@ -63,11 +63,11 @@ class MasterclassDataExtractorTest extends Specification {
       masterclassesContent.map(_.eventId) must contain(exactly("111", "333"))
     }
 
-    "create masterclass content favouring the eventbrite external reference over scraping" in {
+    "create masterclass content including the eventbrite external reference plus what gets scraped" in {
       val itemWithExternalRefAndEBUrlInBody = item.copy(references = List(Reference("eventbrite","eventbrite/111")))
 
       val masterclassesContent = extractEventbriteInformation(itemWithExternalRefAndEBUrlInBody)
-      masterclassesContent.map(_.eventId) must contain(exactly("111"))
+      masterclassesContent.map(_.eventId) must contain(exactly("111","13906168725"))
     }
 
     "not create a masterclass content if there is no eventbrite external ref and body does not contain eventbrite url" in {


### PR DESCRIPTION
* Reinstated the legacy scraping method of extracting eventbrite IDs from the set of masterclass content API articles. This was switched off if the article already had an eventbrite association due to the assumption that there was a 1:1 mapping between a content article and a masterclass eventbrite event.
* Still in disbelief that the fix was this straightforward! Thanks @rtyley for advising about the legacy scraping logic.

<img width="1165" alt="picture 42" src="https://cloud.githubusercontent.com/assets/1515970/13709011/9fa39c2a-e7a9-11e5-905d-d68fd8457935.png">

cc @AWare @tomverran 