### PR TITLE
Put HTTP cache in front of EventBrite API

### DIFF
--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -22,12 +22,12 @@ content.api.key=""
 
 eventbrite.url="http://www.eventbrite.co.uk"
 
-eventbrite.api.url="https://www.eventbriteapi.com/v3"
+eventbrite.api.url="https://d1s44y2vc5rmbm.cloudfront.net/v3"
 eventbrite.api.token=""
 eventbrite.masterclasses.api.token=""
 eventbrite.local.api.token=""
 eventbrite.api.iframe-url="https://www.eventbrite.com/tickets-external?ref=etckt&v=2"
-eventbrite.api.refresh-time-seconds=120
+eventbrite.api.refresh-time-seconds=59
 eventbrite.api.refresh-time-priority-events-seconds=29
 eventbrite.waitlist.url="https://www.eventbrite.co.uk/waitlist"
 eventbrite.limitedAvailabilityCutoff=15

--- a/frontend/conf/dev.conf
+++ b/frontend/conf/dev.conf
@@ -35,8 +35,8 @@ guardian.shortDomain="thegulocal.com"
 aws.access.key=${?AWS_ACCESS_KEY}
 aws.secret.key=${?AWS_SECRET_KEY}
 
-eventbrite.api.refresh-time-seconds=360 # relatively infrequent to avoid devs consuming EventBrite API
-eventbrite.api.refresh-time-priority-events-seconds=300
+eventbrite.api.refresh-time-seconds=59
+eventbrite.api.refresh-time-priority-events-seconds=29
 
 facebook.app.id=232588266837342
 facebook.joiner.conversion.Friend = ""


### PR DESCRIPTION
EventBrite API responses are occasionally taking longer than 10 seconds to return, due to the amount of data we are requesting of them, and the frequency of our calls.

We currently refresh the data in each app for 2 minutes, however the boxes often don't go healthy because they fail to get the live data in the 10 second window when they boot up. To solve this for the short term, we will put an HTTP reverse proxy cache in the way (CloudFront for now), and call it every 60 seconds to keep it warm. The TTL of the entries will be set to around 60+ seconds or so, so all-in-all, we get the same worst case e2e time for updates to appear.

* Use CloudFront URL to facade EventBrite API, with a ttl of 61 seconds.
* Request data from CloudFront more quickly so as to keep the CloudFront cache warm.
* Spread the "live","draft" and "ended" request groups out over the minute so that they're note all scheduled at once.
* Should fix that archive page doesn't contain live events too - which was due to the timeout exception breaking the pagination required to get all the old events.

https://trello.com/c/JiBUBnlo/388-the-events-archive-is-only-displaying-guardian-local-events-https-membership-theguardian-com-events-archive-it-should-show-guard

cc @tomverran @rtyley 