### PR TITLE
Update sbt 0.13.9

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.9


### PR DESCRIPTION
I don't know why sbt 0.13.11 is failing (as with https://github.com/guardian/membership-frontend/pull/1028 & https://github.com/guardian/membership-frontend/pull/1045) - the previous version of sbt was 0.13.9, so updating to that.

All versions of sbt work fine for me when executing the packaged artifact locally on my Ubuntu dev box:

```
cd ~/development/membership-frontend
sbt clean play-artifact
git clean -fd
unzip /home/rtyley/development/membership-frontend/frontend/target/artifacts.zip packages/frontend/app.zip
unzip packages/frontend/app.zip
cd ~/development/membership-frontend/frontend-1.0-SNAPSHOT
bin/frontend -mem 1024 -Dconfig.resource=dev.conf
```