### PR TITLE
Use a BillingSchedule when showing the paid to paid upgrade summary

### DIFF
--- a/frontend/app/controllers/TierController.scala
+++ b/frontend/app/controllers/TierController.scala
@@ -97,10 +97,10 @@ trait UpgradeTier extends StripeServiceProvider with CatalogProvider {
       val targetPlanId = targetPlans.get(subscriber.subscription.plan.billingPeriod).productRatePlanId
 
       for {
-        previewItems <- memberService.previewUpgradeSubscription(subscriber.subscription, targetPlanId)
+        billingSchedule <- memberService.previewUpgradeSubscription(subscriber.subscription, targetPlanId)
         privateFields <- identityUserFieldsF
       } yield {
-        val summary = PaidToPaidUpgradeSummary(previewItems, subscriber.subscription, targetPlanId, card)
+        val summary = PaidToPaidUpgradeSummary(billingSchedule, subscriber.subscription, targetPlanId, card)
         val flashMsgOpt = request.flash.get("error").map(FlashMessage.error)
 
         Ok(views.html.tier.upgrade.paidToPaid(

--- a/frontend/app/services/api/MemberService.scala
+++ b/frontend/app/services/api/MemberService.scala
@@ -1,19 +1,18 @@
 package services.api
 
 import com.gu.identity.play.IdMinimalUser
-import com.gu.membership.{FreeMembershipPlan, PaidMembershipPlan, MembershipPlan}
 import com.gu.memsub.Subscriber._
 import com.gu.memsub.Subscription.{Plan, Paid, ProductRatePlanId}
 import com.gu.memsub._
-import com.gu.salesforce.{Tier, ContactId, PaidTier}
+import com.gu.salesforce.{ContactId, PaidTier}
+import com.gu.services.model.BillingSchedule
 import com.gu.stripe.Stripe
-import com.gu.zuora.soap.models.Queries.PreviewInvoiceItem
 import com.gu.zuora.soap.models.Results.{CreateResult, SubscribeResult}
 import controllers.IdentityRequest
 import forms.MemberForm.{FreeMemberChangeForm, JoinForm, PaidMemberChangeForm, PaidMemberJoinForm}
 import model.Eventbrite.{EBCode, EBOrder, EBTicketClass}
 import model.RichEvent.RichEvent
-import model.{GenericSFContact}
+import model.GenericSFContact
 import views.support.ThankyouSummary
 
 import scala.concurrent.Future
@@ -30,7 +29,7 @@ trait MemberService {
                    campaignCode: Option[CampaignCode]): Future[ContactId]
 
   def previewUpgradeSubscription(subscription: Subscription with Paid,
-                                 newPlanId: ProductRatePlanId): Future[Seq[PreviewInvoiceItem]]
+                                 newPlanId: ProductRatePlanId): Future[BillingSchedule]
 
   def upgradeFreeSubscription(subscriber: FreeMember,
                               newTier: PaidTier,

--- a/frontend/app/views/support/PaidToPaidUpgradeSummary.scala
+++ b/frontend/app/views/support/PaidToPaidUpgradeSummary.scala
@@ -4,8 +4,7 @@ import com.gu.membership.MembershipCatalog
 import com.gu.memsub.Subscription.ProductRatePlanId
 import com.gu.memsub._
 import com.gu.salesforce.PaidTier
-import com.gu.stripe.Stripe.Card
-import com.gu.zuora.soap.models.Queries.PreviewInvoiceItem
+import com.gu.services.model.BillingSchedule
 import model.PaidSubscription
 import model.SubscriptionOps._
 import org.joda.time.{DateTime, LocalDate}
@@ -23,19 +22,12 @@ object PaidToPaidUpgradeSummary {
     override def getMessage = s"Failure while trying to display an upgrade summary for the subscription $subNumber to $targetTier: $msg"
   }
 
-  def apply(invoices: Seq[PreviewInvoiceItem], sub: PaidSubscription, targetId: ProductRatePlanId, card: PaymentCard)(implicit catalog: MembershipCatalog): PaidToPaidUpgradeSummary = {
+  def apply(invoices: BillingSchedule, sub: PaidSubscription, targetId: ProductRatePlanId, card: PaymentCard)(implicit catalog: MembershipCatalog): PaidToPaidUpgradeSummary = {
     val plan = catalog.unsafeFindPaid(targetId)
     lazy val upgradeError = UpgradeSummaryError(sub.name, plan.tier) _
     val accountCurrency = sub.currency
+    val firstPayment = Price(invoices.first.amount, accountCurrency)
 
-    // The sorted invoice items list will include as its first element a refund with a negative
-    // price. We add up the refund to the next invoice item, thus computing a pro-rated price for the upgrade.
-    val firstPayment = invoices.sortBy(_.price) match {
-      case refundItem :: targetPlanItem :: _ if refundItem.price < 0 =>
-        Price(refundItem.price + targetPlanItem.price, accountCurrency)
-      case _ => throw new IllegalStateException(
-        s"Failed to compute a pro-rated price from invoice items $invoices. Subscription: ${sub.name.get}, target tier: ${plan.tier.name}")
-    }
 
     val billingPeriod = sub.plan.billingPeriod
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "net.kencochrane.raven" % "raven-logback" % "6.0.0"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.6"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.172"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.174"
   val contentAPI = "com.gu" %% "content-api-client" % "6.4"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache


### PR DESCRIPTION
An assumption was made that the preview invoices we get back from Zuora when upgrading will consist of the following, in order:

 - refund for current plan
 - payment for new plan

As such the code took the first two invoices and added them together.
With discounts however the second invoice item is often a discount, and so we ended up adding up the refund and a discount to give a minus figure for the amount paid today:

![image](https://cloud.githubusercontent.com/assets/1388226/13875897/7642a944-ecf8-11e5-9c89-ed739fbda67d.png)

Now this problem was fixed elsewhere by using a higher level `BillingSchedule` object which groups up invoice items by service start date. As such we can fix this problem by creating one from the PreviewInvoiceItems we were using and it all works perfectly:

![image](https://cloud.githubusercontent.com/assets/1388226/13876127/dbc9f776-ecf9-11e5-8fca-4636e945bd26.png)



