### PR TITLE
Fix build by specifying requirejs exactly

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,11 +38,11 @@
     "karma-chrome-launcher": "^0.1.12",
     "karma-jasmine": "^0.3.5",
     "karma-phantomjs-launcher": "^0.2.0",
-    "karma-requirejs": "~0.2.2",
+    "karma-requirejs": "0.2.5",
     "load-grunt-tasks": "^3.2.0",
     "mkdirp": "^0.5.1",
     "phantomjs": "~1.9.17",
-    "requirejs": "^2.1.18",
+    "requirejs": "2.1.22",
     "rimraf": "^2.4.3",
     "time-grunt": "^1.2.1"
   }


### PR DESCRIPTION
RequireJS v2.2.0 was released 17 hours ago, and that broke our build this morning - because `karma-requirejs` wants `requirejs@~2.1`

https://github.com/requirejs/requirejs/releases/tag/2.2.0

```
[11:13:24][Step 1/3] npm ERR! peerinvalid The package requirejs does not satisfy its siblings' peerDependencies requirements!
[11:13:24][Step 1/3] npm ERR! peerinvalid Peer karma-requirejs@0.2.5 wants requirejs@~2.1
```

https://teamcity-aws.gutools.co.uk/viewLog.html?buildId=877&buildTypeId=memsub_membership_frontend&tab=buildLog#_state=37&focus=362

cc @tomverran 