### PR TITLE
English Heritage promo acceptance for Patron

### DIFF
--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -160,7 +160,9 @@ object Config {
     new Promotion[Incentive](
       appliesTo = AppliesTo.ukOnly(Set(
         prpIds.partnerMonthly,
-        prpIds.partnerYearly
+        prpIds.partnerYearly,
+        prpIds.patronYearly,
+        prpIds.patronMonthly
       )),
       campaignName = "English Heritage Offer - Q4 FY2016",
       codes = PromoCodeSet(PromoCode("EH2016")),


### PR DESCRIPTION
Fix bug where the english heritage promotion code says it's not applicable for a Patron. It's OK because we are giving the offer to all patrons/partners anyway, but it might put someone off completing if they see the error.