### PR TITLE
Remove promos when upgrading

### DIFF
--- a/frontend/app/services/TouchpointBackend.scala
+++ b/frontend/app/services/TouchpointBackend.scala
@@ -64,7 +64,8 @@ object TouchpointBackend {
     val salesforceService = new SalesforceService(backend.salesforce)
     val identityService = IdentityService(IdentityApi)
     val memberService = new MemberService(
-      identityService, salesforceService, zuoraService, stripeService, subscriptionService, catalogService, promoService, paymentService, discounter)
+      identityService, salesforceService, zuoraService, stripeService, subscriptionService, catalogService, promoService, paymentService, discounter,
+        Config.discountRatePlanIds(backend.zuoraEnvName))
 
     TouchpointBackend(
       salesforceService = salesforceService,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "net.kencochrane.raven" % "raven-logback" % "6.0.0"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.6"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.176"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.178"
   val contentAPI = "com.gu" %% "content-api-client" % "6.4"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache


### PR DESCRIPTION
Currently if you sign up with a promotion then upgrade it'll be applied again.
We probably don't want this to happen for discounts, so for now I have made it possible to remove promotions when upgrading.

Before release we'll want to improve this behaviour so you don't lose out if you're half way through a promotion but this should be adequate for now.