### PR TITLE
Fix the roundel description margin

### DIFF
--- a/frontend/assets/stylesheets/components/_roundel.scss
+++ b/frontend/assets/stylesheets/components/_roundel.scss
@@ -53,5 +53,7 @@
         font-size: 13px;
         @include fs-headline(1);
     }
+    margin-bottom: 0;
+
 }
 


### PR DESCRIPTION
Oops:
![image](https://cloud.githubusercontent.com/assets/2670496/13991019/56574bb6-f10e-11e5-8fa0-dcd5c69eca68.png)
Fixed:
![image](https://cloud.githubusercontent.com/assets/2670496/13991030/642e08b0-f10e-11e5-9ba0-1dabc8284416.png)
