### PR TITLE
Use membership common 179

### DIFF
--- a/frontend/app/actions/ActionRefiners.scala
+++ b/frontend/app/actions/ActionRefiners.scala
@@ -82,8 +82,8 @@ object ActionRefiners extends LazyLogging {
       Future.successful(request.paidOrFreeSubscriber.bimap(free =>
         new SubscriptionRequest[A](request) with FreeSubscriber {
           override def subscriber = free
-        }, _ => onPaidMember(request)).swap.toEither
-      )
+        }, _ => onPaidMember(request)).swap.toEither // we convert paid to a response, thus giving Free \/ Response
+      )                                              // but we need Either[Response, Free], hence the swap and toEither
   }
 
   def checkTierChangeTo(targetTier: PaidTier) = new ActionFilter[SubReqWithSub] {

--- a/frontend/app/actions/ActionRefiners.scala
+++ b/frontend/app/actions/ActionRefiners.scala
@@ -49,7 +49,6 @@ object ActionRefiners extends LazyLogging {
   type SubReqWithSub[A] = SubscriptionRequest[A] with Subscriber
 
   private def getSubRequest[A](request: AuthRequest[A]): Future[Option[SubReqWithSub[A]]] = {
-
     implicit val pf = Membership
     val tp = request.touchpointBackend
     val FreeSubscriber = Subscriber[FreeMembershipSub] _

--- a/frontend/app/actions/package.scala
+++ b/frontend/app/actions/package.scala
@@ -7,9 +7,8 @@ import monitoring.MemberAuthenticationMetrics
 import play.api.mvc.Security.AuthenticatedRequest
 import play.api.mvc.{Cookie, WrappedRequest}
 import services._
-
+import scalaz.\/
 import scala.concurrent.{ExecutionContext, Future}
-
 
 package object actions {
 
@@ -39,14 +38,15 @@ package object actions {
   }
 
   trait Subscriber {
-    def subscriber: Member
+    def paidOrFreeSubscriber: FreeMember \/ PaidMember
+    def subscriber: Member = paidOrFreeSubscriber.fold[Member](identity, identity)
   }
 
-  trait PaidSubscriber extends Subscriber {
+  trait PaidSubscriber {
     def subscriber: PaidMember
   }
 
-  trait FreeSubscriber extends Subscriber {
+  trait FreeSubscriber {
     def subscriber: FreeMember
   }
 

--- a/frontend/app/controllers/package.scala
+++ b/frontend/app/controllers/package.scala
@@ -54,7 +54,7 @@ package object controllers extends CommonActions with LazyLogging{
   }
 
   trait SubscriptionServiceProvider {
-    def subscriptionService(implicit request: BackendProvider): SubscriptionService =
+    def subscriptionService(implicit request: BackendProvider): SubscriptionService[MembershipCatalog] =
       request.touchpointBackend.subscriptionService
   }
 

--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -3,6 +3,7 @@ package services
 import com.gu.config.DiscountRatePlanIds
 import com.gu.i18n.{CountryGroup, Country, Currency}
 import com.gu.identity.play.IdMinimalUser
+import com.gu.membership.MembershipCatalog
 import com.gu.memsub.BillingPeriod.year
 import com.gu.memsub.Subscriber.{FreeMember, PaidMember}
 import com.gu.memsub.Subscription.{Feature, MembershipSub, Plan, ProductRatePlanId}
@@ -74,7 +75,7 @@ class MemberService(identityService: IdentityService,
                     salesforceService: api.SalesforceService,
                     zuoraService: ZuoraService,
                     stripeService: StripeService,
-                    subscriptionService: SubscriptionService,
+                    subscriptionService: SubscriptionService[MembershipCatalog],
                     catalogService: CatalogService,
                     promoService: PromoService,
                     paymentService: PaymentService,

--- a/frontend/app/services/TouchpointBackend.scala
+++ b/frontend/app/services/TouchpointBackend.scala
@@ -59,8 +59,8 @@ object TouchpointBackend {
                                         catalogService.membershipCatalog, discounter)
 
     val zuoraService = new ZuoraServiceImpl(zuoraSoapClient, zuoraRestClient, memRatePlanIds)
-    val subscriptionService = new memsub.services.SubscriptionService(zuoraService, stripeService, catalogService)
-    val paymentService = new PaymentService(stripeService, subscriptionService, zuoraService, catalogService)
+    val subscriptionService = new memsub.services.SubscriptionService(zuoraService, stripeService, catalogService.membershipCatalog)
+    val paymentService = new PaymentService(stripeService, zuoraService, catalogService)
     val salesforceService = new SalesforceService(backend.salesforce)
     val identityService = IdentityService(IdentityApi)
     val memberService = new MemberService(
@@ -97,7 +97,7 @@ case class TouchpointBackend(salesforceService: api.SalesforceService,
                              zuoraSoapClient: soap.ClientWithFeatureSupplier,
                              zuoraRestClient: rest.Client,
                              memberService: api.MemberService,
-                             subscriptionService: memsubapi.SubscriptionService,
+                             subscriptionService: memsubapi.SubscriptionService[MembershipCatalog],
                              catalogService: memsubapi.CatalogService,
                              zuoraService: ZuoraService,
                              membershipRatePlanIds: MembershipRatePlanIds,

--- a/frontend/test/services/DestinationServiceTest.scala
+++ b/frontend/test/services/DestinationServiceTest.scala
@@ -6,7 +6,7 @@ import com.gu.contentapi.client.parser.JsonParser
 import com.gu.i18n.{Currency, GBP}
 import com.gu.identity.play.{AccessCredentials, AuthenticatedIdUser, IdMinimalUser}
 import com.gu.membership.PaidMembershipPlan
-import com.gu.memsub.Subscription.{MembershipSub, ProductRatePlanId}
+import com.gu.memsub.Subscription.{PaidMembershipSub, MembershipSub, ProductRatePlanId}
 import com.gu.memsub._
 import com.gu.salesforce.Tier.Partner
 import com.gu.salesforce._
@@ -22,6 +22,7 @@ import play.api.{Application, GlobalSettings}
 import utils.Resource
 
 import scala.concurrent.Future
+import scalaz.\/
 
 class DestinationServiceTest extends PlaySpecification with Mockito with ScalaFutures {
 
@@ -44,7 +45,7 @@ class DestinationServiceTest extends PlaySpecification with Mockito with ScalaFu
     def createRequestWithSession(newSessions: (String, String)*) = {
 
       val testMember = Contact("id", None, Some("fn"), "ln", "email", new DateTime(), "contactId", "accountId")
-      val testSub: MembershipSub = new Subscription(
+      val testSub: PaidMembershipSub = new Subscription(
         id = Subscription.Id(""),
         name = Subscription.Name(""),
         accountId = Subscription.AccountId(""),
@@ -75,7 +76,7 @@ class DestinationServiceTest extends PlaySpecification with Mockito with ScalaFu
       val ar = new AuthenticatedRequest(AuthenticatedIdUser(AccessCredentials.Cookies("foo"), minimalUser), fakeRequest)
 
       new SubscriptionRequest(mock[TouchpointBackend],ar) with Subscriber {
-        override def subscriber = Subscriber(testSub, testMember)
+        override def paidOrFreeSubscriber = \/.right(Subscriber[PaidMembershipSub](testSub, testMember))
       }
 
     }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "net.kencochrane.raven" % "raven-logback" % "6.0.0"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.6"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.178"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.179"
   val contentAPI = "com.gu" %% "content-api-client" % "6.4"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache


### PR DESCRIPTION
This preserves subscription type information and removes some very horrible unsafe casts
I am doing this so I can split up the upgrade controller method to return JSON for paid to paid upgrades 