### PR TITLE
Log error response from Identity

### DIFF
--- a/frontend/app/services/IdentityService.scala
+++ b/frontend/app/services/IdentityService.scala
@@ -128,7 +128,7 @@ trait IdentityApi {
         .map { response =>
           recordAndLogResponse(response.status, "GET user", endpoint)
           val jsResult = (response.json \ "user").validate[IdUser]
-          if (jsResult.isError) Logger.error(s"Id Api response on $url : $jsResult")
+          if (jsResult.isError) Logger.error(s"Id Api response on $url : ${response.json.toString}")
           jsResult.asOpt
         }
         .recover { case e =>


### PR DESCRIPTION
@tomverran

Log the actual response from identity so we can debug the following frequent error:

[Trello card](https://trello.com/c/5j3VDDAE/451-investigate-frequent-failures-during-membership-checkout)
[Sentry event](https://app.getsentry.com/the-guardian/membership/issues/69009792/events/4096693298/)
