### PR TITLE
Fix styling and social links on thank you page

### DIFF
--- a/frontend/app/controllers/Giraffe.scala
+++ b/frontend/app/controllers/Giraffe.scala
@@ -1,44 +1,46 @@
 package controllers
 import com.gu.stripe.Stripe
-import configuration.Config
-import model.{ResponsiveImageGenerator, ResponsiveImageGroup}
-import play.api.libs.json.{JsString, JsArray, Json}
-import play.api.mvc.{Result, Controller}
-import play.api.libs.concurrent.Execution.Implicits._
 import com.gu.stripe.Stripe.Serializer._
 import forms.MemberForm.supportForm
+import play.api.libs.concurrent.Execution.Implicits._
+import play.api.libs.json.{JsArray, JsString, Json}
+import play.api.mvc.{Controller, Result}
 import services.{AuthenticationService, TouchpointBackend}
 import views.support._
+
 import scala.concurrent.Future
 
 object Giraffe extends Controller {
 
   val social: Set[Social] = Set(
-    Twitter("The Panama Papers: how the world's rich and famous hide their money offshore http://www.theguardian.com/news/series/panama-papers #panamapapers"),
-    Facebook("http://www.theguardian.com/news/series/panama-papers","Follow every development with the Guardian as more and more detail emerges from the biggest leak in history.")
+    Twitter("The Panama Papers: how the world's rich and famous hide their money offshore http://www.theguardian.com/news/series/panama-papers?CMP=twt_contribute #panamapapers"),
+    Facebook("http://www.theguardian.com/news/series/panama-papers?CMP=fb_contribute")
   )
 
   val stripe = TouchpointBackend.Normal.giraffeStripeService
   val chargeId = "charge_id"
 
-
   def support = CachedAction { implicit request =>
     val pageInfo = PageInfo(
-      title = "Support",
+      title = "Support the Guardian | Contribute today",
       url = request.path,
       image = Some("https://media.guim.co.uk/727ed45d0601dc4fe85df56f6b24140c68145c16/0_0_2200_1320/1000.jpg"),
       stripePublicKey = Some(stripe.publicKey),
-      description = Some("Support the Guardian"),
+      description = Some("By making a contribution, you'll be supporting independent journalism that speaks truth to power"),
       navigation = Seq.empty
     )
     Ok(views.html.giraffe.support(pageInfo))
   }
 
-  def thanks = CachedAction { implicit request =>
+  def thanks = NoCacheAction { implicit request =>
     request.session.get(chargeId).fold(
       Redirect(routes.Giraffe.support().url, SEE_OTHER)
     )( id =>
       Ok(views.html.giraffe.thankyou(PageInfo(
+        title = "Thank you for supporting the Guardian",
+        url = request.path,
+        image = None,
+        description = Some("Your contribution is much appreciated, and will help us to maintain our independent, investigative journalism."),
         navigation = Seq.empty
       ), id, social))
     )

--- a/frontend/app/views/giraffe/support.scala.html
+++ b/frontend/app/views/giraffe/support.scala.html
@@ -4,7 +4,7 @@
 
 @(pageInfo: PageInfo)
 
-@giraffeMain("Contribute", pageInfo = pageInfo) {
+@giraffeMain(pageInfo) {
     <div class="l-constrained">
         <div class="promo-primary__image promo-primary__image--giraffe">
             <div class="promo-primary__image--overlay"></div>
@@ -12,7 +12,7 @@
                 <h1 class="primary__heading--main">Support the Guardian</h1>
                 <h2 class="primary__heading--sub">Contribute today</h2>
                 <p class="primary__heading--text">
-                    By making a contribution, you’ll be supporting independent journalism that speaks truth to power
+                    By making a contribution, you'll be supporting independent journalism that speaks truth to power
                 </p>
             </div>
         </div>

--- a/frontend/app/views/giraffe/thankyou.scala.html
+++ b/frontend/app/views/giraffe/thankyou.scala.html
@@ -2,13 +2,11 @@
 
 @import views.support.Social
 @(pageInfo: PageInfo, reference: String, social: Set[Social])
-@giraffeMain("Support", pageInfo = pageInfo) {
+@giraffeMain(pageInfo) {
     <div class="support-wrapper page-slice l-constrained support-thanks">
-        <h1 class="support-thanks__title">Thank you for supporting the Guardian</h1>
+        <h1 class="support-thanks__title">@pageInfo.title</h1>
 
-        <p class="support-thanks__message">
-            Your contribution is much appreciated, and will help us to maintain our independent, investigative journalism.
-        </p>
+        <p class="support-thanks__message">@pageInfo.description</p>
 
         <div class="support-thanks__message">
             Please take a moment to share the <a class="support-thanks__link" href="//www.theguardian.com/news/series/panama-papers" onClick="s.tl(true,'o','panamapapers')">Panama Papers</a> series.

--- a/frontend/app/views/giraffeMain.scala.html
+++ b/frontend/app/views/giraffeMain.scala.html
@@ -2,8 +2,7 @@
 @import com.gu.i18n.CountryGroup
 @import org.joda.time.DateTime
 @import model.Nav
-@(  title: String,
-    pageInfo: PageInfo = views.support.PageInfo(),
+@(  pageInfo: PageInfo = views.support.PageInfo(),
     countryGroup: Option[CountryGroup] = None
 )(content: Html)
 @import play.api.libs.json.Json
@@ -13,8 +12,7 @@
 <html class="js-off id--signed-out">
     <head>
         <meta charset="utf-8">
-        <title>@if(title.isEmpty){ @Config.siteTitle } else { @(s"$title | ${Config.siteTitle}") }</title>
-
+        <title>@pageInfo.title</title>
         @fragments.meta.mobile()
         <meta name="description" content="@pageInfo.description"/>
         <meta name="rating" content="general"/>
@@ -22,7 +20,7 @@
         <meta name="Rating" content="general"/>
         <meta name="Distribution" content="Global"/>
 
-        <meta property="og:title" content="@pageInfo.title | @Config.siteTitle"/>
+        <meta property="og:title" content="@pageInfo.title"/>
         <meta property="og:description" content="@pageInfo.description"/>
         @for(pageImage <- pageInfo.image) {
             <meta property="og:image" content="@pageImage"/>

--- a/frontend/app/views/info/feedback.scala.html
+++ b/frontend/app/views/info/feedback.scala.html
@@ -1,12 +1,8 @@
-@import views.html.helper.CSRF
 @(flashMsgOpt: Option[model.FlashMessage] = None, feedbackText: Option[String] = None)(implicit token: play.filters.csrf.CSRF.Token)
 
-    @mainFunction = @{
-        if(feedbackText.isDefined) giraffeMain("Feedback") _ else main("Feedback") _
-    }
+@import views.html.helper.CSRF
 
-    @mainFunction {
-
+@main("Feedback") {
 
     <main role="main" class="page-content l-constrained">
 

--- a/frontend/assets/stylesheets/giraffe.scss
+++ b/frontend/assets/stylesheets/giraffe.scss
@@ -319,9 +319,13 @@
 }
 
 .support-thanks__title {
-    font-family: $f-serif-headline;
-    font-weight: 500;
     color: #05b2c9;
+    font-family: $f-serif-headline;
+    font-size: 28px;
+    font-weight: 500;
+    line-height: 32px;
+    margin-bottom: 22px;
+    margin-top: 11px;
 }
 
 .support-thanks__message {
@@ -333,21 +337,12 @@
         padding: 0 10px;
     }
 
-    .support-thanks__title {
-        font-size: 42px;
-    }
-
     .support-thanks__message {
         font-size: 18px;
     }
 }
 
 @include mq($from: desktop) {
-
-    .support-thanks__title {
-        margin-bottom: 32px;
-        margin-top: 16px;
-    }
 
     .support-thanks__one-col:last-child {
         border-right: none;
@@ -360,6 +355,13 @@
     .support-thanks {
         max-width: 940px;
         padding: 0 60px;
+    }
+
+    .support-thanks__title {
+        font-size: 42px;
+        line-height: 46px;
+        margin-bottom: 32px;
+        margin-top: 16px;
     }
 
     .support-thanks__message {


### PR DESCRIPTION
Tweak open graph links so the sharing of the /contribute page is correct.
Ensure the correct, trackable URLs are in the Twitter and FB share buttons on the /thank-you page.
Fix thank you page header font.

cc @AWare 