### PR TITLE
Watch CSS, JS and images separately to speed up dev

### DIFF
--- a/frontend/Gruntfile.js
+++ b/frontend/Gruntfile.js
@@ -217,9 +217,17 @@ module.exports = function (grunt) {
          ***********************************************************************/
 
         watch: {
-            compile: {
-                files: ['<%= dirs.assets.stylesheets %>/**/*.scss', '<%= dirs.assets.javascripts %>/**/*.js'],
-                tasks: ['compile']
+            compile_css: {
+                files: ['<%= dirs.assets.stylesheets %>/**/*.scss'],
+                tasks: ['compile:css']
+            },
+            compile_js: {
+                files: ['<%= dirs.assets.javascripts %>/**/*.js'],
+                tasks: ['compile:js']
+            },
+            compile_images: {
+                files: ['<%= dirs.assets.images %>/**/*'],
+                tasks: ['compile:images']
             }
         },
 
@@ -353,13 +361,15 @@ module.exports = function (grunt) {
 
     grunt.registerTask('compile:css', [
         'clean:css',
-        'clean:images',
-        'build:images',
         'build:css'
     ]);
     grunt.registerTask('compile:bookmarklets', [
         'clean:bookmarklets',
         'copy:bookmarklets'
+    ]);
+    grunt.registerTask('compile:images', [
+        'clean:images',
+        'build:images'
     ]);
     grunt.registerTask('compile:js', function() {
         if (!isDev) {
@@ -380,6 +390,7 @@ module.exports = function (grunt) {
         grunt.task.run([
             'clean:public',
             'compile:css',
+            'compile:images',
             'compile:js',
             'compile:bookmarklets'
         ]);


### PR DESCRIPTION
It's ridiculous waiting for JS and images to minify when you've just changed a font-size in CSS. This should speed things up.

My one concern would be that there is a reason why `clean:images` and `build:images` had to go in between the `clean:css` and `build:css` steps. But I can't think of any and it seems to work for me.

I would suggest maybe people pull in this branch and dev against it for a bit to check if there are any issues before merging?

@paulbrown1982 @AWare @tomverran 