### PR TITLE
Fix cross-browser issues and links in giraffe header

### DIFF
--- a/frontend/app/controllers/Giraffe.scala
+++ b/frontend/app/controllers/Giraffe.scala
@@ -1,5 +1,6 @@
 package controllers
 import com.gu.stripe.Stripe
+import configuration.Config
 import com.gu.stripe.Stripe.Serializer._
 import forms.MemberForm.supportForm
 import play.api.libs.concurrent.Execution.Implicits._
@@ -27,7 +28,8 @@ object Giraffe extends Controller {
       image = Some("https://media.guim.co.uk/727ed45d0601dc4fe85df56f6b24140c68145c16/0_0_2200_1320/1000.jpg"),
       stripePublicKey = Some(stripe.publicKey),
       description = Some("By making a contribution, you'll be supporting independent journalism that speaks truth to power"),
-      navigation = Seq.empty
+      navigation = Seq.empty,
+      customSignInUrl = Some(Config.idWebAppUrl)
     )
     Ok(views.html.giraffe.support(pageInfo))
   }

--- a/frontend/app/views/fragments/global/primaryNavigation.scala.html
+++ b/frontend/app/views/fragments/global/primaryNavigation.scala.html
@@ -1,5 +1,5 @@
 @import views.support.PageInfo
-@(pageInfo: PageInfo, showMembersArea: Boolean = true)
+@(pageInfo: PageInfo, isMembershipBranded: Boolean = true)
 
 @import model.Nav
 @import configuration.Links
@@ -14,7 +14,7 @@
     <div class="global-navigation__scroll l-constrained">
         <ul class="global-navigation__list">
             <li class="global-navigation__item global-navigation__item--home">
-                <a href="/" class="global-navigation__link js-nav-link-home">
+                <a href="@if(isMembershipBranded) {/} else {http://theguardian.com/}" class="global-navigation__link js-nav-link-home">
                     @fragments.inlineIcon("home")
                     <span class="u-h">Home</span>
                 </a>
@@ -30,7 +30,7 @@
                 }
             }
             <li class="global-navigation__item global-navigation__item--right">
-                @if(showMembersArea) {
+                @if(isMembershipBranded) {
                     <a href="@Links.membershipFront" class="global-navigation__link global-navigation__link--last js-members-area is-hidden">Members' Area</a>
                 }
             </li>

--- a/frontend/app/views/giraffeMain.scala.html
+++ b/frontend/app/views/giraffeMain.scala.html
@@ -101,16 +101,13 @@
                         </div>
                         @* Branding *@
                         <div class="global-header__logo">
-                            <a href="/" class="global-header__logo__link" id="qa-header-logo">
-                                <span class="u-h">@Config.siteTitle</span>
+                            <a href="http://theguardian.com/" class="global-header__logo__link" id="qa-header-logo">
                                 <div class="inline-svg global-header__logo__image" role="img">
                                     <?xml version="1.0" encoding="UTF-8" standalone="no"?>
                                     <svg
                                     version="1.1"
                                     id="svg4203"
-                                    viewBox="0 0 320 60"
-                                    height="60"
-                                    width="320">
+                                    viewBox="0 0 320 60">
                                         <metadata
                                         id="metadata4213">
                                             <rdf:RDF>

--- a/frontend/assets/stylesheets/components/_global-header.scss
+++ b/frontend/assets/stylesheets/components/_global-header.scss
@@ -37,23 +37,25 @@
         margin-right: -20px;
     }
 }
-.global-header__logo__image {
-    width: auto;
+.global-header__logo__image,
+.global-header__logo__link {
     height: 50px;
 
     @include mq(tablet) {
         height: 90px;
     }
 }
+.global-header__logo__image {
+    width: auto;
+}
+.global-header__logo__link {
+    display: block;
+}
 .js-on .global-header__logo__image img {
     visibility: hidden;
 }
 .global-header__logo__image img.is-loaded {
     visibility: visible;
-}
-.global-header__logo__link {
-    display: block;
-    height: 90px;
 }
 
 /* Header - In App

--- a/frontend/assets/stylesheets/giraffe.scss
+++ b/frontend/assets/stylesheets/giraffe.scss
@@ -159,12 +159,13 @@
 
     .global-header__logo {
         svg {
-            height: auto;
+            height: 30px;
             width: 160px;
         }
 
         @include mq(tablet) {
             svg {
+                height: 60px;
                 width: 320px;
             }
         }


### PR DESCRIPTION
Two things:

1. Points the links on the generic giraffe header to theguardian.com rather than membership.

2. A styling fix for the Guardian logo on Safari, IE and some mobile browsers. The height attributes on the svg element combined with `height: auto` in the CSS (which is supposed to calculate based on width & aspect ratio) were causing these browsers to give the `<svg>` a height that was too large, making it to bottom-align like this:
![picture 197](https://cloud.githubusercontent.com/assets/5122968/14281268/00331ec8-fb30-11e5-9405-55869ba4cc39.png)
Removing the attributes from the `<svg>` element and setting manual heights fixed the issue:
![picture 198](https://cloud.githubusercontent.com/assets/5122968/14281277/070ff6d0-fb30-11e5-83ee-f19e8be4dc9c.png)


@tomverran since you have grappled with this svg before :stuck_out_tongue_winking_eye: 