### PR TITLE
Fix membership doctype

### DIFF
--- a/frontend/app/views/giraffeMain.scala.html
+++ b/frontend/app/views/giraffeMain.scala.html
@@ -8,8 +8,8 @@
 @import play.api.libs.json.Json
 @import configuration.{Config, Social}
 @import views.support.Asset
-<!DOCTYPE html lang="en-GB">
-<html class="js-off id--signed-out">
+<!DOCTYPE html>
+<html lang="en-GB" class="js-off id--signed-out">
     <head>
         <meta charset="utf-8">
         <title>@pageInfo.title</title>

--- a/frontend/app/views/main.scala.html
+++ b/frontend/app/views/main.scala.html
@@ -7,8 +7,8 @@
 @import play.api.libs.json.Json
 @import configuration.{Config, Social}
 @import views.support.Asset
-<!DOCTYPE html lang="en-GB">
-<html class="js-off id--signed-out">
+<!DOCTYPE html>
+<html lang="en-GB" class="js-off id--signed-out">
     <head>
         <meta charset="utf-8">
         <title>@if(title.isEmpty){ @Config.siteTitle } else { @(s"$title | ${Config.siteTitle}") }</title>


### PR DESCRIPTION
Fixed what is clearly a copy-paste error where the lang attribute was on the doctype rather than the <html> tag. This causes the Facebook crawler not to pick up the open-graph details.

cc @joelochlann 