### PR TITLE
Fix the height of the membership header image

### DIFF
--- a/frontend/assets/stylesheets/components/_global-header.scss
+++ b/frontend/assets/stylesheets/components/_global-header.scss
@@ -53,6 +53,7 @@
 }
 .global-header__logo__link {
     display: block;
+    height: 90px;
 }
 
 /* Header - In App


### PR DESCRIPTION
Before

![image](https://cloud.githubusercontent.com/assets/1388226/14286221/42e774d8-fb46-11e5-8f7b-58d335b2808d.png)

After

![image](https://cloud.githubusercontent.com/assets/1388226/14286248/5720ccb0-fb46-11e5-9234-9ac8276bc017.png)

The contribute template still looks okay
