### PR TITLE
Fix SBT test command semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,11 +125,6 @@ Note that we read the shared secret for these from the `identity.test.users.secr
 
 ### Automated
 
-
-#### Scala unit tests
-
-`sbt test`
-
 #### JavaScript unit tests
 
 ```
@@ -137,13 +132,22 @@ cd frontend/
 npm test
 ```
 
+
+#### Scala unit tests
+
+`sbt fast-test`
+
 #### Acceptance tests
 
 1. Run local membership-frontend: `sbt devrun`
-2. Run local [frontend](https://github.com/guardian/frontend): `./sbt "project identity" idrun`
+2. Run local [idenity-frontend](https://github.com/guardian/identity-frontend): `sbt devrun`
 3. `sbt acceptance-test`
 
 These are browser driving Selenium tests.
+
+#### All tests
+
+`sbt test`
 
 
 ## Deployment

--- a/project/Membership.scala
+++ b/project/Membership.scala
@@ -62,7 +62,7 @@ object Membership extends Build with Membership {
                 .settings(libraryDependencies ++= frontendDependencies)
                 .settings(addCommandAlias("devrun", "run -Dconfig.resource=dev.conf 9100"): _*)
                 .settings(libraryDependencies ++= acceptanceTestDependencies)
-                .settings(addCommandAlias("test", "testOnly -- -l Acceptance"))
+                .settings(addCommandAlias("fast-test", "testOnly -- -l Acceptance"))
                 .settings(addCommandAlias("acceptance-test", "testOnly acceptance.JoinPartnerSpec"))
 
   val root = Project("root", base=file(".")).aggregate(frontend)


### PR DESCRIPTION
@AWare @tomverran 

Semantics of `sbt test` is to execute all tests [by design](http://www.scala-sbt.org/0.13/docs/Testing.html), and should not be redefined by us. To run just unit tests execute `sbt fast-test` in the same way as we do for [subscription-frontend](https://github.com/guardian/subscriptions-frontend/blob/065e56a3f2dc053a63558cd4ee647021214378b7/build.sbt#L76).