### PR TITLE
Add australia contribute and thank you pages

### DIFF
--- a/frontend/app/configuration/Links.scala
+++ b/frontend/app/configuration/Links.scala
@@ -19,6 +19,7 @@ object Links {
 
   val giraffeTerms = "https://www.theguardian.com/info/2016/apr/04/contribution-terms-and-conditions"
   val giraffeTermsUS = "https://www.theguardian.com/info/2016/apr/07/us-contribution-terms-and-conditions"
+  val giraffeTermsAustralia = "https://www.theguardian.com/info/2016/apr/08/au-contribution-terms-and-conditions"
 }
 
 object ProfileLinks {

--- a/frontend/app/views/giraffe/contributeAustralia.scala.html
+++ b/frontend/app/views/giraffe/contributeAustralia.scala.html
@@ -1,0 +1,223 @@
+@import views.support.PageInfo
+@import views.support.Asset
+@import configuration.Links
+
+@(pageInfo: PageInfo)
+
+@giraffeMain(pageInfo) {
+    <div class="l-constrained">
+        <div class="promo-primary__image promo-primary__image--giraffe">
+            <div class="promo-primary__image--overlay"></div>
+            <div class="primary__heading">
+                <h1 class="primary__heading--main">Support the Guardian</h1>
+                <h2 class="primary__heading--sub">Contribute today</h2>
+                <p class="primary__heading--text">
+                    By making a contribution, you'll be supporting independent journalism that speaks truth to power
+                </p>
+            </div>
+        </div>
+    </div>
+
+    <div class="support-wrapper page-slice l-constrained">
+
+        <form id="form" class="form js-form" role="main" method="POST" autocomplete="on" novalidate action="@routes.Giraffe.pay()">
+            <div class="form__column">
+                <h3 class="form__column-heading form__column-heading--first headline-text--bolder"><span class="num">1</span>
+                    Your details</h3>
+                <ul class="u-unstyled">
+                    <li class="form-field">
+                        <label for="name" class="label">Full name</label>
+                        <div class="input">
+                            <input type="text" id="name" class="input-text js-name" name="name" tabindex="1" aria-required="true" spellcheck="false" autocorrect="off" autocapitalize="off" placeholder="Full name" required>
+                            @fragments.form.errorMessage("Please enter your full name")
+                        </div>
+                    </li>
+                    <li id="email_field" class="form-field">
+                        <label for="email" class="label">Email address</label>
+                        <div class="input">
+                            <input type="email" id="email" class="input-text js-email" name="email" tabindex="2" aria-required="true" spellcheck="false" autocorrect="off" autocapitalize="off" placeholder="Email address" required data-validation="native">
+                            @fragments.form.errorMessage("Please enter a valid email address")
+                        </div>
+                    </li>
+
+                    <li id="postcode" class="form-field">
+                        <label for="email" class="label">Postcode</label>
+                        <div class="input">
+                            <input type="text" id="postcode" class="input-text" name="postcode" tabindex="3" aria-required="true" spellcheck="false" autocorrect="off" autocapitalize="off" placeholder="Postcode">
+                        </div>
+                    </li>
+
+                    <div class="giraffe-checkbox">
+                        <input id="guardian-opt-in" type="checkbox" name="guardian-opt-in" value="true">
+                        <label for="guardian-opt-in">
+                            Keep me up to date with offers from the Guardian
+                        </label>
+                    </div>
+                </ul>
+            </div>
+
+            <div class="form__column">
+                <h3 class="form__column-heading headline-text--bolder"><span class="num">2</span> Your amount</h3>
+                <ul class="u-unstyled">
+                    <li id="currency_field" class="form-field" hidden>
+                        <label for="currency" class="label u-h">Currency</label>
+                        <div class="input">
+                            <div class="button-group u-cf">
+                                <button type="button" tabindex="4" class="js-currency-switcher option-button" data-currency="gbp" data-symbol="&pound;">&pound;&nbsp;GBP</button>
+                                <button type="button" tabindex="5" class="js-currency-switcher option-button" data-currency="usd" data-symbol="&#36;">&#36;&nbsp;USD</button>
+                                <button type="button" tabindex="6" class="js-currency-switcher option-button active" data-currency="aud" data-symbol="&#36;">&#36;&nbsp;AUD</button>
+                                <button type="button" tabindex="7" class="js-currency-switcher option-button" data-currency="eur" data-symbol="&euro;">&euro;&nbsp;EUR</button>
+                            </div>
+                            <input type="hidden" id="currency" name="currency" class="js-currency-field" value="aud">
+                        </div>
+                    </li>
+
+                    <li id="amount_field" class="form-field">
+                        <label for="amount" class="label u-h">Amount</label>
+                        <div class="input">
+                            <div class="button-group u-cf">
+                                <button type="button" tabindex="8" class="option-button option-button--bold active" data-amount="5">
+                                    <span class="currency js-currency">&#36;</span>5
+                                </button>
+                                <button type="button" tabindex="9" class="option-button option-button--bold" data-amount="20">
+                                    <span class="currency js-currency">&#36;</span>20
+                                </button>
+                                <button type="button" tabindex="10" class="option-button option-button--bold" data-amount="50">
+                                    <span class="currency js-currency">&#36;</span>50
+                                </button>
+                                <button type="button" tabindex="11" class="option-button option-button--bold" data-amount="100">
+                                    <span class="currency js-currency">&#36;</span>100
+                                </button>
+                            </div>
+                            <div id="other_amount_field">
+                                <div class="other_amount_currency headline-text--bolder js-currency">&#36;</div>
+                                <input type="number" id="other_amount" class="input-text js-amount js-amount-field" placeholder="Other amount" maxlength="6" tabindex="12" data-validation="giraffe">
+
+                                <input type="hidden" name="amount" class="js-amount js-amount-hidden" value="5.00">
+                            </div>
+                            @fragments.form.errorMessage("Please enter a valid amount.")
+                        </div>
+                    </li>
+                    <li>
+                        <div class="security-note">We are currently only able to accept contributions of <span class="currency js-currency">&#36;</span>500 or less</div>
+                    </li>
+                </ul>
+            </div>
+
+            <div class="form__column">
+                <h3 class="form__column-heading headline-text--bolder"><span class="num">3</span> Your payment</h3>
+                @fragments.form.securityNote()
+                <ul class="u-unstyled">
+                    <li id="card_number_field" class="form-field">
+                        <label for="cc-num">Card number</label>
+                        <div class="credit-card-container">
+                            <i class="credit-card--input-visualisation sprite-card sprite-card--unknown js-credit-card-image"></i>
+                            <input type="text" pattern="[0-9]*"
+                            tabindex="13"
+                            size="20"
+                            data-stripe="number"
+                            class="input-text credit-card-input js-credit-card-number"
+                            id="cc-num"
+                            placeholder="0000 0000 0000 0000"
+                            maxlength="19"
+                            autocomplete="off"
+                            data-validation="validCreditCardNumber"/>
+                            @fragments.form.errorMessage("Sorry, the card number that you have entered is incorrect. Please check and retype.")
+                        </div>
+                    </li>
+
+                    <li id="card_expiry_field" class="form-field">
+                        <label class="label">Expires</label>
+                        <div class="input">
+                            <label for="card_expiry_month" class="u-h form-field__note form-field__note--sub">Month</label>
+                            <select id="card_expiry_month" data-stripe="exp-month" tabindex="14" aria-required="true" class="js-credit-card-exp-month" data-validation="validCreditCardMonth">
+                                <option value="1">01</option>
+                                <option value="2">02</option>
+                                <option value="3">03</option>
+                                <option value="4">04</option>
+                                <option value="5">05</option>
+                                <option value="6">06</option>
+                                <option value="7">07</option>
+                                <option value="8">08</option>
+                                <option value="9">09</option>
+                                <option value="10">10</option>
+                                <option value="11">11</option>
+                                <option value="12">12</option>
+                            </select>
+                            <span>/</span>
+                            <label for="card_expiry_year" class="u-h form-field__note form-field__note--sub">Year</label>
+                            <select id="card_expiry_year" data-stripe="exp-year" tabindex="15" aria-required="true" class="js-credit-card-exp-year" data-validation="validCreditCardYear">
+                                <option value="16">16</option>
+                                <option value="17">17</option>
+                                <option value="18">18</option>
+                                <option value="19">19</option>
+                                <option value="20">20</option>
+                                <option value="21">21</option>
+                            </select>
+                        </div>
+                        @fragments.form.errorMessage("Sorry, the expiry date that you have entered is invalid. Please check and re-enter.")
+                    </li>
+
+                    <li id="card_cvc_field" class="form-field">
+                        <label for="card_cvc" class="label">Security code</label>
+                        <div class="input">
+                            <input type="tel" id="card_cvc" class="input-text js-credit-card-cvc" data-stripe="cvc" tabindex="16" aria-required="true" maxlength="4" x-autocompletetype="cc-csc" pattern="\d*" autocomplete="off" placeholder="CVC" data-validation="validCVC">
+                            <div class="form-field__note form-field__note--below form-field__note--right">
+                                <a class="cvc-cta text-link js-toggle" data-toggle="js-cvc-image-container" href="#">What's this?</a>
+                            </div>
+                        </div>
+                        @fragments.form.errorMessage("Sorry, the security code that you have entered is incorrect. Please check and retype.")
+                    </li>
+
+                    <div id="js-cvc-image-container" class="cvc u-cf" data-toggle-hidden>
+                        <div class="u-cf">
+                            <div class="cvc__image">
+                                <img src="@Asset.at("images/form/cvc-card.png")" alt="CVC explanation"/>
+                            </div>
+                            <div class="cvc__detail">
+                                <h3 class="cvc__heading">Visa, Mastercard</h3>
+                                <p class="cvc__body">
+                                    The last 3 digits printed on the back within the signature strip
+                                </p>
+                            </div>
+                        </div>
+                        <div class="u-cf">
+                            <div class="cvc__image">
+                                <img src="@Asset.at("images/form/cvc-card-american-express.png")" alt="CVC explanation American Express"/>
+                            </div>
+                            <div class="cvc__detail">
+                                <h3 class="cvc__heading">American Express</h3>
+                                <p class="cvc__body">
+                                    The 4 digits printed on the front above the card number
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                    <li id="submit_field" class="form-field">
+                        <button class="action action--contribute js-submit-input" type="submit" tabindex="17">Pay <span class="js-currency">&#36;</span><span class="js-amount">5</span></button>
+                        <div class="loader js-loader"></div>
+                    </li>
+
+                    <div class="fieldset__note">
+                        <p>By proceeding, you are agreeing to our
+                            <a href="@Links.giraffeTermsAustralia" class="text-link" target="_blank">Terms and Conditions</a> and
+                            <a href="@Links.guardianPrivacyPolicy" class="text-link" target="_blank">Privacy Policy</a>.
+                        </p>
+                    </div>
+                </ul>
+            </div>
+        </form>
+
+        <div class="feedback">
+            <p>If you have any questions about contributing to the Guardian, please
+                <a href="mailto:contribution.support@@theguardian.com" class="support-thanks__link">contact us here</a>.
+            </p>
+            <p>
+                The ultimate owner of the Guardian is The Scott Trust Limited, whose role it is to secure the editorial and financial independence of the Guardian in perpetuity. Reader contributions support the Guardian’s journalism.
+            </p>
+            <p>
+                Please note that your support of the Guardian’s journalism does not constitute a charitable donation, as such your contribution is not eligible for Gift Aid in the UK nor a tax-deduction elsewhere.
+            </p>
+        </div>
+    </div>
+}

--- a/frontend/app/views/giraffe/thankyouAustralia.scala.html
+++ b/frontend/app/views/giraffe/thankyouAustralia.scala.html
@@ -1,0 +1,39 @@
+@import views.support.PageInfo
+
+@import views.support.Social
+@(pageInfo: PageInfo, reference: String, social: Set[Social])
+@giraffeMain(pageInfo) {
+    <div class="support-wrapper page-slice l-constrained support-thanks">
+        <h1 class="support-thanks__title">@pageInfo.title</h1>
+
+        <p class="support-thanks__message">@pageInfo.description</p>
+
+        <div class="support-thanks__message">
+            Please take a moment to share the <a class="support-thanks__link" href="//www.theguardian.com/news/series/panama-papers" onClick="s.tl(true,'o','panamapapers')">Panama Papers</a> series.
+            @fragments.social(social)
+        </div>
+
+        <p class="support-thanks__message">
+            Enjoy more of the Guardian's journalism from breaking investigations to politics, sports, arts and more.
+        </p>
+
+        <div class="support-thanks__row blue-border u-cf">
+            <div class="support-thanks__one-col">
+                <h3 class="support-thanks__sub-subtitle headline-text--bolder">Get the app </h3>
+                <p>Up-to-the-minute coverage, personalised alerts, off​line​ reading and more. <br><a href="https://itunes.apple.com/au/app/the-guardian/id409128287?mt=8" class="support-thanks__link" onClick="s.tl(true,'o','iApp')">iPhone and iPad app</a> <br><a href="https://play.google.com/store/apps/details?id=com.guardian" class="support-thanks__link" onClick="s.tl(true,'o','aApp')">Android app</a></p>
+            </div>
+            <div class="support-thanks__one-col">
+                <h3 class="support-thanks__sub-subtitle headline-text--bolder">Subscribe to daily email</h3>
+                <p><a href="https://www.theguardian.com/info/2015/dec/08/daily-email-au?CMP=contribution_thankyou" class="support-thanks__link" onClick="s.tl(true,'o','email')">Get the must-read stories</a> delivered straight to your inbox each morning in one handy email</p>
+            </div>
+            <div class="support-thanks__one-col">
+                <h3 class="support-thanks__sub-subtitle headline-text--bolder">Follow on Facebook</h3>
+                <p><a href="https://www.facebook.com/theguardian" class="support-thanks__link" onClick="s.tl(true,'o','follow')">Follow the Guardian's daily reporting</a>, features and investigative journalism</p>
+            </div>
+        </div>
+
+        <div class="support-thanks__feedback">
+            If you have any questions about contributing to the Guardian, please <a href="mailto:contribution.support@@theguardian.com" class="support-thanks__link" onClick="s.tl(true,'o','emailUs')">contact us here</a>.
+        </div>
+    </div>
+}

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -128,10 +128,13 @@ GET            /english-heritage                      controllers.Default.redire
 GET            /currencies                            controllers.PricingApi.currencies
 
 # Giraffe
-GET            /contribute/                           controllers.Default.redirect(to="/contribute")
 GET            /contribute                            controllers.Giraffe.contribute
 GET            /us/contribute                         controllers.Giraffe.contributeUSA
-POST           /contribute/pay                        controllers.Giraffe.pay
+GET            /au/contribute                         controllers.Giraffe.contributeAustralia
+
 GET            /contribute/thank-you                  controllers.Giraffe.thanks
 GET            /us/contribute/thank-you               controllers.Giraffe.thanksUSA
+GET            /au/contribute/thank-you               controllers.Giraffe.thanksAustralia
+
+POST           /contribute/pay                        controllers.Giraffe.pay
 


### PR DESCRIPTION
We now have three copy-pasted variants of the contribute & thank you pages. This is because the three variants are still subject to unpredictable change at very short notice and we need the flexibility to be able to quickly modify any part of them independently. Once the dust is settled and we have a sense of what probably will and won't vary between countries, we'll refactor to eliminate this duplication.

### Differences from UK page

##### Contribute page
* Aussie dollars instead of pounds
* Marketing preferences unticked

##### Thank you page
* Links to Apple App Store and Guardian Daily Email updated to be Australia-specific

### What's likely to change?
* Terms & Conditions link (currently gives 404 since it's just a guess as to what the URL from Central Production might be)
* Disclaimer text at the bottom

![screencapture-mem-thegulocal-com-au-contribute-1460113430025](https://cloud.githubusercontent.com/assets/5122968/14381972/22872768-fd82-11e5-8ece-1bb0c2bfd9f9.png)