### PR TITLE
Disambiguate aussie dollars

### DIFF
--- a/frontend/app/views/giraffe/contributeAustralia.scala.html
+++ b/frontend/app/views/giraffe/contributeAustralia.scala.html
@@ -77,20 +77,20 @@
                         <div class="input">
                             <div class="button-group u-cf">
                                 <button type="button" tabindex="8" class="option-button option-button--bold active" data-amount="5">
-                                    <span class="currency js-currency">&#36;</span>5
+                                    <span class="currency js-currency">A&#36;</span>5
                                 </button>
                                 <button type="button" tabindex="9" class="option-button option-button--bold" data-amount="20">
-                                    <span class="currency js-currency">&#36;</span>20
+                                    <span class="currency js-currency">A&#36;</span>20
                                 </button>
                                 <button type="button" tabindex="10" class="option-button option-button--bold" data-amount="50">
-                                    <span class="currency js-currency">&#36;</span>50
+                                    <span class="currency js-currency">A&#36;</span>50
                                 </button>
                                 <button type="button" tabindex="11" class="option-button option-button--bold" data-amount="100">
-                                    <span class="currency js-currency">&#36;</span>100
+                                    <span class="currency js-currency">A&#36;</span>100
                                 </button>
                             </div>
                             <div id="other_amount_field">
-                                <div class="other_amount_currency headline-text--bolder js-currency">&#36;</div>
+                                <div class="other_amount_currency headline-text--bolder js-currency">A&#36;</div>
                                 <input type="number" id="other_amount" class="input-text js-amount js-amount-field" placeholder="Other amount" maxlength="6" tabindex="12" data-validation="giraffe">
 
                                 <input type="hidden" name="amount" class="js-amount js-amount-hidden" value="5.00">
@@ -99,7 +99,7 @@
                         </div>
                     </li>
                     <li>
-                        <div class="security-note">We are currently only able to accept contributions of <span class="currency js-currency">&#36;</span>500 or less</div>
+                        <div class="security-note">We are currently only able to accept contributions of <span class="currency js-currency">A&#36;</span>500 or less</div>
                     </li>
                 </ul>
             </div>
@@ -194,7 +194,7 @@
                         </div>
                     </div>
                     <li id="submit_field" class="form-field">
-                        <button class="action action--contribute js-submit-input" type="submit" tabindex="17">Pay <span class="js-currency">&#36;</span><span class="js-amount">5</span></button>
+                        <button class="action action--contribute js-submit-input" type="submit" tabindex="17">Pay <span class="js-currency">A&#36;</span><span class="js-amount">5</span></button>
                         <div class="loader js-loader"></div>
                     </li>
 


### PR DESCRIPTION
Graham suggested making it clear that it's Australian dollars. According to [wikipedia](https://en.wikipedia.org/wiki/Australian_dollar) A$ is a standard symbol for distinguishing Australian dollars from other dollar currencies.

#### before
![picture 208](https://cloud.githubusercontent.com/assets/5122968/14383702/ad395456-fd8e-11e5-83e1-d46d86eeb9b1.png)

#### after
![picture 209](https://cloud.githubusercontent.com/assets/5122968/14383707/b1c15500-fd8e-11e5-948b-3a1582c440eb.png)
