### PR TITLE
Giraffe Australia amendments

### DIFF
--- a/frontend/app/configuration/Links.scala
+++ b/frontend/app/configuration/Links.scala
@@ -19,7 +19,7 @@ object Links {
 
   val giraffeTerms = "https://www.theguardian.com/info/2016/apr/04/contribution-terms-and-conditions"
   val giraffeTermsUS = "https://www.theguardian.com/info/2016/apr/07/us-contribution-terms-and-conditions"
-  val giraffeTermsAustralia = "https://www.theguardian.com/info/2016/apr/08/au-contribution-terms-and-conditions"
+  val giraffeTermsAustralia = "https://www.theguardian.com/info/2016/apr/08/australia-contribution-terms-and-conditions"
 }
 
 object ProfileLinks {

--- a/frontend/app/views/giraffe/contributeAustralia.scala.html
+++ b/frontend/app/views/giraffe/contributeAustralia.scala.html
@@ -215,9 +215,6 @@
             <p>
                 The ultimate owner of the Guardian is The Scott Trust Limited, whose role it is to secure the editorial and financial independence of the Guardian in perpetuity. Reader contributions support the Guardian’s journalism.
             </p>
-            <p>
-                Please note that your support of the Guardian’s journalism does not constitute a charitable donation, as such your contribution is not eligible for Gift Aid in the UK nor a tax-deduction elsewhere.
-            </p>
         </div>
     </div>
 }

--- a/frontend/assets/stylesheets/giraffe.scss
+++ b/frontend/assets/stylesheets/giraffe.scss
@@ -418,12 +418,12 @@ $desktop-col-padding-right: 16px;
 
     background-color: #ffffff;
 
-    &.active {
-        background-color: color(news-support-1);
-    }
-
     &:hover {
         background-color: lighten(color(news-support-1), 10%);
+    }
+
+    &.active {
+        background-color: color(news-support-1);
     }
 }
 


### PR DESCRIPTION
Addresses these points from @blackyjnz's email:

> * Link to the T&C's https://www.theguardian.com/info/2016/apr/08/australia-contribution-terms-and-conditions
> * Validate we are using the correct colour of the amount-selection buttons as per Ben's comment above
> * Also, just checking that we've removed the below text as well (as per Nick's comment) as this is UK specific: "Please note that your support of the Guardian’s journalism does not constitute a charitable donation, as such your contribution is not eligible for Gift Aid in the UK nor a tax-deduction elsewhere."
