### PR TITLE
Fix so that billing address correctly changes displayed currency

### DIFF
--- a/frontend/app/views/joiner/form/payment.scala.html
+++ b/frontend/app/views/joiner/form/payment.scala.html
@@ -78,7 +78,6 @@
 
                     <div class="form-group">
                         <h2 class="form-group__title">Billing</h2>
-                        @fragments.form.paymentOptions(plans)
                         @fragments.form.billingAddress("Billing address")
                         @fragments.form.addressDetail(
                             countriesWithCurrencies = countriesWithCurrencies,
@@ -90,6 +89,7 @@
                             postcode = idUser.privateFields.billingPostcode,
                             county = idUser.privateFields.billingAddress4
                         )
+                        @fragments.form.paymentOptions(plans)
                         @fragments.form.cardDetail(plans)
                     </div>
 

--- a/frontend/app/views/tier/upgrade/freeToPaid.scala.html
+++ b/frontend/app/views/tier/upgrade/freeToPaid.scala.html
@@ -69,7 +69,6 @@
 
                   <div class="form-group">
                       <h2 class="form-group__title">Billing</h2>
-                      @fragments.form.paymentOptions(targetPlans)
                       @fragments.form.billingAddress("Billing address")
                       @fragments.form.addressDetail(
                           countriesWithCurrencies = countriesWithCurrency,
@@ -83,6 +82,7 @@
                           postcode = userFields.billingPostcode,
                           county = userFields.billingAddress4
                       )
+                      @fragments.form.paymentOptions(targetPlans)
                       @fragments.form.cardDetail(targetPlans)
                   </div>
 

--- a/frontend/assets/javascripts/src/modules/form/promoCode.js
+++ b/frontend/assets/javascripts/src/modules/form/promoCode.js
@@ -12,7 +12,8 @@ define(
         'use strict';
 
         var $PROMO_CODE_INPUT = $('#promo-code'),
-            $COUNTRY_SELECT = $('.js-country'),
+            $DELIVERY_COUNTRY_SELECT = $('#country-deliveryAddress'),
+            $BILLING_COUNTRY_SELECT = $('#country-billingAddress'),
             $TIER_ELEMENT = $('input[name="tier"]'),
             $APPLY_BUTTON = $('.js-promo-code-validate'),
             $FEEDBACK_CONTAINER = $('.js-promo-feedback-container');
@@ -79,7 +80,7 @@ define(
                 url: '/lookupPromotion',
                 data: {
                     promoCode: trimmedCode,
-                    country: $COUNTRY_SELECT.val(),
+                    country: $DELIVERY_COUNTRY_SELECT.val(),
                     tier: $TIER_ELEMENT.val()
                 }
             })
@@ -101,8 +102,11 @@ define(
                     return;
                 }
                 // revalidate the code if we change / click stuff
-                if ($COUNTRY_SELECT.length > 0) {
-                    bean.on($COUNTRY_SELECT[0], 'change', validatePromoCode);
+                if ($DELIVERY_COUNTRY_SELECT.length > 0) {
+                    bean.on($DELIVERY_COUNTRY_SELECT[0], 'change', validatePromoCode);
+                }
+                if ($BILLING_COUNTRY_SELECT.length > 0) {
+                    bean.on($BILLING_COUNTRY_SELECT[0], 'change', validatePromoCode);
                 }
                 if ($APPLY_BUTTON.length > 0) {
                     bean.on($APPLY_BUTTON[0], 'click', validatePromoCode);


### PR DESCRIPTION
Fixed a bug where changing the country of a billing address did not change the payment options display, and worse the CTA. It did change the Ongoing payments section and actual backend billing, just fine as it always has.

I also moved the paymentOptions to being below the billing address, so that the render change does not happen above the customer's viewport. This makes it very clear that the change of billing address has changed the charged currency.

The promotion validity remains determined by the delivery country.

cc @AWare @tomverran 