### PR TITLE
endpoint to preview upgrades with promo codes

### DIFF
--- a/frontend/app/actions/ActionRefiners.scala
+++ b/frontend/app/actions/ActionRefiners.scala
@@ -117,7 +117,7 @@ object ActionRefiners extends LazyLogging {
                             joinStaffMembership(_).flashing("error" -> "Identity email must match Guardian email")) = new ActionFilter[IdentityGoogleAuthRequest] {
     override def filter[A](request: IdentityGoogleAuthRequest[A]) = {
       for {
-        user <- IdentityService(IdentityApi).getFullUserDetails(request.identityUser, IdentityRequest(request))
+        user <- IdentityService(IdentityApi).getFullUserDetails(request.identityUser)(IdentityRequest(request))
       } yield {
         if (GuardianDomains.emailsMatch(request.googleUser.email, user.primaryEmailAddress)) None
         else Some(onNonGuEmail(request))

--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -187,7 +187,7 @@ object Config {
       campaignName = "Become a Partner for just £99/year",
       codes = PromoCodeSet(PromoCode("PARTNER99")),
       description = "",
-      expires = DateTime.parse("2016-04-01T01:00:00Z"),
+      expires = DateTime.parse("2017-04-01T01:00:00Z"),
       imageUrl = None,
       promotionType = PercentDiscount(
         durationMonths = None,

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -82,7 +82,7 @@ object Joiner extends Controller with ActivityTracking
 
     userSignedIn match {
       case Some(user) => for {
-        fullUser <- IdentityService(IdentityApi).getFullUserDetails(user, IdentityRequest(request))
+        fullUser <- IdentityService(IdentityApi).getFullUserDetails(user)(IdentityRequest(request))
         primaryEmailAddress = fullUser.primaryEmailAddress
         displayName = fullUser.publicFields.displayName
         avatarUrl = fullUser.privateFields.flatMap(_.socialAvatarUrl)

--- a/frontend/app/views/support/PaidToPaidUpgradeSummary.scala
+++ b/frontend/app/views/support/PaidToPaidUpgradeSummary.scala
@@ -1,5 +1,6 @@
 package views.support
 
+import com.gu.i18n.Currency
 import com.gu.membership.MembershipCatalog
 import com.gu.memsub.Subscription.ProductRatePlanId
 import com.gu.memsub._
@@ -8,6 +9,8 @@ import com.gu.services.model.BillingSchedule
 import model.PaidSubscription
 import model.SubscriptionOps._
 import org.joda.time.{DateTime, LocalDate}
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
 
 case class CurrentSummary(tier: PaidTier, startDate: LocalDate, payment: Price, card: PaymentCard)
 
@@ -57,4 +60,29 @@ object PaidToPaidUpgradeSummary {
 
     PaidToPaidUpgradeSummary(billingPeriod, currentSummary, targetSummary)
   }
+
+
+  implicit val currencyWrites = new Writes[Currency] {
+    override def writes(o: Currency): JsValue = JsString(o.glyph)
+  }
+
+  implicit val tierWrites = new Writes[PaidTier] {
+    override def writes(o: PaidTier): JsValue = JsString(o.name)
+  }
+
+  implicit val paymentCardWrites = Json.writes[PaymentCard]
+  implicit val priceWrites = Json.writes[Price]
+
+  implicit val billingPeriodWrites = new Writes[BillingPeriod] {
+    override def writes(o: BillingPeriod): JsValue = JsString(o.noun)
+  }
+
+  implicit val currentSummaryWrites = Json.writes[CurrentSummary]
+  implicit val targetSummaryWrites = Json.writes[TargetSummary]
+
+  implicit val summaryWrites: Writes[PaidToPaidUpgradeSummary] = (
+    (JsPath \ "billingPeriod").write[BillingPeriod] and
+      (JsPath \ "currentSummary").write[CurrentSummary] and
+      (JsPath \ "targetSummary").write[TargetSummary]
+    )(unlift(PaidToPaidUpgradeSummary.unapply))
 }

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -83,6 +83,7 @@ GET            /tier/change/friend                    controllers.TierController
 POST           /tier/change/friend                    controllers.TierController.downgradeToFriendConfirm
 GET            /tier/change/friend/summary            controllers.TierController.downgradeToFriendSummary
 GET            /tier/change/:tier                     controllers.TierController.upgrade(tier: PaidTier)
+GET            /tier/preview/:tier                    controllers.TierController.upgradePreview(tier: PaidTier, promoCode: Option[PromoCode])
 POST           /tier/change/:tier                     controllers.TierController.upgradeConfirm(tier: PaidTier)
 GET            /tier/change/:tier/summary             controllers.TierController.upgradeThankyou(tier: PaidTier)
 

--- a/frontend/test/services/IdentityServiceTest.scala
+++ b/frontend/test/services/IdentityServiceTest.scala
@@ -83,7 +83,7 @@ class IdentityServiceTest extends Specification with Mockito {
       Some(Address("line one", "line 2", "town", "country", "postcode", Country.UK.name))
     )
 
-    identityService.updateUserFieldsBasedOnUpgrade(user.id, addressDetails, identityRequest)
+    identityService.updateUserFieldsBasedOnUpgrade(user.id, addressDetails)(identityRequest)
 
     val expectedJson = Resource.getJson(s"model/identity/update-upgrade.json").as[JsObject]
     there was one(identityAPI).post("user/4444", Some(expectedJson), headers, trackingParameters, "update-user")


### PR DESCRIPTION
So what I had to do to get this to work is the following

 - Split the _creation_ of a PaymentSummary out from the display of the preview page
 - Add a JSON version of the preview page that calls the above method then JSONifies it

Then to pass a promo code through to the preview API call I basically had to do the same thing:

 - Split the creation of the Amend command out from the actual sending of it to Zuora
 - Call that method, then set preview mode to true on the resulting Amend before running it