### PR TITLE
Fix promotion text on thank you page when no description

### DIFF
--- a/frontend/app/views/fragments/pricing/billingPeriodChoice.scala.html
+++ b/frontend/app/views/fragments/pricing/billingPeriodChoice.scala.html
@@ -93,7 +93,7 @@
                     notes = [];
                 if (this.promoted) {
                     if(annual.discountDurationMonths > 0) {
-                        notes.unshift(formattedDiscountedPrice(checkoutForm.currency, annual.amount, 0) + '/year thereafter');
+                        notes.unshift("Then " + formattedDiscountedPrice(checkoutForm.currency, annual.amount, 0) + ' annually');
                     }
                 } else {
                     notes.unshift(annual.savingInfo[currency]);
@@ -104,7 +104,7 @@
                 var annual = checkoutForm.billingPeriods.annual,
                     suffix = '/year';
                 if (this.promoted && annual.discountDurationMonths > 0) {
-                    suffix = ' this year';
+                    suffix = ' today';
                 }
                 return annual.generateDisplayAmount() + suffix;
             },

--- a/frontend/app/views/fragments/pricing/billingPeriodChoice.scala.html
+++ b/frontend/app/views/fragments/pricing/billingPeriodChoice.scala.html
@@ -93,7 +93,7 @@
                     notes = [];
                 if (this.promoted) {
                     if(annual.discountDurationMonths > 0) {
-                        notes.unshift("Then " + formattedDiscountedPrice(checkoutForm.currency, annual.amount, 0) + ' @year.adverb');
+                        notes.unshift('Then ' + formattedDiscountedPrice(checkoutForm.currency, annual.amount, 0) + ' @year.adverb');
                     }
                 } else {
                     notes.unshift(annual.savingInfo[currency]);

--- a/frontend/app/views/fragments/pricing/billingPeriodChoice.scala.html
+++ b/frontend/app/views/fragments/pricing/billingPeriodChoice.scala.html
@@ -93,7 +93,7 @@
                     notes = [];
                 if (this.promoted) {
                     if(annual.discountDurationMonths > 0) {
-                        notes.unshift("Then " + formattedDiscountedPrice(checkoutForm.currency, annual.amount, 0) + ' annually');
+                        notes.unshift("Then " + formattedDiscountedPrice(checkoutForm.currency, annual.amount, 0) + ' @year.adverb');
                     }
                 } else {
                     notes.unshift(annual.savingInfo[currency]);

--- a/frontend/app/views/joiner/thankyou.scala.html
+++ b/frontend/app/views/joiner/thankyou.scala.html
@@ -119,7 +119,7 @@
                     <h2 class="page-section__headline">Promotion applied</h2>
                 </div>
                 <div class="page-section__content">
-                    <p>@promo.description</p>
+                    <p>@if(promo.description.isEmpty) { @promo.title } else { @promo.description }</p>
                     @promo.whenIncentive.map {a => <p>@a.promotionType.redemptionInstructions</p> }
                 </div>
             </section>


### PR DESCRIPTION
Fix that the promotion text is not presented on the thank you page if it has no description - solution is to show the promotion title (or headline) if there's no description.

cc @AWare 