### PR TITLE
Ability to load ES6 modules with requirejs-babel

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,10 @@
         "browser": true,
         "node": true
     },
+    "parserOptions": {
+        "ecmaVersion": 6,
+        "sourceType": "module",
+    },
     "globals"   : {
         "guardian": true
     },

--- a/frontend/Gruntfile.js
+++ b/frontend/Gruntfile.js
@@ -118,8 +118,11 @@ module.exports = function (grunt) {
                         'gumshoe': 'lib/bower-components/gumshoe/dist/js/gumshoe',
                         'smoothScroll': 'lib/bower-components/smooth-scroll/dist/js/smooth-scroll',
                         'ajax': 'src/utils/ajax',
-                        'text':'lib/bower-components/requirejs-text/text'
+                        'text':'lib/bower-components/requirejs-text/text',
+                        'es6': "../../node_modules/requirejs-babel/es6",
+                        'babel': "../../node_modules/requirejs-babel/babel-5.8.34.min",
                     },
+                    stubModules: ['babel', 'es6'],
                     findNestedDependencies: false,
                     wrapShim: true,
                     optimize: isDev ? 'none' : 'uglify2',

--- a/frontend/app/views/fragments/javaScriptLaterSteps.scala.html
+++ b/frontend/app/views/fragments/javaScriptLaterSteps.scala.html
@@ -11,6 +11,7 @@
             omniture: '@Asset.at("javascripts/lib/omniture/omniture.js")',
             stripe: 'https://js.stripe.com/v2/stripe-dss3',
             uet: '@Asset.at("javascripts/lib/uet/uet.js")',
+            es6: 'require',
             text: 'text'
         }
     };

--- a/frontend/app/views/fragments/javaScriptLaterSteps.scala.html
+++ b/frontend/app/views/fragments/javaScriptLaterSteps.scala.html
@@ -11,8 +11,8 @@
             omniture: '@Asset.at("javascripts/lib/omniture/omniture.js")',
             stripe: 'https://js.stripe.com/v2/stripe-dss3',
             uet: '@Asset.at("javascripts/lib/uet/uet.js")',
-            es6: 'require',
-            text: 'text'
+            text: 'text',
+            es6: 'es6'
         }
     };
 </script>

--- a/frontend/assets/javascripts/src/main.js
+++ b/frontend/assets/javascripts/src/main.js
@@ -22,7 +22,7 @@ require([
     'src/modules/form/processSubmit',
     'src/modules/identityPopup',
     'src/modules/identityPopupDetails',
-    'src/modules/comparisonTable',
+    'es6!src/modules/comparisonTable',
     'src/modules/metrics',
     'src/modules/patterns',
     'src/modules/giraffe'

--- a/frontend/assets/javascripts/src/modules/comparisonTable.js
+++ b/frontend/assets/javascripts/src/modules/comparisonTable.js
@@ -1,50 +1,46 @@
-define([
-    '$',
-    'bean'
-], function ($, bean) {
-    'use strict';
+import * as bean from 'bean'
+import * as $ from '$'
 
-    var COMPARISON_TABLE_SELECTOR = '.comparison-table';
-    var COMPARISON_TABLE = document.querySelector(COMPARISON_TABLE_SELECTOR);
+'use strict';
 
-    var HOVER_CLASS = 'is-hover';
-    var ACTIVE_CLASS = 'is-active';
-    var HOVERED = COMPARISON_TABLE_SELECTOR + ' .is-hover';
-    var CLICKABLE = COMPARISON_TABLE_SELECTOR + ' .js-clickable';
+const COMPARISON_TABLE_SELECTOR = '.comparison-table';
+const COMPARISON_TABLE = document.querySelector(COMPARISON_TABLE_SELECTOR);
 
-    function init() {
-        if (!COMPARISON_TABLE) {
-            return;
-        }
+const HOVER_CLASS = 'is-hover';
+const ACTIVE_CLASS = 'is-active';
+const HOVERED = COMPARISON_TABLE_SELECTOR + ' .is-hover';
+const CLICKABLE = COMPARISON_TABLE_SELECTOR + ' .js-clickable';
 
-        addHoverListeners();
+export function init() {
+    if (!COMPARISON_TABLE) {
+        return;
     }
 
-    function tierSelector(tier) {
-        return '[data-tier="' + tier + '"]';
-    }
+    addHoverListeners();
+}
 
-    // We have to do this in JavaScript rather than using a CSS :hover class
-    // because we have no single container which holds a tier column.
-    // Instead they are split between rows, so we use data-tier to group them together.
-    function addHoverListeners() {
-        bean.on(COMPARISON_TABLE, 'mouseenter', CLICKABLE, function (e) {
-            var tier = $(e.currentTarget).data('tier');
-            var $elemsInThisTier = $(CLICKABLE + tierSelector(tier));
-            var $elemsInOtherTiers = $(CLICKABLE + ':not(' + tierSelector(tier) + ')');
+function tierSelector(tier) {
+    return '[data-tier="' + tier + '"]';
+}
 
-            $elemsInThisTier.addClass(HOVER_CLASS);
-            $elemsInThisTier.addClass(ACTIVE_CLASS);
-            $elemsInOtherTiers.removeClass(ACTIVE_CLASS);
-        });
+// We have to do this in JavaScript rather than using a CSS :hover class
+// because we have no single container which holds a tier column.
+// Instead they are split between rows, so we use data-tier to group them together.
+function addHoverListeners() {
+    bean.on(COMPARISON_TABLE, 'mouseenter', CLICKABLE, e => {
+        let tier = $(e.currentTarget).data('tier');
+        let $elemsInThisTier = $(CLICKABLE + tierSelector(tier));
+        let $elemsInOtherTiers = $(CLICKABLE + ':not(' + tierSelector(tier) + ')');
 
-        bean.on(COMPARISON_TABLE, 'mouseleave', CLICKABLE, function () {
-            $(HOVERED).removeClass(HOVER_CLASS);
-        });
-    }
+        $elemsInThisTier.addClass(HOVER_CLASS);
+        $elemsInThisTier.addClass(ACTIVE_CLASS);
+        $elemsInOtherTiers.removeClass(ACTIVE_CLASS);
+    });
+
+    bean.on(COMPARISON_TABLE, 'mouseleave', CLICKABLE, () => {
+        $(HOVERED).removeClass(HOVER_CLASS);
+    });
+}
 
 
-    return {
-        init: init
-    };
-});
+

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,7 @@
     "vinyl-fs": "2.2.1",
     "grunt-contrib-requirejs": "^0.4.4",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-eslint": "^17.2.0",
+    "grunt-eslint": "^18.0.0",
     "grunt-karma": "~0.11.0",
     "grunt-postcss": "^0.5.1",
     "grunt-px-to-rem": "^0.4.0",
@@ -44,6 +44,7 @@
     "mkdirp": "^0.5.1",
     "phantomjs": "~1.9.17",
     "requirejs": "2.1.22",
+    "requirejs-babel": "0.0.9",
     "rimraf": "^2.4.3",
     "time-grunt": "^1.2.1"
   }


### PR DESCRIPTION
This allows you to write ES6 modules and import them with requirejs by prefixing their path with es6!

i.e.

```javascript
// filepath: my/es6/module.js
import * as template from 'lodash/string/template'
import * as ajax from 'ajax'

export function init() {
    //nice es6 code
}
```

```javascript
// filepath: main.js
require(['es6!my/es6/module'], function(module)) {
    module.init()
}
```

RequireJS then uses the es6 module loader to resolve the ES6 modules when compiling all the modules into a single file. Because the babelising is a compile time step both the es6 loader and babel then get stubbed out in the resulting JS bundle to stop it becoming massive.

I'm going to do the frontend for paid to paid upgrades as ES6 but I thought I'd make this a separate PR so we can ensure nothing breaks

Note that we have no polyfills yet, this only allows ES6 syntax for modules etc.