### PR TITLE
Tracking promotions

### DIFF
--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -168,7 +168,8 @@ object Config {
       campaignName = "English Heritage Offer - Q4 FY2016",
       codes = PromoCodeSet(PromoCode("EH2016")),
       description = "Free English Heritage membership worth £88 when you become a Partner or Patron Member",
-      expires = DateTime.parse("2016-04-01T01:00:00Z"),
+      starts = new LocalDate(2016,3,1).toDateTime(LocalTime.Midnight, timezone),
+      expires = new LocalDate(2016,4,1).toDateTime(LocalTime.Midnight, timezone),
       imageUrl = Some("https://s3-eu-west-1.amazonaws.com/memsub-promo-images/eh2016.png"),
       promotionType = Incentive(
         redemptionInstructions = "We'll send you an email with instructions on redeeming your English Heritage offer within 35 days.",
@@ -188,6 +189,7 @@ object Config {
       campaignName = "Become a Guardian Partner for just £99",
       codes = PromoCodeSet(PromoCode("PARTNER99")),
       description = "",
+      starts = new LocalDate(2016,4,13).toDateTime(LocalTime.Midnight, timezone),
       expires = new LocalDate(2016,5,1).toDateTime(LocalTime.Midnight, timezone),
       imageUrl = None,
       promotionType = PercentDiscount(

--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -201,6 +201,23 @@ object Config {
     ).some
   }
 
+  def trackingPromo(env: String): Option[Promotion[Tracking.type]] = {
+    val prpIds = membershipRatePlanIds(env)
+    new Promotion(
+      appliesTo = AppliesTo.all(prpIds.productRatePlanIds),
+      campaignName = "Example tracking-only promo code",
+      codes = PromoCodeSet(PromoCode("TRACK01")),
+      description = "This will not affect the price, payment delay, or register for an incentive",
+      starts = new LocalDate(2016,4,1).toDateTime(LocalTime.Midnight, timezone),
+      expires = new LocalDate(2016,6,1).toDateTime(LocalTime.Midnight, timezone),
+      imageUrl = None,
+      promotionType = Tracking,
+      roundelHtml = "",
+      title = "Example tracking-only promo code"
+    ).some
+  }
+
+
   object Implicits {
     implicit val akkaSystem = Akka.system
   }

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -214,7 +214,7 @@ object Joiner extends Controller with ActivityTracking
         card,
         destination,
         upgrade,
-        promotion
+        promotion.filterNot(_.whenTracking.isDefined)
     )).discardingCookies(TierChangeCookies.deletionCookies:_*)
   }
 

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -96,7 +96,7 @@ object Joiner extends Controller with ActivityTracking
 
   def NonMemberAction(tier: Tier) = AuthenticatedAction andThen onlyNonMemberFilter(onMember = redirectMemberAttemptingToSignUp(tier))
 
-  def enterPaidDetails(tier: PaidTier, countryGroup: CountryGroup, codeFromRequest: Option[PromoCode]) = NonMemberAction(tier).async { implicit request =>
+  def enterPaidDetails(tier: PaidTier, countryGroup: CountryGroup, promoCode: Option[PromoCode]) = NonMemberAction(tier).async { implicit request =>
     implicit val backendProvider: BackendProvider = request
 
     for {
@@ -109,7 +109,7 @@ object Joiner extends Controller with ActivityTracking
         initialCheckoutForm = CheckoutForm.forIdentityUser(identityUser, plans, Some(countryGroup))
       )
 
-      val promoCode = codeFromRequest orElse codeFromSession
+      val providedPromoCode = promoCode orElse codeFromSession
       val promotion = promoCode.flatMap(promoService.findPromotion)
 
       Ok(views.html.joiner.form.payment(
@@ -117,8 +117,8 @@ object Joiner extends Controller with ActivityTracking
          countriesWithCurrencies = CountryWithCurrency.whitelisted(supportedCurrencies, GBP),
          idUser = identityUser,
          pageInfo = pageInfo,
-         trackingPromoCode = promotion.filter(_.whenTracking.isDefined).flatMap(p => promoCode),
-         promoCodeToDisplay = promotion.filterNot(_.whenTracking.isDefined).flatMap(p => promoCode)))
+         trackingPromoCode = promotion.filter(_.whenTracking.isDefined).flatMap(p => providedPromoCode),
+         promoCodeToDisplay = promotion.filterNot(_.whenTracking.isDefined).flatMap(p => providedPromoCode)))
     }
   }
 

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -5,7 +5,7 @@ import actions.{RichAuthRequest, _}
 import com.github.nscala_time.time.Imports._
 import com.gu.i18n.CountryGroup.UK
 import com.gu.i18n.{CountryGroup, GBP}
-import com.gu.memsub.promo.PromoCode
+import com.gu.memsub.promo.{Tracking, PromoCode}
 import com.gu.salesforce._
 import com.gu.stripe.Stripe
 import com.gu.stripe.Stripe.Serializer._
@@ -110,7 +110,7 @@ object Joiner extends Controller with ActivityTracking
       )
 
       val providedPromoCode = promoCode orElse codeFromSession
-      val promotion = promoCode.flatMap(promoService.findPromotion)
+      val promotion = providedPromoCode.flatMap(promoService.findPromotion)
 
       Ok(views.html.joiner.form.payment(
          plans = plans,

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -6,7 +6,6 @@ import com.github.nscala_time.time.Imports._
 import com.gu.i18n.CountryGroup.UK
 import com.gu.i18n.{CountryGroup, GBP}
 import com.gu.memsub.promo.PromoCode
-import com.gu.memsub.{Membership, ProductFamily}
 import com.gu.salesforce._
 import com.gu.stripe.Stripe
 import com.gu.stripe.Stripe.Serializer._
@@ -21,9 +20,10 @@ import play.api.i18n.Messages.Implicits._
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json.Json
 import play.api.mvc._
+import services.PromoSessionService.codeFromSession
 import services.{GuardianContentService, _}
 import tracking.ActivityTracking
-import utils.{TestUsers, CampaignCode, TierChangeCookies}
+import utils.{CampaignCode, TierChangeCookies}
 import views.support
 import views.support.Pricing._
 import views.support.TierPlans._
@@ -32,7 +32,6 @@ import views.support.{CheckoutForm, CountryWithCurrency, PageInfo}
 import scala.concurrent.Future
 import scalaz.OptionT
 import scalaz.std.scalaFuture._
-import PromoSessionService.codeFromSession
 
 object Joiner extends Controller with ActivityTracking
                                  with LazyLogging
@@ -97,7 +96,7 @@ object Joiner extends Controller with ActivityTracking
 
   def NonMemberAction(tier: Tier) = AuthenticatedAction andThen onlyNonMemberFilter(onMember = redirectMemberAttemptingToSignUp(tier))
 
-  def enterPaidDetails(tier: PaidTier, countryGroup: CountryGroup, promoCode: Option[PromoCode]) = NonMemberAction(tier).async { implicit request =>
+  def enterPaidDetails(tier: PaidTier, countryGroup: CountryGroup, codeFromRequest: Option[PromoCode]) = NonMemberAction(tier).async { implicit request =>
     implicit val backendProvider: BackendProvider = request
 
     for {
@@ -110,12 +109,16 @@ object Joiner extends Controller with ActivityTracking
         initialCheckoutForm = CheckoutForm.forIdentityUser(identityUser, plans, Some(countryGroup))
       )
 
+      val promoCode = codeFromRequest orElse codeFromSession
+      val promotion = promoCode.flatMap(promoService.findPromotion)
+
       Ok(views.html.joiner.form.payment(
          plans = plans,
          countriesWithCurrencies = CountryWithCurrency.whitelisted(supportedCurrencies, GBP),
          idUser = identityUser,
          pageInfo = pageInfo,
-         promoCode = promoCode orElse codeFromSession))
+         trackingPromoCode = promotion.filter(_.whenTracking.isDefined).flatMap(p => promoCode),
+         promoCodeToDisplay = promotion.filterNot(_.whenTracking.isDefined).flatMap(p => promoCode)))
     }
   }
 

--- a/frontend/app/controllers/Promotions.scala
+++ b/frontend/app/controllers/Promotions.scala
@@ -102,6 +102,7 @@ object Promotions extends Controller {
       for {
         promotion <- promoService.findPromotion(promoCode) \/> notFound //if we can't find the promotion fail out of the for comprehension with a notFound
         _ <- failWhen(promoCodeStr.toUpperCase != promoCodeStr,redirectToUpperCase)
+        _ <- failWhen(promotion.starts.isAfterNow,notFound)
         _ <- failWhen(promotion.expires.isBeforeNow,notFound)
         html <- findTemplateForPromotion(promoCode, promotion, request.path) \/> notFound
         response <- \/.right(Ok(html).withCookies(sessionCookieFromCode(promoCode)))

--- a/frontend/app/controllers/TierController.scala
+++ b/frontend/app/controllers/TierController.scala
@@ -1,16 +1,17 @@
 package controllers
 
+import _root_.services.PromoSessionService.codeFromSession
 import actions.BackendProvider
-import com.gu.membership.{PaidMembershipPlans, MembershipCatalog}
-import com.gu.memsub.promo.PromoCode
-import services.api.MemberService.{PendingAmendError, MemberError, NoCardError}
-import services.{IdentityApi, IdentityService, PromoSessionService}
 import com.gu.i18n.CountryGroup
 import com.gu.i18n.CountryGroup._
 import com.gu.identity.play.PrivateFields
-import com.gu.memsub.Subscriber.{PaidMember, FreeMember}
-import com.gu.memsub._
-import com.gu.memsub.BillingPeriod
+import com.gu.membership.{MembershipCatalog, PaidMembershipPlans}
+import com.gu.memsub.Subscriber.{FreeMember, PaidMember}
+import com.gu.memsub.promo.PromoCode
+import controllers.Joiner._
+import services.api.MemberService.{MemberError, NoCardError, PendingAmendError}
+import services.{IdentityApi, IdentityService}
+import com.gu.memsub.{BillingPeriod, _}
 import com.gu.salesforce._
 import com.gu.stripe.Stripe
 import com.gu.stripe.Stripe.Serializer._
@@ -24,16 +25,16 @@ import play.api.libs.json.Json
 import play.api.mvc.{Controller, Result}
 import play.filters.csrf.CSRF.Token.getToken
 import tracking.ActivityTracking
-import utils.{TierChangeCookies, CampaignCode}
+import utils.{CampaignCode, TierChangeCookies}
+import views.support.Pricing._
 import views.support.{CheckoutForm, CountryWithCurrency, PageInfo, PaidToPaidUpgradeSummary}
-import scala.language.implicitConversions
-import scalaz.EitherT
+
 import scala.concurrent.Future
+import scala.language.implicitConversions
+import scalaz.{EitherT, \/}
 import scalaz.std.scalaFuture._
 import scalaz.syntax.monad._
 import scalaz.syntax.std.option._
-import scalaz.\/
-import views.support.Pricing._
 
 object TierController extends Controller with ActivityTracking
                                          with CatalogProvider
@@ -118,7 +119,7 @@ object TierController extends Controller with ActivityTracking
     } yield PaidToPaidUpgradeSummary(preview, sub, targetChoice.productRatePlanId, card)).run
   }
 
-  def upgrade(target: PaidTier, promoCode: Option[PromoCode]) = ChangeToPaidAction(target).async { implicit request =>
+  def upgrade(target: PaidTier, codeFromRequest: Option[PromoCode]) = ChangeToPaidAction(target).async { implicit request =>
     implicit val c = catalog
     implicit val r = IdentityRequest(request)
     val sub = request.subscriber.subscription
@@ -143,6 +144,9 @@ object TierController extends Controller with ActivityTracking
       PageInfo(initialCheckoutForm = formI18n, stripePublicKey = stripeKey)
     }
 
+    val promoCode = codeFromRequest orElse codeFromSession
+    val promotion = promoCode.flatMap(promoService.findPromotion)
+
     request.paidOrFreeSubscriber.fold({freeSubscriber =>
       identityUserFieldsF.map(privateFields =>
         Ok(views.html.tier.upgrade.freeToPaid(
@@ -151,7 +155,8 @@ object TierController extends Controller with ActivityTracking
           countriesWithCurrencies,
           privateFields,
           pageInfo(privateFields, BillingPeriod.year),
-          promoCode orElse PromoSessionService.codeFromSession
+          trackingPromoCode = promotion.filter(_.whenTracking.isDefined).flatMap(p => promoCode),
+          promoCodeToDisplay = promotion.filterNot(_.whenTracking.isDefined).flatMap(p => promoCode)
         )(getToken, request))
       )
     }, { paidSubscriber =>

--- a/frontend/app/forms/MemberForm.scala
+++ b/frontend/app/forms/MemberForm.scala
@@ -40,6 +40,7 @@ object MemberForm {
   trait PaidMemberForm {
     val featureChoice: Set[FeatureChoice]
     val zuoraAccountAddress : Address
+    val trackingPromoCode: Option[PromoCode]
     val promoCode: Option[PromoCode]
     val payment: PaymentForm
   }
@@ -64,6 +65,7 @@ object MemberForm {
                                 casId: Option[String],
                                 subscriberOffer: Boolean,
                                 featureChoice: Set[FeatureChoice],
+                                trackingPromoCode: Option[PromoCode],
                                 promoCode: Option[PromoCode]
                                ) extends JoinForm with PaidMemberForm {
 
@@ -76,10 +78,11 @@ object MemberForm {
   trait MemberChangeForm {
     val featureChoice: Set[FeatureChoice]
     val addressDetails: Option[AddressDetails]
+    val trackingPromoCode: Option[PromoCode]
     val promoCode: Option[PromoCode]
   }
 
-  case class PaidMemberChangeForm(password: String, featureChoice: Set[FeatureChoice], promoCode: Option[PromoCode]) extends MemberChangeForm {
+  case class PaidMemberChangeForm(password: String, featureChoice: Set[FeatureChoice], trackingPromoCode: Option[PromoCode], promoCode: Option[PromoCode]) extends MemberChangeForm {
     val addressDetails = None
   }
 
@@ -87,6 +90,7 @@ object MemberForm {
                                   deliveryAddress: Address,
                                   billingAddress: Option[Address],
                                   featureChoice: Set[FeatureChoice],
+                                  trackingPromoCode: Option[PromoCode],
                                   promoCode: Option[PromoCode]
                                   ) extends MemberChangeForm with PaidMemberForm {
     val addressDetails = Some(AddressDetails(deliveryAddress, billingAddress))
@@ -141,6 +145,7 @@ object MemberForm {
       Map(key -> value.identifier)
   }
 
+  val trackingPromoCode = of[PromoCode] as promoCodeFormatter
   val promoCode = of[PromoCode] as promoCodeFormatter
 
   val nonPaidAddressMapping: Mapping[Address] = mapping(
@@ -215,6 +220,7 @@ object MemberForm {
       "casId" -> optional(nonEmptyText),
       "subscriberOffer" -> default(boolean, false),
       "featureChoice" -> productFeature,
+      "trackingPromoCode" -> optional(trackingPromoCode),
       "promoCode" -> optional(promoCode)
     )(PaidMemberJoinForm.apply)(PaidMemberJoinForm.unapply)
   )
@@ -225,6 +231,7 @@ object MemberForm {
       "deliveryAddress" -> paidAddressMapping,
       "billingAddress" -> optional(paidAddressMapping),
       "featureChoice" -> productFeature,
+      "trackingPromoCode" -> optional(trackingPromoCode),
       "promoCode" -> optional(promoCode)
   )(FreeMemberChangeForm.apply)(FreeMemberChangeForm.unapply)
   )
@@ -233,6 +240,7 @@ object MemberForm {
     mapping(
       "password" -> nonEmptyText,
       "featureChoice" -> productFeature,
+      "trackingPromoCode" -> optional(trackingPromoCode),
       "promoCode" -> optional(promoCode)
     )(PaidMemberChangeForm.apply)(PaidMemberChangeForm.unapply)
   )

--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -412,7 +412,7 @@ class MemberService(identityService: IdentityService,
               name = nameData)
     }
 
-    subscribe.map(promoService.applyPromotion(_, joinData.promoCode, joinData.zuoraAccountAddress.country.some))
+    subscribe.map(promoService.applyPromotion(_, joinData.promoCode.orElse(joinData.trackingPromoCode), joinData.zuoraAccountAddress.country.some))
              .flatMap(zuoraService.createSubscription)
   }
 
@@ -475,7 +475,7 @@ class MemberService(identityService: IdentityService,
 
     (for {
       s <- EitherT(subOrPendingAmendError(sub))
-      command <- EitherT(amend(sub, contact, planChoice, form.featureChoice, form.promoCode).map(\/.right))
+      command <- EitherT(amend(sub, contact, planChoice, form.featureChoice, form.promoCode.orElse(form.trackingPromoCode)).map(\/.right))
       _ <- salesforceService.updateMemberStatus(IdMinimalUser(contact.identityId, None), newPlan.tier, customerOpt).liftM
       _ <- zuoraService.upgradeSubscription(command).liftM
     } yield {

--- a/frontend/app/services/TouchpointBackend.scala
+++ b/frontend/app/services/TouchpointBackend.scala
@@ -20,7 +20,7 @@ import model.FeatureChoice
 import monitoring.TouchpointBackendMetrics
 import tracking._
 import utils.TestUsers.isTestUser
-import configuration.Config.{demoPromo, discountPromo}
+import configuration.Config.{demoPromo, discountPromo, trackingPromo}
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
 object TouchpointBackend {
@@ -59,7 +59,7 @@ object TouchpointBackend {
     val catalogService = CatalogService(zuoraRestClient, memRatePlanIds, digipackRatePlanIds, backendType.name)
     val discounter = new Discounter(Config.discountRatePlanIds(backend.zuoraEnvName))
 
-    val promoService = new PromoService(Seq(demoPromo(backend.zuoraEnvName)) ++ discountPromo(backend.zuoraEnvName),
+    val promoService = new PromoService(Seq(demoPromo(backend.zuoraEnvName)) ++ discountPromo(backend.zuoraEnvName) ++ trackingPromo(backend.zuoraEnvName),
                                         catalogService.membershipCatalog, discounter)
 
     val zuoraService = new ZuoraServiceImpl(zuoraSoapClient, zuoraRestClient, memRatePlanIds)

--- a/frontend/app/views/fragments/form/promoCode.scala.html
+++ b/frontend/app/views/fragments/form/promoCode.scala.html
@@ -1,6 +1,6 @@
 @import com.gu.memsub.promo.PromoCode
 
-@(promoCode: Option[PromoCode])
+@(trackingPromoCode: Option[PromoCode], promoCodeToDisplay: Option[PromoCode])
 
 <fieldset class="fieldset">
     <div class="fieldset__heading">
@@ -10,7 +10,8 @@
     <div class="fieldset__fields">
         <div class="form-field">
             <div class="promo-code">
-                <input id="promo-code" name="promoCode" value="@promoCode.map(_.get).getOrElse("")" class="input-text js-input promo-code__field"/>
+                <input id="promo-code-hidden" type="hidden" name="trackingPromoCode" value="@trackingPromoCode.map(_.get).getOrElse("")"/>
+                <input id="promo-code" name="promoCode" value="@promoCodeToDisplay.map(_.get).getOrElse("")" type="text" class="input-text js-input promo-code__field"/>
                 <button type="button" class="promo-code__apply action js-promo-code-validate">Apply</button>
             </div>
             <div class="js-promo-feedback-container"></div>

--- a/frontend/app/views/joiner/form/payment.scala.html
+++ b/frontend/app/views/joiner/form/payment.scala.html
@@ -13,7 +13,8 @@
   countriesWithCurrencies: List[CountryWithCurrency],
   idUser: IdentityUser,
   pageInfo: PageInfo,
-  promoCode: Option[PromoCode]
+  trackingPromoCode: Option[PromoCode],
+  promoCodeToDisplay: Option[PromoCode]
 )(implicit token: play.filters.csrf.CSRF.Token, request: actions.AuthRequest[_])
 
 @main(plans.tier.cta, pageInfo=pageInfo) {
@@ -73,7 +74,7 @@
 
                     <div class="form-group">
                         <h2 class="form-group__title">Promotion</h2>
-                        @fragments.form.promoCode(promoCode)
+                        @fragments.form.promoCode(trackingPromoCode, promoCodeToDisplay)
                     </div>
 
                     <div class="form-group">

--- a/frontend/app/views/tier/upgrade/freeToPaid.scala.html
+++ b/frontend/app/views/tier/upgrade/freeToPaid.scala.html
@@ -18,7 +18,8 @@
   countriesWithCurrency: List[CountryWithCurrency],
   userFields: com.gu.identity.play.PrivateFields,
   pageInfo: PageInfo,
-  promoCode: Option[PromoCode]
+  trackingPromoCode: Option[PromoCode],
+  promoCodeToDisplay: Option[PromoCode]
 )(implicit token: csrf.CSRF.Token, request: RequestHeader)
 
 @import views.html.helper._
@@ -71,7 +72,7 @@
 
                   <div class="form-group">
                       <h2 class="form-group__title">Promotion</h2>
-                      @fragments.form.promoCode(promoCode)
+                      @fragments.form.promoCode(trackingPromoCode, promoCodeToDisplay)
                   </div>
 
                   <div class="form-group">

--- a/frontend/test/services/IdentityServiceTest.scala
+++ b/frontend/test/services/IdentityServiceTest.scala
@@ -64,6 +64,7 @@ class IdentityServiceTest extends Specification with Mockito {
         None,
         subscriberOffer = false,
         Set.empty,
+        None,
         None
       )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,8 +9,8 @@ object Dependencies {
   val sentryRavenLogback = "net.kencochrane.raven" % "raven-logback" % "6.0.0"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.6"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.184"
-  val contentAPI = "com.gu" %% "content-api-client" % "8.5"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.187"
+  val contentAPI = "com.gu" %% "content-api-client" % "6.4"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache
   val awsSimpleEmail = "com.amazonaws" % "aws-java-sdk-ses" % awsClientVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.6"
   val membershipCommon = "com.gu" %% "membership-common" % "0.187"
-  val contentAPI = "com.gu" %% "content-api-client" % "6.4"
+  val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache
   val awsSimpleEmail = "com.amazonaws" % "aws-java-sdk-ses" % awsClientVersion


### PR DESCRIPTION
- Visiting https://membership.theguardian.com/p/TRACK01 will redirect to the homepage (setting an INTCMP query string to track in GA/Omniture) and TRACK01 will be stored in the session.
- When the user arrives on the checkout or upgrade form the hidden trackingPromoCode field will be filled with the session value.
- The main promo code field will remain blank and can be used as normal - any valid promo code added in that field overrides the trackingPromoCode when the subscription is made.

https://trello.com/c/3sMxyCLI/485-tracking-codes-for-membership

cc @tomverran 