### PR TITLE
Update content-api-client to v8.5

### DIFF
--- a/frontend/app/controllers/Info.scala
+++ b/frontend/app/controllers/Info.scala
@@ -228,7 +228,7 @@ trait Info extends Controller {
 
     val results =
       GuardianContentService.offersAndCompetitionsContent.map(ContentItemOffer).filter(item =>
-        item.content.fields.map(_("membershipAccess")).isEmpty && ! item.content.webTitle.startsWith("EXPIRED") && item.imgOpt.nonEmpty)
+        item.content.fields.flatMap(_.membershipAccess).isEmpty && ! item.content.webTitle.startsWith("EXPIRED") && item.imgOpt.nonEmpty)
 
     Ok(views.html.info.offersAndCompetitions(TouchpointBackend.Normal.catalog, results))
   }

--- a/frontend/app/model/ResponsiveImage.scala
+++ b/frontend/app/model/ResponsiveImage.scala
@@ -1,6 +1,6 @@
 package model
 
-import com.gu.contentapi.client.model.{Element, Content}
+import com.gu.contentapi.client.model.v1.{Element, Content}
 import views.support.Asset
 import model.RichEvent.GridImage
 
@@ -27,12 +27,13 @@ object ResponsiveImageGroup {
     elements <- content.elements
     element <- elements.find(hasConsistentAspectRatio)
   } yield ResponsiveImageGroup(
-    altText = element.assets.headOption.flatMap(_.typeData.get("altText")),
+    altText = element.assets.headOption.flatMap(_.typeData.flatMap(_.altText)),
     metadata = None,
     availableImages = for {
       asset <- element.assets
-      file <- asset.typeData.get("secureFile")
-      width <- asset.typeData.get("width")
+      typeData <- asset.typeData
+      file <- typeData.secureFile
+      width <- typeData.width
     } yield ResponsiveImage(file, width.toInt)
   )
 

--- a/frontend/app/model/RichContent.scala
+++ b/frontend/app/model/RichContent.scala
@@ -1,6 +1,6 @@
 package model
 
-import com.gu.contentapi.client.model.Content
+import com.gu.contentapi.client.model.v1.Content
 
 abstract class RichContent(content: Content) {
   val imgOpt = ResponsiveImageGroup.fromContent(content)

--- a/frontend/app/model/RichEvent.scala
+++ b/frontend/app/model/RichEvent.scala
@@ -1,7 +1,7 @@
 package model
 
 import com.github.nscala_time.time.Imports._
-import com.gu.contentapi.client.model.Content
+import com.gu.contentapi.client.model.v1.Content
 import com.gu.salesforce.Tier
 import configuration.Links
 import controllers.routes

--- a/frontend/app/services/MasterclassDataExtractor.scala
+++ b/frontend/app/services/MasterclassDataExtractor.scala
@@ -1,6 +1,6 @@
 package services
 
-import com.gu.contentapi.client.model.{Asset, Content}
+import com.gu.contentapi.client.model.v1.{Asset, Content}
 import model.ResponsiveImageGroup
 
 import scala.util.matching.Regex
@@ -23,7 +23,7 @@ object MasterclassDataExtractor {
   }
 
   def scrapeEventbriteIdsFrom(content: Content): Seq[String] = for {
-    body <- content.fields.map(_("body")).toSeq
+    body <- content.fields.flatMap(_.body).toSeq
     eventId <- regex.findAllIn(body).map(_.split("-").last)
   } yield eventId
 }

--- a/frontend/app/views/fragments/content/articleSnapshot.scala.html
+++ b/frontend/app/views/fragments/content/articleSnapshot.scala.html
@@ -8,8 +8,8 @@
     }
     <div class="article-snapshot__content">
         <h2 class="article-snapshot__title no-underline--override">@item.content.webTitle</h2>
-        @for(fields <- item.content.fields) {
-            <p class="article-snapshot__trail hidden-mobile">@Html(fields("trailText"))</p>
+        @for(fields <- item.content.fields; trailtext <- fields.trailText) {
+            <p class="article-snapshot__trail hidden-mobile">@Html(trailtext)</p>
         }
     </div>
 </a>

--- a/frontend/test/resources/model/content.api/item.json
+++ b/frontend/test/resources/model/content.api/item.json
@@ -3,6 +3,7 @@
     "userTier": "internal",
     "total": 1,
     "content": {
+        "type": "article",
         "elements": [
             {
                 "id": "f0ed86f9d4c4e82d8e1fc8989b9e1dd37aaf8329",

--- a/frontend/test/services/DestinationServiceTest.scala
+++ b/frontend/test/services/DestinationServiceTest.scala
@@ -87,7 +87,7 @@ class DestinationServiceTest extends PlaySpecification with Mockito with ScalaFu
         val request = createRequestWithSession("join-referrer" -> "http://www.theguardian.com/membership/2015/apr/17/guardian-live-diversity-in-the-arts")
 
         //mock the Content API response
-        val item = JsonParser.parseItem(Resource.get("model/content.api/item.json"))
+        val item = JsonParser.parseItemThrift(Resource.get("model/content.api/item.json"))
         destinationService.contentApiService.contentItemQuery("/membership/2015/apr/17/guardian-live-diversity-in-the-arts") returns Future.successful(item)
 
         //call the method under test
@@ -127,7 +127,7 @@ class DestinationServiceTest extends PlaySpecification with Mockito with ScalaFu
         val request = createRequestWithSession("join-referrer" -> "http://www.theguardian.com/membership/2015/apr/17/guardian-live-diversity-in-the-arts", "preJoinReturnUrl" -> "/event/0123456/buy")
 
         //mock the Content API response
-        val item = JsonParser.parseItem(Resource.get("model/content.api/item.json"))
+        val item = JsonParser.parseItemThrift(Resource.get("model/content.api/item.json"))
         destinationService.contentApiService.contentItemQuery("/membership/2015/apr/17/guardian-live-diversity-in-the-arts") returns Future.successful(item)
 
         //mock the Eventbrite response and discount creation

--- a/frontend/test/services/MasterclassDataExtractorTest.scala
+++ b/frontend/test/services/MasterclassDataExtractorTest.scala
@@ -1,6 +1,6 @@
 package services
 
-import com.gu.contentapi.client.model.{Reference, Asset, Element, Content}
+import com.gu.contentapi.client.model.v1._
 import org.specs2.mutable.Specification
 import services.MasterclassDataExtractor.extractEventbriteInformation
 
@@ -10,25 +10,22 @@ class MasterclassDataExtractorTest extends Specification {
     "<p><br /><strong>If you're using a mobile device, <a href=\"https://www.eventbrite.co.uk/e/the-essentials-of-creativity-in-business-tickets-13906168725?ref=etck\">" +
     "click here to book</a></strong></p><h2>Details</h2><p><strong>Date:</strong> Tuesday 25 November 2014<br /><strong>Times:</strong> " +
     "6.30pm-9.30pm. Check-in begins 30 minutes before the start time.<br />"
-  val fields = Map("body" -> body)
+  val fields = ContentFields(body = Some(body))
+  val asset1 = Asset(AssetType.Image, Some("image/jpeg"), Some("main-image-file-location-1"), Some(AssetFields(width = Some(460), height = Some(276))))
+  val asset2 = Asset(AssetType.Image, Some("image/jpeg"), Some("main-image-file-location-2"), Some(AssetFields(width = Some(300), height = Some(300))))
+  val asset3 = Asset(AssetType.Image, Some("image/jpeg"), Some("body-image-file-location-3"), Some(AssetFields(width = Some(460), height = Some(271))))
 
-  val asset1 = new Asset("image", Some("image/jpeg"), Some("main-image-file-location-1"), Map("width" -> "460", "height" -> "276"))
-  val asset2 = new Asset("image", Some("image/jpeg"), Some("main-image-file-location-2"), Map("width" -> "300", "height" -> "300"))
-  val asset3 = new Asset("image", Some("image/jpeg"), Some("body-image-file-location-3"), Map("width" -> "460", "height" -> "271"))
+  val mainElement = Element("gu-image-243234", "main", ElementType.Image, None, List(asset1, asset2))
+  val thumbnailElement = Element("gu-image-233", "thumbnail", ElementType.Image, None, List(asset3))
 
-  val mainElement = new Element("gu-image-243234", "main", "image", None, List(asset1, asset2))
-  val thumbnailElement = new Element("gu-image-233", "thumbnail", "image", None, List(asset3))
-
-  val item = new Content(
+  val item = Content(
    "guardian-masterclasses/a-writing-course",
-   None, None, None,
-   "a writing course title", "writing-gu-url", "writing-api-url",
-    Some(fields),
-    Nil,
-    Some(List(mainElement, thumbnailElement)),
-    Nil, None)
+   webTitle="a writing course title", webUrl="writing-gu-url", apiUrl="writing-api-url",
+    fields = Some(fields),
+    elements = Some(List(mainElement, thumbnailElement))
+  )
 
-  val itemWithoutBody = item.copy(fields = Some(Map("body" -> "no eventrbite url")))
+  val itemWithoutBody = item.copy(fields = Some(ContentFields(body = Some("no eventrbite url"))))
 
   "MasterclassDataExtractor" should {
 
@@ -43,7 +40,7 @@ class MasterclassDataExtractorTest extends Specification {
     "create multiple masterclass content for multiple eventbrite urls" in {
       val eventbriteUrlsInBody = body + "some more text about the article <a href=\"http://www.eventbrite.co.uk/e/the-essentials-of-creativity-in-business-tickets-1234\"> more" +
         "great things about the course"
-      val newItem = item.copy(fields = Some(Map("body" -> eventbriteUrlsInBody)))
+      val newItem = item.copy(fields = Some(ContentFields(body = Some(eventbriteUrlsInBody))))
 
       val masterclassesContent = extractEventbriteInformation(newItem)
       masterclassesContent.size mustEqual(2)
@@ -53,10 +50,10 @@ class MasterclassDataExtractorTest extends Specification {
     }
 
     "create masterclass content if there is an eventbrite external reference" in {
-      val itemWithExternalRef = itemWithoutBody.copy(references = List(
-        Reference("eventbrite","eventbrite/111"),
-        Reference("sausages","eventbrite/222"),
-        Reference("eventbrite","eventbrite/333")
+      val itemWithExternalRef = itemWithoutBody.copy(references = Seq(
+        Reference(`type` = "eventbrite",id = "eventbrite/111"),
+        Reference(`type` = "sausages",id = "eventbrite/222"),
+        Reference(`type` = "eventbrite",id = "eventbrite/333")
       ))
 
       val masterclassesContent = extractEventbriteInformation(itemWithExternalRef)
@@ -64,7 +61,7 @@ class MasterclassDataExtractorTest extends Specification {
     }
 
     "create masterclass content including the eventbrite external reference plus what gets scraped" in {
-      val itemWithExternalRefAndEBUrlInBody = item.copy(references = List(Reference("eventbrite","eventbrite/111")))
+      val itemWithExternalRefAndEBUrlInBody = item.copy(references = List(Reference(`type` = "eventbrite",id = "eventbrite/111")))
 
       val masterclassesContent = extractEventbriteInformation(itemWithExternalRefAndEBUrlInBody)
       masterclassesContent.map(_.eventId) must contain(exactly("111","13906168725"))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.6"
   val membershipCommon = "com.gu" %% "membership-common" % "0.184"
-  val contentAPI = "com.gu" %% "content-api-client" % "6.4"
+  val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache
   val awsSimpleEmail = "com.amazonaws" % "aws-java-sdk-ses" % awsClientVersion


### PR DESCRIPTION
This was kind of prompted by noting that [when Frontend upgraded their content-api-dependency, it broke a small bit of Member's Area functionality](https://github.com/guardian/frontend/pull/11466#commitcomment-17085986).

When a non-member tries to access a piece of Member content, the redirect is sending them to:

https://membership.theguardian.com/choose-tier?membershipAccess=MembersOnly

rather than:

https://membership.theguardian.com/choose-tier?membershipAccess=members-only

...because "MembersOnly" is the `name` value of `com.gu.contentapi.client.model.v1.MembershipTier.MembersOnly` (note that this class is generated from [the master Thrift file](https://github.com/guardian/content-api-models/blob/caaa8ce0a/src/main/thrift/content/v1.thrift#L177))

I could have just changed [the strings that we match on](https://github.com/guardian/membership-frontend/blob/9b031888/frontend/app/model/MembershipAccess.scala#L4-L5), but I thought _maybe_ it would be better to use the content-API values.

cc @tomverran 