### PR TITLE
Fix display of members-content signup message

### DIFF
--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -3,6 +3,7 @@ package controllers
 import actions.ActionRefiners._
 import actions.{RichAuthRequest, _}
 import com.github.nscala_time.time.Imports._
+import com.gu.contentapi.client.model.v1.{MembershipTier=>ContentAccess}
 import com.gu.i18n.CountryGroup.UK
 import com.gu.i18n.{CountryGroup, GBP}
 import com.gu.memsub.promo.PromoCode
@@ -55,7 +56,7 @@ object Joiner extends Controller with ActivityTracking
 
   def tierChooser = NoCacheAction { implicit request =>
     val eventOpt = PreMembershipJoiningEventFromSessionExtractor.eventIdFrom(request).flatMap(EventbriteService.getBookableEvent)
-    val accessOpt = request.getQueryString("membershipAccess").map(MembershipAccess)
+    val accessOpt = request.getQueryString("membershipAccess").flatMap(ContentAccess.valueOf)
     val contentRefererOpt = request.headers.get(REFERER)
 
     val signInUrl = contentRefererOpt.map { referer =>

--- a/frontend/app/model/MembershipAccess.scala
+++ b/frontend/app/model/MembershipAccess.scala
@@ -1,6 +1,0 @@
-package model
-
-case class MembershipAccess(accessType: String) {
-  val isMembersOnly = accessType.equals("members-only")
-  val isPaidMembersOnly = accessType.equals("paid-members-only")
-}

--- a/frontend/app/views/joiner/tierChooser.scala.html
+++ b/frontend/app/views/joiner/tierChooser.scala.html
@@ -4,10 +4,11 @@
 
 @import views.support.PageInfo
 @import views.support.TierPlans._
+@import com.gu.contentapi.client.model.v1.{MembershipTier=>ContentAccess}
 @(catalog: MembershipCatalog,
   pageInfo: PageInfo,
   eventOpt: Option[model.RichEvent.RichEvent],
-  accessOpt: Option[model.MembershipAccess],
+  accessOpt: Option[ContentAccess],
   signInUrl: String
 )(implicit token: play.filters.csrf.CSRF.Token, countryGroup: CountryGroup)
 
@@ -21,8 +22,8 @@
 @sectionTitle = @{
     val defaultTitle = "Choose a membership tier to continue"
     accessOpt.map {
-        case i if i.isMembersOnly => "You need to be a Guardian member to view this page"
-        case i if i.isPaidMembersOnly => "You need to be a Partner or a Patron to view this page"
+        case ContentAccess.MembersOnly => "You need to be a Guardian member to view this page"
+        case ContentAccess.PaidMembersOnly => "You need to be a Partner or a Patron to view this page"
         case _ => defaultTitle
     }.getOrElse(eventOpt.fold(defaultTitle)(_.metadata.chooseTier.sectionTitle))
 }


### PR DESCRIPTION
We want to let users know why they're seeing a 'Join Membership' page when they click on members-only content, like this:

![image](https://cloud.githubusercontent.com/assets/52038/14526561/f6de32aa-023b-11e6-85d0-88e8f9109c2c.png)

This got broke a little while ago: https://github.com/guardian/frontend/pull/11466#commitcomment-17085986 ...and this new commit Membership-Frontend to read the new value that dotcom-Frontend is sending us, ie:

https://membership.theguardian.com/choose-tier?membershipAccess=MembersOnly


Sidenote: I feel that the `MembershipTier` class is rather misleadingly named for us (because it doesn't actually supply the Membership tier, which would be 'Partner', 'Friend', etc - instead it supplies`MembersOnly` / `PaidMembersOnly`, so I've used an import rename of `MembershipTier=>ContentAccess` to make it's purpose clearer in our codebase.

This PR follows on from https://github.com/guardian/membership-frontend/pull/1135

cc @tomverran 