### PR TITLE
Redirect non UK friends to the supporter landing page for tier change

### DIFF
--- a/frontend/app/controllers/Info.scala
+++ b/frontend/app/controllers/Info.scala
@@ -12,14 +12,11 @@ import views.support.{Asset, PageInfo}
 import com.netaporter.uri.dsl._
 import com.netaporter.uri.Uri
 import scala.concurrent.Future
+import utils.RequestCountry._
 
 trait Info extends Controller {
   def supporterRedirect = NoCacheAction { implicit request =>
-    val countryGroup =
-      request.headers
-        .get("X-GU-GeoIP-Country-Code")
-        .flatMap(CountryGroup.byFastlyCountryCode)
-        .getOrElse(CountryGroup.RestOfTheWorld)
+    val countryGroup = request.getFastlyCountry.getOrElse(CountryGroup.RestOfTheWorld)
 
     val baseUrl: Uri = redirectToSupporterPage(countryGroup).absoluteURL
     val paramsToPropagate = Seq("INTCMP", "CMP")

--- a/frontend/app/utils/RequestCountry.scala
+++ b/frontend/app/utils/RequestCountry.scala
@@ -1,0 +1,26 @@
+package utils
+
+import actions._
+import com.gu.i18n.CountryGroup
+import controllers.IdentityRequest
+import play.api.mvc.Request
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+
+object RequestCountry {
+  implicit class RequestWithFastlyCountry(r: Request[_]) {
+    def getFastlyCountry = r.headers.get("X-GU-GeoIP-Country-Code").flatMap(CountryGroup.byFastlyCountryCode)
+  }
+  implicit class AuthenticatedRequestWithIdentity(r:AuthRequest[_])
+  {
+    def getIdentityCountryGroup = {
+      implicit val identityRequest = IdentityRequest(r)
+      r.touchpointBackend.identityService
+        .getFullUserDetails(r.user)
+        .map(
+          _.privateFields
+            .flatMap(_.country)
+            .flatMap(CountryGroup.byCountryNameOrCode)
+        )
+    }
+  }
+}


### PR DESCRIPTION
Redirect non UK friends to the the supporter page when they try and change tier- as there's no partner/patron tier for them to upgrade to. 