### PR TITLE
Fix inconsistencies between different giraffe pages

### DIFF
--- a/frontend/app/views/giraffe/contribute.scala.html
+++ b/frontend/app/views/giraffe/contribute.scala.html
@@ -60,7 +60,7 @@
             <div class="form__column">
                 <h3 class="form__column-heading headline-text--bolder"><span class="num">2</span> Your amount</h3>
                 <ul class="u-unstyled">
-                    <li id="currency_field" class="form-field">
+                    <li id="currency_field" class="form-field" hidden>
                         <label for="currency" class="label u-h">Currency</label>
                         <div class="input">
                             <div class="js-button-group button-group u-cf">

--- a/frontend/app/views/giraffe/contributeAustralia.scala.html
+++ b/frontend/app/views/giraffe/contributeAustralia.scala.html
@@ -62,11 +62,11 @@
                     <li id="currency_field" class="form-field" hidden>
                         <label for="currency" class="label u-h">Currency</label>
                         <div class="input">
-                            <div class="button-group u-cf">
-                                <button type="button" tabindex="4" class="js-currency-switcher option-button" data-currency="gbp" data-symbol="&pound;">&pound;&nbsp;GBP</button>
-                                <button type="button" tabindex="5" class="js-currency-switcher option-button" data-currency="usd" data-symbol="&#36;">&#36;&nbsp;USD</button>
-                                <button type="button" tabindex="6" class="js-currency-switcher option-button active" data-currency="aud" data-symbol="&#36;">&#36;&nbsp;AUD</button>
-                                <button type="button" tabindex="7" class="js-currency-switcher option-button" data-currency="eur" data-symbol="&euro;">&euro;&nbsp;EUR</button>
+                            <div class="js-button-group button-group u-cf">
+                                <button type="button" tabindex="4" class="js-button js-currency-switcher option-button" data-currency="gbp" data-symbol="&pound;">&pound;&nbsp;GBP</button>
+                                <button type="button" tabindex="5" class="js-button js-currency-switcher option-button" data-currency="usd" data-symbol="&#36;">&#36;&nbsp;USD</button>
+                                <button type="button" tabindex="6" class="js-button js-currency-switcher option-button active" data-currency="aud" data-symbol="&#36;">&#36;&nbsp;AUD</button>
+                                <button type="button" tabindex="7" class="js-button js-currency-switcher option-button" data-currency="eur" data-symbol="&euro;">&euro;&nbsp;EUR</button>
                             </div>
                             <input type="hidden" id="currency" name="currency" class="js-currency-field" value="aud">
                         </div>
@@ -75,17 +75,17 @@
                     <li id="amount_field" class="form-field">
                         <label for="amount" class="label u-h">Amount</label>
                         <div class="input">
-                            <div class="button-group u-cf">
-                                <button type="button" tabindex="8" class="option-button option-button--bold active" data-amount="5">
+                            <div class="js-button-group button-group u-cf">
+                                <button type="button" tabindex="8" class="js-button option-button option-button--bold active" data-amount="5">
                                     <span class="currency js-currency">&#36;</span>5
                                 </button>
-                                <button type="button" tabindex="9" class="option-button option-button--bold" data-amount="20">
+                                <button type="button" tabindex="9" class="js-button option-button option-button--bold" data-amount="20">
                                     <span class="currency js-currency">&#36;</span>20
                                 </button>
-                                <button type="button" tabindex="10" class="option-button option-button--bold" data-amount="50">
+                                <button type="button" tabindex="10" class="js-button option-button option-button--bold" data-amount="50">
                                     <span class="currency js-currency">&#36;</span>50
                                 </button>
-                                <button type="button" tabindex="11" class="option-button option-button--bold" data-amount="100">
+                                <button type="button" tabindex="11" class="js-button option-button option-button--bold" data-amount="100">
                                     <span class="currency js-currency">&#36;</span>100
                                 </button>
                             </div>

--- a/frontend/app/views/giraffe/contributeUSA.scala.html
+++ b/frontend/app/views/giraffe/contributeUSA.scala.html
@@ -63,11 +63,11 @@
                     <li id="currency_field" class="form-field" hidden>
                         <label for="currency" class="label u-h">Currency</label>
                         <div class="input">
-                            <div class="button-group u-cf">
-                                <button type="button" tabindex="4" class="js-currency-switcher option-button" data-currency="gbp" data-symbol="&pound;">&pound;&nbsp;GBP</button>
-                                <button type="button" tabindex="5" class="js-currency-switcher option-button active" data-currency="usd" data-symbol="&#36;">&#36;&nbsp;USD</button>
-                                <button type="button" tabindex="6" class="js-currency-switcher option-button" data-currency="aud" data-symbol="&#36;">&#36;&nbsp;CAD</button>
-                                <button type="button" tabindex="7" class="js-currency-switcher option-button" data-currency="eur" data-symbol="&euro;">&euro;&nbsp;EUR</button>
+                            <div class="js-button-group button-group u-cf">
+                                <button type="button" tabindex="4" class="js-button js-currency-switcher option-button" data-currency="gbp" data-symbol="&pound;">&pound;&nbsp;GBP</button>
+                                <button type="button" tabindex="5" class="js-button js-currency-switcher option-button active" data-currency="usd" data-symbol="&#36;">&#36;&nbsp;USD</button>
+                                <button type="button" tabindex="6" class="js-button js-currency-switcher option-button" data-currency="aud" data-symbol="&#36;">&#36;&nbsp;CAD</button>
+                                <button type="button" tabindex="7" class="js-button js-currency-switcher option-button" data-currency="eur" data-symbol="&euro;">&euro;&nbsp;EUR</button>
                             </div>
                             <input type="hidden" id="currency" name="currency" class="js-currency-field" value="usd">
                         </div>
@@ -76,17 +76,17 @@
                     <li id="amount_field" class="form-field">
                         <label for="amount" class="label u-h">Amount</label>
                         <div class="input">
-                            <div class="button-group u-cf">
-                                <button type="button" tabindex="8" class="option-button option-button--bold active" data-amount="5">
+                            <div class="js-button-group button-group u-cf">
+                                <button type="button" tabindex="8" class="js-button option-button option-button--bold active" data-amount="5">
                                     <span class="currency js-currency">&#36;</span>5
                                 </button>
-                                <button type="button" tabindex="9" class="option-button option-button--bold" data-amount="20">
+                                <button type="button" tabindex="9" class="js-button option-button option-button--bold" data-amount="20">
                                     <span class="currency js-currency">&#36;</span>20
                                 </button>
-                                <button type="button" tabindex="10" class="option-button option-button--bold" data-amount="50">
+                                <button type="button" tabindex="10" class="js-button option-button option-button--bold" data-amount="50">
                                     <span class="currency js-currency">&#36;</span>50
                                 </button>
-                                <button type="button" tabindex="11" class="option-button option-button--bold" data-amount="100">
+                                <button type="button" tabindex="11" class="js-button option-button option-button--bold" data-amount="100">
                                     <span class="currency js-currency">&#36;</span>100
                                 </button>
                             </div>


### PR DESCRIPTION
In #1137 I removed the `hidden` attribute from the currency selector on the UK page by mistake. It should still be hidden.

I also added some classes to the buttons & button parents which are now necessary for "option button" functionality (a group of buttons which function like radio buttons). I only added these to the UK page - we need them for other countries too.

@AWare 