### PR TITLE
Add sbt-assembly to run as a CI task to identify classpath clashes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ before_cache:
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" -type f -delete -print
 before_install:
   - export TZ=Europe/London
-script: sbt ++$TRAVIS_SCALA_VERSION test
+script: sbt ++$TRAVIS_SCALA_VERSION assembly

--- a/project/Membership.scala
+++ b/project/Membership.scala
@@ -4,6 +4,8 @@ import play.sbt.PlayScala
 import sbt.Keys._
 import sbt._
 import sbtbuildinfo.Plugin._
+import sbtassembly._
+import sbtassembly.AssemblyKeys._
 
 trait Membership {
 
@@ -37,6 +39,13 @@ trait Membership {
     publishArtifact in (Compile, packageDoc) := false,
     parallelExecution in Global := false,
     updateOptions := updateOptions.value.withCachedResolution(true),
+    assemblyMergeStrategy in assembly := { // We only use sbt-assembly as a canary to tell us about clashes - we DON'T use the generated uber-jar, instead the native-packaged zip
+      case x if x.startsWith("com/google/gdata/util/common/base/") => MergeStrategy.first // https://github.com/playframework/playframework/issues/3365#issuecomment-198399016
+      case "version.txt"                                           => MergeStrategy.discard // identity jars all include version.txt
+      case x =>
+        val oldStrategy = (assemblyMergeStrategy in assembly).value
+        oldStrategy(x)
+    },
     javaOptions in Test += "-Dconfig.file=test/acceptance/conf/acceptance-test.conf",
     testOptions in Test += Tests.Argument("-oD") // display execution times in Scalatest output
   ) ++ buildInfoPlugin
@@ -60,6 +69,10 @@ trait Membership {
 object Membership extends Build with Membership {
   val frontend = app("frontend")
                 .settings(libraryDependencies ++= frontendDependencies)
+                .settings(libraryDependencies ~= { _ map {
+                  _.exclude("commons-logging", "commons-logging") // our dependencies include jcl-over-slf4j http://www.slf4j.org/legacy.html#jcl-over-slf4j
+                    .exclude("org.slf4j", "slf4j-simple") // snatches SLF4J logging from Logback, our chosen logging system
+                }})
                 .settings(addCommandAlias("devrun", "run -Dconfig.resource=dev.conf 9100"): _*)
                 .settings(libraryDependencies ++= acceptanceTestDependencies)
                 .settings(addCommandAlias("fast-test", "testOnly -- -l Acceptance"))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,3 +6,5 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.6")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.3.2")
+
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.2")


### PR DESCRIPTION
This is related to the various issues we've had recently that have been due to classpath conflicts - several of these issues (eg https://github.com/guardian/membership-frontend/pull/1008 and https://github.com/guardian/membership-frontend/pull/1047#issuecomment-198331201) could have been detected by running `sbt assembly`, which fails the build if there are classpath conflicts. It does make build time a little longer, and I'd like to stress that we_don't deploy_ the resulting uber-jar - the deployable is still the `native-packager` zip of library jars, we just build the uber-jar with `assembly` to check that we _can_ do so without clashes.

In order for `sbt assembly` to work, this change addresses all the classpath clashes that currently occur in our build - normally by excluding the unwanted ones:

https://github.com/sbt/sbt-assembly#exclude-specific-transitive-deps

There's a nasty classpath clash brought in by Play-WS, but unfortunately we can't exclude that dependency just yet... https://github.com/guardian/membership-frontend/pull/1052

Note that the sbt `assembly` task also runs `test`.

One issue that `assembly` would not have been able to detect would have been the dependency diamond problem we had recently with membership-common.

@AWare  @blackyjnz 