### PR TITLE
Tracking promo code on friend signup

### DIFF
--- a/frontend/app/forms/MemberForm.scala
+++ b/frontend/app/forms/MemberForm.scala
@@ -206,7 +206,8 @@ object MemberForm {
       "name" -> nameMapping,
       "deliveryAddress" -> nonPaidAddressMapping,
       "marketingChoices" -> marketingChoicesMapping,
-      "password" -> optional(nonEmptyText)
+      "password" -> optional(nonEmptyText),
+      "trackingPromoCode" -> optional(trackingPromoCode)
     )(StaffJoinForm.apply)(StaffJoinForm.unapply)
   )
 

--- a/frontend/app/forms/MemberForm.scala
+++ b/frontend/app/forms/MemberForm.scala
@@ -52,7 +52,8 @@ object MemberForm {
   }
 
   case class StaffJoinForm(name: NameForm, deliveryAddress: Address, marketingChoices: MarketingChoicesForm,
-                            password: Option[String], trackingPromoCode: Option[PromoCode] = None) extends JoinForm {
+                            password: Option[String]) extends JoinForm {
+    val trackingPromoCode = None
     override val planChoice: FreePlanChoice = FreePlanChoice(staff)
   }
 
@@ -206,8 +207,7 @@ object MemberForm {
       "name" -> nameMapping,
       "deliveryAddress" -> nonPaidAddressMapping,
       "marketingChoices" -> marketingChoicesMapping,
-      "password" -> optional(nonEmptyText),
-      "trackingPromoCode" -> optional(trackingPromoCode)
+      "password" -> optional(nonEmptyText)
     )(StaffJoinForm.apply)(StaffJoinForm.unapply)
   )
 

--- a/frontend/app/forms/MemberForm.scala
+++ b/frontend/app/forms/MemberForm.scala
@@ -34,6 +34,7 @@ object MemberForm {
     val deliveryAddress: Address
     val marketingChoices: MarketingChoicesForm
     val password: Option[String]
+    val trackingPromoCode: Option[PromoCode]
     val planChoice: PlanChoice
   }
 
@@ -46,12 +47,12 @@ object MemberForm {
   }
 
   case class FriendJoinForm(name: NameForm, deliveryAddress: Address, marketingChoices: MarketingChoicesForm,
-                            password: Option[String]) extends JoinForm {
+                            password: Option[String], trackingPromoCode: Option[PromoCode]) extends JoinForm {
     override val planChoice: FreePlanChoice = FreePlanChoice(friend)
   }
 
   case class StaffJoinForm(name: NameForm, deliveryAddress: Address, marketingChoices: MarketingChoicesForm,
-                            password: Option[String]) extends JoinForm {
+                            password: Option[String], trackingPromoCode: Option[PromoCode] = None) extends JoinForm {
     override val planChoice: FreePlanChoice = FreePlanChoice(staff)
   }
 
@@ -195,7 +196,8 @@ object MemberForm {
       "name" -> nameMapping,
       "deliveryAddress" -> nonPaidAddressMapping,
       "marketingChoices" -> marketingChoicesMapping,
-      "password" -> optional(nonEmptyText)
+      "password" -> optional(nonEmptyText),
+      "trackingPromoCode" -> optional(trackingPromoCode)
     )(FriendJoinForm.apply)(FriendJoinForm.unapply)
   )
 

--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -385,7 +385,8 @@ class MemberService(identityService: IdentityService,
         paymentMethod = None,
         ratePlans = NonEmptyList(RatePlan(planId.get, None)),
         name = joinData.name,
-        address = joinData.deliveryAddress
+        address = joinData.deliveryAddress,
+        promoCode = joinData.trackingPromoCode
       ))
     } yield result
   }

--- a/frontend/app/views/fragments/form/promoCode.scala.html
+++ b/frontend/app/views/fragments/form/promoCode.scala.html
@@ -3,6 +3,8 @@
 @(trackingPromoCode: Option[PromoCode], promoCodeToDisplay: Option[PromoCode])
 
 <fieldset class="fieldset">
+    @fragments.form.trackingPromoCode(trackingPromoCode)
+
     <div class="fieldset__heading">
         <h2 class="fieldset__headline">Do you have a promo code?</h2>
     </div>
@@ -10,7 +12,6 @@
     <div class="fieldset__fields">
         <div class="form-field">
             <div class="promo-code">
-                <input id="promo-code-hidden" type="hidden" name="trackingPromoCode" value="@trackingPromoCode.map(_.get).getOrElse("")"/>
                 <input id="promo-code" name="promoCode" value="@promoCodeToDisplay.map(_.get).getOrElse("")" type="text" class="input-text js-input promo-code__field"/>
                 <button type="button" class="promo-code__apply action js-promo-code-validate">Apply</button>
             </div>

--- a/frontend/app/views/fragments/form/trackingPromoCode.scala.html
+++ b/frontend/app/views/fragments/form/trackingPromoCode.scala.html
@@ -1,0 +1,4 @@
+@import com.gu.memsub.promo.PromoCode
+
+@(trackingPromoCode: Option[PromoCode])
+<input id="promo-code-hidden" type="hidden" name="trackingPromoCode" value="@trackingPromoCode.map(_.get).getOrElse("")"/>

--- a/frontend/app/views/joiner/form/friendSignup.scala.html
+++ b/frontend/app/views/joiner/form/friendSignup.scala.html
@@ -8,11 +8,13 @@
 @import views.support.IdentityUser
 @import com.gu.membership.FreeMembershipPlan
 @import com.gu.memsub.Current
+@import com.gu.memsub.promo.PromoCode
 
 @import views.support.FreePlan
 @(friendPlan: FreeMembershipPlan[Current, Friend],
   idUser: IdentityUser,
-  pageInfo: PageInfo
+  pageInfo: PageInfo,
+  trackingPromoCode: Option[PromoCode]
 )(implicit token: play.filters.csrf.CSRF.Token)
 
 @main("Become a Friend", pageInfo) {
@@ -61,6 +63,7 @@
                             county = idUser.privateFields.address4
                         )
                         @fragments.form.marketingChoices(idUser.marketingChoices.receiveGnmMarketing, idUser.marketingChoices.receive3rdPartyMarketing)
+                        @fragments.form.trackingPromoCode(trackingPromoCode)
 
                         @if(!idUser.passwordExists) {
                             @fragments.form.createPassword()

--- a/frontend/test/services/IdentityServiceTest.scala
+++ b/frontend/test/services/IdentityServiceTest.scala
@@ -39,6 +39,7 @@ class IdentityServiceTest extends Specification with Mockito {
         NameForm("Joe", "Bloggs"),
         Address("line one", "line 2", "town", "country", "postcode", Country.UK.name),
         MarketingChoicesForm(Some(false), Some(false)),
+        None,
         None
       )
 


### PR DESCRIPTION
Added the trackingPromoCode field to the Friend signup form, which gets filled from the promoCode stored in the session, iff it's a code for a Tracking-only promotion.

cc @tomverran @AWare 