### PR TITLE
Update to the latest Membership Common version.

### DIFF
--- a/frontend/app/services/IdentityService.scala
+++ b/frontend/app/services/IdentityService.scala
@@ -96,7 +96,7 @@ case class IdentityService(identityApi: IdentityApi) {
       "address3" -> addressForm.town,
       "address4" -> addressForm.countyOrState,
       "postcode" -> addressForm.postCode,
-      "country" -> addressForm.country.name
+      "country" -> addressForm.country.fold(addressForm.countryName)(_.name)
     )
   }
 
@@ -107,7 +107,7 @@ case class IdentityService(identityApi: IdentityApi) {
       "billingAddress3" -> billingAddress.town,
       "billingAddress4" -> billingAddress.countyOrState,
       "billingPostcode" -> billingAddress.postCode,
-      "billingCountry" -> billingAddress.country.name
+      "billingCountry" -> billingAddress.country.fold(billingAddress.countryName)(_.name)
     )
   }
 }

--- a/frontend/app/services/SalesforceService.scala
+++ b/frontend/app/services/SalesforceService.scala
@@ -1,5 +1,6 @@
 package services
 
+import com.gu.i18n.Country._
 import com.gu.identity.play.{IdMinimalUser, IdUser}
 import com.gu.salesforce.ContactDeserializer.Keys
 import com.gu.salesforce._
@@ -76,7 +77,7 @@ class SalesforceService(salesforceConfig: SalesforceConfig) extends api.Salesfor
       Keys.MAILING_CITY -> formData.deliveryAddress.town,
       Keys.MAILING_STATE -> formData.deliveryAddress.countyOrState,
       Keys.MAILING_POSTCODE -> formData.deliveryAddress.postCode,
-      Keys.MAILING_COUNTRY -> formData.deliveryAddress.country.alpha2,
+      Keys.MAILING_COUNTRY -> formData.deliveryAddress.country.getOrElse(UK).alpha2,
       Keys.ALLOW_MEMBERSHIP_MAIL -> true
     )) ++ Map(
       Keys.ALLOW_THIRD_PARTY_EMAIL -> formData.marketingChoices.thirdParty,
@@ -84,5 +85,5 @@ class SalesforceService(salesforceConfig: SalesforceConfig) extends api.Salesfor
     ).collect { case (k, Some(v)) => Json.obj(k -> v) }
   }.reduce(_ ++ _)
 
-  private def upsert(userId: UserId, value: JsObject) = repository.upsert(userId, value)
+  private def upsert(userId: UserId, value: JsObject) = repository.upsert(Some(userId), value)
 }

--- a/frontend/app/tracking/ActivityTracking.scala
+++ b/frontend/app/tracking/ActivityTracking.scala
@@ -3,6 +3,7 @@ package tracking
 import java.util.{Map => JMap}
 
 import com.github.t3hnar.bcrypt._
+import com.gu.i18n.Country._
 import com.gu.identity.play.IdMinimalUser
 import com.gu.membership.{MembershipPlan, PaidMembershipPlan}
 import com.gu.memsub.{Subscription, PaymentStatus, BillingPeriod, Status}
@@ -232,7 +233,7 @@ trait ActivityTracking {
         subscriptionPaymentAnnual = subscriptionPaymentAnnual,
         marketingChoices = Some(formData.marketingChoices),
         city = Some(formData.deliveryAddress.town),
-        country = Some(formData.deliveryAddress.country.name),
+        country = Some(formData.deliveryAddress.country.fold(formData.deliveryAddress.countryName)(_.name)),
         campaignCode = campaignCode
       )
 
@@ -256,7 +257,7 @@ trait ActivityTracking {
           subscriptionPaymentAnnual = Some(newRatePlan.billingPeriod.annual),
           marketingChoices = None,
           city = addressDetails.map(_.deliveryAddress.town),
-          country = addressDetails.map(_.deliveryAddress.country.name),
+          country = addressDetails.map(addressDetails => addressDetails.deliveryAddress.country.fold(addressDetails.deliveryAddress.countryName)(_.name)),
           campaignCode = campaignCode
         )),
       member)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "net.kencochrane.raven" % "raven-logback" % "6.0.0"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.6"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.187"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.192"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache


### PR DESCRIPTION
Handle the fact that the country inside memcommon's Address case class has been changed to an option. In most cases we fall back to the Address.countryName string, which the optional Address.country is derived from anyway.