### PR TITLE
show currency names in payment chooser

### DIFF
--- a/frontend/app/views/fragments/pricing/billingPeriodChoice.scala.html
+++ b/frontend/app/views/fragments/pricing/billingPeriodChoice.scala.html
@@ -16,7 +16,7 @@
     }
 
     function formattedDiscountedPrice(currency, amount, discount) {
-        return checkoutForm.currencySymbols[currency] + discountedPriceFormatted(amount[currency], discount).toFixed(2).replace('.00','');
+        return checkoutForm.currencyIdentifiers[currency] + discountedPriceFormatted(amount[currency], discount).toFixed(2).replace('.00','');
     }
 
     function formattedDiscountedCharge(currency, amount, discount) {


### PR DESCRIPTION
![](http://i.giphy.com/ADgfsbHcS62Jy.gif)

![image](https://cloud.githubusercontent.com/assets/2670496/14714764/255ed268-07de-11e6-8782-d9478c810ae6.png)
![image](https://cloud.githubusercontent.com/assets/2670496/14714736/09e5f0a2-07de-11e6-902f-693e93065104.png)
![image](https://cloud.githubusercontent.com/assets/2670496/14714753/170be174-07de-11e6-8feb-9ec8094b8e25.png)

Easiest fix to https://trello.com/c/762rvdhe/484-specifiy-ca-whenever-we-refer-to-the-canadian-dollar-price-on-our-site otherwise, we'll need to take a closer look at how we display currencies.