### PR TITLE
Only respect Identity Cookie for authentication, use Token for name only

### DIFF
--- a/frontend/app/services/AuthenticationService.scala
+++ b/frontend/app/services/AuthenticationService.scala
@@ -1,17 +1,15 @@
 package services
 
-import com.gu.identity.play.{AccessCredentials, AuthenticatedIdUser}
+import com.gu.identity.play.AccessCredentials.{Cookies, Token}
+import com.gu.identity.play.AuthenticatedIdUser.Provider
 import configuration.Config
-import play.api.mvc.RequestHeader
 
 object AuthenticationService extends com.gu.identity.play.AuthenticationService {
   def idWebAppSigninUrl(returnUrl: String) = Config.idWebAppSigninUrl(returnUrl)
 
   val identityKeys = Config.idKeys
 
-  override lazy val authenticatedIdUserProvider: (RequestHeader) => Option[AuthenticatedIdUser] = AuthenticatedIdUser.provider(
-    AccessCredentials.Cookies.authProvider(identityKeys),
-    AccessCredentials.Token.authProvider(identityKeys, "membership")
-  )
+  override lazy val authenticatedIdUserProvider: Provider =
+    Cookies.authProvider(identityKeys).withDisplayNameProvider(Token.authProvider(identityKeys, "membership"))
 
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   //libraries
   val sentryRavenLogback = "net.kencochrane.raven" % "raven-logback" % "6.0.0"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
-  val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.6"
+  val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.7"
   val membershipCommon = "com.gu" %% "membership-common" % "0.194"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws


### PR DESCRIPTION
We seem to be getting the Mobile apps hitting us with only an Identity token, and no valid Identity cookie.

This change means that, at the very least, those users will be prompted to sign in when they try to hit the checkout page, rather than an error.

https://github.com/guardian/identity-play-auth/commit/e716abb0549810d87851839f0f616e6e7997a44b

cc @tomverran @mario-galic @DiegoVazquezNanini @alfavata