### PR TITLE
Fix sign out return url

### DIFF
--- a/frontend/app/configuration/Links.scala
+++ b/frontend/app/configuration/Links.scala
@@ -41,7 +41,7 @@ object ProfileLinks {
       routes.FrontPage.welcome.url
     )
 
-    if(exclusions.contains(path)) {
+    if(!exclusions.contains(path)) {
       baseUrl ? ("returnUrl" -> Config.membershipUrl)
     } else baseUrl
 

--- a/frontend/app/configuration/Links.scala
+++ b/frontend/app/configuration/Links.scala
@@ -35,16 +35,7 @@ object ProfileLinks {
   val changePassword =  Config.idWebAppUrl / "password/change" ? Config.idMember
 
   def signOut(path: String) = {
-
-    val baseUrl = Config.idWebAppUrl / "signout" ? Config.idMember
-    val exclusions = Seq(
-      routes.FrontPage.welcome.url
-    )
-
-    if(!exclusions.contains(path)) {
-      baseUrl ? ("returnUrl" -> Config.membershipUrl)
-    } else baseUrl
-
+    Config.idWebAppUrl / "signout" ? Config.idMember ? ("returnUrl" -> (Config.membershipUrl + path))
   }
 
 }


### PR DESCRIPTION
.Previously, if you signed out from membership you were redirected
to the home page. This seems to be due to a missing negation in
the sign out url builder, namely that instead of not adding
a return URL to anything namedin a sequence of excpetions,
it was not adding the return URL to anything not named in the
sequence, meaning all but the welcome page