### PR TITLE
Update Salesforce tier on free to paid upgrades

### DIFF
--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -187,7 +187,6 @@ class MemberService(identityService: IdentityService,
         contact = sub.contact,
         planChoice = PaidPlanChoice(newTier, sub.subscription.plan.billingPeriod),
         form = form,
-        customerOpt = None,
         campaignCode = code
       ))
     } yield {
@@ -476,7 +475,6 @@ class MemberService(identityService: IdentityService,
                                   contact: Contact,
                                   planChoice: PlanChoice,
                                   form: MemberChangeForm,
-                                  customerOpt: Option[Customer],
                                   campaignCode: Option[CampaignCode])(implicit r: IdentityRequest): Future[MemberError \/ ContactId] = {
 
     val addressDetails = form.addressDetails
@@ -488,8 +486,8 @@ class MemberService(identityService: IdentityService,
       country <- EitherT(country(contact).map(\/.right))
       promo = promoService.validateMany[Upgrades](country, planChoice.productRatePlanId)(form.promoCode, form.trackingPromoCode).toOption.flatten
       command <- EitherT(amend(sub, planChoice, form.featureChoice, promo).map(\/.right))
-      _ <- salesforceService.updateMemberStatus(IdMinimalUser(contact.identityId, None), newPlan.tier, customerOpt).liftM
       _ <- zuoraService.upgradeSubscription(command).liftM
+      _ <- salesforceService.updateMemberStatus(IdMinimalUser(contact.identityId, None), newPlan.tier, None).liftM
     } yield {
       salesforceService.metrics.putUpgrade(tier)
       addressDetails.foreach(identityService.updateUserFieldsBasedOnUpgrade(contact.identityId, _))

--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -165,6 +165,7 @@ class MemberService(identityService: IdentityService,
       customer <- stripeService.Customer.create(friend.contact.identityId, form.payment.token).liftM
       paymentResult <- createPaymentMethod(friend.contact, customer).liftM
       subRes <- createPaidSubscription(friend.contact,form,NameForm(friend.contact.firstName.getOrElse(""),friend.contact.lastName),newTier,customer,code).liftM
+      _ <- salesforceService.updateMemberStatus(IdMinimalUser(friend.contact.identityId, None), newTier, Some(customer)).liftM
       _ <- zuoraService.cancelPlan(sub, DateTime.now.toLocalDate).liftM
     } yield {
       form.addressDetails.foreach(identityService.updateUserFieldsBasedOnUpgrade(friend.contact.identityId, _))


### PR DESCRIPTION
Following on from guardian/members-data-api#95 ("Get accurate Membership status from Zuora on webhook update") we noticed that we were not updating Salesforce with the new Tier when doing a
free-to-paid upgrade (we _do_ do it for all other join/upgrade paths that I can see). This seemed to stop the Salesforce outgoing webhook from firing, even though I _think_ Z360 should have taken care of that.

So this change makes the free-to-paid upgrade fall into line with the other code paths.

Note that it is really sad that we can't just have this bit of code in *one* place:

```
salesforceService.updateMemberStatus(idUser, tier, customer)
```

...but that's due for a bigger refactor.

cc @tomverran @AWare 