### PR TITLE
Only prefill promo code when relevant

### DIFF
--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -15,7 +15,6 @@ import com.gu.zuora.soap.models.errors._
 import com.netaporter.uri.dsl._
 import com.typesafe.scalalogging.LazyLogging
 import configuration.{Config, CopyConfig}
-import controllers.TierController._
 import forms.MemberForm._
 import model._
 import play.api.Play.current


### PR DESCRIPTION
Use the promoService.validate to pre-validate a promo code before displaying a checkout page. This stops a Partner-only promo from appearing [with an invalid warning] on a Supporter checkout page.

https://trello.com/c/ar6GxFSu/501-bugfix-only-prefill-promo-code-when-valid-on-join-upgrade-page

cc @tomverran 