### PR TITLE
Set the optimizely flag to false

### DIFF
--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -83,7 +83,7 @@ snowplow.url=""
 activity.tracking.bcrypt.salt=""
 activity.tracking.bcrypt.pepper=""
 
-optimizely.enabled=true
+optimizely.enabled=false
 
 cas.url=""
 


### PR DESCRIPTION
Optimizely is massive (~70kb), and we don't seem to have any tests running with them at the moment. 

- Do we actually have any tests set up?
- Do we want to keep using them for A/B tests?
- Is it right that optimizely only runs on prod?

@blackyjnz 