### PR TITLE
More CORS headers on AJAX calls

### DIFF
--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -102,10 +102,13 @@ object Config {
     "https://profile.theguardian.com",
     // theguardian.com
     "http://www.thegulocal.com",
+    "https://www.thegulocal.com",
     "http://m.code.dev-theguardian.com",
+    "https://m.code.dev-theguardian.com",
     "http://preview.gutools.co.uk",
     "https://preview.gutools.co.uk",
     "http://www.theguardian.com",
+    "https://www.theguardian.com",
     // composer
     "https://composer.gutools.co.uk",
     "https://composer.code.dev-gutools.co.uk",


### PR DESCRIPTION
Fixing the CORS header on our AJAX calls so that www.theguardian.com/membership can go HTTPS.

cc @tomverran 