### PR TITLE
Use correct raven module

### DIFF
--- a/frontend/assets/javascripts/src/modules/analytics/krux.js
+++ b/frontend/assets/javascripts/src/modules/analytics/krux.js
@@ -1,4 +1,4 @@
-define(['raven'],function(raven) {
+define(['src/modules/raven'],function(raven) {
     'use strict';
 
     var KRUX_ID = 'JglooLwn';

--- a/frontend/assets/javascripts/src/modules/analytics/omniture.js
+++ b/frontend/assets/javascripts/src/modules/analytics/omniture.js
@@ -1,7 +1,7 @@
 /*global s_gi */
 define([
     'src/utils/user',
-    'raven'
+    'src/modules/raven'
 ], function (user,raven) {
     'use strict';
 

--- a/frontend/assets/javascripts/src/modules/analytics/ophan.js
+++ b/frontend/assets/javascripts/src/modules/analytics/ophan.js
@@ -1,4 +1,4 @@
-define(['raven'],function(raven) {
+define(['src/modules/raven'],function(raven) {
     'use strict';
 
     function init() {

--- a/frontend/assets/javascripts/src/modules/form/payment/processing.js
+++ b/frontend/assets/javascripts/src/modules/form/payment/processing.js
@@ -7,7 +7,7 @@ define([
     'src/modules/form/helper/loader',
     'config/paymentErrorMessages',
     'src/modules/form/validation/display',
-    'raven'
+    'src/modules/raven'
 ], function (ajax, utilsHelper, formUtil, serializer, loader, paymentErrorMessages, display,raven) {
     'use strict';
 

--- a/frontend/assets/javascripts/src/modules/raven.js
+++ b/frontend/assets/javascripts/src/modules/raven.js
@@ -1,4 +1,4 @@
-define(['src/utils/user', 'raven','raven-js'], function (user, Raven) {
+define(['src/utils/user','raven-js'], function (user, Raven) {
     'use strict';
 
     function init(dsn) {

--- a/frontend/assets/javascripts/src/modules/videoOverlay.js
+++ b/frontend/assets/javascripts/src/modules/videoOverlay.js
@@ -1,5 +1,5 @@
 /* global YT */
-define(['raven'],function(raven) {
+define(['src/modules/raven'],function(raven) {
     'use strict';
 
     var SELECTOR_PLAYER = '.js-video';

--- a/frontend/assets/javascripts/src/utils/decodeBase64.js
+++ b/frontend/assets/javascripts/src/utils/decodeBase64.js
@@ -1,5 +1,5 @@
 /*global escape*/
-define(['src/utils/atob','raven'], function (AtoB,raven) {
+define(['src/utils/atob','src/modules/raven'], function (AtoB,raven) {
     'use strict';
 
     return function(str) {

--- a/frontend/webpack.conf.js
+++ b/frontend/webpack.conf.js
@@ -13,7 +13,6 @@ module.exports = function(debug) { return {
             'reqwest': 'reqwest/reqwest',
             'respimage': 'respimage/respimage',
             'lazySizes': 'lazysizes/lazysizes',
-            'raven': 'raven-js/dist/raven',
             'gumshoe': 'gumshoe/dist/js/gumshoe',
             'smoothScroll': 'smooth-scroll/dist/js/smooth-scroll',
             'ajax': 'src/utils/ajax'


### PR DESCRIPTION
- Ensure our raven.js module uses the webpack-provided raven-js dependency.
- Remove non-installed aliased (bower) version of raven and ensure our modules are using our wrapped raven module instead.

cc @AWare @tomverran 