### PR TITLE
Giraffe uat switch

### DIFF
--- a/frontend/app/actions/package.scala
+++ b/frontend/app/actions/package.scala
@@ -5,7 +5,7 @@ import com.gu.salesforce._
 import com.gu.memsub.util.Timing
 import monitoring.MemberAuthenticationMetrics
 import play.api.mvc.Security.AuthenticatedRequest
-import play.api.mvc.{Cookie, WrappedRequest}
+import play.api.mvc.{Request, Cookie, WrappedRequest}
 import services._
 import scalaz.\/
 import scala.concurrent.{ExecutionContext, Future}
@@ -36,6 +36,9 @@ package object actions {
     def this(other: SubscriptionRequest[A]) =
       this(other.touchpointBackend, other.request)
   }
+
+  case class OptionallyAuthenticatedRequest[A](touchpointBackend: TouchpointBackend, user: Option[AuthenticatedIdUser], request: Request[A])
+    extends WrappedRequest[A](request) with BackendProvider
 
   trait Subscriber {
     def paidOrFreeSubscriber: FreeMember \/ PaidMember

--- a/frontend/app/controllers/Giraffe.scala
+++ b/frontend/app/controllers/Giraffe.scala
@@ -28,6 +28,10 @@ object Giraffe extends Controller {
   val chargeId = "charge_id"
   val maxAmount: Option[Int] = 500.some
 
+  def stripePublicKey = OptionallyAuthenticatedAction { implicit request =>
+    Ok(request.touchpointBackend.giraffeStripeService.publicKey)
+  }
+
   // Once things have settled down and we have a reasonable idea of what might
   // and might not vary between different countries, we should merge these country-specific
   // controllers & templates into a single one which varies on a number of parameters

--- a/frontend/app/views/giraffe/contribute.scala.html
+++ b/frontend/app/views/giraffe/contribute.scala.html
@@ -3,7 +3,7 @@
 @import configuration.Links
 
 @import com.gu.i18n.CountryGroup
-@(pageInfo: PageInfo, maxAmount: Option[Int], countryGroup: CountryGroup)
+@(pageInfo: PageInfo, maxAmount: Option[Int], countryGroup: CountryGroup, isUAT: Boolean)
 
 @giraffeMain(pageInfo) {
     <div class="l-constrained">
@@ -202,7 +202,7 @@
                         </div>
                     </div>
                     <li id="submit_field" class="form-field">
-                        <button class="action action--contribute js-submit-input" type="submit" tabindex="17">Pay <span class="js-currency">&pound;</span><span class="js-amount">5</span></button>
+                        <button class="action action--contribute js-submit-input" type="submit" tabindex="17">Pay <span class="js-currency">&pound;</span><span class="js-amount">5</span>@if(isUAT){ (UAT)}</button>
                         <div class="loader js-loader"></div>
                     </li>
 

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -138,4 +138,4 @@ GET            /us/contribute/thank-you               controllers.Giraffe.thanks
 GET            /au/contribute/thank-you               controllers.Giraffe.thanksAustralia
 
 POST           /contribute/pay                        controllers.Giraffe.pay
-
+GET            /contribute/stripekey                  controllers.Giraffe.stripePublicKey

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -138,4 +138,3 @@ GET            /us/contribute/thank-you               controllers.Giraffe.thanks
 GET            /au/contribute/thank-you               controllers.Giraffe.thanksAustralia
 
 POST           /contribute/pay                        controllers.Giraffe.pay
-GET            /contribute/stripekey                  controllers.Giraffe.stripePublicKey


### PR DESCRIPTION
This pull request turns contribute into a non-cached page which will react in the following way. 

If the user is not logged in, the real touchpoint backend is used
If the user is logged in and is not a test user, the real touchpoint backend is used
If the user is logged in and is a test user, the test touchpoint backend is used (this is shown visually on the pay button, which has (UAT) appended to the text)


<img width="374" alt="screenshot at may 13 17-14-00" src="https://cloud.githubusercontent.com/assets/2844554/15254313/17270ad8-192e-11e6-8efa-d175c9d3c1a1.png">