### PR TITLE
Updated US video link plus promo landing page tweaks

### DIFF
--- a/frontend/app/configuration/Videos.scala
+++ b/frontend/app/configuration/Videos.scala
@@ -41,7 +41,7 @@ object Videos {
   )
 
   val supportersUSA =  Video(
-    srcUrl="//www.youtube.com/embed/CAzEi7vDxcg?enablejsapi=1&wmode=transparent",
+    srcUrl="//www.youtube.com/embed/MsZL6dhyXW8?enablejsapi=1&wmode=transparent",
     posterImage=Some(
       ResponsiveImageGroup(
         altText=Some("If you read the Guardian, join the Guardian"),

--- a/frontend/app/controllers/Promotions.scala
+++ b/frontend/app/controllers/Promotions.scala
@@ -24,7 +24,7 @@ import scalaz.{Monad, \/}
 
 object Promotions extends Controller {
 
-  import TouchpointBackend.TestUser.{catalog, promoService}
+  import TouchpointBackend.Normal.{catalog, promoService}
 
   private val pageImages = Seq(
     ResponsiveImageGroup(

--- a/frontend/app/views/promotions/discountLandingPage.scala.html
+++ b/frontend/app/views/promotions/discountLandingPage.scala.html
@@ -9,7 +9,7 @@
 @import com.gu.memsub.promo.PromoCode
 @import com.gu.memsub.promo.PercentDiscount
 @import com.gu.memsub.promo.Promotion.PromotionWithLandingPage
-@import com.gu.salesforce.Tier.Partner
+@import com.gu.salesforce.Tier.Supporter
 @import com.gu.membership.PaidMembershipPlans
 @import views.support.PageInfo
 @import model.Highlights
@@ -46,7 +46,7 @@
     @fragments.promotions.roundel(promotion.landingPage.roundelHtml, classModifier = Some("alt"))
 
     @fragments.page.heroBanner("hero-banner--newsroom hero-banner--alt-accent") {
-        Become a Guardian @pricePlan.tier.name for just @discountedPrice.pretty today
+        @promotion.landingPage.title.getOrElse(promotion.name)
     } {
         Support the independence of the Guardian and our award-winning journalism, plus enjoy a host of benefits
     }()
@@ -58,7 +58,7 @@
             promoCode = Some(promoCode.get),
             modifierClass = Some("package-promo--clean"),
             customPrice = Some(fragments.promos.discountedPrice(originalPrice, discountedPrice, discountDuration)),
-            secondaryButton = Some(CtaButton("Find out more", "/", Map.empty))
+            secondaryButton = if (pricePlan.tier != Supporter()) Some(CtaButton("Find out more", "/", Map.empty)) else None
         )
     }
 
@@ -68,7 +68,6 @@
 
     @fragments.page.sectionCardStack(promotionImage) {
         <div class="listing__text">
-            @promotion.landingPage.title.map { t => <p>@t</p> }
             <p>@Html(promotion.landingPage.description.getOrElse(promotion.description))</p>
             <p>
                 <a class="action" href="@{routes.Joiner.enterPaidDetails(pricePlan.tier)}?countryGroup=@countryGroup.id">Become a @pricePlan.tier.name</a>

--- a/frontend/app/views/promotions/incentiveLandingPage.scala.html
+++ b/frontend/app/views/promotions/incentiveLandingPage.scala.html
@@ -1,6 +1,7 @@
 @import com.gu.i18n.CountryGroup
 @import com.gu.memsub.Current
 @import com.gu.salesforce.PaidTier
+@import com.gu.salesforce.Tier.Supporter
 @import com.gu.membership.PaidMembershipPlans
 @import views.support.PageInfo
 @import views.model.Roundel
@@ -25,7 +26,7 @@
     @fragments.promotions.roundel(promotion.landingPage.roundelHtml, classModifier = Some("alt"))
 
     @fragments.page.heroBanner("hero-banner--newsroom hero-banner--alt-accent") {
-        Become a Guardian @pricePlans.tier.name
+        @promotion.landingPage.title.getOrElse(promotion.name)
     } {
         Support the independence of the Guardian and our award-winning journalism, plus enjoy a host of benefits
     }()
@@ -36,7 +37,7 @@
             countryGroup,
             promoCode = Some(promoCode.get),
             modifierClass = Some("package-promo--clean"),
-            button = Some(CtaButton("Find out more", "/", Map.empty))
+            button = if (pricePlans.tier != Supporter()) Some(CtaButton("Find out more", "/", Map.empty)) else None
         )
     }
 
@@ -46,7 +47,6 @@
 
     @fragments.page.sectionCardStack(promotionImage, promotion.landingPage.title orElse Some(promotion.name)) {
         <div class="listing__text">
-            @promotion.landingPage.title.map { t => <p>@t</p> }
             <p>@Html(promotion.landingPage.description.getOrElse(promotion.description))</p>
             <p>
                 <a class="action" href="@{routes.Joiner.enterPaidDetails(pricePlans.tier)}?countryGroup=@countryGroup.id">Become a @pricePlans.tier.name</a>
@@ -74,7 +74,7 @@
             countryGroup,
             promoCode = Some(promoCode.get),
             modifierClass = Some("package-promo--clean"),
-            button = Some(CtaButton("Find out more", "/", Map.empty))
+            button = if (pricePlans.tier != Supporter()) Some(CtaButton("Find out more", "/", Map.empty)) else None
         )
     }
 }


### PR DESCRIPTION
- Updated US video link.
- Put promo title on to top of promo page (obviously).
- Hide "Find out more" if the promo page is rendering as Supporter tier.
- Ensure promo page is rendering from Normal Touchpoint backend.

cc @tomverran @nlindblad 