### PR TITLE
remove explicit panama sharing section from thankyou page

### DIFF
--- a/frontend/app/views/giraffe/thankyou.scala.html
+++ b/frontend/app/views/giraffe/thankyou.scala.html
@@ -8,12 +8,7 @@
         <h1 class="support-thanks__title">@pageInfo.title</h1>
 
         <p class="support-thanks__message">@pageInfo.description</p>
-
-        <div class="support-thanks__message">
-            Please take a moment to share the <a class="support-thanks__link" href="//www.theguardian.com/news/series/panama-papers" onClick="s.tl(true,'o','panamapapers')">Panama Papers</a> series.
-            @fragments.social(social)
-        </div>
-
+        
         <p class="support-thanks__message" data-shown="gbp">
             Enjoy more of the Guardian's journalism from breaking investigations to politics, sport, culture and more.
         </p>


### PR DESCRIPTION
remove explicit panama sharing section from thankyou page

<img width="970" alt="screenshot at may 24 08-07-06" src="https://cloud.githubusercontent.com/assets/2844554/15495165/5d52e94a-2186-11e6-933f-3405f2493586.png">
