### PR TITLE
Update messaging on thank you page

### DIFF
--- a/frontend/app/controllers/Giraffe.scala
+++ b/frontend/app/controllers/Giraffe.scala
@@ -17,8 +17,8 @@ import scala.concurrent.Future
 object Giraffe extends Controller {
 
   val social: Set[Social] = Set(
-    Twitter("The Panama Papers: how the world's rich and famous hide their money offshore http://www.theguardian.com/news/series/panama-papers?CMP=twt_contribute #panamapapers"),
-    Facebook("http://www.theguardian.com/news/series/panama-papers?CMP=fb_contribute")
+    Twitter("I've just contributed to the Guardian. Join me in supporting independent journalism https://membership.theguardian.com/contribute"),
+    Facebook("https://membership.theguardian.com/contribute")
   )
 
 

--- a/frontend/app/views/giraffe/thankyou.scala.html
+++ b/frontend/app/views/giraffe/thankyou.scala.html
@@ -9,8 +9,10 @@
 
         <p class="support-thanks__message">@pageInfo.description</p>
 
+        <h1 class="support-thanks__title">Spread the word</h1>
+
         <div class="support-thanks__message">
-            Please take a moment to share the <a class="support-thanks__link" href="//www.theguardian.com/news/series/panama-papers" onClick="s.tl(true,'o','panamapapers')">Panama Papers</a> series.
+            We report for everyone. Do tell your friends and family how they can support the Guardian too.
             @fragments.social(social)
         </div>
 


### PR DESCRIPTION
Removed old panama messaging from thank you page, added new copy and social links

<img width="710" alt="screenshot at may 24 10-17-36" src="https://cloud.githubusercontent.com/assets/2844554/15498721/abc51a3c-2198-11e6-8715-fee03eafb282.png">
<img width="649" alt="screenshot at may 24 10-17-49" src="https://cloud.githubusercontent.com/assets/2844554/15498722/abd6b49a-2198-11e6-8dc3-4b40a1e1bb84.png">
<img width="751" alt="screenshot at may 24 10-18-03" src="https://cloud.githubusercontent.com/assets/2844554/15498723/abde57ea-2198-11e6-8779-b90e5e59e1fe.png">
