### PR TITLE
Landing page for tracking-only promo codes

### DIFF
--- a/frontend/app/views/promotions/singlePricePlanDiscountLandingPage.scala.html
+++ b/frontend/app/views/promotions/singlePricePlanDiscountLandingPage.scala.html
@@ -80,7 +80,7 @@
             Asset.at("images/common/katharine-viner-cutout.png"),
             "Katharine Viner, editor-in-chief of the Guardian"
         ) {
-            <blockquote class="blockquote blockquote--feature">
+            <blockquote class="blockquote">
                 With Guardian Members we have a profound opportunity to
                 defend the Guardian’s independent journalism and collaborate
                 together on a better, more informed future.

--- a/frontend/app/views/promotions/singleTierLandingPage.scala.html
+++ b/frontend/app/views/promotions/singleTierLandingPage.scala.html
@@ -8,8 +8,7 @@
 @import model.Highlights
 @import model.PackagePromo.CtaButton
 @import com.netaporter.uri.dsl._
-@import com.gu.memsub.promo.Incentive
-@import com.gu.memsub.promo.Promotion.PromotionWithLandingPage
+@import com.gu.memsub.promo.Promotion.AnyPromotionWithLandingPage
 @import com.gu.memsub.promo.PromoCode
 @import views.support.Asset
 
@@ -17,7 +16,7 @@
     pageInfo: PageInfo,
     promotionImage: model.ResponsiveImageGroup,
     promoCode: PromoCode,
-    promotion: PromotionWithLandingPage[Incentive]
+    promotion: AnyPromotionWithLandingPage
 )(implicit countryGroup: CountryGroup)
 
 
@@ -37,7 +36,7 @@
             countryGroup,
             promoCode = Some(promoCode.get),
             modifierClass = Some("package-promo--clean"),
-            button = if (pricePlans.tier != Supporter()) Some(CtaButton("Find out more", "/", Map.empty)) else None
+            secondaryButton = if (pricePlans.tier != Supporter()) Some(CtaButton("Find out more", "/", Map.empty)) else None
         )
     }
 
@@ -45,7 +44,7 @@
         @fragments.listing.introducingMembers()
     }
 
-    @fragments.page.sectionCardStack(promotionImage, promotion.landingPage.title orElse Some(promotion.name)) {
+    @fragments.page.sectionCardStack(promotionImage) {
         <div class="listing__text">
             <p>@Html(promotion.landingPage.description.getOrElse(promotion.description))</p>
             <p>
@@ -74,7 +73,7 @@
             countryGroup,
             promoCode = Some(promoCode.get),
             modifierClass = Some("package-promo--clean"),
-            button = if (pricePlans.tier != Supporter()) Some(CtaButton("Find out more", "/", Map.empty)) else None
+            secondaryButton = if (pricePlans.tier != Supporter()) Some(CtaButton("Find out more", "/", Map.empty)) else None
         )
     }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "7.2.3"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.7"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.207"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.209"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache


### PR DESCRIPTION
- Show a single tier landing page for tracking promotions
- Rename the discountLandingPage to singlePricePlanDiscountLandingPage
- Fixed bug with wrong CTA buttons showing
- Removed the non-defined "blockquote--feature" class

cc @tomverran 