### PR TITLE
update ophan.js to use an amd module

### DIFF
--- a/frontend/assets/javascripts/src/modules/analytics/ophan.js
+++ b/frontend/assets/javascripts/src/modules/analytics/ophan.js
@@ -1,14 +1,17 @@
 define(['src/modules/raven'],function(raven) {
     'use strict';
 
+    var ophanUrl = '//j.ophan.co.uk/membership.js';
+    var ophan = curl(ophanUrl);
+
     function init() {
-        var ophanUrl = '//j.ophan.co.uk/ophan.membership.js';
-        curl('js!' + ophanUrl).then(null, function(err) {
+        ophan.then(null, function(err) {
             raven.Raven.captureException(err);
         });
     }
 
     return {
-        init: init
+        init: init,
+        ophan: ophan
     };
 });


### PR DESCRIPTION
Depends on https://github.com/guardian/ophan/pull/1480 
This will let us call ophan's record function in our code, albeit as:
`            ophan.ophan.then(function(ophan){ 
                ophan.record(???)}); 
`
(NB, this has four wheels so is stable ;) )

@joelochlann @philwills 