### PR TITLE
Add the change members status permission page

### DIFF
--- a/frontend/app/controllers/MembershipStatus.scala
+++ b/frontend/app/controllers/MembershipStatus.scala
@@ -1,0 +1,33 @@
+package controllers
+
+import com.gu.i18n._
+import com.gu.stripe.Stripe
+import configuration.Config
+import com.gu.stripe.Stripe.Serializer._
+import forms.MemberForm.supportForm
+import play.api.libs.concurrent.Execution.Implicits._
+import play.api.libs.json.{JsArray, JsString, Json}
+import play.api.mvc.{Controller, Cookie, Result}
+import services.{AuthenticationService, TouchpointBackend}
+import com.netaporter.uri.dsl._
+import views.support.{TestTrait, _}
+
+import scalaz.syntax.std.option._
+import scala.concurrent.Future
+
+object MembershipStatus extends Controller {
+
+
+
+
+  // Once things have settled down and we have a reasonable idea of what might
+  // and might not vary between different countries, we should merge these country-specific
+  // controllers & templates into a single one which varies on a number of parameters
+  def load = AuthenticatedAction { implicit request =>
+    Ok(views.html.info.membershipStatus())
+  }
+
+
+
+
+}

--- a/frontend/app/controllers/MembershipStatus.scala
+++ b/frontend/app/controllers/MembershipStatus.scala
@@ -1,5 +1,7 @@
 package controllers
 
+import actions.Fallbacks._
+import actions._
 import com.gu.i18n._
 import com.gu.stripe.Stripe
 import configuration.Config
@@ -17,13 +19,22 @@ import scala.concurrent.Future
 
 object MembershipStatus extends Controller {
 
-
+  val AuthorisedTester = GoogleAuthenticatedStaffAction andThen OAuthActions.requireGroup[GoogleAuthRequest](Set(
+    "membership.dev@guardian.co.uk",
+    "mobile.core@guardian.co.uk",
+    "membership.team@guardian.co.uk",
+    "dig.dev.web-engineers@guardian.co.uk",
+    "membership.testusers@guardian.co.uk",
+    "touchpoint@guardian.co.uk",
+    "crm@guardian.co.uk",
+    "identitydev@guardian.co.uk"
+  ), unauthorisedStaff(views.html.fragments.oauth.staffWrongGroup())(_))
 
 
   // Once things have settled down and we have a reasonable idea of what might
   // and might not vary between different countries, we should merge these country-specific
   // controllers & templates into a single one which varies on a number of parameters
-  def load = AuthenticatedAction { implicit request =>
+  def load = AuthorisedTester { implicit request =>
     Ok(views.html.info.membershipStatus())
   }
 

--- a/frontend/app/views/info/membershipStatus.scala.html
+++ b/frontend/app/views/info/membershipStatus.scala.html
@@ -1,0 +1,10 @@
+@()(implicit token: play.filters.csrf.CSRF.Token)
+
+@import views.html.helper.CSRF
+
+@main("Change Membership Status Permission") {
+
+    <main role="main" class="page-content l-constrained">
+        <label><input class="memCheck" id="memCheck" type='checkbox'>Display Membership status when commenting</label>
+    </main>
+}

--- a/frontend/app/views/info/membershipStatus.scala.html
+++ b/frontend/app/views/info/membershipStatus.scala.html
@@ -5,6 +5,8 @@
 @main("Change Membership Status Permission") {
 
     <main role="main" class="page-content l-constrained">
-        <label><input class="memCheck" id="memCheck" type='checkbox'>Display Membership status when commenting</label>
+        <div class="memCheck">
+            <label><input class="memCheck" id="memCheck" type='checkbox'>Display Membership status when commenting</label>
+        </div >
     </main>
 }

--- a/frontend/assets/javascripts/src/main.js
+++ b/frontend/assets/javascripts/src/main.js
@@ -25,7 +25,8 @@ require([
     'src/modules/comparisonTable',
     'src/modules/metrics',
     'src/modules/patterns',
-    'src/modules/paidToPaid'
+    'src/modules/paidToPaid',
+    'src/modules/memstatus'
 ], function(
     ajax,
     raven,
@@ -53,7 +54,8 @@ require([
     comparisonTable,
     metrics,
     patterns,
-    paidToPaid
+    paidToPaid,
+    memstatus
 ) {
     'use strict';
 
@@ -99,4 +101,6 @@ require([
 
 
     paidToPaid.init();
+
+    memstatus.init();
 });

--- a/frontend/assets/javascripts/src/modules/memstatus.es6
+++ b/frontend/assets/javascripts/src/modules/memstatus.es6
@@ -6,15 +6,13 @@ import $ from '$'
 
 
 function ajaxRequest(allowP){
-    alert("its " + allowP);
 
     ajax({
         url: 'https://members-data-api.thegulocal.com/user-attributes/tier/public',
         method: 'POST',
-        crossOrigin: true,
         withCredentials: true,
         data: {
-            allowPublic: allowP
+            allowPublic: allowP                                                                         
         }
     });
 }

--- a/frontend/assets/javascripts/src/modules/memstatus.es6
+++ b/frontend/assets/javascripts/src/modules/memstatus.es6
@@ -1,0 +1,38 @@
+import * as display from 'src/modules/form/validation/display'
+import * as helper from 'src/utils/helper'
+import ajax from 'ajax'
+import $ from '$'
+
+
+
+function ajaxRequest(allowP){
+    alert("its " + allowP);
+
+    ajax({
+        url: 'https://members-data-api.thegulocal.com/user-attributes/tier/public',
+        method: 'POST',
+        crossOrigin: true,
+        withCredentials: true,
+        data: {
+            allowPublic: allowP
+        }
+    });
+}
+
+export function init() {
+    if (!document.querySelector('.memCheck')) {
+        return;
+    }
+
+    // Custom amount
+    document.querySelector('.memCheck').addEventListener('change', function (e) {
+        if (e.target.checked) {
+            //opt in
+            ajaxRequest(true);
+        }else {
+            //opt out
+            ajaxRequest(false);
+        }
+    });
+
+}

--- a/frontend/assets/stylesheets/memsstatus.scss
+++ b/frontend/assets/stylesheets/memsstatus.scss
@@ -1,3 +1,3 @@
-.memCheck{
-    margin-top: 30px;
+.memCheck {
+    margin-top:10px;
 }

--- a/frontend/assets/stylesheets/memsstatus.scss
+++ b/frontend/assets/stylesheets/memsstatus.scss
@@ -1,0 +1,3 @@
+.memCheck{
+    margin-top: 30px;
+}

--- a/frontend/assets/stylesheets/style.scss
+++ b/frontend/assets/stylesheets/style.scss
@@ -115,3 +115,5 @@
 
 // Giraffe
 @import 'giraffe';
+
+@import 'memsstatus';

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -139,3 +139,5 @@ GET            /us/contribute/thank-you               controllers.Giraffe.thanks
 GET            /au/contribute/thank-you               controllers.Giraffe.thanksAustralia
 
 POST           /contribute/pay                        controllers.Giraffe.pay
+
+GET            /change-mem-status-permission          controllers.MembershipStatus.load


### PR DESCRIPTION
Adds a page to membership front end that controls whether a users membership status should display when they comment 

Currently only accessible to guardian staff members

<img width="1266" alt="screenshot at jun 10 13-10-18" src="https://cloud.githubusercontent.com/assets/2844554/15963754/5044a840-2f0c-11e6-8c45-e69c6d77def7.png">
