### PR TITLE
Automatic geo-relocation on Contribute

### DIFF
--- a/frontend/app/controllers/Giraffe.scala
+++ b/frontend/app/controllers/Giraffe.scala
@@ -71,10 +71,8 @@ object Giraffe extends Controller {
     val countryGroup = request.getFastlyCountry.getOrElse(CountryGroup.RestOfTheWorld)
 
     val baseUrl: Uri = redirectToGiraffe(countryGroup).absoluteURL
-    val paramsToPropagate = Seq("INTCMP", "CMP")
+    val paramsToPropagate = request.queryString.map { case (k,v) => k }.toSeq
     val urlWithParams = paramsToPropagate.foldLeft[Uri](baseUrl) { (url, param) =>
-      // No need to filter out the params that aren't present because if the `?` method gets a key-value tuple
-      // with value of None, that parameter will not be rendered when toString is called
       url ? (param -> request.getQueryString(param))
     }
 

--- a/frontend/app/controllers/Giraffe.scala
+++ b/frontend/app/controllers/Giraffe.scala
@@ -113,6 +113,7 @@ object Giraffe extends Controller {
       val redirect = f.currency match {
         case USD => routes.Giraffe.thanksUSA().url
         case AUD => routes.Giraffe.thanksAustralia().url
+        case EUR => routes.Giraffe.thanksEurope().url
         case _ => routes.Giraffe.thanksUK().url
       }
 

--- a/frontend/app/controllers/Giraffe.scala
+++ b/frontend/app/controllers/Giraffe.scala
@@ -82,10 +82,12 @@ object Giraffe extends Controller {
   def contributeUK = contribute(CountryGroup.UK)
   def contributeUSA = contribute(CountryGroup.US)
   def contributeAustralia = contribute(CountryGroup.Australia)
+  def contributeEurope = contribute(CountryGroup.Europe)
 
-  def thanksUK = thanks(CountryGroup.UK, routes.Giraffe.contributeUK().url)
-  def thanksUSA = thanks(CountryGroup.US, routes.Giraffe.contributeUSA().url)
-  def thanksAustralia = thanks(CountryGroup.Australia, routes.Giraffe.contributeAustralia().url)
+  def thanksUK = thanks(CountryGroup.UK, routes.Giraffe.contributeRedirect().url)
+  def thanksUSA = thanks(CountryGroup.US, routes.Giraffe.contributeRedirect().url)
+  def thanksAustralia = thanks(CountryGroup.Australia, routes.Giraffe.contributeRedirect().url)
+  def thanksEurope = thanks(CountryGroup.Europe, routes.Giraffe.contributeRedirect().url)
 
 
 

--- a/frontend/app/controllers/Redirects.scala
+++ b/frontend/app/controllers/Redirects.scala
@@ -25,6 +25,7 @@ trait Redirects extends Controller {
       case CountryGroup.UK => routes.Giraffe.contributeUK()
       case CountryGroup.US => routes.Giraffe.contributeUSA()
       case CountryGroup.Australia => routes.Giraffe.contributeAustralia()
+      case CountryGroup.Europe => routes.Giraffe.contributeEurope()
       case _ => routes.Giraffe.contributeUK()
     }
   }

--- a/frontend/app/controllers/Redirects.scala
+++ b/frontend/app/controllers/Redirects.scala
@@ -19,6 +19,17 @@ trait Redirects extends Controller {
       case _ => routes.Info.supporterFor(countryGroup)
     }
   }
+
+  def redirectToGiraffe(countryGroup: CountryGroup): Call = {
+    countryGroup match {
+      case CountryGroup.UK => routes.Giraffe.contributeUK()
+      case CountryGroup.US => routes.Giraffe.contributeUSA()
+      case CountryGroup.Australia => routes.Giraffe.contributeAustralia()
+      case _ => routes.Giraffe.contributeUK()
+    }
+  }
+
+
 }
 
 object Redirects extends Redirects

--- a/frontend/app/views/giraffe/contribute.scala.html
+++ b/frontend/app/views/giraffe/contribute.scala.html
@@ -197,7 +197,7 @@
         </form>
 
         <div class="feedback">
-        <span data-shown="gbp">
+        <span data-shown="gbp eur">
             <p>If you have any questions about contributing to the Guardian, please
                 <a href="mailto:contribution.support@@theguardian.com" class="support-thanks__link">contact us here</a>.
             </p>

--- a/frontend/app/views/giraffe/thankyou.scala.html
+++ b/frontend/app/views/giraffe/thankyou.scala.html
@@ -18,7 +18,7 @@
         @fragments.social(social)
         </div>
 
-        <p class="support-thanks__message" data-shown="gbp">
+        <p class="support-thanks__message" data-shown="gbp eur">
             Enjoy more of the Guardian's journalism from breaking investigations to politics, sport, culture and more.
         </p>
 
@@ -34,7 +34,7 @@
             <div class="support-thanks__one-col">
                 <h3 class="support-thanks__sub-subtitle headline-text--bolder">Get the app </h3>
                 <p>Up-to-the-minute coverage, personalised alerts, off​line​ reading and more. <br>
-                    <a data-shown="gbp" href="https://itunes.apple.com/gb/app/the-guardian/id409128287?mt=8" class="support-thanks__link" onClick="s.tl(true,'o','iApp')">iPhone and iPad app</a>
+                    <a data-shown="gbp eur" href="https://itunes.apple.com/gb/app/the-guardian/id409128287?mt=8" class="support-thanks__link" onClick="s.tl(true,'o','iApp')">iPhone and iPad app</a>
                     <a data-shown="aud" href="https://itunes.apple.com/au/app/the-guardian/id409128287?mt=8" class="support-thanks__link" onClick="s.tl(true,'o','iApp')">iPhone and iPad app</a>
                     <a data-shown="usd" href="https://itunes.apple.com/us/app/the-guardian/id409128287?mt=8" class="support-thanks__link" onClick="s.tl(true,'o','iApp')">iPhone and iPad app</a>
                     <br><a href="https://play.google.com/store/apps/details?id=com.guardian" class="support-thanks__link" onClick="s.tl(true,'o','aApp')">Android app</a></p>
@@ -42,7 +42,7 @@
             <div class="support-thanks__one-col">
                 <h3 class="support-thanks__sub-subtitle headline-text--bolder">Subscribe to daily email</h3>
                 <p>
-                    <a data-shown="gbp" href="https://www.theguardian.com/info/2015/dec/08/daily-email-uk?CMP=contribution_thankyou" class="support-thanks__link" onClick="s.tl(true,'o','email')">Get the must-read stories</a> delivered straight to your inbox each morning in one handy email
+                    <a data-shown="gbp eur" href="https://www.theguardian.com/info/2015/dec/08/daily-email-uk?CMP=contribution_thankyou" class="support-thanks__link" onClick="s.tl(true,'o','email')">Get the must-read stories</a> delivered straight to your inbox each morning in one handy email
                     <a data-shown="aud" href="https://www.theguardian.com/info/2015/dec/08/daily-email-us?CMP=contribution_thankyou" class="support-thanks__link" onClick="s.tl(true,'o','email')">Get the must-read stories</a> delivered straight to your inbox each morning in one handy email
                     <a data-shown="usd" href="https://www.theguardian.com/info/2015/dec/08/daily-email-au?CMP=contribution_thankyou" class="support-thanks__link" onClick="s.tl(true,'o','email')">Get the must-read stories</a> delivered straight to your inbox each morning in one handy email
                 </p>

--- a/frontend/assets/stylesheets/giraffe.scss
+++ b/frontend/assets/stylesheets/giraffe.scss
@@ -528,7 +528,7 @@ $desktop-col-padding-right: 16px;
      display:none;
 }
 
-$currencies: gbp usd aud;
+$currencies: gbp usd aud eur;
 @each $currency in $currencies {
     .currency-#{$currency} {
         [data-shown*=#{$currency}] {

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -132,9 +132,12 @@ GET            /english-heritage                      controllers.Default.redire
 GET            /currencies                            controllers.PricingApi.currencies
 
 # Giraffe
-GET            /contribute                            controllers.Giraffe.contributeUK
+GET            /contribute                            controllers.Giraffe.contributeRedirect
+
+GET            /uk/contribute                         controllers.Giraffe.contributeUK
 GET            /us/contribute                         controllers.Giraffe.contributeUSA
 GET            /au/contribute                         controllers.Giraffe.contributeAustralia
+
 
 GET            /contribute/thank-you                  controllers.Giraffe.thanksUK
 GET            /us/contribute/thank-you               controllers.Giraffe.thanksUSA

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -137,11 +137,13 @@ GET            /contribute                            controllers.Giraffe.contri
 GET            /uk/contribute                         controllers.Giraffe.contributeUK
 GET            /us/contribute                         controllers.Giraffe.contributeUSA
 GET            /au/contribute                         controllers.Giraffe.contributeAustralia
+GET            /eu/contribute                         controllers.Giraffe.contributeEurope
 
 
 GET            /contribute/thank-you                  controllers.Giraffe.thanksUK
 GET            /us/contribute/thank-you               controllers.Giraffe.thanksUSA
 GET            /au/contribute/thank-you               controllers.Giraffe.thanksAustralia
+GET            /eu/contribute/thank-you               controllers.Giraffe.thanksEurope
 
 POST           /contribute/pay                        controllers.Giraffe.pay
 


### PR DESCRIPTION
- Checks the users location from the fastly header and if they are from UK, US or AU, redirects to the appropriate page, else defaults to the UK page

- Also makes sure to redirect with existing parameters