### PR TITLE
Add support for CAD

### DIFF
--- a/frontend/app/controllers/Giraffe.scala
+++ b/frontend/app/controllers/Giraffe.scala
@@ -76,14 +76,15 @@ object Giraffe extends Controller {
 
   def contributeUK = contribute(CountryGroup.UK)
   def contributeUSA = contribute(CountryGroup.US)
+  def contributeCanada = contribute(CountryGroup.Canada)
   def contributeAustralia = contribute(CountryGroup.Australia)
   def contributeEurope = contribute(CountryGroup.Europe)
 
   def thanksUK = thanks(CountryGroup.UK, routes.Giraffe.contributeUK().url)
   def thanksUSA = thanks(CountryGroup.US, routes.Giraffe.contributeUSA().url)
   def thanksAustralia = thanks(CountryGroup.Australia, routes.Giraffe.contributeAustralia().url)
+  def thanksCanada = thanks(CountryGroup.Canada, routes.Giraffe.contributeCanada().url)
   def thanksEurope = thanks(CountryGroup.Europe, routes.Giraffe.contributeEurope().url)
-
 
 
   def pay = OptionallyAuthenticatedAction.async { implicit request =>
@@ -111,6 +112,7 @@ object Giraffe extends Controller {
         case USD => routes.Giraffe.thanksUSA().url
         case AUD => routes.Giraffe.thanksAustralia().url
         case EUR => routes.Giraffe.thanksEurope().url
+        case CAD => routes.Giraffe.thanksCanada().url
         case _ => routes.Giraffe.thanksUK().url
       }
 

--- a/frontend/app/controllers/Redirects.scala
+++ b/frontend/app/controllers/Redirects.scala
@@ -27,6 +27,7 @@ trait Redirects extends Controller {
       case CountryGroup.US => CountryGroup.US
       case CountryGroup.Australia => CountryGroup.Australia
       case CountryGroup.Europe => CountryGroup.Europe
+      case CountryGroup.Canada => CountryGroup.Canada
       case _ => CountryGroup.UK
     }
   }

--- a/frontend/app/views/giraffe/contribute.scala.html
+++ b/frontend/app/views/giraffe/contribute.scala.html
@@ -223,12 +223,67 @@
                                 Privacy Policy</a>.
                         </p>
                     </div>
+<<<<<<< HEAD
                     </ul>
                 </div>
                 <input type="hidden" name="ophanId" class="js-ophan-id">
                 <input type="hidden" name="cmp" value="@cmpCode.mkString">
                 <input type="hidden" name="intcmp" value="@intCmpCode.mkString">
             </form>
+=======
+                </ul>
+            </div>
+            <input type="hidden" name="ophanId" class="js-ophan-id">
+            <input type="hidden" name="cmp" value="@cmpCode.mkString">
+            <input type="hidden" name="intcmp" value="@intCmpCode.mkString">
+        </form>
+
+        <div class="feedback">
+        <span data-shown="gbp eur">
+            <p>If you have any questions about contributing to the Guardian, please
+                <a href="mailto:contribution.support@@theguardian.com" class="support-thanks__link">contact us here</a>.
+            </p>
+            <p>
+                The ultimate owner of the Guardian is The Scott Trust Limited, whose role it is to secure the editorial and financial independence of the Guardian in perpetuity. Reader contributions support the Guardian’s journalism.
+            </p>
+            <p>
+                Please note that your support of the Guardian’s journalism does not constitute a charitable donation, as such your contribution is not eligible for Gift Aid in the UK nor a tax-deduction elsewhere.
+            </p>
+        </span>
+
+        <span data-shown="aud">
+            <p>If you have any questions about contributing to the Guardian, please
+                <a href="mailto:contribution.support@@theguardian.com" class="support-thanks__link">contact us here</a>.
+            </p>
+            <p>
+                The ultimate owner of the Guardian is The Scott Trust Limited, whose role it is to secure the editorial and financial independence of the Guardian in perpetuity. Reader contributions support the Guardian’s journalism.
+            </p>
+        </span>
+
+        <span data-shown="cad">
+            <p>If you have any questions about contributing to the Guardian, please
+                <a href="mailto:contribution.support@@theguardian.com" class="support-thanks__link">contact us here</a>.
+            </p>
+            <p>
+                The ultimate owner of the Guardian is The Scott Trust Limited, whose role it is to secure the editorial and financial independence of the Guardian in perpetuity. Reader contributions support the Guardian’s journalism.
+            </p>
+        </span>
+
+        <span data-shown="usd">
+            <p>If you have any questions about contributing to the Guardian, please
+                <a href="mailto:contribution.support@@theguardian.com" class="support-thanks__link">contact us here</a>.
+            </p>
+            <p>
+                The ultimate owner of the Guardian is The Scott Trust Limited, whose role it is to secure the editorial and financial independence of the Guardian in perpetuity. Reader contributions support the Guardian’s journalism.
+            </p>
+            <p>
+                Please note that the Guardian is not a charity, will not use your support for charitable
+                programs, and your support of the Guardian’s journalism does not constitute a
+                charitable donation. As such your contribution is not eligible to be treated as a
+                charitable deduction for federal or state taxes in the United States or elsewhere.
+            </p>
+            </span>
+>>>>>>> add support for CAD
         </div>
     </div>
 </div>

--- a/frontend/app/views/giraffe/thankyou.scala.html
+++ b/frontend/app/views/giraffe/thankyou.scala.html
@@ -26,6 +26,10 @@
             Enjoy more of the Guardian's journalism from breaking investigations to politics, sports, arts and more.
         </p>
 
+        <p class="support-thanks__message" data-shown="cad">
+            Enjoy more of the Guardian's journalism from breaking investigations to politics, sports, arts and more.
+        </p>
+
         <p class="support-thanks__message" data-shown="aud">
             Enjoy more of the Guardian's journalism from breaking investigations to politics, sports, arts and more.
         </p>
@@ -37,6 +41,7 @@
                     <a data-shown="gbp eur" href="https://itunes.apple.com/gb/app/the-guardian/id409128287?mt=8" class="support-thanks__link" onClick="s.tl(true,'o','iApp')">iPhone and iPad app</a>
                     <a data-shown="aud" href="https://itunes.apple.com/au/app/the-guardian/id409128287?mt=8" class="support-thanks__link" onClick="s.tl(true,'o','iApp')">iPhone and iPad app</a>
                     <a data-shown="usd" href="https://itunes.apple.com/us/app/the-guardian/id409128287?mt=8" class="support-thanks__link" onClick="s.tl(true,'o','iApp')">iPhone and iPad app</a>
+                    <a data-shown="cad" href="https://itunes.apple.com/ca/app/the-guardian/id409128287?mt=8" class="support-thanks__link" onClick="s.tl(true,'o','iApp')">iPhone and iPad app</a>
                     <br><a href="https://play.google.com/store/apps/details?id=com.guardian" class="support-thanks__link" onClick="s.tl(true,'o','aApp')">Android app</a></p>
             </div>
             <div class="support-thanks__one-col">
@@ -44,7 +49,7 @@
                 <p>
                     <a data-shown="gbp eur" href="https://www.theguardian.com/info/2015/dec/08/daily-email-uk?CMP=contribution_thankyou" class="support-thanks__link" onClick="s.tl(true,'o','email')">Get the must-read stories</a> delivered straight to your inbox each morning in one handy email
                     <a data-shown="aud" href="https://www.theguardian.com/info/2015/dec/08/daily-email-us?CMP=contribution_thankyou" class="support-thanks__link" onClick="s.tl(true,'o','email')">Get the must-read stories</a> delivered straight to your inbox each morning in one handy email
-                    <a data-shown="usd" href="https://www.theguardian.com/info/2015/dec/08/daily-email-au?CMP=contribution_thankyou" class="support-thanks__link" onClick="s.tl(true,'o','email')">Get the must-read stories</a> delivered straight to your inbox each morning in one handy email
+                    <a data-shown="usd cad" href="https://www.theguardian.com/info/2015/dec/08/daily-email-au?CMP=contribution_thankyou" class="support-thanks__link" onClick="s.tl(true,'o','email')">Get the must-read stories</a> delivered straight to your inbox each morning in one handy email
                 </p>
             </div>
             <div class="support-thanks__one-col">

--- a/frontend/assets/stylesheets/giraffe.scss
+++ b/frontend/assets/stylesheets/giraffe.scss
@@ -512,7 +512,7 @@ $desktop-col-padding-right: 16px;
     display: none !important;
 }
 
-$currencies: gbp usd aud eur;
+$currencies: gbp usd aud eur cad;
 @each $currency in $currencies {
     .currency-#{$currency} {
         [data-shown*=#{$currency}] {

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -138,11 +138,13 @@ GET            /uk/contribute                         controllers.Giraffe.contri
 GET            /us/contribute                         controllers.Giraffe.contributeUSA
 GET            /au/contribute                         controllers.Giraffe.contributeAustralia
 GET            /eu/contribute                         controllers.Giraffe.contributeEurope
+GET            /ca/contribute                         controllers.Giraffe.contributeCanada
 
 GET            /contribute/thank-you                  controllers.Giraffe.thanksUK
 GET            /us/contribute/thank-you               controllers.Giraffe.thanksUSA
 GET            /au/contribute/thank-you               controllers.Giraffe.thanksAustralia
 GET            /eu/contribute/thank-you               controllers.Giraffe.thanksEurope
+GET            /ca/contribute/thank-you               controllers.Giraffe.thanksCanada
 
 POST           /contribute/pay                        controllers.Giraffe.pay
 

--- a/frontend/test/controllers/MakeGiraffeRedirectURL$Test.scala
+++ b/frontend/test/controllers/MakeGiraffeRedirectURL$Test.scala
@@ -47,7 +47,7 @@ class MakeGiraffeRedirectURL$Test extends Specification {
   "Canada" in {
     val fakeRequest = FakeRequest("GET", "/contribute?test1=a&test2=b")
 
-    MakeGiraffeRedirectURL(fakeRequest, CountryGroup.Canada).toString() must_== "/uk/contribute?test1=a&test2=b"
+    MakeGiraffeRedirectURL(fakeRequest, CountryGroup.Canada).toString() must_== "/ca/contribute?test1=a&test2=b"
   }
 
   "Rest of world" in {


### PR DESCRIPTION
This PR adds support for Canadian Dollars to the contribute page. As well as adding the /ca/contribute page that takes payment, it also auto-redirects users from Canada to this page.

In terms of copy, if anyone knows Canada well and can write anything unique and possibly using the word "loonie" then feel free to make a suggestion (please note, this is as I have been led to believe that "loonie" is a term Canadians use to describe their currency). At the moment I have used the US copy