### PR TITLE
babel polyfills

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "babel-core": "^6.7.6",
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.6.0",
+    "babel-plugin-transform-runtime": "^6.9.0",
     "bean": "~1.0.6",
     "bonzo": "~2.0.0",
     "bower": "^1.5.3",

--- a/frontend/webpack.conf.js
+++ b/frontend/webpack.conf.js
@@ -27,7 +27,8 @@ module.exports = function(debug) { return {
                 loader: 'babel',
                 query: {
                     presets: ['es2015'],
-                    cacheDirectory: ''
+                    cacheDirectory: '',
+                    plugins: ['transform-runtime']
                 }
             }
         ]


### PR DESCRIPTION
Use polyfills so we can use ES6 when we use ES6. 