### PR TITLE
Revert "Use membership common 227"

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "7.2.3"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.7"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.227"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.225"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache


### PR DESCRIPTION
Reverts guardian/membership-frontend#1266

As of membership-common 226 (which was never pushed to membership frontend) we now can't parse the production membership product catalog, I am reproducing in a test and sorting out now...