### PR TITLE
Provided INTCMP campaign code takes precedence over the FROM_P_[promo code]

### DIFF
--- a/frontend/app/controllers/Promotions.scala
+++ b/frontend/app/controllers/Promotions.scala
@@ -100,7 +100,9 @@ object Promotions extends Controller {
   def promotionPage(promoCodeStr: String) = CachedAction { implicit request =>
 
     val promoCode = PromoCode(promoCodeStr)
-    val homepageWithCampaignCode = "/" ? ("INTCMP" -> s"FROM_P_${promoCode.get}")
+    // Any provided internal campaign code takes precidence over the "From Promo Code" version.
+    val internalCampaignCode = request.getQueryString("INTCMP").getOrElse(s"FROM_P_${promoCode.get}")
+    val homepageWithCampaignCode = "/" ? ("INTCMP" -> internalCampaignCode)
     val redirectToHomepage = Redirect(homepageWithCampaignCode)
     val redirectToUpperCase = Redirect("/p/" + promoCodeStr.toUpperCase)
     val redirectToHomepageWithSession = Redirect(homepageWithCampaignCode).withCookies(sessionCookieFromCode(promoCode))

--- a/frontend/app/controllers/Promotions.scala
+++ b/frontend/app/controllers/Promotions.scala
@@ -100,7 +100,7 @@ object Promotions extends Controller {
   def promotionPage(promoCodeStr: String) = CachedAction { implicit request =>
 
     val promoCode = PromoCode(promoCodeStr)
-    // Any provided internal campaign code takes precidence over the "From Promo Code" version.
+    // Any provided internal campaign code takes precedence over the "From Promo Code" version.
     val internalCampaignCode = request.getQueryString("INTCMP").getOrElse(s"FROM_P_${promoCode.get}")
     val homepageWithCampaignCode = "/" ? ("INTCMP" -> internalCampaignCode)
     val redirectToHomepage = Redirect(homepageWithCampaignCode)


### PR DESCRIPTION
Make the provided INTCMP campaign code take precedence over the  FROM_P_[promo code] version (when a promotion expires or is not valid or present).

cc @JuliaBellis 