### PR TITLE
Remove competitions from nav

### DIFF
--- a/frontend/app/model/Nav.scala
+++ b/frontend/app/model/Nav.scala
@@ -22,7 +22,6 @@ object Nav {
       NavItem("archive", routes.WhatsOn.listArchive.url, "Archive")
     )),
     NavItem("masterclasses", "/masterclasses", "Masterclasses"),
-    NavItem("competitions", "/offers-competitions", "Competitions"),
     NavItem("patrons", "/patrons", "Patrons"),
     NavItem("feedback", "/feedback", "Feedback")
   )


### PR DESCRIPTION
Competitions are currently on hold therefore removing them from the nav for now.

<img width="586" alt="screen shot 2016-07-13 at 15 24 44" src="https://cloud.githubusercontent.com/assets/406099/16806729/9c8f914a-490d-11e6-983b-afecbd3fad2d.png">
