### PR TITLE
Endpoint for returning paid Membership plans with prices

### DIFF
--- a/frontend/app/controllers/PricingApi.scala
+++ b/frontend/app/controllers/PricingApi.scala
@@ -1,12 +1,18 @@
 package controllers
 
 import com.gu.i18n._
-import play.api.libs.json.{JsString, JsValue, Writes, Json}
+import com.gu.membership.MembershipCatalog
+import com.gu.salesforce.PaidTier
+import play.api.libs.json.{JsArray, JsString, JsValue, Writes, Json}
 import play.api.mvc.Controller
-import views.support.CountryWithCurrency
+import services.TouchpointBackend
+import views.support.{Pricing, CountryWithCurrency}
 
-object CountryWithCurrencyResponse {
-  implicit val countryWrites = Json.writes[Country]
+case class MembershipPlan(tier: PaidTier, prices: List[Pricing])
+
+case class MembershipPlanResponse(plans: List[MembershipPlan])
+
+object PricingFormats {
   implicit val currencyWrites = new Writes[Currency] {
     override def writes(currency: Currency): JsValue = currency match {
       case GBP => JsString("GBP")
@@ -17,13 +23,50 @@ object CountryWithCurrencyResponse {
       case USD => JsString("USD")
     }
   }
+  implicit val countryWrites = Json.writes[Country]
   implicit val countryCurrencyWrites = Json.writes[CountryWithCurrency]
+
+  implicit val pricingsWrites = new Writes[List[Pricing]] {
+    override def writes(pricings: List[Pricing]): JsValue = {
+      JsArray(
+        pricings
+          .flatMap { pricing => Seq("monthly" -> pricing.monthly, "annually" -> pricing.yearly) }
+          .map { case (bp, price) =>
+            Json.obj(
+              "billingPeriod" -> bp,
+              "amount" -> f"${ price.amount }%.2f",
+              "currency" -> price.currency
+            )
+          }
+      )
+    }
+  }
+
+  implicit val tierWrites = new Writes[PaidTier] {
+    override def writes(tier: PaidTier): JsValue = JsString(tier.name)
+  }
+  implicit val planWrites = Json.writes[MembershipPlan]
+  implicit val writes = Json.writes[MembershipPlanResponse]
 }
 
 object PricingApi extends Controller {
-  import CountryWithCurrencyResponse._
+
+  import PricingFormats._
+  import views.support.Pricing._
+
+  val membersCatalog: MembershipCatalog = TouchpointBackend.Normal.catalog
+
   def currencies = CachedAction {
     Ok(Json.toJson(CountryWithCurrency.all))
+  }
+
+  def ratePlans = CachedAction {
+    val plansByTier = for {
+      tier <- PaidTier.all
+      plan = membersCatalog.findPaid(tier)
+    } yield MembershipPlan(plan.tier, plan.allPricing)
+
+    Ok(Json.toJson(MembershipPlanResponse(plansByTier.toList)))
   }
 }
 

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -130,6 +130,7 @@ GET            /english-heritage                      controllers.Default.redire
 # REST
 # Pricing
 GET            /currencies                            controllers.PricingApi.currencies
+GET            /rate-plans                            controllers.PricingApi.ratePlans
 
 # Giraffe
 GET            /contribute                            controllers.Giraffe.contributeRedirect


### PR DESCRIPTION
Mobile apps are implementing native membership flows and think these information will be helpful.

Compared to https://membership.theguardian.com/staff/catalog#, free, legacy and tests plans are excluded.

Endpoint will be accessible under `/rate-plans`, here is sample json output:
![rate-plans-api](https://cloud.githubusercontent.com/assets/8526142/16842625/0c4beaba-49d6-11e6-86fd-a6f60f387785.png)

cc @chrisjowen @rtyley 