### PR TITLE
first name and last name fields added to contribute

### DIFF
--- a/frontend/app/forms/MemberForm.scala
+++ b/frontend/app/forms/MemberForm.scala
@@ -20,7 +20,8 @@ object MemberForm {
   case class NameForm(first: String, last: String) extends FullName
 
   case class SupportForm(
-    name: String,
+    firstName: String,
+    lastName: String,
     currency: Currency,
     amount: BigDecimal,
     email: String,
@@ -278,7 +279,8 @@ object MemberForm {
 
   val supportForm: Form[SupportForm] = Form(
     mapping(
-      "name" -> nonEmptyText,
+      "firstName" -> nonEmptyText,
+      "lastName" -> nonEmptyText,
       "currency" -> of[Currency],
       "amount" -> bigDecimal(10, 2),
       "email" -> email,

--- a/frontend/app/views/giraffe/contribute.scala.html
+++ b/frontend/app/views/giraffe/contribute.scala.html
@@ -3,7 +3,8 @@
 @import configuration.Links
 @import com.gu.i18n.CountryGroup
 @import views.support.ChosenVariants
-@(pageInfo: PageInfo, maxAmount: Option[Int], countryGroup: CountryGroup, isUAT: Boolean, chosenVariants: ChosenVariants, cmpCode: Option[String], intCmpCode: Option[String], years: List[Int])
+@import views.support.IdentityUser
+@(pageInfo: PageInfo, maxAmount: Option[Int], idUser: Option[IdentityUser], countryGroup: CountryGroup, isUAT: Boolean, chosenVariants: ChosenVariants, cmpCode: Option[String], intCmpCode: Option[String], years: List[Int])
 
 @giraffeMain(pageInfo){
 <div class="support-wrapper__outer__a">
@@ -71,9 +72,23 @@
                         Your details</h3>
                     <ul class="u-unstyled">
                         <li class="form-field">
-                            <label for="name" class="label">Full name</label>
+                            <label for="firstName" class="label">First Name</label>
                             <div class="input">
-                                <input type="text" id="name" class="input-text js-name" name="name" tabindex="1" aria-required="true" spellcheck="false" autocorrect="off" autocapitalize="off" required>
+                                @idUser.fold {
+                                    <input type="text" id="firstName" class="input-text js-name" name="firstName" tabindex="1" aria-required="true" spellcheck="false" autocorrect="off" autocapitalize="off" required>
+                                } { id =>
+                                <input type="text" id="firstName" class="input-text js-name" name="firstName" value=@id.privateFields.firstName  tabindex="1" aria-required="true" spellcheck="false" autocorrect="off" autocapitalize="off" required>
+                                }
+                             </div>
+                        </li>
+                        <li class="form-field">
+                            <label for="lastName" class="label">Last Name</label>
+                            <div class="input">
+                                @idUser.fold {
+                                    <input type="text" id="lastName" class="input-text js-name" name="lastName" tabindex="1" aria-required="true" spellcheck="false" autocorrect="off" autocapitalize="off" required>
+                                } { id =>
+                                    <input type="text" id="lastName" class="input-text js-name" name="lastName" value=@id.privateFields.secondName tabindex="1" aria-required="true" spellcheck="false" autocorrect="off" autocapitalize="off" required>
+                                }
                             </div>
                         </li>
                         <li id="email_field" class="form-field">

--- a/frontend/assets/javascripts/src/modules/giraffe.es6
+++ b/frontend/assets/javascripts/src/modules/giraffe.es6
@@ -108,6 +108,7 @@ function setAmount(amount) {
 }
 
 function getStuffFromIdentity() {
+    //let IDENTITY_API = 'https://idapi-code-proxy.thegulocal.com/user/me/'
     let IDENTITY_API = 'https://idapi.theguardian.com/user/me/';
     ajax.reqwest({
         url: IDENTITY_API,
@@ -117,7 +118,6 @@ function getStuffFromIdentity() {
     }).then(function (resp) {
         if (resp.user) {
             EMAIL_FIELD.value = resp.user.primaryEmailAddress;
-            NAME_FIELD.value = resp.user.publicFields.displayName;
         }
     })
 }


### PR DESCRIPTION
This PR replaces the name field on the contribute page with separate first name and last name fields. This was necessary in order to better analyse the data from contributions. 

