### PR TITLE
Double Spaces Removal

### DIFF
--- a/frontend/app/views/support/ABTest.scala
+++ b/frontend/app/views/support/ABTest.scala
@@ -38,12 +38,12 @@ object AmountHighlightTest extends TestTrait {
     Variant("Amount - 5 highlight","5",0,views.html.fragments.giraffe.contributeAmountButtons(List(5,25,50,100),Some(5))),
     Variant("Amount - 25 highlight","25",0,views.html.fragments.giraffe.contributeAmountButtons(List(5,25,50,100),Some(25))),
     Variant("Amount - no highlight","None",0,views.html.fragments.giraffe.contributeAmountButtons(List(5,25,50,100), None)),
-    Variant("Amount -  35 highlight","35",0,views.html.fragments.giraffe.contributeAmountButtons(List(10,35,65,100),Some(35))),
-    Variant("Amount -  35 highlight descending","35-descending",0,views.html.fragments.giraffe.contributeAmountButtons(List(100,65,35,10),Some(35))),
-    Variant("Amount -  100 highlight","100",0,views.html.fragments.giraffe.contributeAmountButtons(List(25,50,100,250),Some(100))),
-    Variant("Amount -  50 highlight","50",0.33,views.html.fragments.giraffe.contributeAmountButtons(List(25,50,100,250),Some(50))),
-    Variant("Amount -  15","15",0.33,views.html.fragments.giraffe.contributeAmountButtons(List(15,35,65,100),Some(35))),
-    Variant("Amount -  40 highlight","40",0.33,views.html.fragments.giraffe.contributeAmountButtons(List(20,40,75,100),Some(40)))
+    Variant("Amount - 35 highlight","35",0,views.html.fragments.giraffe.contributeAmountButtons(List(10,35,65,100),Some(35))),
+    Variant("Amount - 35 highlight descending","35-descending",0,views.html.fragments.giraffe.contributeAmountButtons(List(100,65,35,10),Some(35))),
+    Variant("Amount - 100 highlight","100",0,views.html.fragments.giraffe.contributeAmountButtons(List(25,50,100,250),Some(100))),
+    Variant("Amount - 50 highlight","50",0.33,views.html.fragments.giraffe.contributeAmountButtons(List(25,50,100,250),Some(50))),
+    Variant("Amount - 15","15",0.33,views.html.fragments.giraffe.contributeAmountButtons(List(15,35,65,100),Some(35))),
+    Variant("Amount - 40 highlight","40",0.33,views.html.fragments.giraffe.contributeAmountButtons(List(20,40,75,100),Some(40)))
   )
 }
 


### PR DESCRIPTION
Removed accidental double spaces in variant names.  See Jack email:

----

Mark,

Some of the Amount VariantNames coming through to Stripe have double spaces in. e.g.

Amount - 50 highlight
Amount -  50 highlight

are both showing up (the former is preferable because it's simpler).

It's not crucial because it can be cleared up a bit in the analysis but it would make life a bit easier if it was all uniform.

Thanks,
Jack