### PR TITLE
pin grunt asset hash

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,7 @@
     "curl-amd": "~0.8.10",
     "domready": "~1.0.5",
     "grunt": "^0.4.5",
-    "grunt-asset-hash": "^0.1.6",
+    "grunt-asset-hash": "0.1.6",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-copy": "^0.8.0",


### PR DESCRIPTION
There's a new version of grunt-asset-hash that's compatible with new versions of grunt....
...and our ^ised version number matches it and breaks. 