### PR TITLE
Remove upsert of Membership_Tier__c in Salesforce

### DIFF
--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -135,10 +135,6 @@ class MemberService(identityService: IdentityService,
       } yield zuoraSub.subscriptionName).andThen { case Failure(e) =>
         logger.error(s"Could not create free Zuora subscription for user ${user.id}", e)}
 
-    def updateSalesforceContactWithMembership(stripeCustomer: Option[Customer]): Future[ContactId] =
-      salesforceService.updateMemberStatus(user, tier, stripeCustomer).andThen { case Failure(e) =>
-        logger.error(s"Could not update Salesforce contact with membership status for user ${user.id}", e)}
-
     formData match {
       case paid: PaidMemberJoinForm => //
         for {
@@ -146,7 +142,6 @@ class MemberService(identityService: IdentityService,
           idUser          <- getIdentityUserDetails
           sfContact       <- createSalesforceContact(idUser)
           zuoraSubName    <- createPaidZuoraSubscription(sfContact, stripeCustomer, paid)
-          _               <- updateSalesforceContactWithMembership(Some(stripeCustomer))  // FIXME: This should go!
           _               <- updateIdentity()
         } yield (sfContact, zuoraSubName)
 
@@ -155,7 +150,6 @@ class MemberService(identityService: IdentityService,
           idUser          <- getIdentityUserDetails
           sfContact       <- createSalesforceContact(idUser)
           zuoraSubName    <- createFreeZuoraSubscription(sfContact, formData)
-          _               <- updateSalesforceContactWithMembership(None)                  // FIXME: This should go!
           _               <- updateIdentity()
         } yield (sfContact, zuoraSubName)
     }
@@ -488,7 +482,6 @@ class MemberService(identityService: IdentityService,
       promo = promoService.validateMany[Upgrades](country, planChoice.productRatePlanId)(form.promoCode, form.trackingPromoCode).toOption.flatten
       command <- EitherT(amend(sub, planChoice, form.featureChoice, promo).map(\/.right))
       _ <- zuoraService.upgradeSubscription(command).liftM
-      _ <- salesforceService.updateMemberStatus(IdMinimalUser(contact.identityId, None), newPlan.tier, None).liftM
     } yield {
       salesforceService.metrics.putUpgrade(tier)
       addressDetails.foreach(identityService.updateUserFieldsBasedOnUpgrade(contact.identityId, _))

--- a/frontend/app/services/SalesforceService.scala
+++ b/frontend/app/services/SalesforceService.scala
@@ -1,10 +1,9 @@
 package services
 
 import com.gu.i18n.Country._
-import com.gu.identity.play.{IdMinimalUser, IdUser}
+import com.gu.identity.play.IdUser
 import com.gu.salesforce.ContactDeserializer.Keys
 import com.gu.salesforce._
-import com.gu.stripe.Stripe.Customer
 import forms.MemberForm.JoinForm
 import model.GenericSFContact
 import monitoring.MemberMetrics
@@ -36,18 +35,6 @@ class SalesforceService(salesforceConfig: SalesforceConfig) extends api.Salesfor
 
   override def upsert(user: IdUser, joinData: JoinForm): Future[ContactId] =
     upsert(user.id, initialData(user, joinData))
-
-  override def updateMemberStatus(user: IdMinimalUser, tier: Tier, customer: Option[Customer]): Future[ContactId] =
-    upsert(user.id, memberData(tier, customer))
-
-  private def memberData(tier: Tier, customerOpt: Option[Customer]): JsObject = Json.obj(
-    Keys.TIER -> tier.name
-  ) ++ customerOpt.map { customer =>
-    Json.obj(
-      Keys.STRIPE_CUSTOMER_ID -> customer.id,
-      Keys.DEFAULT_CARD_ID -> customer.card.id
-    )
-  }.getOrElse(Json.obj())
 
   private def initialData(user: IdUser, formData: JoinForm): JsObject = {
     Seq(Json.obj(

--- a/frontend/app/services/api/SalesforceService.scala
+++ b/frontend/app/services/api/SalesforceService.scala
@@ -1,8 +1,7 @@
 package services.api
 
-import com.gu.identity.play.{IdMinimalUser, IdUser}
-import com.gu.salesforce.{ContactId, Tier}
-import com.gu.stripe.Stripe.Customer
+import com.gu.identity.play.IdUser
+import com.gu.salesforce.ContactId
 import forms.MemberForm.JoinForm
 import model.GenericSFContact
 import monitoring.MemberMetrics
@@ -14,5 +13,4 @@ trait SalesforceService {
   def getMember(userId: UserId): Future[Option[GenericSFContact]]
   def metrics: MemberMetrics
   def upsert(user: IdUser, userData: JoinForm): Future[ContactId]
-  def updateMemberStatus(user: IdMinimalUser, tier: Tier, customer: Option[Customer]): Future[ContactId]
 }


### PR DESCRIPTION
@paulbrown1982 @tomverran 

[Trello card](https://trello.com/c/qqlH92NZ/48-contact-and-subsproductcharge-objects-out-of-sync-in-salesforce)

`Membership_Tier__c` field in `Contact` object in Salesforce can be calculated automatically by Salesforce after Zuroa 360 Sync of `Zuora__SubscriptionProductCharge__c` object. Thus there is no need to make this extra HTTP request (which often fails due to a timeout).

**NOTE:** Do not merge until Touchpoint makes a corresponding update in their Apex code.