### PR TITLE
Use common code for redirecting with campaign codes

### DIFF
--- a/frontend/app/controllers/Giraffe.scala
+++ b/frontend/app/controllers/Giraffe.scala
@@ -2,21 +2,16 @@ package controllers
 
 import com.gu.i18n._
 import play.api.mvc._
+import tracking.RedirectWithCampaignCodes._
 
 object Giraffe extends Controller {
 
-  val CampaignCodesToForward = Set("INTCMP", "CMP", "mcopy")
-
-  def redirectWithCampaignCodes(contributionsUrl: String)(implicit request: RequestHeader): Result = {
-    Redirect(contributionsUrl, request.queryString.filterKeys(CampaignCodesToForward), MOVED_PERMANENTLY)
-  }
-
   def redirectToContributions() = NoCacheAction { implicit request =>
-    redirectWithCampaignCodes("https://contribute.theguardian.com/")
+    redirectWithCampaignCodes("https://contribute.theguardian.com/", MOVED_PERMANENTLY)
   }
 
   def redirectToContributionsFor(countryGroup: CountryGroup) = NoCacheAction { implicit request =>
-    redirectWithCampaignCodes(s"https://contribute.theguardian.com/${countryGroup.id}")
+    redirectWithCampaignCodes(s"https://contribute.theguardian.com/${countryGroup.id}", MOVED_PERMANENTLY)
   }
 
 }

--- a/frontend/app/controllers/Info.scala
+++ b/frontend/app/controllers/Info.scala
@@ -12,6 +12,7 @@ import services.{AuthenticationService, EmailService, GuardianContentService, To
 import views.support.{Asset, PageInfo}
 import com.netaporter.uri.dsl._
 import com.netaporter.uri.Uri
+import tracking.RedirectWithCampaignCodes._
 
 import scala.concurrent.Future
 import utils.RequestCountry._
@@ -20,15 +21,7 @@ trait Info extends Controller {
   def supporterRedirect = NoCacheAction { implicit request =>
     val countryGroup = request.getFastlyCountry.getOrElse(CountryGroup.RestOfTheWorld)
 
-    val baseUrl: Uri = redirectToSupporterPage(countryGroup).absoluteURL.withScheme("https")
-    val paramsToPropagate = Seq("INTCMP", "CMP", "mcopy")
-    val urlWithParams = paramsToPropagate.foldLeft[Uri](baseUrl) { (url, param) =>
-      // No need to filter out the params that aren't present because if the `?` method gets a key-value tuple
-      // with value of None, that parameter will not be rendered when toString is called
-      url ? (param -> request.getQueryString(param))
-    }
-
-    Redirect(urlWithParams, SEE_OTHER)
+    redirectWithCampaignCodes(redirectToSupporterPage(countryGroup).url, SEE_OTHER)
   }
 
   def supporterUK = CachedAction { implicit request =>

--- a/frontend/app/tracking/RedirectWithCampaignCodes.scala
+++ b/frontend/app/tracking/RedirectWithCampaignCodes.scala
@@ -1,0 +1,12 @@
+package tracking
+
+import controllers.Giraffe._
+import play.api.mvc.{RequestHeader, Result}
+
+object RedirectWithCampaignCodes {
+
+  val CampaignCodesToForward = Set("INTCMP", "CMP", "mcopy")
+
+  def redirectWithCampaignCodes(url: String, status: Int)(implicit request: RequestHeader): Result =
+    Redirect(url, request.queryString.filterKeys(CampaignCodesToForward), status)
+}


### PR DESCRIPTION
This code was introduced with https://github.com/guardian/membership-frontend/pull/1294, but I noticed that there was similar code over in `Info`.

cc @paulbrown1982 