### PR TITLE
Fix some supporter page redirects for Australian customers

### DIFF
--- a/frontend/app/controllers/Info.scala
+++ b/frontend/app/controllers/Info.scala
@@ -18,10 +18,9 @@ import scala.concurrent.Future
 import utils.RequestCountry._
 
 trait Info extends Controller {
-  def supporterRedirect = NoCacheAction { implicit request =>
-    val countryGroup = request.getFastlyCountry.getOrElse(CountryGroup.RestOfTheWorld)
-
-    redirectWithCampaignCodes(redirectToSupporterPage(countryGroup).url, SEE_OTHER)
+  def supporterRedirect(countryGroup: Option[CountryGroup]) = NoCacheAction { implicit request =>
+    val determinedCountryGroup = (countryGroup orElse request.getFastlyCountry).getOrElse(CountryGroup.RestOfTheWorld)
+    redirectWithCampaignCodes(redirectToSupporterPage(determinedCountryGroup).url, SEE_OTHER)
   }
 
   def supporterUK = CachedAction { implicit request =>

--- a/frontend/app/controllers/Redirects.scala
+++ b/frontend/app/controllers/Redirects.scala
@@ -9,7 +9,7 @@ trait Redirects extends Controller {
   def homepageRedirect = CachedAction(MovedPermanently("/"))
 
   def supporterRedirect = CachedAction {
-    MovedPermanently(routes.Info.supporterRedirect.path)
+    MovedPermanently(routes.Info.supporterRedirect(None).path)
   }
 
   def redirectToSupporterPage(countryGroup: CountryGroup): Call = {
@@ -17,17 +17,8 @@ trait Redirects extends Controller {
       case CountryGroup.UK => routes.Info.supporterUK()
       case CountryGroup.US => routes.Info.supporterUSA()
       case CountryGroup.Europe => routes.Info.supporterEurope()
+      case CountryGroup.Australia => routes.Info.supporterAustralia()
       case _ => routes.Info.supporterFor(countryGroup)
-    }
-  }
-
-  def getRedirectCountryCodeGiraffe(countryGroup: CountryGroup): CountryGroup = {
-    countryGroup match {
-      case CountryGroup.UK => CountryGroup.UK
-      case CountryGroup.US => CountryGroup.US
-      case CountryGroup.Australia => CountryGroup.Australia
-      case CountryGroup.Europe => CountryGroup.Europe
-      case _ => CountryGroup.UK
     }
   }
 

--- a/frontend/app/controllers/TierController.scala
+++ b/frontend/app/controllers/TierController.scala
@@ -72,7 +72,7 @@ object TierController extends Controller with ActivityTracking
       cg <- request.getIdentityCountryGroup
     } yield {
       if (cg.exists(_ != CountryGroup.UK) && isFreeSubscriber)
-        Redirect(routes.Info.supporterRedirect)
+        Redirect(routes.Info.supporterRedirect(cg))
       else
         Ok(views.html.tier.change(request.subscriber.subscription.plan.tier, catalog))
     }

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -91,11 +91,12 @@ GET            /tier/change/:tier/summary             controllers.TierController
 
 # Information
 GET            /patrons                               controllers.Info.patron
-GET            /supporter                             controllers.Info.supporterRedirect
+GET            /supporter                             controllers.Info.supporterRedirect(countryGroup: Option[CountryGroup])
 GET            /uk/supporter                          controllers.Info.supporterUK
 GET            /us/supporter                          controllers.Info.supporterUSA
 GET            /eu/supporter                          controllers.Info.supporterEurope
 GET            /au/supporter                          controllers.Info.supporterAustralia
+GET            /about/supporter                       controllers.Redirects.supporterRedirect
 GET            /:countryGroup/supporter               controllers.Info.supporterFor(countryGroup: CountryGroup)
 GET            /help                                  controllers.Info.help
 GET            /feedback                              controllers.Info.feedback
@@ -113,7 +114,6 @@ GET            /subscriber-offer                      controllers.Redirects.home
 
 # Redirects
 GET            /about                                 controllers.Redirects.homepageRedirect
-GET            /about/supporter                       controllers.Redirects.supporterRedirect
 GET            /founder                               controllers.VanityUrl.redirect
 GET            /join-challenger                       controllers.Redirects.homepageRedirect
 GET            /join                                  controllers.Redirects.homepageRedirect


### PR DESCRIPTION
- Fix some supporter page redirects for Australian customers
- Remove some old, now unused, Giraffe redirects
- Moved the /about/supporter up the chain as it was accidentally getting caught by /:country/supporter route.
- For logged in users, have their Identity account country to take precedence over geo-ip on the /tier/change redirect

cc @AWare 