### PR TITLE
/join to go to Supporter landing page

### DIFF
--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -116,7 +116,7 @@ GET            /subscriber-offer                      controllers.Redirects.home
 GET            /about                                 controllers.Redirects.homepageRedirect
 GET            /founder                               controllers.VanityUrl.redirect
 GET            /join-challenger                       controllers.Redirects.homepageRedirect
-GET            /join                                  controllers.Redirects.homepageRedirect
+GET            /join                                  controllers.Info.supporterRedirect(countryGroup: Option[CountryGroup])
 
 GET            /assets/bookmarklets/*bookmarklet      controllers.CachedAssets.bookmarkletAt(path="/public/bookmarklets/", bookmarklet)
 


### PR DESCRIPTION
Let's make /join (which is linked to from the MMA page amongst other pages) go to the relevant Supporter page for that account, rather than the homepage. There's a second button in the UI 
which goes to /about which also goes to the homepage, which we can leave alone - and the customer can self-select based on how much they know already about membership.

<img width="741" alt="picture 159" src="https://cloud.githubusercontent.com/assets/1515970/17366541/b4a99a7e-5983-11e6-9ac4-20bea3e4a4ec.png">

The redirect was previously a 301, so this might not be 100% reliable, but neither scenario are a bad thing.

Cc @AWare @rtyley 