### PR TITLE
Change social thank you to link to supporter url

### DIFF
--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -31,6 +31,7 @@ object Config {
   val guardianShortDomain = config.getString("guardian.shortDomain")
 
   val membershipUrl = config.getString("membership.url")
+  val membershipSupporterUrl = config.getString("membership.supporter.url")
   val membershipHost = Uri.parse(Config.membershipUrl).host.get
 
   val membersDataAPIUrl = config.getString("members-data-api.url")

--- a/frontend/app/views/support/Social.scala
+++ b/frontend/app/views/support/Social.scala
@@ -60,8 +60,8 @@ object Social {
   )
 
   val joinThankyou: Set[Social] = Set(
-    Email("I'm the newest Guardian member", s"I'm the newest Guardian member ${Config.membershipUrl}"),
-    Twitter(s"I'm the newest Guardian member ${Config.membershipUrl} ${SocialConfig.twitterHashtag}"),
-    Facebook(Config.membershipUrl)
+    Email("I'm the newest Guardian member", s"I'm the newest Guardian member ${Config.membershipSupporterUrl}"),
+    Twitter(s"I'm the newest Guardian member ${Config.membershipSupporterUrl} ${SocialConfig.twitterHashtag}"),
+    Facebook(Config.membershipSupporterUrl)
   )
 }

--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -13,6 +13,7 @@ guardian.shortDomain="theguardian.com"
 
 membership.url="https://membership.theguardian.com"
 membership.feedback="membershipfeedback@theguardian.com"
+membership.supporter.url="https://membership.theguardian.com/supporter"
 
 members-data-api.url=""
 


### PR DESCRIPTION
Currently the social supporter link goes to the homepage, which is a bit UK centric. 
Maybe this should point to the supporter page. (Need to build this at work)