### PR TITLE
Make the opengraph stuff for members only content a bit better

### DIFF
--- a/frontend/app/controllers/MemberOnlyContent.scala
+++ b/frontend/app/controllers/MemberOnlyContent.scala
@@ -34,8 +34,9 @@ object MemberOnlyContent extends Controller with LazyLogging {
           val pageInfo = PageInfo(
             title = headline,
             url = request.path,
-            description = Some(CopyConfig.copyDescriptionChooseTier),
-            customSignInUrl = Some(signInUrl)
+            description = capiContent.trailText,
+            customSignInUrl = Some(signInUrl),
+            image = capiContent.mainPicture.map(_.defaultImage)
           )
           Ok(views.html.joiner.membershipContent(pageInfo, accessOpt, signInUrl, capiContent, s"Exclusive Members Content: $headline")).
             withSession(request.session +  (DestinationService.JoinReferrer -> ("https://" + Config.guardianHost +"/" + referringContent)))


### PR DESCRIPTION
Make the description the trail and the image the mainPicture from the imageGroup. 
When the codefreeze is done, maybe figure out how to add the nice blue bottom border. 
@tomverran 