### PR TITLE
Make longer section names show properly

### DIFF
--- a/frontend/assets/stylesheets/components/_articles.scss
+++ b/frontend/assets/stylesheets/components/_articles.scss
@@ -244,9 +244,16 @@
     float: left;
     padding-right: $gs-gutter/3;
 
-    @include mq(tablet) {
+    @include mq(wide) {
         @include fs-header(4);
         line-height: get-line-height(header, 2);
+        float: none;
+        padding-right: 0;
+    }
+
+    @include mq(mem-full, wide) {
+        font-size: 20px;
+        line-height: 24px;
         float: none;
         padding-right: 0;
     }

--- a/frontend/assets/stylesheets/components/_articles.scss
+++ b/frontend/assets/stylesheets/components/_articles.scss
@@ -245,8 +245,9 @@
     padding-right: $gs-gutter/3;
 
     @include mq(wide) {
-        @include fs-header(4);
-        line-height: get-line-height(header, 2);
+        font-size: 22px;
+        line-height: 24px;
+        @include f-header;
         float: none;
         padding-right: 0;
     }
@@ -254,6 +255,7 @@
     @include mq(mem-full, wide) {
         font-size: 20px;
         line-height: 24px;
+        @include f-header;
         float: none;
         padding-right: 0;
     }

--- a/frontend/assets/stylesheets/components/_articles.scss
+++ b/frontend/assets/stylesheets/components/_articles.scss
@@ -241,13 +241,13 @@
 
 .content__section-label {
     @include fs-header(1);
+    @include f-header;
     float: left;
     padding-right: $gs-gutter/3;
 
     @include mq(wide) {
         font-size: 22px;
         line-height: 24px;
-        @include f-header;
         float: none;
         padding-right: 0;
     }
@@ -255,7 +255,6 @@
     @include mq(mem-full, wide) {
         font-size: 20px;
         line-height: 24px;
-        @include f-header;
         float: none;
         padding-right: 0;
     }

--- a/frontend/assets/stylesheets/utilities/_util-layout.scss
+++ b/frontend/assets/stylesheets/utilities/_util-layout.scss
@@ -98,7 +98,6 @@
 
 .u-horizontal-inset {
     padding-left: $gs-gutter/2;
-    padding-right: $gs-gutter/2;
 }
 
 .u-mobile-gutter {


### PR DESCRIPTION
Before:

![image](https://cloud.githubusercontent.com/assets/68329/18556697/132148b6-7b64-11e6-931d-ebd385c898fa.png)

After:

![image](https://cloud.githubusercontent.com/assets/68329/18556714/275c528a-7b64-11e6-8620-52db15b27249.png)
