### PR TITLE
Convert DestinationService into a class

### DIFF
--- a/frontend/app/services/DestinationService.scala
+++ b/frontend/app/services/DestinationService.scala
@@ -1,54 +1,49 @@
 package services
-
-import actions._
+import com.gu.memsub.Subscriber.Member
 import com.netaporter.uri.dsl._
 import configuration.Config
+import model.Eventbrite.EBCode
+import model.RichEvent.RichEvent
 import model.{ContentDestination, ContentItem, Destination, EventDestination}
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import scalaz.syntax.monadPlus._
+import play.api.mvc.Session
 
-import scala.concurrent.Future
-
-trait DestinationService {
-
-  def memberService(request: SubscriptionRequest[_]): api.MemberService
-
-  val JoinReferrer = "join-referrer"
-  val contentApiService: GuardianContentService
-  val eventbriteService: EventbriteCollectiveServices
-
-  def returnDestinationFor(request: SubscriptionRequest[_] with Subscriber): Future[Option[Destination]] = {
-    Future.sequence(Seq(contentDestinationFor(request), eventDestinationFor(request))).map(_.flatten.headOption)
-  }
-
-  def contentDestinationFor(implicit request: SubscriptionRequest[_]): Future[Option[ContentDestination]] = {
-    request.session.get(JoinReferrer).map { referer =>
-      if(referer.host.contains(Config.guardianHost)) {
-        contentApiService.contentItemQuery(referer.path).map { resp =>
-          resp.content.map(ContentItem).map(ContentDestination)
-        } recover { case _ => None }
-      } else {
-        Future.successful(None)
-      }
-    }.getOrElse(Future.successful(None))
-  }
-
-  def eventDestinationFor(implicit request: SubscriptionRequest[_] with Subscriber): Future[Option[EventDestination]] = {
-    val tier = request.subscriber.subscription.plan.tier
-    val optFuture = for {
-      eventId <- PreMembershipJoiningEventFromSessionExtractor.eventIdFrom(request)
-      event <- eventbriteService.getBookableEvent(eventId) if event.isBookableByTier(tier)
-    } yield memberService(request).createEBCode(request.subscriber, event).map { discountOpt =>
-      EventDestination(event, Config.eventbriteApiIframeUrl ? ("eid" -> event.id) & ("discount" -> discountOpt.map(_.code)))
-    }
-
-    optFuture.map(_.map(Some(_))).getOrElse(Future.successful(None))
-  }
+import scala.language.higherKinds
+import scalaz.{Monad, OptionT}
+object DestinationService {
+  val JoinReferrer = "join-referrer" //session key
 }
 
-object DestinationService extends DestinationService  {
-  val contentApiService = GuardianContentService
-  val eventbriteService = EventbriteService
+class DestinationService[M[+_] : Monad](
+  getBookableEvent: String => Option[RichEvent],
+  capiItemQuery: String => M[com.gu.contentapi.client.model.v1.ItemResponse],
+  createCode: (Member, RichEvent) => M[Option[EBCode]]) {
 
-  override def memberService(request: SubscriptionRequest[_]): api.MemberService =
-    request.touchpointBackend.memberService
+  /**
+    * Given a request from a member, figure out where they came from
+    * and get them a destination to go back to (either restricted content or an event)
+    */
+  def returnDestinationFor(session: Session, member: Member): M[Option[Destination]] = (
+    OptionT[M, Destination](contentDestinationFor(session)) orElse
+    OptionT[M, Destination](eventDestinationFor(session, member))
+  ).run
+
+  /**
+    * If the member has come in from some restricted content on The Guardian
+    * then lets find the bit of content they want to see and send them back to it
+    */
+  def contentDestinationFor(session: Session): M[Option[ContentDestination]] = (for {
+    guardianReferrer <- OptionT(session.get(DestinationService.JoinReferrer).filter(_.host.contains(Config.guardianHost)).point[M])
+    contentItem <- OptionT(capiItemQuery(guardianReferrer.path).map(resp => resp.content.map(ContentItem).map(ContentDestination)))
+  } yield contentItem).run
+
+  /**
+    * So if the user is joining membership to buy an event we'll have logged the event in the request
+    * So we dig it out and if the member is actually now able to book the event we send them back with a discount
+    */
+  def eventDestinationFor(session: Session, member: Member): M[Option[EventDestination]] = (for {
+    eventId <- OptionT(PreMembershipJoiningEventFromSessionExtractor.eventIdFrom(session).point[M])
+    event <- OptionT(getBookableEvent(eventId).point[M]) if event.isBookableByTier(member.subscription.plan.tier)
+    eventDiscount <- OptionT(createCode(member, event))
+  } yield EventDestination(event, Config.eventbriteApiIframeUrl ? ("eid" -> event.id) & ("discount" -> eventDiscount.code))).run
 }

--- a/frontend/app/services/DestinationService.scala
+++ b/frontend/app/services/DestinationService.scala
@@ -7,9 +7,9 @@ import model.RichEvent.RichEvent
 import model.{ContentDestination, ContentItem, Destination, EventDestination}
 import scalaz.syntax.monadPlus._
 import play.api.mvc.Session
-
 import scala.language.higherKinds
 import scalaz.{Monad, OptionT}
+
 object DestinationService {
   val JoinReferrer = "join-referrer" //session key
 }

--- a/frontend/app/services/DestinationService.scala
+++ b/frontend/app/services/DestinationService.scala
@@ -44,6 +44,6 @@ class DestinationService[M[+_] : Monad](
   def eventDestinationFor(session: Session, member: Member): M[Option[EventDestination]] = (for {
     eventId <- OptionT(PreMembershipJoiningEventFromSessionExtractor.eventIdFrom(session).point[M])
     event <- OptionT(getBookableEvent(eventId).point[M]) if event.isBookableByTier(member.subscription.plan.tier)
-    eventDiscount <- OptionT(createCode(member, event))
-  } yield EventDestination(event, Config.eventbriteApiIframeUrl ? ("eid" -> event.id) & ("discount" -> eventDiscount.code))).run
+    eventDiscount <- OptionT(createCode(member, event).map[Option[Option[EBCode]]](opt => Some(opt))) // this is perhaps a bit silly
+  } yield EventDestination(event, Config.eventbriteApiIframeUrl ? ("eid" -> event.id) & ("discount" -> eventDiscount.map(_.code)))).run
 }

--- a/frontend/app/services/PreMembershipJoiningEventFromSessionExtractor.scala
+++ b/frontend/app/services/PreMembershipJoiningEventFromSessionExtractor.scala
@@ -1,6 +1,6 @@
 package services
 
-import play.api.mvc.RequestHeader
+import play.api.mvc.{RequestHeader, Session}
 
 object EventIdExtractor {
   def apply(url: String): Option[String] = {
@@ -14,9 +14,9 @@ object EventIdExtractor {
 }
 
 object PreMembershipJoiningEventFromSessionExtractor {
-  def eventIdFrom(request: RequestHeader): Option[String] = {
+  def eventIdFrom(session: Session): Option[String] = {
     for {
-      url <- request.session.get("preJoinReturnUrl")
+      url <- session.get("preJoinReturnUrl")
       eventId <- EventIdExtractor(url)
     }  yield eventId
   }

--- a/frontend/app/services/TouchpointBackend.scala
+++ b/frontend/app/services/TouchpointBackend.scala
@@ -3,8 +3,8 @@ package services
 import com.gu.config.MembershipRatePlanIds
 import com.gu.identity.play.IdMinimalUser
 import com.gu.membership.MembershipCatalog
-import com.gu.memsub.promo.{PromotionCollection, DynamoPromoCollection}
-import com.gu.memsub.services.{api => memsubapi, PromoService, CatalogService, PaymentService}
+import com.gu.memsub.promo.{DynamoPromoCollection, PromotionCollection}
+import com.gu.memsub.services.{CatalogService, PaymentService, PromoService, api => memsubapi}
 import com.gu.memsub
 import com.gu.monitoring.{ServiceMetrics, StatusMetrics}
 import com.gu.salesforce._
@@ -13,7 +13,8 @@ import com.gu.subscriptions.Discounter
 import com.gu.touchpoint.TouchpointBackendConfig
 import com.gu.zuora.api.ZuoraService
 import com.gu.zuora.soap.ClientWithFeatureSupplier
-import com.gu.zuora.{ZuoraService => ZuoraServiceImpl, rest, soap}
+import scalaz.std.scalaFuture._
+import com.gu.zuora.{rest, soap, ZuoraService => ZuoraServiceImpl}
 import com.netaporter.uri.Uri
 import configuration.Config
 import configuration.Config.Implicits.akkaSystem
@@ -22,6 +23,7 @@ import monitoring.TouchpointBackendMetrics
 import tracking._
 import utils.TestUsers.isTestUser
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import scala.concurrent.Future
 
 object TouchpointBackend {
 
@@ -76,6 +78,11 @@ object TouchpointBackend {
       stripeService = stripeService,
       giraffeStripeService = giraffeStripeService,
       zuoraSoapClient = zuoraSoapClient,
+      destinationService = new DestinationService[Future](
+        EventbriteService.getBookableEvent,
+        GuardianContentService.contentItemQuery,
+        memberService.createEBCode
+      ),
       zuoraRestClient = zuoraRestClient,
       memberService = memberService,
       subscriptionService = subscriptionService,
@@ -103,6 +110,7 @@ case class TouchpointBackend(salesforceService: api.SalesforceService,
                              stripeService: StripeService,
                              giraffeStripeService: StripeService,
                              zuoraSoapClient: soap.ClientWithFeatureSupplier,
+                             destinationService: DestinationService[Future],
                              zuoraRestClient: rest.Client,
                              memberService: api.MemberService,
                              subscriptionService: memsubapi.SubscriptionService[MembershipCatalog],

--- a/frontend/app/views/joiner/thankyou.scala.html
+++ b/frontend/app/views/joiner/thankyou.scala.html
@@ -163,7 +163,7 @@
   
             }
             case contentDestination: model.ContentDestination => {
-                @getStarted("Rerturn to article") {
+                @getStarted("Return to article") {
                     @fragments.content.articleSnapshot(contentDestination.item)
                     <a class="action" href="@contentDestination.item.content.webUrl">View now</a>
                 }

--- a/frontend/test/services/DestinationServiceTest.scala
+++ b/frontend/test/services/DestinationServiceTest.scala
@@ -1,12 +1,9 @@
 package services
-
-import actions.{Subscriber, SubscriptionRequest}
 import com.github.nscala_time.time.Imports._
 import com.gu.contentapi.client.parser.JsonParser
 import com.gu.i18n.{Currency, GBP}
-import com.gu.identity.play.{AccessCredentials, AuthenticatedIdUser, IdMinimalUser}
 import com.gu.membership.PaidMembershipPlan
-import com.gu.memsub.Subscription.{PaidMembershipSub, MembershipSub, ProductRatePlanId}
+import com.gu.memsub.Subscription.{PaidMembershipSub, ProductRatePlanId}
 import com.gu.memsub._
 import com.gu.salesforce.Tier.Partner
 import com.gu.salesforce._
@@ -14,33 +11,22 @@ import model.Eventbrite.EBAccessCode
 import model.EventbriteTestObjects._
 import model.{ContentDestination, EventDestination}
 import org.joda.time.LocalDate
-import org.scalatest.concurrent.ScalaFutures
-import org.specs2.mock.Mockito
-import play.api.mvc.Security.AuthenticatedRequest
-import play.api.test.{FakeApplication, FakeRequest, PlaySpecification}
-import play.api.{Application, GlobalSettings}
+import org.specs2.mutable.Specification
+import play.api.mvc.Session
+import play.api.test.FakeRequest
 import utils.Resource
 
-import scala.concurrent.Future
-import scalaz.\/
+import scalaz.Id._
 
-class DestinationServiceTest extends PlaySpecification with Mockito with ScalaFutures {
+class DestinationServiceTest extends Specification {
 
   "DestinationService" should {
 
-    val fakeApplicationWithGlobal = FakeApplication(withGlobal = Some(new GlobalSettings() {
-      override def onStart(app: Application) {}
-    }))
-
-    val fakeMemberService = mock[MemberService]
-
-    object DestinationServiceTest extends DestinationService {
-      override val contentApiService = mock[GuardianContentService]
-      override val eventbriteService = mock[EventbriteCollectiveServices]
-      override def memberService(request: SubscriptionRequest[_]): MemberService = fakeMemberService
-    }
-
-    val destinationService = DestinationServiceTest
+    val destinationService = new DestinationService[Id](
+      getBookableEvent = _ => Some(TestRichEvent(eventWithName().copy(id = "0123456"))),
+      capiItemQuery = _ => JsonParser.parseItemThrift(Resource.get("model/content.api/item.json")),
+      createCode = (_, _) => Some(EBAccessCode("some-discount-code", 2))
+    )
 
     def createRequestWithSession(newSessions: (String, String)*) = {
 
@@ -62,92 +48,37 @@ class DestinationServiceTest extends PlaySpecification with Mockito with ScalaFu
         ratePlanId = "",
         isPaid = true
       ) with PaidPS[PaidMembershipPlan[Status, PaidTier, BillingPeriod]] {
-
         override def recurringPrice: Price = new Price(0.1f, GBP)
         override def firstPaymentDate: LocalDate = new LocalDate("2015-01-01")
         override def chargedThroughDate: Option[LocalDate] = None
         override def priceAfterTrial: Price = recurringPrice
         override def hasPendingAmendment: Boolean = false
-        override def plan = new PaidMembershipPlan[Current, Partner, Month](Current(), Tier.Partner(), Month(), ProductRatePlanId(""), PricingSummary(Map(GBP -> Price(0.1f, GBP))) )
+        override def plan = new PaidMembershipPlan[Current, Partner, Month](Current(), Tier.Partner(), Month(), ProductRatePlanId(""), PricingSummary(Map(GBP -> Price(0.1f, GBP))))
       }
 
-      val minimalUser: IdMinimalUser = IdMinimalUser("123", None)
-      val fakeRequest = FakeRequest().withSession(newSessions: _*)
-      val ar = new AuthenticatedRequest(AuthenticatedIdUser(AccessCredentials.Cookies("foo"), minimalUser), fakeRequest)
-
-      new SubscriptionRequest(mock[TouchpointBackend],ar) with Subscriber {
-        override def paidOrFreeSubscriber = \/.right(Subscriber[PaidMembershipSub](testSub, testMember))
-      }
-
+      val testSubscriber: Subscriber.Member = Subscriber(testSub, testMember)
+      (Session(newSessions.toMap), testSubscriber)
     }
 
     "should return a content destination url if join-referrer is in the request session" in {
-      running(fakeApplicationWithGlobal) {
-
-        val request = createRequestWithSession("join-referrer" -> "http://www.theguardian.com/membership/2015/apr/17/guardian-live-diversity-in-the-arts")
-
-        //mock the Content API response
-        val item = JsonParser.parseItemThrift(Resource.get("model/content.api/item.json"))
-        destinationService.contentApiService.contentItemQuery("/membership/2015/apr/17/guardian-live-diversity-in-the-arts") returns Future.successful(item)
-
-        //call the method under test
-        val futureResult = destinationService.contentDestinationFor(request)
-
-        //verify eventDestinationFor returns a valid content destination
-        whenReady(futureResult) { contentDestinationOpt =>
-          contentDestinationOpt.get.item.content.id mustEqual "membership/2015/apr/17/guardian-live-diversity-in-the-arts"
-        }
-      }
+      val (request, _) = createRequestWithSession("join-referrer" -> "http://www.theguardian.com/membership/2015/apr/17/guardian-live-diversity-in-the-arts")
+      val result = destinationService.contentDestinationFor(request)
+      result.get.item.content.id mustEqual "membership/2015/apr/17/guardian-live-diversity-in-the-arts"
     }
 
     "should return an event destination url if preJoinReturnUrl is in the request session" in {
-      running(fakeApplicationWithGlobal) {
-
-        val request = createRequestWithSession("preJoinReturnUrl" -> "/event/0123456/buy")
-
-
-        //mock the Eventbrite response and discount creation
-        val event = TestRichEvent(eventWithName().copy(id = "0123456"))
-        destinationService.eventbriteService.getBookableEvent("0123456") returns Some(event)
-        fakeMemberService.createEBCode(request.subscriber, event) returns Future.successful(Some(EBAccessCode("some-discount-code", 2)))
-
-        //call the method under test
-        val futureResult = destinationService.eventDestinationFor(request)
-
-        //verify eventDestinationFor returns a valid event destination
-        whenReady(futureResult) { eventDestinationOpt =>
-          eventDestinationOpt.get.event.id mustEqual "0123456"
-        }
-      }
+      val (request, member) = createRequestWithSession("preJoinReturnUrl" -> "/event/0123456/buy")
+      val result = destinationService.eventDestinationFor(request, member)
+      result.get.event.id mustEqual "0123456"
     }
 
     "should return either content or event destination if both are supplied" in {
-      running(fakeApplicationWithGlobal) {
+      val (request, member) = createRequestWithSession("join-referrer" -> "http://www.theguardian.com/membership/2015/apr/17/guardian-live-diversity-in-the-arts", "preJoinReturnUrl" -> "/event/0123456/buy")
 
-        val request = createRequestWithSession("join-referrer" -> "http://www.theguardian.com/membership/2015/apr/17/guardian-live-diversity-in-the-arts", "preJoinReturnUrl" -> "/event/0123456/buy")
-
-        //mock the Content API response
-        val item = JsonParser.parseItemThrift(Resource.get("model/content.api/item.json"))
-        destinationService.contentApiService.contentItemQuery("/membership/2015/apr/17/guardian-live-diversity-in-the-arts") returns Future.successful(item)
-
-        //mock the Eventbrite response and discount creation
-        val event = TestRichEvent(eventWithName().copy(id = "0123456"))
-        destinationService.eventbriteService.getBookableEvent("0123456") returns Some(event)
-        fakeMemberService.createEBCode(request.subscriber, event) returns Future.successful(Some(EBAccessCode("some-discount-code", 2)))
-
-        //call the method under test with the request
-        val futureResult = destinationService.returnDestinationFor(request)
-
-        //verify returnForDestination returns a valid destination
-        whenReady(futureResult) { destinationOpt =>
-          val destination = destinationOpt.get
-          destination match {
-            case eventDestination: EventDestination => eventDestination.event.id mustEqual "0123456"
-            case contentDestination: ContentDestination => contentDestination.item.content.id mustEqual "membership/2015/apr/17/guardian-live-diversity-in-the-arts"
-          }
-          val validDestination = destination.isInstanceOf[ContentDestination] || destination.isInstanceOf[EventDestination]
-          validDestination must_== true
-        }
+      destinationService.returnDestinationFor(request, member) match {
+        case Some(EventDestination(event, _)) => event.id mustEqual "0123456"
+        case Some(ContentDestination(item)) => item.content.id mustEqual "membership/2015/apr/17/guardian-live-diversity-in-the-arts"
+        case _ => 1 mustEqual 0 // surely this can be improved!
       }
     }
   }

--- a/frontend/test/services/DestinationServiceTest.scala
+++ b/frontend/test/services/DestinationServiceTest.scala
@@ -13,9 +13,7 @@ import model.{ContentDestination, EventDestination}
 import org.joda.time.LocalDate
 import org.specs2.mutable.Specification
 import play.api.mvc.Session
-import play.api.test.FakeRequest
 import utils.Resource
-
 import scalaz.Id._
 
 class DestinationServiceTest extends Specification {
@@ -75,10 +73,9 @@ class DestinationServiceTest extends Specification {
     "should return either content or event destination if both are supplied" in {
       val (request, member) = createRequestWithSession("join-referrer" -> "http://www.theguardian.com/membership/2015/apr/17/guardian-live-diversity-in-the-arts", "preJoinReturnUrl" -> "/event/0123456/buy")
 
-      destinationService.returnDestinationFor(request, member) match {
-        case Some(EventDestination(event, _)) => event.id mustEqual "0123456"
-        case Some(ContentDestination(item)) => item.content.id mustEqual "membership/2015/apr/17/guardian-live-diversity-in-the-arts"
-        case _ => 1 mustEqual 0 // surely this can be improved!
+      destinationService.returnDestinationFor(request, member).get match {
+        case EventDestination(event, _) => event.id mustEqual "0123456"
+        case ContentDestination(item) => item.content.id mustEqual "membership/2015/apr/17/guardian-live-diversity-in-the-arts"
       }
     }
   }


### PR DESCRIPTION
`DestinationService` is a relatively small service that given a session figures out where you came from when you signed up to become a member (either an event or some restricted content) and then shows you some content on the thank you page (either an eventbrite iframe or a link back to the article)

It was implemented as a trait for testability but because it depended on some quite serious objects (most notably _the entirety of TouchpointBackend_) the test was written with mockito. This is the only test we have which uses mockito and I'd rather we ensure that code depends on the minimum possible and is generic enough that we don't need to use it.

The test also depended on an entire play app running, so I got rid of that.

Also `DestinationService` deals with Futures of Options but was written before OptionT was available so I simplified the implementation a bit 