### PR TITLE
Fix issue where path was displayed as text on error page.

### DIFF
--- a/frontend/app/monitoring/ErrorHandler.scala
+++ b/frontend/app/monitoring/ErrorHandler.scala
@@ -1,5 +1,7 @@
 package monitoring
 
+import java.lang.Long
+import java.lang.System.currentTimeMillis
 import javax.inject._
 
 import com.gu.googleauth.UserIdentity
@@ -45,7 +47,8 @@ class ErrorHandler @Inject() (
     Future.successful(NoCache(InternalServerError(views.html.error500(exception))))
 
   override protected def onBadRequest(request: RequestHeader, message: String): Future[Result] = {
-    logServerError(request, new PlayException("Bad request","A very bad request was received!"))
-    Future.successful(NoCache(BadRequest(views.html.error400(request,message))))
+    val reference = Long.toString(currentTimeMillis(), 36).toUpperCase
+    logServerError(request, new PlayException("Bad request", s"A bad request was received. URI: ${request.uri}, Reference: $reference"))
+    Future.successful(NoCache(BadRequest(views.html.error400(request, s"Bad request received. Reference: $reference"))))
   }
 }

--- a/frontend/app/views/error400.scala.html
+++ b/frontend/app/views/error400.scala.html
@@ -8,10 +8,8 @@
                     Sorry, there was an error with this page. Please contact support at: <a href="mailto:membershipsupport@@theguardian.com">membershipsupport@@theguardian.com</a>.
                 </p>
 
-                    <p>Please provide the following error code to help identify the issue.</p>
-                    <pre>Error: @err</pre>
-                    <pre>Path: @req.path</pre>
-
+                <p>Please provide the following error code to help identify the issue.</p>
+                <pre>Error: @err</pre>
             </div>
         </section>
     </main>


### PR DESCRIPTION
Fixed security issue where path was displayed as text on error page.

cc @adamnfish @philwills @JuliaBellis 

https://trello.com/c/vZHtNn6V/15-fix-error-content-injection-in-membership-frontend

Bad:

![picture 197](https://cloud.githubusercontent.com/assets/1515970/18986328/3f88384c-86f4-11e6-82ef-e8b9d7ff9fff.png)

Good:

![picture 198](https://cloud.githubusercontent.com/assets/1515970/18986359/55f1dc64-86f4-11e6-8386-7eeace0551fd.png)
