### PR TITLE
The ssl certificate name was wrong in membership.conf

### DIFF
--- a/nginx/membership.conf
+++ b/nginx/membership.conf
@@ -22,8 +22,8 @@ server {
     server_name mem.thegulocal.com;
 
     ssl on;
-    ssl_certificate keys/mem-thegulocal-com-exp2017-03-31-bundle.crt;
-    ssl_certificate_key keys/mem-thegulocal-com-exp2017-03-31.key;
+    ssl_certificate membership.crt;
+    ssl_certificate_key membership.key;
 
     ssl_session_timeout 5m;
 


### PR DESCRIPTION
At least it wasn't the same as in the setup.sh script so ssl was failing