### PR TITLE
Bump membership common version and fix application name for metrics

### DIFF
--- a/frontend/app/monitoring/Metrics.scala
+++ b/frontend/app/monitoring/Metrics.scala
@@ -7,5 +7,5 @@ import configuration.Config
 trait Metrics extends CloudWatch {
   val region = Region.getRegion(Regions.EU_WEST_1)
   val stage = Config.stage
-  val application = "Frontend"
+  val application = "membership" // This sets the namespace for Custom Metrics in AWS (see CloudWatch)
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "7.2.3"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.7"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.282"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.285"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache


### PR DESCRIPTION
This PR bumps the membership-common to the latest version, which includes a fix to stop us spamming AWS with huge numbers of Custom Metrics (see https://github.com/guardian/membership-common/pull/335).

It also sets the application name to "membership" for all metrics (currently we had half of the metrics going to the 'Frontend' namespace, and the other half going to the 'membership', which looked pretty messy in AWS).