### PR TITLE
Removed a GA validation that was always false.

### DIFF
--- a/frontend/assets/javascripts/src/modules/metrics/triggers.js
+++ b/frontend/assets/javascripts/src/modules/metrics/triggers.js
@@ -13,7 +13,7 @@ define([
 
     function init() {
         var trackingElems = document.querySelectorAll('[' + METRIC_ATTRS.trigger + ']');
-        if (window.ga && trackingElems) {
+        if (trackingElems) {
             configureListeners(trackingElems);
         }
     }


### PR DESCRIPTION
Due to the fact that the line [#40 of setup.js](https://github.com/guardian/membership-frontend/blob/master/frontend/assets/javascripts/src/modules/analytics/setup.js#L40) was setting up google analytics as the second step of a promise, this condition was always false and therefore the listeners were never bound and we were not tracking events.

Please @paulbrown1982 @AWare @rtyley review this change before merging it into master. 