### PR TITLE
Update Instructions For Running Locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,6 @@ npm run watch
 
 **Pattern Library**: A library of common patterns used across the membership site is available at [membership.theguardian.com/patterns](https://membership.theguardian.com/patterns).
 
-### Setup NGINX
-
-Follow the instructions in [`/nginx/README.md`](./nginx/README.md) in this project.
-
 ### Setup AWS credentials
 
 Install the awscli:
@@ -77,8 +73,11 @@ Install the awscli:
 brew install awscli
 ```
 
-Fetch the developer AWS credentials, discuss how we do this with a team member.
+Fetch the developer AWS credentials, discuss how we do this with a team member (or, if you are aware of how [Janus](https://github.com/guardian/janus) works, get yourself set up with membership developer permissions).
 
+### Setup NGINX
+
+Follow the instructions in [`/nginx/README.md`](./nginx/README.md) in this project. Make sure you get your AWS credentials set up first.
 
 ### Download private keys
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Install the awscli:
 brew install awscli
 ```
 
-Fetch the developer AWS credentials, discuss how we do this with a team member (or, if you are aware of how [Janus](https://github.com/guardian/janus) works, get yourself set up with membership developer permissions).
+Setup membership developer AWS credentials using [Janus](https://github.com/guardian/janus) (you will need access to the Janus repo).
 
 ### Setup NGINX
 

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -24,7 +24,7 @@ If you want an automated setup run (from the project root):
 ./nginx/setup.sh
 ```
 
-Or follow the steps in that file. This will create a `site-enabled directory` in you nginx home directory.
+Or follow the steps in that file. This will create a `site-enabled directory` in you nginx home directory. Make sure you get your AWS credentials set up before you run this.
 
 ### Update your hosts file
 


### PR DESCRIPTION
Clarifies the process for retrieving AWS credentials when running locally. @guardian/membership-and-subscriptions 