### PR TITLE
Fix Campaign Querystring When Coming From Supporter Landing Page

### DIFF
--- a/frontend/app/actions/RegistrationUri.scala
+++ b/frontend/app/actions/RegistrationUri.scala
@@ -4,6 +4,7 @@ import com.gu.i18n.CountryGroup
 import com.gu.i18n.CountryGroup.RestOfTheWorld
 import com.gu.salesforce.Tier
 import com.netaporter.uri.Uri
+import com.netaporter.uri.dsl._
 import configuration.Config
 import play.api.mvc.RequestHeader
 
@@ -33,10 +34,10 @@ object RegistrationUri {
     controllers.routes.Joiner.joinFriend().path -> "FRI"
   )
 
-  def parse(request: RequestHeader) = {
+  def parse(request: RequestHeader): String = {
     val redirectUrl: String = Config.idWebAppRegisterUrl(request.uri)
     val campaignCode = extractCampaignCode(request.headers.get(REFERRER_HEADER), request.path)
-    redirectUrl.concat(s"&INTCMP=$campaignCode")
+    (redirectUrl ? ("INTCMP" -> campaignCode)).toString
   }
 
   private def extractCampaignCode(refererOpt: Option[String], path: String) : String = {

--- a/frontend/app/actions/RegistrationUri.scala
+++ b/frontend/app/actions/RegistrationUri.scala
@@ -35,8 +35,9 @@ object RegistrationUri {
   )
 
   def parse(request: RequestHeader): String = {
-    val redirectUrl: String = Config.idWebAppRegisterUrl(request.uri)
     val campaignCode = extractCampaignCode(request.headers.get(REFERRER_HEADER), request.path)
+    val returnUri: String = (request.uri ? ("INTCMP" -> campaignCode))
+    val redirectUrl: String = Config.idWebAppRegisterUrl(returnUri)
     (redirectUrl ? ("INTCMP" -> campaignCode)).toString
   }
 

--- a/frontend/app/actions/RegistrationUri.scala
+++ b/frontend/app/actions/RegistrationUri.scala
@@ -36,9 +36,8 @@ object RegistrationUri {
 
   def parse(request: RequestHeader): String = {
     val campaignCode = extractCampaignCode(request.headers.get(REFERRER_HEADER), request.path)
-    val returnUri: String = (request.uri ? ("INTCMP" -> campaignCode))
-    val redirectUrl: String = Config.idWebAppRegisterUrl(returnUri)
-    (redirectUrl ? ("INTCMP" -> campaignCode)).toString
+    val returnHereUrl: String = (request.uri ? ("INTCMP" -> campaignCode))
+    Config.idWebAppRegisterUrl(returnHereUrl)
   }
 
   private def extractCampaignCode(refererOpt: Option[String], path: String) : String = {


### PR DESCRIPTION
# Problem

When a user is on the supporter landing page, and they click on the button to become a supporter, they are sent to the `enter-details` page. However, if they are not logged in they are first sent to the identity `registration` page. This page is given the `enter-details` page as a return url, so they can continue once they've signed up:

```
Supporter Landing Page
         |
         V
Enter-Details Endpoint (not signed-in)
         |
         V
Registration (Return Url = Enter Details Page)
         |
         V
Enter Details Page (signed in)
```

This return url was being constructed incorrectly, and was dropping the campaign (`INTCMP`) query param after signup (it wasn't encoded, and was thus being interpreted as a query param by the `registration` page).

This is probably what has led to campaigns not being reported properly in the data lake.

# Fix

Add the campaign code param to the return url, rather than the registration page url. It is now encoded properly and is passed on to the `enter-details` page once the user has signed up.

@guardian/membership-and-subscriptions @rtyley 