### PR TITLE
Removed the event tracking for the join event category.

### DIFF
--- a/frontend/app/views/fragments/tier/packagePromo.scala.html
+++ b/frontend/app/views/fragments/tier/packagePromo.scala.html
@@ -73,7 +73,7 @@
                     }
                 }
                 </div>
-                <a class="action qa-package-@plans.tier.slug  @if(!secondaryButton.isDefined){u-no-bottom-margin}" href="@promoButton.to" @promoButton.attributes.html>
+                <a class="action qa-package-@plans.tier.slug  @if(!secondaryButton.isDefined){u-no-bottom-margin}" href="@promoButton.to">
                     @promoButton.text
                 </a>
                 @for(button <- secondaryButton){


### PR DESCRIPTION
We are not interested in tracking events other than the ones generated in the supporter landing page (`/:countryCode/supporter`). Therefore, I am removing the events trackers from `/` and `/choose-tier`.