### PR TITLE
Prevent Campaign Code Overwrite

### DIFF
--- a/frontend/app/actions/RegistrationUri.scala
+++ b/frontend/app/actions/RegistrationUri.scala
@@ -7,7 +7,6 @@ import com.netaporter.uri.Uri
 import com.netaporter.uri.dsl._
 import configuration.Config
 import play.api.mvc.RequestHeader
-import play.utils.UriEncoding
 import utils.CampaignCode
 
 import scala.util.Try

--- a/frontend/app/actions/RegistrationUri.scala
+++ b/frontend/app/actions/RegistrationUri.scala
@@ -7,6 +7,8 @@ import com.netaporter.uri.Uri
 import com.netaporter.uri.dsl._
 import configuration.Config
 import play.api.mvc.RequestHeader
+import play.utils.UriEncoding
+import utils.CampaignCode
 
 import scala.util.Try
 
@@ -35,7 +37,12 @@ object RegistrationUri {
   )
 
   def parse(request: RequestHeader): String = {
-    val campaignCode = extractCampaignCode(request.headers.get(REFERRER_HEADER), request.path)
+
+    val campaignCode = CampaignCode.fromRequest(request) match {
+      case Some(CampaignCode(code)) => code
+      case None => extractCampaignCode(request.headers.get(REFERRER_HEADER), request.path)
+    }
+
     val returnHereUrl: String = (request.uri ? ("INTCMP" -> campaignCode))
     Config.idWebAppRegisterUrl(returnHereUrl)
   }

--- a/frontend/app/utils/CampaignCode.scala
+++ b/frontend/app/utils/CampaignCode.scala
@@ -1,12 +1,12 @@
 package utils
 
-import play.api.mvc.Request
+import play.api.mvc.RequestHeader
 import play.utils.UriEncoding
 
 case class CampaignCode(get: String)
 
 object CampaignCode {
-  def fromRequest(implicit request: Request[_]): Option[CampaignCode] =
+  def fromRequest(implicit request: RequestHeader): Option[CampaignCode] =
     for {
       cookie <- request.cookies.get("s_sess")
       decodedCookie = UriEncoding.decodePathSegment(cookie.value, "utf-8")


### PR DESCRIPTION
# Problem

As one thing is fixed, another thing breaks. Fixing the supporter campaign codes in #1345 has led to loss of reporting for the engagement banner campaign codes. Because the banner links to the supporter landing page, the campaign codes that are set when redirecting to sign-in from the landing page overwrite the original ones set by the engagement banner:

```
Engagement Banner (cc: mem_uk_banner)
          |
          V
Supporter Landing Page (cc: mem_uk_banner)
          |
          V
Sign-In (cc: mem_supuk_sup)
          |
          V
Checkout (reported cc: mem_supuk_sup)
```

# Solution

Existing campaign codes take priority. If a campaign code already exists in a cookie (i.e. if it has already been set by the engagement banner), it will be passed through on the sign-in redirect. Otherwise, the supporter page campaign code will be set.

# Changes

- Update the `CampaignCode.fromRequest` method to take the more generic `RequestHeader` type, as it still allows us to retrieve the cookie information.
- Set up the redirect uri generator to check the cookie for a campaign code first, before setting the supporter code.

# Longevity

This is a short-term fix to get the reporting working again correctly (needed urgently). Long-term, this code relies on omniture, so we'll be stripping some of it out and replacing with our own solution soon.

@rtyley @guardian/membership-and-subscriptions