### PR TITLE
Fix Graphical Bugs On Membership Homepage

### DIFF
--- a/frontend/app/views/fragments/tier/friendTeaser.scala.html
+++ b/frontend/app/views/fragments/tier/friendTeaser.scala.html
@@ -12,7 +12,7 @@
     <div class="package-teaser__action">
         <a href="@routes.Joiner.enterFriendDetails().url"
             class="action action--secondary qa-friend-join"
-            aria-title="Join as a Friend for free"
+            aria-title="Join as a Friend for free">
             Become a Friend
             @fragments.actionIcon("arrow-right")
         </a>

--- a/frontend/assets/stylesheets/components/_packages.scss
+++ b/frontend/assets/stylesheets/components/_packages.scss
@@ -27,7 +27,6 @@ $_package-promo__actions_height: 117px;
         p { margin-bottom: 0; }
     }
     .package-promo__actions {
-        white-space: nowrap;
         margin: rem($gs-gutter / 2) 0;
     }
     .package-promo__actions--multiple {


### PR DESCRIPTION
# Problem

Two graphical bugs affecting membership homepage.

## Bug 1

"Become a Friend" button appearing blank:

![blank-friend-button](https://cloud.githubusercontent.com/assets/5131341/19641490/d3053560-99d8-11e6-8aa6-3d61964aab15.png)

Introduced in #1342, missing `>` on the anchor tag.

## Bug 2

A number of package action buttons wrapping weirdly in Firefox:

![firefox-button-wrapping](https://cloud.githubusercontent.com/assets/5131341/19641694/ba3fa5be-99d9-11e6-8b60-b3ef6df1ff48.png)

possibly caused by [this Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=488725). We already have code dealing with another case of this [here](https://github.com/guardian/membership-frontend/blob/a799ebade9eb94868e18ad0a90981ccb2d9f36de/frontend/assets/stylesheets/components/_packages.scss#L35).

# Solution

## Bug 1

Add `>` to anchor tag:

![fixed-friend-button](https://cloud.githubusercontent.com/assets/5131341/19641794/3ddc3fa4-99da-11e6-814a-3d3d1668bd92.png)

## Bug 2

Remove `white-space: nowrap` property, which prevents the conflict with `float`. As far as I can tell, the default of `white-space: normal` looks fine across different browsers and breakpoints, and fixes the problem in Firefox:

![fixed-firefox-buttons](https://cloud.githubusercontent.com/assets/5131341/19641879/8a8a5318-99da-11e6-9e8b-5c98de8544f0.png)

@guardian/membership-and-subscriptions 