### PR TITLE
Include email address when creating Zuora sub

### DIFF
--- a/frontend/app/services/api/MemberService.scala
+++ b/frontend/app/services/api/MemberService.scala
@@ -72,10 +72,12 @@ trait MemberService {
                              nameData: NameForm,
                              tier: PaidTier,
                              customer: Stripe.Customer,
-                             campaignCode: Option[CampaignCode]): Future[SubscribeResult]
+                             campaignCode: Option[CampaignCode],
+                             email: String): Future[SubscribeResult]
 
   def createFreeSubscription(contactId: ContactId,
-                             joinData: JoinForm): Future[SubscribeResult]
+                             joinData: JoinForm,
+                             email: String): Future[SubscribeResult]
 }
 
 object MemberService {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "7.2.3"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.7"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.293"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.294"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache


### PR DESCRIPTION
Tiny change which allows us to add a user's email address when creating a new subscription in Zuora (rather than relying on an unreliable Salesforce sync).