### PR TITLE
Pass new campaign codes on redirect

### DIFF
--- a/frontend/app/tracking/RedirectWithCampaignCodes.scala
+++ b/frontend/app/tracking/RedirectWithCampaignCodes.scala
@@ -5,7 +5,22 @@ import play.api.mvc.{RequestHeader, Result}
 
 object RedirectWithCampaignCodes {
 
-  val CampaignCodesToForward = Set("INTCMP", "CMP", "mcopy")
+  // GA parameters - see https://support.google.com/analytics/answer/1033863
+  val GoogleAnalyticsParameters = Set(
+    "utm_source", // Identify the advertiser, site, publication, etc. that is sending traffic to your property, for example: google, newsletter4, billboard.
+    "utm_medium", // The advertising or marketing medium, for example: cpc, banner, email newsletter.
+    "utm_campaign", // The individual campaign name, slogan, promo code, etc. for a product.
+    "utm_term", // Identify paid search keywords. If you're manually tagging paid keyword campaigns, you should also use utm_term to specify the keyword.
+    "utm_content" // Used to differentiate similar content, or links within the same ad. For example, if you have two call-to-action links within the same email
+  )
+
+  val CampaignCodesToForward = GoogleAnalyticsParameters ++ Set(
+    "CMP_BUNIT", // helps business unit report more easily on their marketing campaigns by allowing them to filter by business unit
+    "CMP_TU", // campaign team
+    "INTCMP",
+    "CMP",
+    "mcopy"
+  )
 
   def redirectWithCampaignCodes(url: String, status: Int)(implicit request: RequestHeader): Result =
     Redirect(url, request.queryString.filterKeys(CampaignCodesToForward), status)


### PR DESCRIPTION
I believe that these are new query parameters associated with Google Analytics.

The endpoint:

https://membership.theguardian.com/supporter?anyOldParam=foo

...does an immediate redirect, which means that GA does not run on that page hit- so query parameters in the URL dont get stored. We have code to pass on and repeat certain whitelisted query parameters to the ultimate page (eg https://membership.theguardian.com/uk/supporter?anyOldParam=foo ) ...we just need to know what those parameters need to be!

cc @Ap0c @paulbrown1982 @philwills 


```
---------- Forwarded message ----------
From: Huma Islam
Date: 25 October 2016 at 11:01
To: Roberto Tyley, Paul Brown, Philip Wills


Hi

It looks like the campaign code stuff goes missing for membership e.g. this
from our mails

https://membership.theguardian.com/supporter?utm_source=eml&utm_medium=obrdg&utm_campaign=contributortesta&CMP_TU=macqn&CMP_BUNIT=mem

The workaround suggested to Mark Pesavento and Jess Hayes​ (I don't who
else would be impacted) is: put in /uk /us /int /au into the url
But could we check?

Thanks
Huma
```