### PR TITLE
Fix duplication of jars in packaged zip artifact

### DIFF
--- a/frontend/build.sbt
+++ b/frontend/build.sbt
@@ -53,6 +53,8 @@ javaOptions in Test += "-Dconfig.file=test/acceptance/conf/acceptance-test.conf"
 
 testOptions in Test += Tests.Argument("-oD") // display execution times in Scalatest output
 
+useNativeZip
+
 playArtifactDistSettings
 
 magentaPackageName := "frontend"


### PR DESCRIPTION
Deployment of PR #1358 [failed](https://github.com/guardian/membership-frontend/pull/1358#issuecomment-256401440) due to sbt/sbt-native-packager#759, where jars in an artifact built with native packager occurred twice within the zip file.

On the recommendation of Nepomuk Seiler, we tried using `useNativeZip` on a different project: https://github.com/guardian/members-data-api/pull/100 ...and it seemed to help.

cc @AWare