### PR TITLE
Update to latest membership-common

### DIFF
--- a/frontend/app/controllers/Redirects.scala
+++ b/frontend/app/controllers/Redirects.scala
@@ -16,6 +16,7 @@ trait Redirects extends Controller {
     countryGroup match {
       case CountryGroup.UK => routes.Info.supporterUK()
       case CountryGroup.US => routes.Info.supporterUSA()
+      case CountryGroup.Ireland => routes.Info.supporterEurope()
       case CountryGroup.Europe => routes.Info.supporterEurope()
       case CountryGroup.Australia => routes.Info.supporterAustralia()
       case _ => routes.Info.supporterFor(countryGroup)

--- a/frontend/app/controllers/SiteMap.scala
+++ b/frontend/app/controllers/SiteMap.scala
@@ -16,12 +16,13 @@ object SiteMap extends Controller with LazyLogging {
       <url>
         <loc>{routes.FrontPage.index.absoluteURL(secure = true)}</loc>
         <priority>0.8</priority>
+        {alternatePage(routes.FrontPage.index.absoluteURL(secure = true), "x-default")}
       </url>
     </urlset>
     Ok(foo)
   }
 
-  def supporterPages()(implicit req: RequestHeader): Iterable[Elem] = for {
+  private def supporterPages()(implicit req: RequestHeader): Iterable[Elem] = for {
     countryGroup <- ActiveCountryGroups.all
   } yield {
     <url>
@@ -29,16 +30,20 @@ object SiteMap extends Controller with LazyLogging {
         {routes.Info.supporterFor(countryGroup).absoluteURL(secure = true)}
       </loc>
       <priority>1.0</priority>
-      {alternatePages(ActiveCountryGroups.all.filterNot(_ == countryGroup))}
+      {alternatePages(ActiveCountryGroups.all)}
+      {alternatePage(routes.Info.supporterFor(countryGroup).absoluteURL(secure = true), "x-default")}
     </url>
   }
 
-  def alternatePages(alternateCountryGroups: Seq[CountryGroup])(implicit req: RequestHeader) = for {
+  private def alternatePages(alternateCountryGroups: Seq[CountryGroup])(implicit req: RequestHeader) = for {
     countryGroup <- alternateCountryGroups
   } yield {
-      <xhtml:link
-      rel="alternate"
-      hreflang={countryGroup.defaultCountry.map(c => s"en-${c.alpha2.toLowerCase}").getOrElse("en")}
-      href={routes.Info.supporterFor(countryGroup).absoluteURL(secure = true)}/>
+      alternatePage(
+        routes.Info.supporterFor(countryGroup).absoluteURL(secure = true),
+        countryGroup.defaultCountry.map(c => s"en-${c.alpha2.toUpperCase}").getOrElse("en")
+      )
   }
+
+  private def alternatePage(href: String, hreflang: String) =
+      <xhtml:link rel="alternate" hreflang={hreflang} href={href} />
 }

--- a/frontend/app/controllers/SiteMap.scala
+++ b/frontend/app/controllers/SiteMap.scala
@@ -16,7 +16,6 @@ object SiteMap extends Controller with LazyLogging {
       <url>
         <loc>{routes.FrontPage.index.absoluteURL(secure = true)}</loc>
         <priority>0.8</priority>
-        {alternatePage(routes.FrontPage.index.absoluteURL(secure = true), "x-default")}
       </url>
     </urlset>
     Ok(foo)
@@ -31,7 +30,6 @@ object SiteMap extends Controller with LazyLogging {
       </loc>
       <priority>1.0</priority>
       {alternatePages(ActiveCountryGroups.all)}
-      {alternatePage(routes.Info.supporterFor(countryGroup).absoluteURL(secure = true), "x-default")}
     </url>
   }
 

--- a/frontend/app/model/ActiveCountryGroups.scala
+++ b/frontend/app/model/ActiveCountryGroups.scala
@@ -5,5 +5,5 @@ import com.gu.i18n.Country
 import com.gu.i18n.CountryGroup._
 
 object ActiveCountryGroups {
-  val all = Seq(UK, Europe.copy(defaultCountry = Some(Country.Ireland)), US, Canada, Australia, RestOfTheWorld)
+  val all = Seq(UK, US, Australia, Canada, Europe.copy(defaultCountry = Some(Country.Ireland)), RestOfTheWorld)
 }

--- a/frontend/app/model/ActiveCountryGroups.scala
+++ b/frontend/app/model/ActiveCountryGroups.scala
@@ -1,8 +1,9 @@
 package model
 
 
+import com.gu.i18n.Country
 import com.gu.i18n.CountryGroup._
 
 object ActiveCountryGroups {
-  val all = Seq(UK, Europe, US, Canada, Australia, RestOfTheWorld)
+  val all = Seq(UK, Europe.copy(defaultCountry = Some(Country.Ireland)), US, Canada, Australia, RestOfTheWorld)
 }

--- a/frontend/app/views/support/ABTest.scala
+++ b/frontend/app/views/support/ABTest.scala
@@ -60,6 +60,7 @@ object AmountHighlightTest extends TestTrait {
     US,
     Canada,
     NewZealand,
+    Ireland,
     Europe,
     RestOfTheWorld
   )

--- a/frontend/test/controllers/RedirectsTest.scala
+++ b/frontend/test/controllers/RedirectsTest.scala
@@ -8,6 +8,7 @@ class RedirectsTest extends Specification {
   "redirectToSupporterPage" in {
     redirectToSupporterPage(CountryGroup.UK) must_=== routes.Info.supporterUK()
     redirectToSupporterPage(CountryGroup.US) must_=== routes.Info.supporterUSA()
+    redirectToSupporterPage(CountryGroup.Ireland) must_=== routes.Info.supporterEurope()
     redirectToSupporterPage(CountryGroup.Europe) must_=== routes.Info.supporterEurope()
     redirectToSupporterPage(CountryGroup.Australia) must_=== routes.Info.supporterFor(CountryGroup.Australia)
     redirectToSupporterPage(CountryGroup.Canada) must_=== routes.Info.supporterFor(CountryGroup.Canada)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "7.2.3"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.7"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.294"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.297"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache


### PR DESCRIPTION
The latest Membership-common separated out Ireland as its own country group, rather than it being part of Europe. This was so that the commercial team could have a specific European country to reference on the checkout page - a selected country is required by Subs and Membership promotion logic.

This change updates Membership to handle requests from Ireland like it always has done. Also I tweaked the sitemap page to handle alternate URLs differently, please let me know if that's OK.

cc @rtyley @Ap0c @svillafe 