### PR TITLE
Css tidy up

### DIFF
--- a/frontend/app/views/fragments/page/elevatedCloserGuardianBody.scala.html
+++ b/frontend/app/views/fragments/page/elevatedCloserGuardianBody.scala.html
@@ -4,7 +4,7 @@
 
 <div class="l-constrained elevated-closer-guardian-body">
     <h1 class="elevated-closer-guardian-body__title u-content-width--left">Supporters get closer<br>to the Guardian</h1>
-    
+
     <div class="elevated-closer-guardian-body__col elevated-closer-guardian-body__video u-content-width--left">
         <div class="video-preview video-preview--plain">
             <div class="elevated-preview__video">
@@ -16,27 +16,22 @@
                 <p class="u-responsive-p">As a Guardian Supporter, you’ll enjoy a number of benefits, including:</p>
                 <ul>
     	            <li class="elevated-closer-guardian-body__list_item">
-                        <span class="elevated-closer-guardian-body__list_dot"></span>
                         Exclusive emails from Guardian journalists
                     </li>
                     <hr align="left" class="elevated-closer-guardian-body__list_line"/>
     	            <li class="elevated-closer-guardian-body__list_item">
-                        <span class="elevated-closer-guardian-body__list_dot"></span>
                         An ad-free experience on our mobile app
                     </li>
                     <hr align="left" class="elevated-closer-guardian-body__list_line"/>
     	            <li class="elevated-closer-guardian-body__list_item">
-                        <span class="elevated-closer-guardian-body__list_dot"></span>
                         A weekly look "Inside the Guardian" for our Members
                     </li>
                     <hr align="left" class="elevated-closer-guardian-body__list_line"/>
     	            <li class="elevated-closer-guardian-body__list_item">
-                        <span class="elevated-closer-guardian-body__list_dot"></span>
                         Joining the global Guardian Members community
                     </li>
                     <hr align="left" class="elevated-closer-guardian-body__list_line"/>
     	            <li class="elevated-closer-guardian-body__list_item">
-                        <span class="elevated-closer-guardian-body__list_dot"></span>
                         A welcome gift
                     </li>
                 </ul>

--- a/frontend/app/views/fragments/page/elevatedCloserGuardianBody.scala.html
+++ b/frontend/app/views/fragments/page/elevatedCloserGuardianBody.scala.html
@@ -17,19 +17,15 @@
                 <ul>
     	            <li class="elevated-closer-guardian-body__list_item">
                         Exclusive emails from Guardian journalists
-                        <hr align="left" class="elevated-closer-guardian-body__list_line"/>
                     </li>
     	            <li class="elevated-closer-guardian-body__list_item">
                         An ad-free experience on our mobile app
-                        <hr align="left" class="elevated-closer-guardian-body__list_line"/>
                     </li>
     	            <li class="elevated-closer-guardian-body__list_item">
                         A weekly look "Inside the Guardian" for our Members
-                        <hr align="left" class="elevated-closer-guardian-body__list_line"/>
                     </li>
     	            <li class="elevated-closer-guardian-body__list_item">
                         Joining the global Guardian Members community
-                        <hr align="left" class="elevated-closer-guardian-body__list_line"/>
                     </li>
     	            <li class="elevated-closer-guardian-body__list_item">
                         A welcome gift

--- a/frontend/app/views/fragments/page/elevatedCloserGuardianBody.scala.html
+++ b/frontend/app/views/fragments/page/elevatedCloserGuardianBody.scala.html
@@ -17,20 +17,20 @@
                 <ul>
     	            <li class="elevated-closer-guardian-body__list_item">
                         Exclusive emails from Guardian journalists
+                        <hr align="left" class="elevated-closer-guardian-body__list_line"/>
                     </li>
-                    <hr align="left" class="elevated-closer-guardian-body__list_line"/>
     	            <li class="elevated-closer-guardian-body__list_item">
                         An ad-free experience on our mobile app
+                        <hr align="left" class="elevated-closer-guardian-body__list_line"/>
                     </li>
-                    <hr align="left" class="elevated-closer-guardian-body__list_line"/>
     	            <li class="elevated-closer-guardian-body__list_item">
                         A weekly look "Inside the Guardian" for our Members
+                        <hr align="left" class="elevated-closer-guardian-body__list_line"/>
                     </li>
-                    <hr align="left" class="elevated-closer-guardian-body__list_line"/>
     	            <li class="elevated-closer-guardian-body__list_item">
                         Joining the global Guardian Members community
+                        <hr align="left" class="elevated-closer-guardian-body__list_line"/>
                     </li>
-                    <hr align="left" class="elevated-closer-guardian-body__list_line"/>
     	            <li class="elevated-closer-guardian-body__list_item">
                         A welcome gift
                     </li>

--- a/frontend/assets/images/inline-svgs/raw/arrow-right-button.svg
+++ b/frontend/assets/images/inline-svgs/raw/arrow-right-button.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="18" height="17.121" viewBox="0 0 18 17.121"><path fill="#FFFFFF" d="M0 9.343h14.952L9.09 16.36l.76.76L18 8.95v-.78L9.85 0l-.76.762 5.862 7.016H0"/></svg>
+<svg width="18" height="17.121" viewBox="0 0 18 17.121"><path d="M0 9.343h14.952L9.09 16.36l.76.76L18 8.95v-.78L9.85 0l-.76.762 5.862 7.016H0"/></svg>

--- a/frontend/assets/images/inline-svgs/raw/triangle_neutral1.svg
+++ b/frontend/assets/images/inline-svgs/raw/triangle_neutral1.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1300 36"><path fill="#EAEAEA" d="M1300 36V0L0 36"/></svg>

--- a/frontend/assets/stylesheets/components/_elevated-button.scss
+++ b/frontend/assets/stylesheets/components/_elevated-button.scss
@@ -47,5 +47,5 @@
 }
 
 .elevated-button__icon__border svg {
-    fill : #FFFFFF;
+    fill : #ffffff;
 }

--- a/frontend/assets/stylesheets/components/_elevated-button.scss
+++ b/frontend/assets/stylesheets/components/_elevated-button.scss
@@ -7,9 +7,9 @@
     background-color : guss-colour(guardian-brand);
     border-color : guss-colour(guardian-brand);
 
-    
+
     width: gs-span(3.8);
-    
+
     &:hover {
         background-color: #003557;
         border-color: #003557;
@@ -23,7 +23,7 @@
     padding-bottom: 1px; /*To vertically align the button's text*/
     padding-left: 4px;   /*To horizontally align the button's text*/
     float: left;
-  
+
 }
 
 .elevated-button__icon {
@@ -39,9 +39,13 @@
     border-color: white;
     border-style: solid;
     border-width: 1px;
-    border-radius: 50%;  
-    text-align: center;  
+    border-radius: 50%;
+    text-align: center;
     > svg {
         margin-top: 7px; /*To vertically align the button's logo*/
     }
+}
+
+.elevated-button__icon__border svg {
+    fill : #FFFFFF;
 }

--- a/frontend/assets/stylesheets/components/_elevated-closer-guardian-body.scss
+++ b/frontend/assets/stylesheets/components/_elevated-closer-guardian-body.scss
@@ -67,7 +67,7 @@
     }
 
     @include mq($from: desktop) {
-        margin-top: 0px;
+        margin-top: 0;
     }
 
     @include mq($from: mem-full) {
@@ -78,6 +78,7 @@
 .elevated-closer-guardian-body__list_item {
     @include fs-header(1);
     color : guss-colour(neutral-1);
+    margin-bottom: 18px;
 
     @include mq($from: tablet){
         @include fs-header(3);
@@ -97,6 +98,15 @@
         height: 14px;
         width: 14px;
     }
+}
+
+.elevated-closer-guardian-body__list_item::after {
+    content:"";
+    display:block;
+    width:80px;
+    margin-top: 8px;
+    position:absolute;
+    border-top:1px dotted #333333;
 }
 
 .elevated-closer-guardian-body__list_line {

--- a/frontend/assets/stylesheets/components/_elevated-closer-guardian-body.scss
+++ b/frontend/assets/stylesheets/components/_elevated-closer-guardian-body.scss
@@ -1,10 +1,10 @@
 /* ==========================================================================
    Elevated become supporter body
    ========================================================================== */
-.elevated-closer-guardian-body { 
+.elevated-closer-guardian-body {
     background: guss-colour(neutral-8);
     padding-bottom: 6px;
-    
+
     @include mq($from: tablet) {
         padding-bottom: 36px;
     }
@@ -13,13 +13,13 @@
 .elevated-closer-guardian-body__title {
     padding-top: 6px;
     padding-bottom: 18px;
- 
+
     @include fs-header(5);
     font-weight: 500;
     line-height: 26px;
     color : guss-colour(news-main-1);
 
-    @include mq($from: tablet) {   
+    @include mq($from: tablet) {
         padding-top: 10px;
         padding-bottom: 36px;
 
@@ -31,7 +31,7 @@
 
 .elevated-closer-guardian-body__list {
     p {
-        @include mq($from: tablet) {   
+        @include mq($from: tablet) {
             margin-bottom: 0;
         }
     }
@@ -45,11 +45,11 @@
 	/* Mobile First */
     width: 100%;
 
-    @include mq($from: desktop) {   
+    @include mq($from: desktop) {
         width: 50%;
         display: inline-block;
         vertical-align: middle;
-    }    
+    }
 }
 
 .elevated-closer-guardian-body__video {
@@ -75,26 +75,27 @@
     }
 }
 
-.elevated-closer-guardian-body__list_dot {
-    background-color: #4cc6de;
-    border-radius: 50%;
-    display: inline-block;
-    height: 11px;
-    vertical-align: baseline;
-    width: 11px;
-    
-    @include mq($from: tablet){
-        height: 14px;
-        width: 14px;
-    }
-}
-
 .elevated-closer-guardian-body__list_item {
     @include fs-header(1);
     color : guss-colour(neutral-1);
 
     @include mq($from: tablet){
         @include fs-header(3);
+    }
+}
+
+.elevated-closer-guardian-body__list_item::before{
+    content : "";
+    background-color: #4cc6de;
+    border-radius: 50%;
+    display: inline-block;
+    height: 11px;
+    vertical-align: baseline;
+    width: 11px;
+
+    @include mq($from: tablet){
+        height: 14px;
+        width: 14px;
     }
 }
 
@@ -109,6 +110,6 @@
 
     @include mq($from: tablet) {
         margin-top: 7px;
-        margin-bottom: 7px;        
+        margin-bottom: 7px;
     }
 }


### PR DESCRIPTION
This PR addresses some of the feedback from the ['New Landing Page for Supporter in the UK'](https://github.com/guardian/membership-frontend/pull/1362) PR.

I've left the hr elements in place because I couldn't find a way to get the 80px width using ::after but I've moved them inside the li elements to address 'element not allowed here' warnings.

@svillafe @SiAdcock could you take a look please?