### PR TITLE
Maintenance notice for planned outage due to Salesforce

### DIFF
--- a/frontend/app/actions/Fallbacks.scala
+++ b/frontend/app/actions/Fallbacks.scala
@@ -11,6 +11,9 @@ object Fallbacks {
 
   def changeTier(implicit req: RequestHeader) = redirectTo(controllers.routes.TierController.change())
 
+  def maintenance(implicit request: RequestHeader) =
+    TemporaryRedirect(controllers.routes.Outages.maintenanceMessage.absoluteURL(secure=true))
+
   def memberHome(implicit request: RequestHeader) =
     redirectTo(controllers.routes.FrontPage.welcome)
 

--- a/frontend/app/controllers/Info.scala
+++ b/frontend/app/controllers/Info.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import actions.ActionRefiners.PlannedOutageProtection
 import com.gu.i18n.CountryGroup
 import com.gu.i18n.CountryGroup._
 import com.gu.memsub.images.{Grid, ResponsiveImage, ResponsiveImageGenerator, ResponsiveImageGroup}
@@ -23,7 +24,9 @@ trait Info extends Controller {
     redirectWithCampaignCodes(redirectToSupporterPage(determinedCountryGroup).url, SEE_OTHER)
   }
 
-  def supporterUK = CachedAction { implicit request =>
+  val CachedAndOutageProtected = CachedAction andThen PlannedOutageProtection
+
+  def supporterUK = CachedAndOutageProtected { implicit request =>
     implicit val countryGroup = UK
 
     val heroImage = ResponsiveImageGroup(
@@ -61,7 +64,7 @@ trait Info extends Controller {
       detailImageOrientated))
   }
 
-  def supporterAustralia = CachedAction { implicit request =>
+  def supporterAustralia = CachedAndOutageProtected { implicit request =>
     implicit val countryGroup = Australia
 
     val heroImage = ResponsiveImageGroup(
@@ -103,7 +106,7 @@ trait Info extends Controller {
   }
 
 
-  def supporterUSA = CachedAction { implicit request =>
+  def supporterUSA = CachedAndOutageProtected { implicit request =>
     implicit val countryGroup = US
 
     val pageImages = Seq(
@@ -143,7 +146,7 @@ trait Info extends Controller {
     )
   }
 
-  def supporterEurope = CachedAction { implicit request =>
+  def supporterEurope = CachedAndOutageProtected { implicit request =>
     implicit val countryGroup = Europe
 
     val hero = OrientatedImages(
@@ -178,7 +181,7 @@ trait Info extends Controller {
     )
   }
 
-  def supporterFor(implicit countryGroup: CountryGroup) = CachedAction { implicit request =>
+  def supporterFor(implicit countryGroup: CountryGroup) = CachedAndOutageProtected { implicit request =>
 
     val hero = OrientatedImages(
       portrait = ResponsiveImageGroup(availableImages =
@@ -212,7 +215,7 @@ trait Info extends Controller {
     )
   }
 
-  def patron() = CachedAction { implicit request =>
+  def patron() = CachedAndOutageProtected { implicit request =>
     implicit val countryGroup = UK
 
     val pageInfo = PageInfo(

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -107,7 +107,7 @@ object Joiner extends Controller with ActivityTracking
     }
   }
 
-  def NonMemberAction(tier: Tier) = AuthenticatedAction andThen onlyNonMemberFilter(onMember = redirectMemberAttemptingToSignUp(tier))
+  def NonMemberAction(tier: Tier) = NoCacheAction andThen PlannedOutageProtection andThen authenticated() andThen onlyNonMemberFilter(onMember = redirectMemberAttemptingToSignUp(tier))
 
   def enterPaidDetails(tier: PaidTier, countryGroup: CountryGroup, promoCode: Option[PromoCode]) = NonMemberAction(tier).async { implicit request =>
     implicit val backendProvider: BackendProvider = request

--- a/frontend/app/controllers/Outages.scala
+++ b/frontend/app/controllers/Outages.scala
@@ -1,0 +1,13 @@
+package controllers
+
+import play.api.mvc.Controller
+
+object Outages extends Controller {
+  def maintenanceMessage = CachedAction {
+    Ok(views.html.info.maintenanceMessage())
+  }
+
+  def summary = GoogleAuthenticatedStaffAction {
+    Ok(views.html.staff.plannedOutages())
+  }
+}

--- a/frontend/app/utils/PlannedOutage.scala
+++ b/frontend/app/utils/PlannedOutage.scala
@@ -1,0 +1,30 @@
+package utils
+
+import org.joda.time.DateTimeZone.UTC
+import org.joda.time.{DateTime, Interval}
+
+
+object PlannedOutage {
+
+  val rightNow = new Interval(DateTime.now().minusMinutes(3), DateTime.now().plusMinutes(10))
+
+  /*
+  Salesforce EU0 instance refresh scheduled for November 6, 2016.
+
+  The instance refresh will take place on Sunday, November 6, 2016 during the 02:00–04:45 UTC standard system maintenance window.
+  Your org will be available in read-only mode for the duration of the maintenance.
+ */
+  val salesforceOutage = new Interval(
+    new DateTime(2016,11, 6, 2, 0, UTC),
+    new DateTime(2016,11, 6, 4,45, UTC)
+  )
+
+  val outages = Seq(
+    // rightNow,
+    salesforceOutage
+  ).sortBy(_.getStartMillis)
+
+  def currentOutage = outages.find(_.containsNow)
+
+  def nextOrCurrentOutage = outages.find(_.getEnd.isAfterNow)
+}

--- a/frontend/app/views/info/maintenanceMessage.scala.html
+++ b/frontend/app/views/info/maintenanceMessage.scala.html
@@ -1,0 +1,28 @@
+@import views.support.Asset
+@main("We're down for maintenance") {
+    <main role="main" class="page-content l-constrained">
+        @fragments.page.pageHeader("We'll be back soon...", Some("...we're currently down for maintenance"))
+
+        <section class="page-section">
+            <div class="page-section__content">
+                <p class="text-lead">Right now, the best way you can help us is to
+                    contribute here:</p>
+                <a class="elevated-button action action--no-icon"
+                href="https://contribute.theguardian.com/?INTCMP=mem_maint">
+                    <div class="elevated-button__text">
+                        Make a one-off Contribution
+                    </div>
+                    <div class="elevated-button__icon">
+                        <div class="elevated-button__icon__border">
+                        @for(icon <- Asset.inlineSvg("arrow-right-button")) {
+                            @icon
+                        }
+                        </div>
+                    </div>
+                </a>
+            </div>
+
+        </section>
+
+    </main>
+}

--- a/frontend/app/views/staff/plannedOutages.scala.html
+++ b/frontend/app/views/staff/plannedOutages.scala.html
@@ -1,0 +1,28 @@
+@import utils.PlannedOutage
+@import org.joda.time._
+@import views.support.Dates._
+
+@main("Planned outages") {
+
+    <main class="page-content l-constrained" role="main">
+        <section class="page-section">
+            <div class="page-section__content copy">
+            @PlannedOutage.currentOutage match {
+                case Some(currentOutage) => { It's all on at
+                    <b>@currentOutage.getStart.prettyWithTime</b> - <b>@currentOutage.getEnd.prettyWithTime</b>
+                     }
+                case None => {
+                    @PlannedOutage.nextOrCurrentOutage match {
+                        case Some(nextOutage) => {
+                            Next planned outage is
+                            <div><b>@nextOutage.getStart.prettyWithTime</b> - <b>@nextOutage.getEnd.prettyWithTime</b></div>
+                            starting in
+                            <div><b>@(new Duration(DateTime.now(), nextOutage.getStart).toPeriod().pretty)</b></div>  }
+                        case None => { No upcoming planned outages }
+                    }
+                }
+            }
+            </div>
+        </section>
+    </main>
+}

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -43,6 +43,9 @@ GET            /staff/login                           controllers.OAuth.login
 GET            /staff/loginAction                     controllers.OAuth.loginAction
 GET            /oauth2callback                        controllers.OAuth.oauth2Callback
 
+GET            /maintenance                           controllers.Outages.maintenanceMessage
+GET            /planned-outages                       controllers.Outages.summary
+
 # Staff event page to show discounted events
 GET            /staff/event-overview                  controllers.Staff.eventOverview
 GET            /staff/event-overview/local            controllers.Staff.eventOverviewLocal


### PR DESCRIPTION
Salesforce having a 2h45m read-only maintenance period on Sunday means we can't register new membership sign-ups for that period. So, we'll redirect any page that leads to needing sign-up functionality (eg Supporter Landing Pages, Checkout pages, but not event pages) to a new Maintenance page (https://membership.theguardian.com/maintenance):

![image](https://cloud.githubusercontent.com/assets/52038/20005186/a12ff9a4-a288-11e6-8a33-8f1e4ffa6e9b.png)

...this directs people to Contributions: **https://contribute.theguardian.com/?INTCMP=mem_maint**


**I know the page could look more beautiful, but bear in mind that it will only be shown for 3 hours, and we need to get this sorted before the weekend! So please review this PR based on whether the code/approach is good, and then suggest style changes in a separate PR if the mood takes you.** It would probably be nice to put an amusing Guardian quote in there if anyone can think of one.



These are the urls that will be affected:

* https://membership.theguardian.com/uk/supporter (all locales)
* https://membership.theguardian.com/join/supporter/enter-details
* All other tiers (Partner, Patron)

As this page needs to go up in the middle of the night (for our London-based dev team), the `PlannedOutage` class holds the times that the Maintenance page will be in effect, and for increased confidence that it's going to work I've added a staff-only page:

https://membership.theguardian.com/planned-outages

...which just says:

![image](https://cloud.githubusercontent.com/assets/52038/20005215/d415f2ba-a288-11e6-9ba8-2a4baf17bfa2.png)

```
Next planned outage is
6 November 2016, 2am - 6 November 2016, 4.45am
starting in
38 hours, 1 minute and 40 seconds
```




Salesforce planned outage:
----
https://status.salesforce.com/status/maintenances/9
```
RELATED INSTANCES: EU0
RELATED SERVICES: Core Service
PLANNED START TIME: 02:00, Nov 06 GMT
PLANNED END TIME: 04:45, Nov 06 GMT
TYPE: Scheduled Maintenance
AVAILABILITY: This instance will be read only during this maintenance window.
```

cc @paulbrown1982 @philwills @Ap0c @svillafe 

