### PR TITLE
Become supporter text re organization

### DIFF
--- a/frontend/app/views/fragments/page/elevatedBecomeSupporterBody.scala.html
+++ b/frontend/app/views/fragments/page/elevatedBecomeSupporterBody.scala.html
@@ -1,11 +1,13 @@
 @import configuration.Videos
 
 <div class="elevated-become-supporter-body">
+    
     <div class="elevated-become-supporter-body__col u-content-width--left">
-        <p class="elevated-become-supporter-body__p u-responsive-p">We want to make the world a better, fairer place. We want to keep the powerful honest. And we believe that doing so means keeping society informed by producing quality, independent journalism, which discovers and tells readers the truth.</p>
+        <p class="u-responsive-p">We want to make the world a better, fairer place. We want to keep the powerful honest. And we believe that doing so means keeping society informed by producing quality, independent journalism, which discovers and tells readers the truth.</p>
 
-        <p class="elevated-become-supporter-body__p u-responsive-p">It’s essential for the functioning of democracy. And our unique ownership structure means no one can tell us to censor or drop a story.</p>
+        <p class="u-responsive-p">It’s essential for the functioning of democracy. And our unique ownership structure means no one can tell us to censor or drop a story.</p>
     </div>
+    
     <div class="elevated-become-supporter-body__col elevated-become-supporter-body__video u-content-width--right">
         <div class="video-preview video-preview--plain">
             <div class="elevated-preview__video">
@@ -14,9 +16,10 @@
         </div>
         <p class="elevated-become-supporter-body__caption">Katharine Viner, editor-in-chief, explains the Guardian's unique ownership model</p>
     </div>
+    
     <div class="elevated-become-supporter-body__col u-content-width--left">
-        <p class="elevated-become-supporter-body__p u-responsive-p">But it’s difficult and expensive work. While more people are reading the Guardian than ever before, far fewer are paying for it. And advertising revenues are falling fast.</p>
-        <p class="elevated-become-supporter-body__p  u-responsive-p">So if you read us, if you like us, if you value our perspective – then become a Supporter and help make our future more secure.</p>
+        <p class="u-responsive-p">But it’s difficult and expensive work. While more people are reading the Guardian than ever before, far fewer are paying for it. And advertising revenues are falling fast.</p>
+        <p class="elevated-become-supporter-body__paragraph--last  u-responsive-p">So if you read us, if you like us, if you value our perspective – then become a Supporter and help make our future more secure.</p>
     </div>
 
 </div>

--- a/frontend/app/views/fragments/page/elevatedBecomeSupporterBody.scala.html
+++ b/frontend/app/views/fragments/page/elevatedBecomeSupporterBody.scala.html
@@ -5,12 +5,8 @@
         <p class="elevated-become-supporter-body__p u-responsive-p">We want to make the world a better, fairer place. We want to keep the powerful honest. And we believe that doing so means keeping society informed by producing quality, independent journalism, which discovers and tells readers the truth.</p>
 
         <p class="elevated-become-supporter-body__p u-responsive-p">It’s essential for the functioning of democracy. And our unique ownership structure means no one can tell us to censor or drop a story.</p>
-
-        <p class="elevated-become-supporter-body__p u-responsive-p">But it’s difficult and expensive work. While more people are reading the Guardian than ever before, far fewer are paying for it. And advertising revenues are falling fast.</p>
-
-        <p class="elevated-become-supporter-body__p  u-responsive-p">So if you read us, if you like us, if you value our perspective – then become a Supporter and help make our future more secure.</p>
-        
-    </div><div class="elevated-become-supporter-body__col elevated-become-supporter-body__video u-content-width--right">
+    </div>
+    <div class="elevated-become-supporter-body__col elevated-become-supporter-body__video u-content-width--right">
         <div class="video-preview video-preview--plain">
             <div class="elevated-preview__video">
             @fragments.media.videoPlayer(Videos.scottTrustExplained)
@@ -18,5 +14,10 @@
         </div>
         <p class="elevated-become-supporter-body__caption">Katharine Viner, editor-in-chief, explains the Guardian's unique ownership model</p>
     </div>
+    <div class="elevated-become-supporter-body__col u-content-width--left">
+        <p class="elevated-become-supporter-body__p u-responsive-p">But it’s difficult and expensive work. While more people are reading the Guardian than ever before, far fewer are paying for it. And advertising revenues are falling fast.</p>
+        <p class="elevated-become-supporter-body__p  u-responsive-p">So if you read us, if you like us, if you value our perspective – then become a Supporter and help make our future more secure.</p>
+    </div>
+
 </div>
 

--- a/frontend/app/views/fragments/page/elevatedBecomeSupporterBody.scala.html
+++ b/frontend/app/views/fragments/page/elevatedBecomeSupporterBody.scala.html
@@ -16,10 +16,9 @@
         </div>
         <p class="elevated-become-supporter-body__caption">Katharine Viner, editor-in-chief, explains the Guardian's unique ownership model</p>
     </div>
-    
     <div class="elevated-become-supporter-body__col u-content-width--left">
         <p class="u-responsive-p">But it’s difficult and expensive work. While more people are reading the Guardian than ever before, far fewer are paying for it. And advertising revenues are falling fast.</p>
-        <p class="elevated-become-supporter-body__paragraph--last  u-responsive-p">So if you read us, if you like us, if you value our perspective – then become a Supporter and help make our future more secure.</p>
+        <p class="u-responsive-p">So if you read us, if you like us, if you value our perspective – then become a Supporter and help make our future more secure.</p>
     </div>
 
 </div>

--- a/frontend/app/views/fragments/page/elevatedCloserGuardianBody.scala.html
+++ b/frontend/app/views/fragments/page/elevatedCloserGuardianBody.scala.html
@@ -31,7 +31,7 @@
                         A welcome gift
                     </li>
                 </ul>
-                <p class="u-responsive-p">Most importantly of all, you’ll appreciate every word that you read, in the knowledge that you’ve helped to bring it to the page.</p>
+                <p class="u-responsive-p elevated-closer-guardian-body__paragraph--last">Most importantly of all, you’ll appreciate every word that you read, in the knowledge that you’ve helped to bring it to the page.</p>
         </div>
 	</div>
 </div>

--- a/frontend/app/views/fragments/page/elevatedCloserGuardianBody.scala.html
+++ b/frontend/app/views/fragments/page/elevatedCloserGuardianBody.scala.html
@@ -13,7 +13,7 @@
         </div>
     </div><div class="elevated-closer-guardian-body__col elevated-closer-guardian-body__text u-content-width--right">
         <div class="elevated-closer-guardian-body__list">
-                <p class="u-responsive-p">As a Guardian Supporter, you’ll enjoy a number of benefits, including:</p>
+                <p class="u-responsive-p elevated-closer-guardian-body__paragraph">As a Guardian Supporter, you’ll enjoy a number of benefits, including:</p>
                 <ul>
     	            <li class="elevated-closer-guardian-body__list_item">
                         Exclusive emails from Guardian journalists

--- a/frontend/app/views/fragments/page/elevatedCloserGuardianBody.scala.html
+++ b/frontend/app/views/fragments/page/elevatedCloserGuardianBody.scala.html
@@ -11,9 +11,11 @@
             @fragments.media.videoPlayer(Videos.membershipExplained)
             </div>
         </div>
-    </div><div class="elevated-closer-guardian-body__col elevated-closer-guardian-body__text u-content-width--right">
+    </div>
+
+    <div class="elevated-closer-guardian-body__col elevated-closer-guardian-body__text u-content-width--right">
         <div class="elevated-closer-guardian-body__list">
-                <p class="u-responsive-p elevated-closer-guardian-body__paragraph">As a Guardian Supporter, you’ll enjoy a number of benefits, including:</p>
+                <p class="u-responsive-p">As a Guardian Supporter, you’ll enjoy a number of benefits, including:</p>
                 <ul>
     	            <li class="elevated-closer-guardian-body__list_item">
                         Exclusive emails from Guardian journalists
@@ -31,7 +33,7 @@
                         A welcome gift
                     </li>
                 </ul>
-                <p class="u-responsive-p elevated-closer-guardian-body__paragraph--last">Most importantly of all, you’ll appreciate every word that you read, in the knowledge that you’ve helped to bring it to the page.</p>
+                <p class="u-responsive-p">Most importantly of all, you’ll appreciate every word that you read, in the knowledge that you’ve helped to bring it to the page.</p>
         </div>
 	</div>
 </div>

--- a/frontend/app/views/fragments/page/elevatedWhySupportBody.scala.html
+++ b/frontend/app/views/fragments/page/elevatedWhySupportBody.scala.html
@@ -4,21 +4,21 @@
 
 <div class="l-constrained elevated-why-support-body">
     <div class="elevated-why-support-body__title u-content-width--left">
-        <h1 class="elevated-why-support-body__title__h1">Why do we need<br>our Supporters?</h1>
+        Why do we need<br>our Supporters?
     </div>
     <div class="elevated-why-support-body__col elevated-why-support-body__col--img u-content-width--right">
         <img class="elevated-why-support-body__col__img" src="@image.landscape.defaultImage" />
         <p class="elevated-why-support-body__caption">The Guardian newsroom during a busy afternoon</p>
     </div><div class="elevated-why-support-body__col u-content-width--left">    
-        <p class="elevated-why-support-body__p u-responsive-p">Like many other media organisations, the Guardian is operating in an incredibly challenging financial climate. Our advertising revenues are falling fast. We have huge numbers of readers, and we are increasingly reliant upon their financial support.</p>
+        <p class="elevated-why-support-body__paragraph u-responsive-p">Like many other media organisations, the Guardian is operating in an incredibly challenging financial climate. Our advertising revenues are falling fast. We have huge numbers of readers, and we are increasingly reliant upon their financial support.</p>
 
-        <p class="elevated-why-support-body__p u-responsive-p">We don’t have a wealthy owner pulling the strings. No shareholders, advertisers or billionaire owners can edit our editor.</p>
+        <p class="elevated-why-support-body__paragraph u-responsive-p">We don’t have a wealthy owner pulling the strings. No shareholders, advertisers or billionaire owners can edit our editor.</p>
 
-        <p class="elevated-why-support-body__p u-responsive-p">Our owner, the Scott Trust, safeguards our editorial independence from commercial or political interference. It reinvests revenue into our journalism, as opposed to into shareholders' pockets.</p>
+        <p class="elevated-why-support-body__paragraph u-responsive-p">Our owner, the Scott Trust, safeguards our editorial independence from commercial or political interference. It reinvests revenue into our journalism, as opposed to into shareholders' pockets.</p>
 
-        <p class="elevated-why-support-body__p u-responsive-p">But while the Scott Trust ensures our independence, we need our Supporters, now more than ever before, to help secure our future.</p>
-
-        <p class="elevated-why-support-body__p u-responsive-p">We know that not everyone is in a position to become a Supporter. But if you can, you’ll be an integral part of our mission to make the world a better, fairer place, for everyone.</p>
+        <p class="elevated-why-support-body__paragraph u-responsive-p">But while the Scott Trust ensures our independence, we need our Supporters, now more than ever before, to help secure our future.</p>
+        
+        <p class="elevated-why-support-body__paragraph--last u-responsive-p">We know that not everyone is in a position to become a Supporter. But if you can, you’ll be an integral part of our mission to make the world a better, fairer place, for everyone.</p>
     </div>    
 </div>
 

--- a/frontend/app/views/fragments/page/elevatedWhySupportBody.scala.html
+++ b/frontend/app/views/fragments/page/elevatedWhySupportBody.scala.html
@@ -18,7 +18,7 @@
 
         <p class="elevated-why-support-body__paragraph u-responsive-p">But while the Scott Trust ensures our independence, we need our Supporters, now more than ever before, to help secure our future.</p>
         
-        <p class="elevated-why-support-body__paragraph--last u-responsive-p">We know that not everyone is in a position to become a Supporter. But if you can, you’ll be an integral part of our mission to make the world a better, fairer place, for everyone.</p>
+        <p class="elevated-why-support-body__paragraph  u-responsive-p">We know that not everyone is in a position to become a Supporter. But if you can, you’ll be an integral part of our mission to make the world a better, fairer place, for everyone.</p>
     </div>    
 </div>
 

--- a/frontend/app/views/fragments/page/elevatedWhySupportBody.scala.html
+++ b/frontend/app/views/fragments/page/elevatedWhySupportBody.scala.html
@@ -10,15 +10,15 @@
         <img class="elevated-why-support-body__col__img" src="@image.landscape.defaultImage" />
         <p class="elevated-why-support-body__caption">The Guardian newsroom during a busy afternoon</p>
     </div><div class="elevated-why-support-body__col u-content-width--left">    
-        <p class="elevated-why-support-body__paragraph u-responsive-p">Like many other media organisations, the Guardian is operating in an incredibly challenging financial climate. Our advertising revenues are falling fast. We have huge numbers of readers, and we are increasingly reliant upon their financial support.</p>
+        <p class="u-responsive-p">Like many other media organisations, the Guardian is operating in an incredibly challenging financial climate. Our advertising revenues are falling fast. We have huge numbers of readers, and we are increasingly reliant upon their financial support.</p>
 
-        <p class="elevated-why-support-body__paragraph u-responsive-p">We don’t have a wealthy owner pulling the strings. No shareholders, advertisers or billionaire owners can edit our editor.</p>
+        <p class="u-responsive-p">We don’t have a wealthy owner pulling the strings. No shareholders, advertisers or billionaire owners can edit our editor.</p>
 
-        <p class="elevated-why-support-body__paragraph u-responsive-p">Our owner, the Scott Trust, safeguards our editorial independence from commercial or political interference. It reinvests revenue into our journalism, as opposed to into shareholders' pockets.</p>
+        <p class="u-responsive-p">Our owner, the Scott Trust, safeguards our editorial independence from commercial or political interference. It reinvests revenue into our journalism, as opposed to into shareholders' pockets.</p>
 
-        <p class="elevated-why-support-body__paragraph u-responsive-p">But while the Scott Trust ensures our independence, we need our Supporters, now more than ever before, to help secure our future.</p>
+        <p class="u-responsive-p">But while the Scott Trust ensures our independence, we need our Supporters, now more than ever before, to help secure our future.</p>
         
-        <p class="elevated-why-support-body__paragraph  u-responsive-p">We know that not everyone is in a position to become a Supporter. But if you can, you’ll be an integral part of our mission to make the world a better, fairer place, for everyone.</p>
+        <p class="u-responsive-p">We know that not everyone is in a position to become a Supporter. But if you can, you’ll be an integral part of our mission to make the world a better, fairer place, for everyone.</p>
     </div>    
 </div>
 

--- a/frontend/assets/stylesheets/components/_elevated-banner.scss
+++ b/frontend/assets/stylesheets/components/_elevated-banner.scss
@@ -24,8 +24,6 @@
     } 
 }
 
-
-
 .elevated-banner__content {
     padding-top: 3px;
     

--- a/frontend/assets/stylesheets/components/_elevated-banner.scss
+++ b/frontend/assets/stylesheets/components/_elevated-banner.scss
@@ -61,8 +61,9 @@
     @include mq($from: tablet) {
         font-size: 32px;
         line-height: 34px;
-        max-width: 460px;
+        margin-bottom: 42px;
         margin-top: 2px;
+        max-width: 460px;
 
     }
 }

--- a/frontend/assets/stylesheets/components/_elevated-become-supporter-body.scss
+++ b/frontend/assets/stylesheets/components/_elevated-become-supporter-body.scss
@@ -30,6 +30,7 @@
 .elevated-become-supporter-body__video {
     @include mq($from: desktop) {   
         padding-left: 10px;
+        float: right;
     }
 }
 

--- a/frontend/assets/stylesheets/components/_elevated-become-supporter-body.scss
+++ b/frontend/assets/stylesheets/components/_elevated-become-supporter-body.scss
@@ -2,11 +2,18 @@
    Elevated become supporter body
    ========================================================================== */
 .elevated-become-supporter-body { 
-    padding-top: 12px;
     background: guss-colour(neutral-8);
+    padding-top: 12px;
+    padding-bottom: 36px;
+
+    @include mq($from: tablet) {
+        margin-top: 18px;   
+    }
 
     @include mq($from: desktop) {
-        padding-top: 5px;
+        margin-top: 12px;
+        padding-bottom: 36px;
+        padding-top: 17px;
     }
 }
 
@@ -14,23 +21,17 @@
     background: guss-colour(neutral-8);
     width: 100%;
 
-    @include mq($from: tablet) {
-        margin-top: 18px;   
-    }
-
     @include mq($from: desktop) {
-        width: 50%;
-        margin-top: 12px;
-        margin-bottom: 22px;
         display: inline-block;
         vertical-align: top;
+        width: 50%;
     }    
 }
 
 .elevated-become-supporter-body__video {
-    @include mq($from: desktop) {   
-        padding-left: 10px;
+    @include mq($from: desktop) {
         float: right;
+        padding-left: 10px;
     }
 }
 
@@ -63,8 +64,15 @@
 
     @include mq($from: tablet, $until: desktop) {
         width: 540px;
-        padding-bottom: 36px;
         margin-left: auto;
         margin-right: auto;
     }
+
+    @include mq($from: tablet) {
+        padding-bottom: 36px;
+    }
+}
+
+.elevated-become-supporter-body__paragraph--last {
+    margin-bottom: 0;
 }

--- a/frontend/assets/stylesheets/components/_elevated-become-supporter-body.scss
+++ b/frontend/assets/stylesheets/components/_elevated-become-supporter-body.scss
@@ -4,10 +4,11 @@
 .elevated-become-supporter-body { 
     background: guss-colour(neutral-8);
     padding-top: 12px;
-    padding-bottom: 36px;
+    padding-bottom: 18px;
 
     @include mq($from: tablet) {
-        margin-top: 18px;   
+        margin-top: 18px;
+        padding-bottom: 36px;
     }
 
     @include mq($from: desktop) {
@@ -69,7 +70,7 @@
     }
 
     @include mq($from: tablet) {
-        padding-bottom: 36px;
+        padding-bottom: 24px;
     }
 }
 

--- a/frontend/assets/stylesheets/components/_elevated-become-supporter-body.scss
+++ b/frontend/assets/stylesheets/components/_elevated-become-supporter-body.scss
@@ -30,8 +30,8 @@
 }
 
 .elevated-become-supporter-body__video {
+    float: right;
     @include mq($from: desktop) {
-        float: right;
         padding-left: 10px;
     }
 }

--- a/frontend/assets/stylesheets/components/_elevated-become-supporter-body.scss
+++ b/frontend/assets/stylesheets/components/_elevated-become-supporter-body.scss
@@ -74,6 +74,6 @@
     }
 }
 
-.elevated-become-supporter-body__paragraph--last {
+.elevated-become-supporter-body > div:last-child >  p:last-child {
     margin-bottom: 0;
 }

--- a/frontend/assets/stylesheets/components/_elevated-closer-guardian-body.scss
+++ b/frontend/assets/stylesheets/components/_elevated-closer-guardian-body.scss
@@ -105,7 +105,7 @@
     border-top: 1px dotted #333333;
 }
 
-.elevated-closer-guardian-body__paragraph--last {
+.elevated-closer-guardian-body__list > p:last-child {
     margin-bottom: 0;
 }
 

--- a/frontend/assets/stylesheets/components/_elevated-closer-guardian-body.scss
+++ b/frontend/assets/stylesheets/components/_elevated-closer-guardian-body.scss
@@ -1,5 +1,5 @@
 /* ==========================================================================
-   Elevated become supporter body
+   Elevated closer to the guardian body
    ========================================================================== */
 .elevated-closer-guardian-body {
     background: guss-colour(neutral-8);
@@ -42,19 +42,19 @@
 }
 
 .elevated-closer-guardian-body__col {
-	/* Mobile First */
     width: 100%;
 
-    @include mq($from: desktop) {
-        width: 50%;
+    @include mq($from: desktop) {   
         display: inline-block;
         vertical-align: middle;
-    }
+        width: 50%;
+    }    
 }
 
 .elevated-closer-guardian-body__video {
 	vertical-align: top;
-    @include mq($from: desktop, $until: mem-full){
+    
+    @include mq($from: desktop) {
         float: left;
     }
 }
@@ -69,54 +69,50 @@
     @include mq($from: desktop) {
         margin-top: 0;
     }
-
-    @include mq($from: mem-full) {
-        float: right;
-    }
 }
 
 .elevated-closer-guardian-body__list_item {
     @include fs-header(1);
-    color : guss-colour(neutral-1);
+    color: guss-colour(neutral-1);
     margin-bottom: 18px;
 
-    @include mq($from: tablet){
+    @include mq($from: tablet) {
         @include fs-header(3);
     }
 }
 
 .elevated-closer-guardian-body__list_item::before{
-    content : "";
+    content: "";
     background-color: #4cc6de;
     border-radius: 50%;
     display: inline-block;
     height: 11px;
     vertical-align: baseline;
     width: 11px;
-
-    @include mq($from: tablet){
+    
+    @include mq($from: tablet) {
         height: 14px;
         width: 14px;
     }
 }
 
 .elevated-closer-guardian-body__list_item::after {
-    content:"";
-    display:block;
-    width:80px;
+    content: "";
+    display: block;
+    width: 80px;
     margin-top: 8px;
-    position:absolute;
-    border-top:1px dotted #333333;
+    position: absolute;
+    border-top: 1px dotted #333333;
 }
 
 .elevated-closer-guardian-body__list_line {
     border: none;
-    border-top:1px dotted #333333;
+    border-top: 1px dotted #333333;
     color: #333333;
     height: 1px;
-    width: 80px;
     margin-top: 6px;
     margin-bottom: 6px;
+    width: 80px;
 
     @include mq($from: tablet) {
         margin-top: 7px;

--- a/frontend/assets/stylesheets/components/_elevated-closer-guardian-body.scss
+++ b/frontend/assets/stylesheets/components/_elevated-closer-guardian-body.scss
@@ -3,8 +3,8 @@
    ========================================================================== */
 .elevated-closer-guardian-body {
     background: guss-colour(neutral-8);
-    padding-bottom: 6px;
-
+    padding-bottom: 18px;
+    
     @include mq($from: tablet) {
         padding-bottom: 36px;
     }
@@ -103,6 +103,10 @@
     margin-top: 8px;
     position: absolute;
     border-top: 1px dotted #333333;
+}
+
+.elevated-closer-guardian-body__paragraph--last {
+    margin-bottom: 0;
 }
 
 .elevated-closer-guardian-body__list_line {

--- a/frontend/assets/stylesheets/components/_elevated-footer-button.scss
+++ b/frontend/assets/stylesheets/components/_elevated-footer-button.scss
@@ -3,6 +3,12 @@
    ========================================================================== */
 .elevated-footer-button {
     background: #4bc6df;
+    
+    /*The following two lines are to fix a rendering issue which only takes place in Safari and iPad
+      http://stackoverflow.com/questions/1844207/how-to-make-a-div-to-wrap-two-float-divs-inside*/
+    display: block; 
+    clear: both;
+
 
     @supports (clip-path : polygon(0% 82.2%, 0% 0%, 100% 0%, 100% 100%)) {
         clip-path : polygon(0% 82.2%, 0% 0%, 100% 0%, 100% 100%);

--- a/frontend/assets/stylesheets/components/_elevated-why-support-body.scss
+++ b/frontend/assets/stylesheets/components/_elevated-why-support-body.scss
@@ -41,8 +41,10 @@
 
 .elevated-why-support-body__paragraph {
     padding-right: 5%;
-    padding-bottom: 16px;
-    margin-bottom: 0px;
+}
+
+.elevated-why-support-body__paragraph:last-child {
+    margin-bottom: 0;
 }
 
 .elevated-why-support-body__col--img {
@@ -53,10 +55,6 @@
 
 .elevated-why-support-body__col__img {
 	width: 100%;
-}
-
-.elevated-why-support-body__paragraph--last {
-    margin-bottom: 0;
 }
 
 .elevated-why-support-body__caption {

--- a/frontend/assets/stylesheets/components/_elevated-why-support-body.scss
+++ b/frontend/assets/stylesheets/components/_elevated-why-support-body.scss
@@ -1,58 +1,61 @@
 /* ==========================================================================
-   Elevated why support
+   Elevated why support us
    ========================================================================== */
 .elevated-why-support-body {     
     background: guss-colour(neutral-8);
+
+    @include mq($from: tablet) {
+        padding-bottom: 36px;
+    }
 }
 
 .elevated-why-support-body__col {
-	/* Mobile First */
     margin-top: 24px;
     width: 100%;
 
     @include mq($from: desktop) {   
-        width: 50%;
         display: inline-block;
         vertical-align: middle;
-    }    
-}
-
-.elevated-why-support-body__col--img {
-    
-    @include mq($from: desktop) {   
-        float: right;
+        width: 50%;
     }    
 }
 
 .elevated-why-support-body__title {
+    @include fs-header(5);
+    color: guss-colour(news-main-1);
+    font-weight: 500;
+    line-height: 26px;
     padding-top: 6px;
+    
+    @include mq($from: tablet) {   
+        @include fs-headline(6);
+        font-weight: 500;
+        line-height: 34px;
+    }
 
     @include mq($from: desktop) {
         width:100%;
     }
 }
 
-.elevated-why-support-body__title__h1 {
-    @include fs-header(5);
-    line-height: 26px;
-    font-weight: 500;
-    color:guss-colour(news-main-1);
-
-    @include mq($from: tablet) {   
-        @include fs-headline(6);
-        line-height: 34px;
-        font-weight: 500;
-    }    
+.elevated-why-support-body__paragraph {
+    padding-right: 5%;
+    padding-bottom: 16px;
+    margin-bottom: 0px;
 }
 
-.elevated-why-support-body__p {
-    padding-right: 5%;
-    margin-bottom: 0px;
-    padding-bottom: 16px;
+.elevated-why-support-body__col--img {
+    @include mq($from: desktop) {   
+        float: right;
+    }    
 }
 
 .elevated-why-support-body__col__img {
 	width: 100%;
+}
+
+.elevated-why-support-body__paragraph--last {
+    margin-bottom: 0;
 }
 
 .elevated-why-support-body__caption {

--- a/frontend/assets/stylesheets/components/_elevated-why-support-body.scss
+++ b/frontend/assets/stylesheets/components/_elevated-why-support-body.scss
@@ -3,6 +3,7 @@
    ========================================================================== */
 .elevated-why-support-body {     
     background: guss-colour(neutral-8);
+    padding-bottom: 18px;
 
     @include mq($from: tablet) {
         padding-bottom: 36px;

--- a/frontend/assets/stylesheets/components/_elevated-why-support-body.scss
+++ b/frontend/assets/stylesheets/components/_elevated-why-support-body.scss
@@ -39,11 +39,7 @@
     }
 }
 
-.elevated-why-support-body__paragraph {
-    padding-right: 5%;
-}
-
-.elevated-why-support-body__paragraph:last-child {
+.elevated-why-support-body > div:last-child > p:last-child {
     margin-bottom: 0;
 }
 


### PR DESCRIPTION
Reorganisation of the components inside the Become a Supporter Section. Now in the mobile view, the video is within the paragraph, improving the experience in mobile view.

# BEFORE

![before11](https://cloud.githubusercontent.com/assets/825398/20007369/d9f1891e-a293-11e6-82fd-5fb4bc70aac8.png)


# AFTER

![after11](https://cloud.githubusercontent.com/assets/825398/20007372/df52e0ce-a293-11e6-8b17-dbef6fb9c755.png)
