### PR TITLE
Autoplay/Loop Video on Supporter Landing Page

### DIFF
--- a/frontend/app/configuration/Videos.scala
+++ b/frontend/app/configuration/Videos.scala
@@ -73,7 +73,8 @@ object Videos {
         altText=Some("If you read the Guardian, join the Guardian"),
         availableImages=membershipPlaceholder
       )
-    )
+    ),
+    autoplay=true
   )
 
   val supportersUSA =  Video(

--- a/frontend/app/configuration/Videos.scala
+++ b/frontend/app/configuration/Videos.scala
@@ -74,7 +74,8 @@ object Videos {
         availableImages=membershipPlaceholder
       )
     ),
-    autoplay=true
+    autoplay=true,
+    loop=true
   )
 
   val supportersUSA =  Video(

--- a/frontend/app/model/Video.scala
+++ b/frontend/app/model/Video.scala
@@ -2,5 +2,6 @@ package model
 
 case class Video(
   srcUrl: com.netaporter.uri.Uri,
-  posterImage: Option[com.gu.memsub.images.ResponsiveImageGroup]
+  posterImage: Option[com.gu.memsub.images.ResponsiveImageGroup],
+  autoplay: Boolean = false
 )

--- a/frontend/app/model/Video.scala
+++ b/frontend/app/model/Video.scala
@@ -3,5 +3,6 @@ package model
 case class Video(
   srcUrl: com.netaporter.uri.Uri,
   posterImage: Option[com.gu.memsub.images.ResponsiveImageGroup],
-  autoplay: Boolean = false
+  autoplay: Boolean = false,
+  loop: Boolean = false
 )

--- a/frontend/app/views/fragments/media/videoPlayer.scala.html
+++ b/frontend/app/views/fragments/media/videoPlayer.scala.html
@@ -1,7 +1,7 @@
 @(video: model.Video)
 
 <div class="video-player js-video">
-    <iframe class="video-player__iframe js-video__iframe @if(video.autoplay){autoplay}"  src="@video.srcUrl" width="560" height="315" frameborder="0" allowfullscreen></iframe>
+    <iframe class="video-player__iframe js-video__iframe @if(video.autoplay){autoplay} @if(video.loop){loop}" src="@video.srcUrl" width="560" height="315" frameborder="0" allowfullscreen></iframe>
     @for(posterImage <- video.posterImage) {
         <div class="video-player__overlay js-video__overlay">
             <div class="video-player__overlay__image">

--- a/frontend/app/views/fragments/media/videoPlayer.scala.html
+++ b/frontend/app/views/fragments/media/videoPlayer.scala.html
@@ -1,7 +1,7 @@
 @(video: model.Video)
 
 <div class="video-player js-video">
-    <iframe class="video-player__iframe js-video__iframe"  src="@video.srcUrl" width="560" height="315" frameborder="0" allowfullscreen></iframe>
+    <iframe class="video-player__iframe js-video__iframe @if(video.autoplay){autoplay}"  src="@video.srcUrl" width="560" height="315" frameborder="0" allowfullscreen></iframe>
     @for(posterImage <- video.posterImage) {
         <div class="video-player__overlay js-video__overlay">
             <div class="video-player__overlay__image">

--- a/frontend/assets/javascripts/src/modules/videoOverlay.js
+++ b/frontend/assets/javascripts/src/modules/videoOverlay.js
@@ -64,13 +64,14 @@ define(['src/modules/raven'],function(raven) {
 
     }
 
+    // Sets up click-to-play on overlay, or autoplays if applicable.
     function playerReady(player, playerApi, playerOverlay, autoplay) {
 
         playerOverlay.addEventListener('click', function(event) {
 
             event.preventDefault();
             playVideo(player, playerApi, playerOverlay);
-            
+
         });
 
         if (autoplay) {

--- a/frontend/assets/javascripts/src/modules/videoOverlay.js
+++ b/frontend/assets/javascripts/src/modules/videoOverlay.js
@@ -9,6 +9,16 @@ define(['src/modules/raven'],function(raven) {
 
     var playerEls = document.querySelectorAll(SELECTOR_PLAYER);
 
+    // Adds a class to an element, backwards compat for IE.
+    function addClass (elem, newClass) {
+        elem.className += ' ' + newClass;
+    }
+
+    // Checks for the presence of a class in an element, IE backwards compat.
+    function containsClass (elem, className) {
+        return elem.className.split(' ').indexOf(className) > -1;
+    }
+
     /**
      * Nasty UA detection but calling `playVideo` on iOS
      * results in blank player.
@@ -28,8 +38,8 @@ define(['src/modules/raven'],function(raven) {
 
             if(playerIframe && playerOverlay) {
 
-                var autoplay = playerIframe.classList.contains('autoplay');
-                var loop = playerIframe.classList.contains('autoplay');
+                var autoplay = containsClass(playerIframe, 'autoplay');
+                var loop = containsClass(playerIframe, 'loop');
 
                 var events = {
                     onReady: function() {
@@ -62,7 +72,7 @@ define(['src/modules/raven'],function(raven) {
             }
         }
 
-        player.classList.add(CLASSNAME_IS_PLAYING);
+        addClass(player, CLASSNAME_IS_PLAYING);
 
         setTimeout(function() {
             var parentNode = playerOverlay.parentNode;

--- a/frontend/assets/javascripts/src/modules/videoOverlay.js
+++ b/frontend/assets/javascripts/src/modules/videoOverlay.js
@@ -83,7 +83,7 @@ define(['src/modules/raven'],function(raven) {
 
         });
 
-        if (autoplay) {
+        if (autoplay && !iOSDevice()) {
             playVideo(player, playerApi, playerOverlay, autoplay);
         }
 

--- a/frontend/assets/javascripts/src/modules/videoOverlay.js
+++ b/frontend/assets/javascripts/src/modules/videoOverlay.js
@@ -27,36 +27,56 @@ define(['src/modules/raven'],function(raven) {
             var playerApi;
 
             if(playerIframe && playerOverlay) {
+
+                var autoplay = playerIframe.classList.contains('autoplay');
+
                 playerApi = new YT.Player(playerIframe, {
                     events: {
                         'onReady': function() {
-                            playerReady(player, playerApi, playerOverlay);
+                            playerReady(player, playerApi, playerOverlay, autoplay);
                         }
                     }
                 });
+
             }
         });
     };
 
-    function playerReady(player, playerApi, playerOverlay) {
-        playerOverlay.addEventListener('click', function(event) {
-            event.preventDefault();
+    // Plays the video and hides the overlay.
+    function playVideo (player, playerApi, playerOverlay) {
 
-            if(!iOSDevice()) {
-                try {
-                    playerApi.playVideo();
-                } catch(e) {
-                    raven.Raven.captureException(e, {tags: { level: 'info' }});
-                }
+        if(!iOSDevice()) {
+            try {
+                playerApi.playVideo();
+            } catch(e) {
+                raven.Raven.captureException(e, {tags: { level: 'info' }});
             }
-            player.classList.add(CLASSNAME_IS_PLAYING);
-            setTimeout(function() {
-                var parentNode = playerOverlay.parentNode;
-                if (parentNode) {
-                    parentNode.removeChild(playerOverlay);
-                }
-            }, 2000);
+        }
+
+        player.classList.add(CLASSNAME_IS_PLAYING);
+
+        setTimeout(function() {
+            var parentNode = playerOverlay.parentNode;
+            if (parentNode) {
+                parentNode.removeChild(playerOverlay);
+            }
+        }, 2000);
+
+    }
+
+    function playerReady(player, playerApi, playerOverlay, autoplay) {
+
+        playerOverlay.addEventListener('click', function(event) {
+
+            event.preventDefault();
+            playVideo(player, playerApi, playerOverlay);
+            
         });
+
+        if (autoplay) {
+            playVideo(player, playerApi, playerOverlay, autoplay);
+        }
+
     }
 
     function init() {

--- a/frontend/assets/javascripts/src/modules/videoOverlay.js
+++ b/frontend/assets/javascripts/src/modules/videoOverlay.js
@@ -29,14 +29,23 @@ define(['src/modules/raven'],function(raven) {
             if(playerIframe && playerOverlay) {
 
                 var autoplay = playerIframe.classList.contains('autoplay');
+                var loop = playerIframe.classList.contains('autoplay');
 
-                playerApi = new YT.Player(playerIframe, {
-                    events: {
-                        'onReady': function() {
-                            playerReady(player, playerApi, playerOverlay, autoplay);
+                var events = {
+                    onReady: function() {
+                        playerReady(player, playerApi, playerOverlay, autoplay);
+                    }
+                };
+
+                if (loop) {
+                    events.onStateChange = function (e) {
+                        if (e.data === YT.PlayerState.ENDED) {
+                            playerApi.playVideo();
                         }
                     }
-                });
+                }
+
+                playerApi = new YT.Player(playerIframe, { events: events });
 
             }
         });


### PR DESCRIPTION
# Proposal

We want the second video on the supporter landing page to autoplay and loop. If autoplay is not possible (iOS), we want the default behaviour to occur (i.e. the poster appears over the top, and the user clicks to play).

# Changes

- Added `autoplay` and `loop` parameters to the scala `Video` object, to allow any video to be set to autoplay or loop.
- Set classes on the YouTube iframe that signify autoplaying or looping functionality.
- When loop is set, add event listener for end of video that restarts playback.
- When autoplay is set, fire playback immediately rather than waiting for click.

**Note**: The diff for `videoOverlay.js` makes the changes look a lot more complicated than they are, it might be easier to look at the two versions of the file side-by-side.

**Note Part II**: I will test these changes across browsers and devices on Monday (want to double-check iOS behaviour).

@rtyley @svillafe @rupertbates @JustinPinner 