### PR TITLE
update copy on supporter home page

### DIFF
--- a/frontend/app/views/fragments/page/elevatedBecomeSupporterBody.scala.html
+++ b/frontend/app/views/fragments/page/elevatedBecomeSupporterBody.scala.html
@@ -17,7 +17,7 @@
         <p class="elevated-become-supporter-body__caption">Katharine Viner, editor-in-chief, explains the Guardian's unique ownership model</p>
     </div>
     <div class="elevated-become-supporter-body__col u-content-width--left">
-        <p class="u-responsive-p">But it’s difficult and expensive work. While more people are reading the Guardian than ever before, far fewer are paying for it. And advertising revenues are falling fast.</p>
+        <p class="u-responsive-p">But it’s difficult and expensive work. While more people are reading the Guardian than ever before, far fewer are paying for it. And advertising revenues across the media are falling fast.</p>
         <p class="u-responsive-p">So if you read us, if you like us, if you value our perspective – then become a Supporter and help make our future more secure.</p>
     </div>
 


### PR DESCRIPTION
Updated line about ad revenues falling fast to say 'ad revenues across the media' are falling fast. This change has outperformed the original message for contributions.