### PR TITLE
Auto-update AMI with deploy

### DIFF
--- a/frontend/conf/deploy.json
+++ b/frontend/conf/deploy.json
@@ -1,6 +1,16 @@
 {
     "defaultStacks": ["membership"],
     "packages":{
+        "ami-update": {
+            "type": "ami-cloudformation-parameter",
+            "data": {
+                "amiTags": { "Recipe": "xenial-membership", "AmigoStage": "PROD" },
+                "amiParameter": "ImageId",
+                "cloudFormationStackName": "Memb",
+                "prependStackToCloudFormationStackName" : false,
+                "appendStageToCloudFormationStackName" : true
+            }
+        },
         "frontend":{
             "type":"autoscaling",
             "data":{
@@ -10,7 +20,11 @@
     },
     "recipes":{
         "default":{
-            "actionsBeforeApp": ["frontend.uploadArtifacts", "frontend.deploy"]
+            "actionsBeforeApp": [
+                "ami-update.update",
+                "frontend.uploadArtifacts",
+                "frontend.deploy"
+            ]
         },
         "artifactUploadOnly": {
            "actions": [ "frontend.uploadArtifacts" ]


### PR DESCRIPTION
Following on from https://github.com/guardian/membership-frontend/pull/1376, now that we're using Amigo AMIs, we can auto-update to the latest AMI with every deploy.

This mirrors the AMI updating that was added to Contributions with https://github.com/guardian/contributions-frontend/pull/179 - tho' I've left out the auto-updating of the cloudformation for the moment. See the RiffRaff documentation on the `ami-cloudformation-parameter` deployment type:

https://riffraff.gutools.co.uk/docs/magenta-lib/types#amicloudformationparameter

cc @svillafe @AWare @alexduf 