### PR TITLE
Fix AWS Cloudwatch config

### DIFF
--- a/cloud-formation/membership-app.cf.json
+++ b/cloud-formation/membership-app.cf.json
@@ -115,7 +115,7 @@
                         "chmod 0600 /etc/gu/membership.private.conf",
 
                         "wget https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py",
-                        {"Fn::Sub": "sed -i -e s\"/__DATE/$(date +%F)/\" -e 's/__STAGE/$Stage/' $CONF_DIR/logger.conf"},
+                        {"Fn::Sub": "sed -i -e s\"/__DATE/$(date +%F)/\" -e 's/__STAGE/${Stage}/' $CONF_DIR/logger.conf"},
                         {"Fn::Sub": "python awslogs-agent-setup.py -nr ${AWS::Region} -c $CONF_DIR/logger.conf"},
                         "systemctl enable awslogs",
                         "systemctl start awslogs"

--- a/frontend/conf/logger.conf
+++ b/frontend/conf/logger.conf
@@ -1,8 +1,8 @@
 [general]
 state_file = /var/awslogs/agent-state
 
-[/membership/logs/frontend.log]
-file = /membership/logs/frontend.log
+[membership-logstream]
+file = /var/log/frontend/frontend.log
 log_group_name = FrontendLogs-__STAGE
-log_stream_name = __DATE/__BUILD/{instance_id}/frontend.log
+log_stream_name = __DATE/{instance_id}/frontend.log
 datetime_format = %Y-%m-%d %H:%M-%S


### PR DESCRIPTION
@paulbrown1982 @rtyley 

Tested on a single box (after removing from the auto-scaling group) and can see logs are now being picked up by Cloudwatch.

Note that I removed the __BUILD from the log stream name, as I could see that Roberto had removed this from the Cloudformation file.