### PR TITLE
Switch off youtube videos suggestions 

### DIFF
--- a/frontend/app/configuration/Videos.scala
+++ b/frontend/app/configuration/Videos.scala
@@ -57,7 +57,7 @@ object Videos {
   )
 
   val scottTrustExplained = Video(
-    srcUrl="//www.youtube.com/embed/jn4wAy1Xs5M?enablejsapi=1&wmode=transparent",
+    srcUrl="//www.youtube.com/embed/jn4wAy1Xs5M?enablejsapi=1&wmode=transparent&rel=0",
     posterImage=Some(
       ResponsiveImageGroup(
         altText=Some("If you read the Guardian, join the Guardian"),


### PR DESCRIPTION
In order to avoid the user get distracted by 'related' videos, we switch off that feature. https://developers.google.com/youtube/player_parameters#rel


We are avoiding this behaviour:

<img width="1167" alt="picture 25" src="https://cloud.githubusercontent.com/assets/825398/20593988/56a86e8a-b22c-11e6-8b12-b98689bb2271.png">
