### PR TITLE
Allow removal of legacy rate plans as part of upgrade

### DIFF
--- a/frontend/test/services/MemberServiceTest.scala
+++ b/frontend/test/services/MemberServiceTest.scala
@@ -39,7 +39,7 @@ class MemberServiceTest extends Specification {
     }
   }
 
-  "getRatePlansToRemove" should {
+  "getDiscountRatePlansToRemove" should {
 
     val partnerPrpId = ProductRatePlanId("partner")
     val discountPrpId = ProductRatePlanId("discount")
@@ -54,8 +54,8 @@ class MemberServiceTest extends Specification {
       SubIds(RatePlanId("id3"), manualPrpId)
     )
 
-    "Remove any rate plans in the product catalog with discounts, leaving off any others" in {
-      MemberService.getRatePlanIdsToRemove(current, _ == partnerPrpId, discounts).map(_.get) mustEqual Seq("id1", "id2")
+    "Remove any discount rate plan ids" in {
+      MemberService.getDiscountRatePlanIdsToRemove(current, discounts).map(_.get) mustEqual Seq("id2")
     }
   }
 }


### PR DESCRIPTION
When processing a membership upgrade, we should always remove the 'current rate plan' from the Sub before adding the new rate plan. This PR fixes a bug which failed to remove the 'current rate plan' if it was a legacy plan (i.e. if it was not in the current catalog).

Failure to remove the current rate plan means that Subs end up with overlapping rate plans; at best (in the case that the original subscription was 'Friend'), this is creates mess in Zuora and Salesforce. If the original plan was a paid legacy plan, this could lead to us double-charging a customer.

This PR also includes some improvements to logging in upgrade scenarios.

@johnduffell @paulbrown1982 