### PR TITLE
AB Test Logic for the "New Checkout Flow"

### DIFF
--- a/frontend/app/abtests/CheckoutFlowVariant.scala
+++ b/frontend/app/abtests/CheckoutFlowVariant.scala
@@ -1,0 +1,39 @@
+package abtests
+
+import play.api.mvc.RequestHeader
+
+import scala.util.Random
+
+/**
+  * Created by santiago_fernandez on 25/11/2016.
+  */
+object CheckoutFlowVariant {
+  val cookieName = "ab-checkout-flow"
+
+  val all = Seq[CheckoutFlowVariant](A,B)
+
+  def deriveFlowVariant(implicit request: RequestHeader): CheckoutFlowVariant =
+    getFlowVariantFromRequestCookie(request).getOrElse(CheckoutFlowVariant.all(Random.nextInt(CheckoutFlowVariant.all.size)))
+
+  def getFlowVariantFromRequestCookie(request: RequestHeader): Option[CheckoutFlowVariant] = for {
+    cookieValue <- request.cookies.get(cookieName)
+    variant <- CheckoutFlowVariant.lookup(cookieValue.value)
+  } yield variant
+
+  case object A extends CheckoutFlowVariant {
+    override val testId: String = "test-A"
+    override val identitySkin: String = "members"
+  }
+
+  case object B extends CheckoutFlowVariant {
+    override val testId: String = "test-B"
+    override val identitySkin: String = "membersB"
+  }
+
+  def lookup(name: String): Option[CheckoutFlowVariant] = all.find(_.testId == name)
+}
+
+sealed trait CheckoutFlowVariant {
+  val testId: String
+  val identitySkin: String
+}

--- a/frontend/app/actions/Fallbacks.scala
+++ b/frontend/app/actions/Fallbacks.scala
@@ -1,11 +1,48 @@
 package actions
 
+import com.gu.memsub.subsv2.CatalogPlan.PaidMember
+import com.gu.memsub.subsv2.MonthYearPlans
 import com.gu.salesforce.PaidTier
 import play.api.mvc.Results._
-import play.api.mvc.{Call, RequestHeader}
+import play.api.mvc.{Call, Cookie, RequestHeader}
 import play.twirl.api.Html
 import configuration.Config
+import views.html.joiner.form.paymentB
+import views.support.{CountryWithCurrency, IdentityUser, PageInfo}
 
+import scala.util.Random
+
+
+sealed trait CheckoutFlowVariant {
+  val testId: String
+  val identitySkin: String
+}
+
+object CheckoutFlowVariant {
+  val cookieName = "ab-checkout-flow"
+
+  val all = Seq[CheckoutFlowVariant](A,B)
+
+  def deriveFlowVariant(implicit request: RequestHeader): CheckoutFlowVariant =
+    getFlowVariantFromRequestCookie(request).getOrElse(CheckoutFlowVariant.all(Random.nextInt(CheckoutFlowVariant.all.size)))
+
+  def getFlowVariantFromRequestCookie(request: RequestHeader): Option[CheckoutFlowVariant] = for {
+    cookieValue <- request.cookies.get(cookieName)
+    variant <- CheckoutFlowVariant.lookup(cookieValue.value)
+  } yield variant
+
+  case object A extends CheckoutFlowVariant {
+    override val testId: String = "test-A"
+    override val identitySkin: String = "members"
+  }
+
+  case object B extends CheckoutFlowVariant {
+    override val testId: String = "test-B"
+    override val identitySkin: String = "membersB"
+  }
+
+  def lookup(name: String): Option[CheckoutFlowVariant] = all.find(_.testId == name)
+}
 
 object Fallbacks {
 
@@ -23,7 +60,11 @@ object Fallbacks {
   def notYetAMemberOn(implicit request: RequestHeader) =
     redirectTo(controllers.routes.Joiner.tierChooser()).addingToSession("preJoinReturnUrl" -> request.uri)
 
-  def chooseRegister(implicit request: RequestHeader) = SeeOther(Config.idWebAppRegisterUrl(request.uri))
+  def chooseRegister(implicit request: RequestHeader) = {
+    val flowSelected = CheckoutFlowVariant.deriveFlowVariant(request)
+
+    SeeOther(Config.idWebAppRegisterUrl(request.uri, flowSelected)).withCookies(Cookie(CheckoutFlowVariant.cookieName, flowSelected.testId))
+  }
 
   def joinStaffMembership(implicit request: RequestHeader) =
     redirectTo(controllers.routes.Joiner.staff())
@@ -35,5 +76,3 @@ object Fallbacks {
 
   def redirectTo(call: Call)(implicit req: RequestHeader) = SeeOther(call.absoluteURL(secure = true))
 }
-
-

--- a/frontend/app/actions/Fallbacks.scala
+++ b/frontend/app/actions/Fallbacks.scala
@@ -1,48 +1,11 @@
 package actions
 
-import com.gu.memsub.subsv2.CatalogPlan.PaidMember
-import com.gu.memsub.subsv2.MonthYearPlans
+import abtests.CheckoutFlowVariant
 import com.gu.salesforce.PaidTier
+import configuration.Config
 import play.api.mvc.Results._
 import play.api.mvc.{Call, Cookie, RequestHeader}
 import play.twirl.api.Html
-import configuration.Config
-import views.html.joiner.form.paymentB
-import views.support.{CountryWithCurrency, IdentityUser, PageInfo}
-
-import scala.util.Random
-
-
-sealed trait CheckoutFlowVariant {
-  val testId: String
-  val identitySkin: String
-}
-
-object CheckoutFlowVariant {
-  val cookieName = "ab-checkout-flow"
-
-  val all = Seq[CheckoutFlowVariant](A,B)
-
-  def deriveFlowVariant(implicit request: RequestHeader): CheckoutFlowVariant =
-    getFlowVariantFromRequestCookie(request).getOrElse(CheckoutFlowVariant.all(Random.nextInt(CheckoutFlowVariant.all.size)))
-
-  def getFlowVariantFromRequestCookie(request: RequestHeader): Option[CheckoutFlowVariant] = for {
-    cookieValue <- request.cookies.get(cookieName)
-    variant <- CheckoutFlowVariant.lookup(cookieValue.value)
-  } yield variant
-
-  case object A extends CheckoutFlowVariant {
-    override val testId: String = "test-A"
-    override val identitySkin: String = "members"
-  }
-
-  case object B extends CheckoutFlowVariant {
-    override val testId: String = "test-B"
-    override val identitySkin: String = "membersB"
-  }
-
-  def lookup(name: String): Option[CheckoutFlowVariant] = all.find(_.testId == name)
-}
 
 object Fallbacks {
 

--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -49,14 +49,9 @@ object Config {
   def idWebAppSigninUrl(uri: String): String =
     (idWebAppUrl / "signin") ? ("returnUrl" -> s"$membershipUrl$uri") & idSkipConfirmation & idMember
 
-  def idWebAppRegisterUrl(uri: String, abTestVariant: CheckoutFlowVariant = A): String ={
-
-    val idMember = "clientId" -> abTestVariant.identitySkin
-
-    (idWebAppUrl / "register") ? ("returnUrl" -> s"$membershipUrl$uri") & idSkipConfirmation & idMember
-  }
-
-
+  def idWebAppRegisterUrl(uri: String, abTestVariant: CheckoutFlowVariant = A): String =
+    (idWebAppUrl / "register") ? ("returnUrl" -> s"$membershipUrl$uri") & idSkipConfirmation & "clientId" -> abTestVariant.identitySkin
+  
   def idWebAppSignOutThenInUrl(uri: String): String =
     (idWebAppUrl / "signout") ? ("returnUrl" -> idWebAppSigninUrl(uri)) & idSkipConfirmation & idMember
 

--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -50,8 +50,8 @@ object Config {
     (idWebAppUrl / "signin") ? ("returnUrl" -> s"$membershipUrl$uri") & idSkipConfirmation & idMember
 
   def idWebAppRegisterUrl(uri: String, abTestVariant: CheckoutFlowVariant = A): String =
-    (idWebAppUrl / "register") ? ("returnUrl" -> s"$membershipUrl$uri") & idSkipConfirmation & "clientId" -> abTestVariant.identitySkin
-  
+    (idWebAppUrl / "register") ? ("returnUrl" -> s"$membershipUrl$uri") & idSkipConfirmation & ("clientId" -> abTestVariant.identitySkin)
+
   def idWebAppSignOutThenInUrl(uri: String): String =
     (idWebAppUrl / "signout") ? ("returnUrl" -> idWebAppSigninUrl(uri)) & idSkipConfirmation & idMember
 

--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -1,6 +1,7 @@
 package configuration
-import actions.CheckoutFlowVariant.A
-import actions.{CheckoutFlowVariant, CheckoutFlowVariant$}
+import abtests.CheckoutFlowVariant
+import abtests.CheckoutFlowVariant.A
+import com.getsentry.raven.dsn.Dsn
 import com.gu.config._
 import com.gu.identity.cookie.{PreProductionKeys, ProductionKeys}
 import com.gu.memsub.auth.common.MemSub.Google._
@@ -9,7 +10,6 @@ import com.netaporter.uri.Uri
 import com.netaporter.uri.dsl._
 import com.typesafe.config.ConfigFactory
 import model.Eventbrite.EBEvent
-import com.getsentry.raven.dsn.Dsn
 import play.api.Logger
 import play.api.Play.current
 import play.api.libs.concurrent.Akka

--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -1,4 +1,6 @@
 package configuration
+import actions.CheckoutFlowVariant.A
+import actions.{CheckoutFlowVariant, CheckoutFlowVariant$}
 import com.gu.config._
 import com.gu.identity.cookie.{PreProductionKeys, ProductionKeys}
 import com.gu.memsub.auth.common.MemSub.Google._
@@ -47,8 +49,13 @@ object Config {
   def idWebAppSigninUrl(uri: String): String =
     (idWebAppUrl / "signin") ? ("returnUrl" -> s"$membershipUrl$uri") & idSkipConfirmation & idMember
 
-  def idWebAppRegisterUrl(uri: String): String =
+  def idWebAppRegisterUrl(uri: String, abTestVariant: CheckoutFlowVariant = A): String ={
+
+    val idMember = "clientId" -> abTestVariant.identitySkin
+
     (idWebAppUrl / "register") ? ("returnUrl" -> s"$membershipUrl$uri") & idSkipConfirmation & idMember
+  }
+
 
   def idWebAppSignOutThenInUrl(uri: String): String =
     (idWebAppUrl / "signout") ? ("returnUrl" -> idWebAppSigninUrl(uri)) & idSkipConfirmation & idMember

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import abtests.CheckoutFlowVariant
 import actions.ActionRefiners._
 import actions.{RichAuthRequest, _}
 import com.github.nscala_time.time.Imports._

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -30,13 +30,13 @@ import services.{GuardianContentService, _}
 import tracking.ActivityTracking
 import utils.{CampaignCode, TierChangeCookies}
 import views.support
+import views.support.MembershipCompat._
 import views.support.Pricing._
 import views.support.TierPlans._
 import views.support.{CheckoutForm, CountryWithCurrency, PageInfo}
-import views.support.MembershipCompat._
 
 import scala.concurrent.Future
-import scala.util.{Failure, Random}
+import scala.util.Failure
 import scalaz.OptionT
 import scalaz.std.scalaFuture._
 

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -148,7 +148,7 @@ object Joiner extends Controller with ActivityTracking
           pageInfo,
           trackingPromoCode = validTrackingPromoCode,
           promoCodeToDisplay = validDisplayablePromoCode,
-          Some(countryGroup)))
+          Some(countryGroup))
         case CheckoutFlowVariant.B => views.html.joiner.form.paymentB(
           plans,
           countryCurrencyWhitelist,
@@ -156,7 +156,7 @@ object Joiner extends Controller with ActivityTracking
           pageInfo,
           trackingPromoCode = validTrackingPromoCode,
           promoCodeToDisplay = validDisplayablePromoCode,
-          Some(countryGroup)))
+          Some(countryGroup))
       }).withCookies(Cookie(CheckoutFlowVariant.cookieName, flowSelected.testId))
     }).andThen { case Failure(e) => logger.error(s"User ${request.user.user.id} could not enter details for paid tier ${tier.name}: ${identityRequest.trackingParameters}", e)}
   }

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -20,7 +20,7 @@ GET            /analytics-off                         controllers.Testing.analyt
 GET            /join/staff                            controllers.Joiner.staff
 GET            /join/staff/enter-details              controllers.Joiner.enterStaffDetails
 GET            /join/friend/enter-details             controllers.Joiner.enterFriendDetails
-GET            /join/:tier/enter-details              controllers.Joiner.enterPaidDetails(tier: PaidTier, countryGroup: CountryGroup ?= CountryGroup.UK, promoCode: Option[PromoCode] ?= None, skin: Option[String] ?= None)
+GET            /join/:tier/enter-details              controllers.Joiner.enterPaidDetails(tier: PaidTier, countryGroup: CountryGroup ?= CountryGroup.UK, promoCode: Option[PromoCode] ?= None)
 POST           /join/friend/enter-details             controllers.Joiner.joinFriend
 POST           /join/staff/enter-details              controllers.Joiner.joinStaff
 POST           /join/:tier/enter-details              controllers.Joiner.joinPaid(tier: PaidTier)


### PR DESCRIPTION
## Description

Currently, there is two version of the checkout flow on production, but only one has traffic. This PR implement the logic of the  A/B Test

## Flow's details

1 - The user clicks the "become a supporter button"

2 - We check if the user has the cookie: "ab-checkout-flow"

3 - If not we select A or B randomly and we store that value in the cookie.

4 - If the user is not log in and the test selected is B, we redirect the user to **http://profile...clientId=membersB**. If the test selected is A, we redirect the user to **http://profile...clientId=members**

5 - After the user creates his or her account, we check the cookie again and show him/her the correct checkout page.

Trello card: https://trello.com/c/PpnCnR0N/150-implement-the-ab-test-for-the-new-checkout-flow

