### PR TITLE
Give a better message when users can not upgrade due to locale

### DIFF
--- a/frontend/app/views/tier/upgrade/unavailable.scala.html
+++ b/frontend/app/views/tier/upgrade/unavailable.scala.html
@@ -1,18 +1,36 @@
 @(currentTier: com.gu.salesforce.Tier, targetTier: com.gu.salesforce.Tier)
-
+@import views.support.Asset
 @import configuration.Email
 
 @main("Unavailable Tier") {
 
     <main role="main" class="page-content l-constrained">
+        @fragments.page.pageHeader(s"Thank you for your interest in becoming a ${targetTier.name} of the Guardian", Some(s"You're currently a ${currentTier.name}, we can't upgrade you to a ${targetTier.name}"))
 
-        @fragments.page.pageHeader("Unavailable Tier", Some("Unable to change from " + currentTier.name + " to " + targetTier.name))
+        <section class="page-section">
+            <div class="page-section__content">
+                <p>
+                    At the moment the @targetTier.name benefits can only be accessed in the UK, we are working hard to develop benefits relevant to our readers across the globe.
+                </p>
 
-        <div class="page-section">
-            <div class="page-section__content copy">
-                <p>Sorry you are currently unable to change your tier from <strong>@currentTier.name</strong> to <strong>@targetTier.name</strong>. Please contact <a href="mailto:@Email.membershipSupport">@Email.membershipSupport</a> for assistance.</p>
+                <p class="text-lead">If you're looking for a way to make a greater contribution to the Guardian right now,
+                    the best way you can help us is here:</p>
+                <a class="elevated-button action action--no-icon"
+                href="https://contribute.theguardian.com/?INTCMP=mem_tier_change_unavailable">
+                    <div class="elevated-button__text">
+                        Make a one-off Contribution
+                    </div>
+                    <div class="elevated-button__icon">
+                        <div class="elevated-button__icon__border">
+                        @for(icon <- Asset.inlineSvg("arrow-right-button")) {
+                            @icon
+                        }
+                        </div>
+                    </div>
+                </a>
             </div>
-        </div>
+
+        </section>
 
     </main>
 }


### PR DESCRIPTION
If a user is a Supporter and currently paying in non-GBP currency, they can't upgrade to a higher tier. We don't have prices set in non-GBP currency set for any tier other than Supporter.

We've had some emails from users who are disappointed about this, so this message aims to help them out, and allow them to support the Guardian in another way.

We hit Contributions with the url **https://contribute.theguardian.com/?INTCMP=mem_tier_change_unavailable**

![image](https://cloud.githubusercontent.com/assets/52038/20629225/4cabff22-b322-11e6-99f7-5d2bc39ec22b.png)


cc @philwills 