### PR TITLE
Removed promo code if and only if you are in the supporter checkout page

### DIFF
--- a/frontend/app/views/joiner/form/payment.scala.html
+++ b/frontend/app/views/joiner/form/payment.scala.html
@@ -77,10 +77,12 @@
                         }
                     </div>
 
-                    <div class="form-group">
-                        <h2 class="form-group__title">Promotion</h2>
-                        @fragments.form.promoCode(trackingPromoCode, promoCodeToDisplay)
-                    </div>
+                    @if(plans.tier != Supporter()){
+                        <div class="form-group">
+                            <h2 class="form-group__title">Promotion</h2>
+                            @fragments.form.promoCode(trackingPromoCode, promoCodeToDisplay)
+                        </div>
+                    }
 
                     <div class="form-group">
                         <h2 class="form-group__title">Billing</h2>

--- a/frontend/app/views/joiner/form/paymentB.scala.html
+++ b/frontend/app/views/joiner/form/paymentB.scala.html
@@ -85,10 +85,12 @@
                         }
                     </div>
 
-                    <div class="form-group form-section__promotion">
-                        <h2 class="form-group__title">Promotion</h2>
-                        @fragments.form.promoCode(trackingPromoCode, promoCodeToDisplay)
-                    </div>
+                    @if(plans.tier != Supporter()) {
+                        <div class="form-group form-section__promotion">
+                            <h2 class="form-group__title">Promotion</h2>
+                            @fragments.form.promoCode(trackingPromoCode, promoCodeToDisplay)
+                        </div>
+                    }
 
                     <div class="form-group form-group--little-padding">
                     	<div class="form-section__billing">


### PR DESCRIPTION
In the checkout page for a supporter, we drop the Promo code input if and only if the flow is for the supporter tier.

## Current Form

![currentscreen](https://cloud.githubusercontent.com/assets/825398/20667018/166ef6a0-b55f-11e6-9cf6-02c8f6e7605b.png)

## Desired Form

![currentdesired](https://cloud.githubusercontent.com/assets/825398/20667043/41630978-b55f-11e6-8584-e51812344ee4.png)

Please,@Ap0c, @JustinPinner, can you review this PR?. 