### PR TITLE
CSS bug fix for the checkout page, flow B

### DIFF
--- a/frontend/assets/stylesheets/components/_payment-b.scss
+++ b/frontend/assets/stylesheets/components/_payment-b.scss
@@ -1,7 +1,7 @@
 .skin-checkout-b {
     padding: 0;
     width: 100%;
-    z-index: 500;
+    z-index: 2;
 
     background: #ffffff;
 


### PR DESCRIPTION
Bug Fix for the checkout page in flow B.

## Before
<img width="679" alt="picture 30" src="https://cloud.githubusercontent.com/assets/825398/20712073/82f16e6c-b63a-11e6-822c-e83333e72b13.png">

## After

<img width="484" alt="picture 31" src="https://cloud.githubusercontent.com/assets/825398/20712090/9829692e-b63a-11e6-906e-c7a953440d4f.png">

