### PR TITLE
Signout-to-register flow for "switch user" scenario at supporter checkout

### DIFF
--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -52,9 +52,6 @@ object Config {
   def idWebAppRegisterUrl(uri: String, abTestVariant: CheckoutFlowVariant = A): String =
     (idWebAppUrl / "register") ? ("returnUrl" -> s"$membershipUrl$uri") & idSkipConfirmation & ("clientId" -> abTestVariant.identitySkin)
 
-  def idWebAppSignOutThenInUrl(uri: String): String =
-      (idWebAppUrl / "signout") ? ("returnUrl" -> idWebAppSigninUrl(uri)) & idSkipConfirmation & idMember
-
   def idWebAppSignOutThenRegisterUrl(uri: String, abTestVariant: CheckoutFlowVariant = A): String =
     (idWebAppUrl / "signout") ? ("returnUrl" -> (idWebAppUrl / "register") ? ("returnUrl" -> s"$membershipUrl$uri" & idSkipConfirmation & ("clientId" -> abTestVariant.identitySkin)))
 

--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -52,8 +52,13 @@ object Config {
   def idWebAppRegisterUrl(uri: String, abTestVariant: CheckoutFlowVariant = A): String =
     (idWebAppUrl / "register") ? ("returnUrl" -> s"$membershipUrl$uri") & idSkipConfirmation & ("clientId" -> abTestVariant.identitySkin)
 
-  def idWebAppSignOutThenInUrl(uri: String): String =
-    (idWebAppUrl / "signout") ? ("returnUrl" -> idWebAppSigninUrl(uri)) & idSkipConfirmation & idMember
+  def idWebAppSignOutThenInUrl(uri: String, switchUser: Boolean, abTestVariant: CheckoutFlowVariant = A): String = {
+    if (switchUser) {
+      (idWebAppUrl / "signout") ? ("returnUrl" -> idWebAppRegisterUrl(uri, abTestVariant)) & idSkipConfirmation & idMember
+    } else {
+      (idWebAppUrl / "signout") ? ("returnUrl" -> idWebAppSigninUrl(uri)) & idSkipConfirmation & idMember
+    }
+  }
 
   def idWebAppProfileUrl =
     idWebAppUrl / "membership"/ "edit"

--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -52,13 +52,11 @@ object Config {
   def idWebAppRegisterUrl(uri: String, abTestVariant: CheckoutFlowVariant = A): String =
     (idWebAppUrl / "register") ? ("returnUrl" -> s"$membershipUrl$uri") & idSkipConfirmation & ("clientId" -> abTestVariant.identitySkin)
 
-  def idWebAppSignOutThenInUrl(uri: String, switchUser: Boolean, abTestVariant: CheckoutFlowVariant = A): String = {
-    if (switchUser) {
-      (idWebAppUrl / "signout") ? ("returnUrl" -> idWebAppRegisterUrl(uri, abTestVariant)) & idSkipConfirmation & idMember
-    } else {
+  def idWebAppSignOutThenInUrl(uri: String): String =
       (idWebAppUrl / "signout") ? ("returnUrl" -> idWebAppSigninUrl(uri)) & idSkipConfirmation & idMember
-    }
-  }
+
+  def idWebAppSignOutThenRegisterUrl(uri: String, abTestVariant: CheckoutFlowVariant = A): String =
+    (idWebAppUrl / "signout") ? ("returnUrl" -> (idWebAppUrl / "register") ? ("returnUrl" -> s"$membershipUrl$uri" & idSkipConfirmation & ("clientId" -> abTestVariant.identitySkin)))
 
   def idWebAppProfileUrl =
     idWebAppUrl / "membership"/ "edit"

--- a/frontend/app/views/fragments/joiner/signedInAs.scala.html
+++ b/frontend/app/views/fragments/joiner/signedInAs.scala.html
@@ -1,8 +1,8 @@
 @import abtests.CheckoutFlowVariant
 
-@(returnUri: String, inline: Boolean = false, switchUser: Boolean = false, flowVariant: CheckoutFlowVariant = CheckoutFlowVariant.A)
+@(returnUri: String, inline: Boolean = false, flowVariant: CheckoutFlowVariant = CheckoutFlowVariant.A)
 
-@import configuration.Config.{idWebAppSignOutThenInUrl,idWebAppSignOutThenRegisterUrl}
+@import configuration.Config.idWebAppSignOutThenRegisterUrl
 
 <p class="text-note">
     You're signed in as <strong class="js-user-displayname"></strong>.
@@ -10,9 +10,5 @@
 	</p>
 	<p class="text-note">
 }
-    @if(switchUser) {
-        <a href="@idWebAppSignOutThenRegisterUrl(returnUri, flowVariant)" class="text-link">Sign out</a>
-    } else {
-        <a href="@idWebAppSignOutThenInUrl(returnUri)" class="text-link">Sign out</a>
-    }
+    <a href="@idWebAppSignOutThenRegisterUrl(returnUri, flowVariant)" class="text-link">Sign out</a>
 </p>

--- a/frontend/app/views/fragments/joiner/signedInAs.scala.html
+++ b/frontend/app/views/fragments/joiner/signedInAs.scala.html
@@ -2,7 +2,7 @@
 
 @(returnUri: String, inline: Boolean = false, switchUser: Boolean = false, flowVariant: CheckoutFlowVariant = CheckoutFlowVariant.A)
 
-@import configuration.Config.idWebAppSignOutThenInUrl
+@import configuration.Config.{idWebAppSignOutThenInUrl,idWebAppSignOutThenRegisterUrl}
 
 <p class="text-note">
     You're signed in as <strong class="js-user-displayname"></strong>.
@@ -10,5 +10,9 @@
 	</p>
 	<p class="text-note">
 }
-    <a href="@idWebAppSignOutThenInUrl(returnUri, switchUser, flowVariant)" class="text-link">Sign out</a>
+    @if(switchUser) {
+        <a href="@idWebAppSignOutThenRegisterUrl(returnUri, flowVariant)" class="text-link">Sign out</a>
+    } else {
+        <a href="@idWebAppSignOutThenInUrl(returnUri)" class="text-link">Sign out</a>
+    }
 </p>

--- a/frontend/app/views/fragments/joiner/signedInAs.scala.html
+++ b/frontend/app/views/fragments/joiner/signedInAs.scala.html
@@ -1,4 +1,6 @@
-@(returnUri: String, inline: Boolean = false)
+@import abtests.CheckoutFlowVariant
+
+@(returnUri: String, inline: Boolean = false, switchUser: Boolean = false, flowVariant: CheckoutFlowVariant = CheckoutFlowVariant.A)
 
 @import configuration.Config.idWebAppSignOutThenInUrl
 
@@ -6,7 +8,7 @@
     You're signed in as <strong class="js-user-displayname"></strong>.
 @if(!inline) {
 	</p>
-	<p class="text-note">	
+	<p class="text-note">
 }
-    <a href="@idWebAppSignOutThenInUrl(returnUri)" class="text-link">Sign out</a>
+    <a href="@idWebAppSignOutThenInUrl(returnUri, switchUser, flowVariant)" class="text-link">Sign out</a>
 </p>

--- a/frontend/app/views/joiner/form/payment.scala.html
+++ b/frontend/app/views/joiner/form/payment.scala.html
@@ -46,7 +46,7 @@
             <section class="form-section">
 
                 <div class="form-section__lead-in sign-in-required">
-                    @fragments.joiner.signedInAs(routes.FrontPage.index().url, inline = false, switchUser = true, CheckoutFlowVariant.A)
+                    @fragments.joiner.signedInAs(request.uri, inline = false, switchUser = true, CheckoutFlowVariant.A)
                 </div>
 
                 <div class="form-section__content">

--- a/frontend/app/views/joiner/form/payment.scala.html
+++ b/frontend/app/views/joiner/form/payment.scala.html
@@ -46,7 +46,7 @@
             <section class="form-section">
 
                 <div class="form-section__lead-in sign-in-required">
-                    @fragments.joiner.signedInAs(request.uri, inline = false, switchUser = true, CheckoutFlowVariant.A)
+                    @fragments.joiner.signedInAs(request.uri, inline = false, CheckoutFlowVariant.A)
                 </div>
 
                 <div class="form-section__content">

--- a/frontend/app/views/joiner/form/payment.scala.html
+++ b/frontend/app/views/joiner/form/payment.scala.html
@@ -14,6 +14,7 @@
 @import com.gu.memsub.subsv2.CatalogPlan.PaidMember
 
 @import com.gu.i18n.CountryGroup
+@import abtests.CheckoutFlowVariant
 
 @(plans: MonthYearPlans[PaidMember],
   countriesWithCurrencies: List[CountryWithCurrency],
@@ -45,7 +46,7 @@
             <section class="form-section">
 
                 <div class="form-section__lead-in sign-in-required">
-                    @fragments.joiner.signedInAs(routes.FrontPage.index().url, inline = false)
+                    @fragments.joiner.signedInAs(routes.FrontPage.index().url, inline = false, switchUser = true, CheckoutFlowVariant.A)
                 </div>
 
                 <div class="form-section__content">

--- a/frontend/app/views/joiner/form/paymentB.scala.html
+++ b/frontend/app/views/joiner/form/paymentB.scala.html
@@ -61,7 +61,7 @@
                         <h2 class="form-group__title">Name and address</h2>
 
                         <div class="form-section__lead-in sign-in-required">
-                            @fragments.joiner.signedInAs(request.uri, inline = true, switchUser = true, CheckoutFlowVariant.B)
+                            @fragments.joiner.signedInAs(request.uri, inline = true, CheckoutFlowVariant.B)
                         </div>
 
                         <div class="form-section__name-detail">

--- a/frontend/app/views/joiner/form/paymentB.scala.html
+++ b/frontend/app/views/joiner/form/paymentB.scala.html
@@ -13,6 +13,7 @@
 @import com.gu.memsub.subsv2.MonthYearPlans
 @import com.gu.memsub.subsv2.CatalogPlan.PaidMember
 @import com.gu.i18n.CountryGroup
+@import abtests.CheckoutFlowVariant
 
 @(plans: MonthYearPlans[PaidMember],
     countriesWithCurrencies: List[CountryWithCurrency],
@@ -60,7 +61,7 @@
                         <h2 class="form-group__title">Name and address</h2>
 
                         <div class="form-section__lead-in sign-in-required">
-                            @fragments.joiner.signedInAs(routes.FrontPage.index().url, inline = true)
+                            @fragments.joiner.signedInAs(routes.FrontPage.index().url, inline = true, switchUser = true, CheckoutFlowVariant.B)
                         </div>
 
                         <div class="form-section__name-detail">

--- a/frontend/app/views/joiner/form/paymentB.scala.html
+++ b/frontend/app/views/joiner/form/paymentB.scala.html
@@ -61,7 +61,7 @@
                         <h2 class="form-group__title">Name and address</h2>
 
                         <div class="form-section__lead-in sign-in-required">
-                            @fragments.joiner.signedInAs(routes.FrontPage.index().url, inline = true, switchUser = true, CheckoutFlowVariant.B)
+                            @fragments.joiner.signedInAs(request.uri, inline = true, switchUser = true, CheckoutFlowVariant.B)
                         </div>
 
                         <div class="form-section__name-detail">


### PR DESCRIPTION
When someone is signed in and completing the payment (checkout) form to become a supporter, they may realise they're logged in with the wrong account if they use a shared device.

We should provide a route by which they can log out and then log back in (or create a new account) and resume their journey into supporterdom.

The identity service rejects signin as an onward journey after signout so now we'll send the user to the membership register page (which also includes a sign in link), with a return url copied through from the point at which they were completing the supporter checkout form.

The flow can therefore be as follows;

`sign in -> become a supporter -> join (checkout) -> sign out -> register -> join (checkout)`
or
`sign in -> become a supporter -> join (checkout) -> sign out -> sign in (via the link on the register page) -> join (checkout)`

@svillafe I've passed the checkout flow variant through, but I wonder if this is needed. What do you think?

I've also made this an additional feature, rather than replacing the current behaviour whereby clicking sign out from the same link but in other places (e.g. friend sign up or free to paid upgrade) returns the reader to the dotcom front page as per current functionality.

cc @Ap0c @rtyley @rupertbates 



 https://trello.com/c/TEaX9RUB/133-fix-sign-out-link-on-membership-checkout-page - 
![upload_4_11_2016_at_14_31_30](https://cloud.githubusercontent.com/assets/52038/20714114/d1d59d20-b642-11e6-86b3-60e06e4be4f7.png)
