### PR TITLE
update to latest membership-common

### DIFF
--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -5,8 +5,9 @@ import actions.ActionRefiners._
 import actions.{RichAuthRequest, _}
 import com.github.nscala_time.time.Imports._
 import com.gu.contentapi.client.model.v1.{MembershipTier => ContentAccess}
+import com.gu.i18n.CountryGroup
 import com.gu.i18n.CountryGroup.UK
-import com.gu.i18n.{CountryGroup, GBP}
+import com.gu.i18n.Currency.GBP
 import com.gu.memsub.BillingPeriod
 import com.gu.memsub.promo.{NewUsers, PromoCode}
 import com.gu.memsub.util.Timing

--- a/frontend/app/controllers/PatternLibrary.scala
+++ b/frontend/app/controllers/PatternLibrary.scala
@@ -1,12 +1,9 @@
 package controllers
 
-import com.gu.i18n.GBP
 import com.gu.i18n.CountryGroup._
-import com.gu.memsub.images.ResponsiveImageGenerator
-import com.gu.memsub.images.ResponsiveImageGroup
+import com.gu.memsub.images.{ResponsiveImageGenerator, ResponsiveImageGroup}
 import play.api.mvc.Controller
 import services.{EventbriteService, GuardianLiveEventService, TouchpointBackend}
-import play.api.libs.concurrent.Execution.Implicits._
 
 trait PatternLibrary extends Controller {
   val guLiveEvents: EventbriteService

--- a/frontend/app/controllers/PricingApi.scala
+++ b/frontend/app/controllers/PricingApi.scala
@@ -1,6 +1,7 @@
 package controllers
 
-import com.gu.i18n._
+import com.gu.i18n.{Country, Currency}
+import com.gu.i18n.Currency._
 import com.gu.memsub.subsv2.Catalog
 import com.gu.salesforce.PaidTier
 import play.api.libs.json.{JsArray, JsString, JsValue, Json, Writes}

--- a/frontend/app/controllers/Promotions.scala
+++ b/frontend/app/controllers/Promotions.scala
@@ -1,7 +1,8 @@
 package controllers
 
 import actions.RichAuthRequest
-import com.gu.i18n.{Country, CountryGroup, GBP}
+import com.gu.i18n.Currency.GBP
+import com.gu.i18n.{Country, CountryGroup}
 import com.gu.memsub.Subscription.ProductRatePlanId
 import com.gu.memsub.images.{ResponsiveImage, ResponsiveImageGenerator, ResponsiveImageGroup}
 import com.gu.memsub.promo.Formatters.PromotionFormatters._

--- a/frontend/app/model/Eventbrite.scala
+++ b/frontend/app/model/Eventbrite.scala
@@ -1,7 +1,7 @@
 package model
 
 import com.github.nscala_time.time.Imports._
-import com.gu.i18n.GBP
+import com.gu.i18n.Currency.GBP
 import com.gu.memsub.Price
 import com.gu.salesforce.Tier
 import com.netaporter.uri.Uri

--- a/frontend/app/views/joiner/form/addressWithWelcomePack.scala.html
+++ b/frontend/app/views/joiner/form/addressWithWelcomePack.scala.html
@@ -1,12 +1,8 @@
-@import views.support.CountryWithCurrency
-@import com.gu.i18n.GBP
-@import views.support.IdentityUser
-@import com.gu.memsub.Current
 @import com.gu.memsub.subsv2._
-@import com.gu.memsub.Staff
 @import com.gu.salesforce.Tier.{Staff => SFStaff}
+@import views.support.{CountryWithCurrency, FreePlan, IdentityUser}
+@import com.gu.i18n.Currency.GBP
 
-@import views.support.FreePlan
 @(staffPlan: CatalogPlan.Staff,
   idUser: IdentityUser,
   flashMessage: Option[model.FlashMessage]

--- a/frontend/app/views/joiner/form/friendSignup.scala.html
+++ b/frontend/app/views/joiner/form/friendSignup.scala.html
@@ -1,15 +1,10 @@
-@import views.support.PageInfo
-@import com.gu.i18n.GBP
-@import views.support.CountryWithCurrency
+@import com.gu.i18n.Currency.GBP
+@import com.gu.memsub.promo.PromoCode
+@import com.gu.memsub.subsv2._
 @import views.html.helper._
 @import views.support.DisplayText._
-@import views.support.IdentityUser
-@import com.gu.memsub.Current
-@import com.gu.memsub.Friend
-@import com.gu.memsub.subsv2._
-@import com.gu.memsub.promo.PromoCode
+@import views.support.{CountryWithCurrency, FreePlan, IdentityUser, PageInfo}
 
-@import views.support.FreePlan
 @(friendPlan: CatalogPlan.Friend,
   idUser: IdentityUser,
   pageInfo: PageInfo,

--- a/frontend/app/views/patterns/patterns.scala.html
+++ b/frontend/app/views/patterns/patterns.scala.html
@@ -6,7 +6,7 @@
 @import views.support.Asset
 @import views.support.Pricing._
 
-@import com.gu.i18n.GBP
+@import com.gu.i18n.Currency.GBP
 @import com.gu.salesforce.Tier
 @import views.support.TierPlans._
 @import com.gu.memsub.subsv2.Catalog

--- a/frontend/app/views/support/CheckoutForm.scala
+++ b/frontend/app/views/support/CheckoutForm.scala
@@ -1,5 +1,6 @@
 package views.support
 
+import com.gu.i18n.Currency.GBP
 import com.gu.i18n._
 import com.gu.memsub.BillingPeriod
 import com.typesafe.scalalogging.LazyLogging

--- a/frontend/app/views/support/MembershipCompat.scala
+++ b/frontend/app/views/support/MembershipCompat.scala
@@ -1,5 +1,7 @@
 package views.support
-import com.gu.i18n.{Country, CountryGroup, Currency, GBP}
+
+import com.gu.i18n.Currency.GBP
+import com.gu.i18n.{Country, CountryGroup, Currency}
 import com.gu.memsub.Product.Membership
 import com.gu.memsub.Subscription.ProductRatePlanId
 import com.gu.memsub.subsv2.{CatalogPlan, _}

--- a/frontend/app/views/support/PageInfo.scala
+++ b/frontend/app/views/support/PageInfo.scala
@@ -1,10 +1,10 @@
 package views.support
 
-import com.gu.i18n.{Country, CountryGroup, Currency, GBP}
+import com.gu.i18n.{Country, CountryGroup, Currency}
 import com.gu.memsub.BillingPeriod
 import configuration.{Config, CopyConfig}
-import model.{EventSchema, Nav}
 import model.Nav.NavItem
+import model.{EventSchema, Nav}
 import play.api.libs.json._
 
 case class PageInfo(title: String = CopyConfig.copyTitleDefault,

--- a/frontend/app/views/support/Pricing.scala
+++ b/frontend/app/views/support/Pricing.scala
@@ -1,10 +1,9 @@
 package views.support
 
-import com.gu.i18n.{Currency, GBP}
+import com.gu.i18n.Currency
+import com.gu.memsub.Price
 import com.gu.memsub.subsv2.CatalogPlan.PaidMember
 import com.gu.memsub.subsv2.MonthYearPlans
-import com.gu.memsub.{Current, Price}
-import com.gu.salesforce.PaidTier
 
 case class Pricing(yearly: Price, monthly: Price) {
   require(yearly.currency == monthly.currency, "The yearly and monthly prices should have the same currency")

--- a/frontend/test/services/DestinationServiceTest.scala
+++ b/frontend/test/services/DestinationServiceTest.scala
@@ -1,10 +1,12 @@
 package services
 import com.github.nscala_time.time.Imports._
 import com.gu.contentapi.client.parser.JsonParser
-import com.gu.i18n.GBP
+import com.gu.i18n.Currency.GBP
 import com.gu.memsub.Subscription.{ProductRatePlanId, RatePlanId}
 import com.gu.memsub._
-import com.gu.memsub.subsv2.{PaidCharge, PaidSubscriptionPlan, Subscription, SubscriptionPlan}
+import com.gu.memsub.services
+import com.gu.memsub.subsv2.Subscription
+import com.gu.memsub.subsv2._
 import com.gu.salesforce._
 import model.Eventbrite.EBAccessCode
 import model.EventbriteTestObjects._
@@ -28,7 +30,7 @@ class DestinationServiceTest extends Specification {
 
     def createRequestWithSession(newSessions: (String, String)*) = {
 
-      val testMember = Contact("id", None, None, Some("fn"), "ln", "email", new DateTime(), "contactId", "accountId")
+      val testMember = Contact("id", None, None, Some("fn"), "ln", Some("email"), new DateTime(), "contactId", "accountId", None, None, None, None, None)
       val partnerCharge: PaidCharge[com.gu.memsub.Partner.type, Month] = PaidCharge[com.gu.memsub.Partner.type, Month](com.gu.memsub.Partner, Month(), PricingSummary(Map(GBP -> Price(0.1f, GBP))))
       val testSub: Subscription[SubscriptionPlan.Member] = new Subscription[SubscriptionPlan.Partner](
         id = com.gu.memsub.Subscription.Id(""),
@@ -45,7 +47,8 @@ class DestinationServiceTest extends Specification {
           id = RatePlanId(""), productRatePlanId = ProductRatePlanId(""), name = "name", product = Product.Membership, description = "", features = Nil,
           charges = partnerCharge,
           chargedThrough = None, start = new LocalDate("2015-01-01"), end = new LocalDate("2016-01-01"), productName = ""),
-        hasPendingFreePlan = false
+        hasPendingFreePlan = false,
+        readerType = ReaderType.Direct
       )
 
       val testSubscriber: Subscriber.Member = Subscriber(testSub, testMember)

--- a/frontend/test/views/support/CheckoutFormTest.scala
+++ b/frontend/test/views/support/CheckoutFormTest.scala
@@ -1,12 +1,12 @@
 package views.support
 
+import com.gu.i18n.Currency._
 import com.gu.i18n._
 import com.gu.identity.play.{PrivateFields, StatusFields}
 import com.gu.memsub.Subscription.ProductRatePlanId
 import com.gu.memsub._
 import com.gu.memsub.subsv2.{CatalogPlan, MonthYearPlans, PaidCharge}
 import org.specs2.mutable.Specification
-import views.support.TierPlans._
 
 
 class CheckoutFormTest extends Specification {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "7.2.3"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.7"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.294"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.308"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache


### PR DESCRIPTION
This gets membership in line with subscriptions for membership-common library.

The main changes are just making a few things optional that we might not have for migrated in weekly subs.  And the move of GBP to Currency object caused a lot of excessive changes but hopefully makes things tidier in future.

I have tested in UAT a signup, then upgrade, and it all seems to work.

@pvighi @guardian/membership-and-subscriptions 