### PR TITLE
Ignore weekly one off plan instead of crashing on startup

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "7.2.3"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.7"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.311"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.312"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache


### PR DESCRIPTION
Update membership-common to the latest version which ignores weekly one off plans in the zuora catalog instead of crashing when reading it
@paulbrown1982 @jacobwinch @johnduffell 