### PR TITLE
upwrap email address from its option

### DIFF
--- a/frontend/app/views/joiner/thankyou.scala.html
+++ b/frontend/app/views/joiner/thankyou.scala.html
@@ -61,7 +61,12 @@
 </script>
     <main role="main" class="page-content l-constrained">
 
-        @fragments.page.pageHeader(pageHeader, Some(s"You're the newest ${member.subscription.plan.tier.name} of the Guardian and we're thrilled to have you on board. We've sent confirmation of your membership to ${member.contact.email}"),classes = Seq("sessioncamhidetext"))
+        @fragments.page.pageHeader(
+            pageHeader,
+            Some(s"You're the newest ${member.subscription.plan.tier.name} of the Guardian and we're thrilled to have you on board. " +
+                member.contact.email.map(email => s"We've sent confirmation of your membership to $email").getOrElse("Our system failed to store your email address, please contact customer services.")),
+            classes = Seq("sessioncamhidetext")
+        )
 
         <section class="page-section page-section--bordered">
             <div class="page-section__lead-in">


### PR DESCRIPTION
When I made email address optional in our model reading from salesforce, I didn't spot that membership uses it in its thank you page

As such we were telling users we have emailed them on Some(joe.bloggs@guardian.co.uk) 😨 

I've fixed it up and made it all helpful too if the option is not filled, but since this would have 500'd before and it's basically an unlikely error, I'm not sure if `.get` would be good enough? thoughts?

![image](https://cloud.githubusercontent.com/assets/7304387/20803657/dcf2d10e-b7e7-11e6-8165-7d49028cb59d.png)

@guardian/membership-and-subscriptions 