### PR TITLE
Turn off the A/B Test

### DIFF
--- a/frontend/app/abtests/CheckoutFlowVariant.scala
+++ b/frontend/app/abtests/CheckoutFlowVariant.scala
@@ -10,13 +10,13 @@ import scala.util.Random
 object CheckoutFlowVariant {
   val cookieName = "ab-checkout-flow"
   val runningTest = false
-  val chosenFlow = A
+  val default = A
 
   val all = Seq[CheckoutFlowVariant](A,B)
 
   def deriveFlowVariant(implicit request: RequestHeader): CheckoutFlowVariant =
     if(runningTest) getFlowVariantFromRequestCookie(request).getOrElse(CheckoutFlowVariant.all(Random.nextInt(CheckoutFlowVariant.all.size)))
-    else chosenFlow
+    else default
 
   def getFlowVariantFromRequestCookie(request: RequestHeader): Option[CheckoutFlowVariant] =
     if(runningTest)
@@ -24,7 +24,7 @@ object CheckoutFlowVariant {
         cookieValue <- request.cookies.get(cookieName)
         variant <- CheckoutFlowVariant.lookup(cookieValue.value)
       } yield variant
-    else Some(chosenFlow)
+    else Some(default)
 
   case object A extends CheckoutFlowVariant {
     override val testId: String = "test-A"

--- a/frontend/app/abtests/CheckoutFlowVariant.scala
+++ b/frontend/app/abtests/CheckoutFlowVariant.scala
@@ -9,16 +9,22 @@ import scala.util.Random
   */
 object CheckoutFlowVariant {
   val cookieName = "ab-checkout-flow"
+  val runningTest = false
+  val chosenFlow = A
 
   val all = Seq[CheckoutFlowVariant](A,B)
 
   def deriveFlowVariant(implicit request: RequestHeader): CheckoutFlowVariant =
-    getFlowVariantFromRequestCookie(request).getOrElse(CheckoutFlowVariant.all(Random.nextInt(CheckoutFlowVariant.all.size)))
+    if(runningTest) getFlowVariantFromRequestCookie(request).getOrElse(CheckoutFlowVariant.all(Random.nextInt(CheckoutFlowVariant.all.size)))
+    else chosenFlow
 
-  def getFlowVariantFromRequestCookie(request: RequestHeader): Option[CheckoutFlowVariant] = for {
-    cookieValue <- request.cookies.get(cookieName)
-    variant <- CheckoutFlowVariant.lookup(cookieValue.value)
-  } yield variant
+  def getFlowVariantFromRequestCookie(request: RequestHeader): Option[CheckoutFlowVariant] =
+    if(runningTest)
+      for {
+        cookieValue <- request.cookies.get(cookieName)
+        variant <- CheckoutFlowVariant.lookup(cookieValue.value)
+      } yield variant
+    else Some(chosenFlow)
 
   case object A extends CheckoutFlowVariant {
     override val testId: String = "test-A"


### PR DESCRIPTION
# Turning off the checkout A/B Test

## Trello card: [Here](https://trello.com/c/hM6lGY4r)

## Why?
The A/B Test has finished and **Flow A** is the winner. 
It is important to notice that there is another Trello card ([here](https://trello.com/c/4fUSaBPm)) to refactor the A/B Test code and apply the winner flow into the code. This PR is just for turning the A/B Test off.

## Changes
* `CheckoutFlowVariant.scala`: Modified the `getFlowVariantFromRequestCookie` and `deriveFlowVariant` methods in order to read a local, `runningTest`, which specifies if we are running a A/B Test.

