### PR TITLE
Fix Post-Deploy Tests - Display Name Check

### DIFF
--- a/frontend/test/acceptance/pages/EnterDetails.scala
+++ b/frontend/test/acceptance/pages/EnterDetails.scala
@@ -9,7 +9,7 @@ case class EnterDetails(val testUser: TestUser) extends Page with Browser {
 
   def pageHasLoaded: Boolean = pageHasElement(id("cc-cvc"))
 
-  def userIsSignedIn: Boolean = elementHasText(userDisplayName, testUser.username.toLowerCase)
+  def userIsSignedIn: Boolean = elementHasText(userDisplayName, testUser.username)
 
   def fillInDeliveryAddress() { DeliveryAddress.fillIn() }
 


### PR DESCRIPTION
# Problem

I broke the post-deploy tests in #1394 (sorry!). By removing the profile display name field on the checkout page, the test that checks the display name against the test user fails ("And should be logged in with their Identity account.").

# Solution

Fortunately, there is another location on the checkout page that shows the display name, the only difference being that it is not shown in lower case. Removing the `toLowerCase` method call allows the test to pass again 😃 (thanks Mario for figuring this out!).

@mario-galic @rupertbates @svillafe @JustinPinner 