### PR TITLE
Tracking billing period (monthly/annual) in the payment button.

### DIFF
--- a/frontend/app/views/joiner/form/payment.scala.html
+++ b/frontend/app/views/joiner/form/payment.scala.html
@@ -103,7 +103,7 @@
                     </div>
 
                     @fragments.form.errorMessageDisplay()
-                    @fragments.form.submit(PaidPlans(plans), countryGroup = countryGroup, dataCategory = Some("checkout page"), dataLabel = Some("payment a"))
+                    @fragments.form.submit(PaidPlans(plans), countryGroup = countryGroup, dataCategory = Some("checkout page"), dataLabel = Some("payment a-annual"))
                 </div>
             </section>
         </form>

--- a/frontend/app/views/joiner/form/paymentB.scala.html
+++ b/frontend/app/views/joiner/form/paymentB.scala.html
@@ -113,7 +113,7 @@
                     </div>
                     @fragments.form.terms(countryGroup)
                     @fragments.form.errorMessageDisplay()
-                    @fragments.form.submit(PaidPlans(plans), membershipTermsAndConditions = false, countryGroup = countryGroup, dataCategory = Some("checkout page"), dataLabel = Some("payment b"))
+                    @fragments.form.submit(PaidPlans(plans), membershipTermsAndConditions = false, countryGroup = countryGroup, dataCategory = Some("checkout page"), dataLabel = Some("payment b-annual"))
                 </div>
             </section>
         </form>

--- a/frontend/assets/javascripts/src/modules/form/billingPeriodChoice.js
+++ b/frontend/assets/javascripts/src/modules/form/billingPeriodChoice.js
@@ -14,9 +14,9 @@ define(
             billingPeriods = guardian.membership.checkoutForm.billingPeriods,
             $BILLING_PERIOD_CONTAINER = $('.js-billing-period__container');
 
-        function notifyOtherModulesToRender() {
+        function notifyOtherModulesToRender(payload) {
             ongoingCardPayments.render();
-            submitButton.render();
+            submitButton.render(payload);
         }
 
         function render() {
@@ -46,7 +46,7 @@ define(
                     bean.on($BILLING_PERIOD_CONTAINER[0], 'change', '[type=radio]', function (el) {
                         el.target.checked = true;
                         checkoutForm.billingPeriod = el.target.value;
-                        notifyOtherModulesToRender();
+                        notifyOtherModulesToRender(el.target.value);
                     });
                     render();
                 }

--- a/frontend/assets/javascripts/src/modules/form/submitButton.js
+++ b/frontend/assets/javascripts/src/modules/form/submitButton.js
@@ -7,11 +7,16 @@ define(
     function($, template, submitButtonTemplate) {
         'use strict';
 
-        var $SUBMIT_BUTTON = $('.js-submit-input-cta');
+        var $SUBMIT_BUTTON = $('.js-submit-input');
+        var $SUBMIT_SPAN = $('.js-submit-input-cta');
 
-        function render() {
-            if ($SUBMIT_BUTTON.length > 0) {
-                $SUBMIT_BUTTON.html(template(submitButtonTemplate)(guardian.membership.checkoutForm));
+        function render(payload) {
+            if ($SUBMIT_SPAN.length > 0) {
+                $SUBMIT_SPAN.html(template(submitButtonTemplate)(guardian.membership.checkoutForm));
+                if(payload) {
+                    var currentValue = $SUBMIT_BUTTON[0].getAttribute("data-metric-label");
+                    $SUBMIT_BUTTON[0].setAttribute("data-metric-label", currentValue.split("-")[0] + "-" + payload);
+                }
             }
         }
 

--- a/frontend/assets/javascripts/src/modules/form/submitButton.js
+++ b/frontend/assets/javascripts/src/modules/form/submitButton.js
@@ -14,8 +14,8 @@ define(
             if ($SUBMIT_SPAN.length > 0) {
                 $SUBMIT_SPAN.html(template(submitButtonTemplate)(guardian.membership.checkoutForm));
                 if(payload) {
-                    var currentValue = $SUBMIT_BUTTON[0].getAttribute("data-metric-label");
-                    $SUBMIT_BUTTON[0].setAttribute("data-metric-label", currentValue.split("-")[0] + "-" + payload);
+                    var currentValue = $SUBMIT_BUTTON[0].getAttribute('data-metric-label');
+                    $SUBMIT_BUTTON[0].setAttribute('data-metric-label', currentValue.split('-')[0] + '-' + payload);
                 }
             }
         }


### PR DESCRIPTION
# Tracking billing periods in the checkout page

## Trello card: [Here](https://trello.com/c/cyKgv9eD)

## Why?
In order to A/B test the price of the pay button, we should be able to track if the users are converting using the monthly price or the annual price.

## Changes
* `billingPeriodChoice.js`: After a change event takes place, I am sending the type of pricing as a payload to the listeners.
* `submitButton.js`: The submit module receives the payload and appends it to the button's `data-metric-label`

## Images

We are sending events labels correctly.

![picture 39](https://cloud.githubusercontent.com/assets/825398/20923099/c60810ee-bba2-11e6-8364-c9760be52611.png)
