### PR TITLE
Put extra card info to Zuora

### DIFF
--- a/frontend/app/controllers/Info.scala
+++ b/frontend/app/controllers/Info.scala
@@ -4,23 +4,22 @@ import actions.ActionRefiners.PlannedOutageProtection
 import com.gu.i18n.CountryGroup
 import com.gu.i18n.CountryGroup._
 import com.gu.memsub.images.{Grid, ResponsiveImage, ResponsiveImageGenerator, ResponsiveImageGroup}
+import com.netaporter.uri.dsl._
 import configuration.CopyConfig
 import controllers.Redirects.redirectToSupporterPage
-import model.{ContentItemOffer, FlashMessage, Nav, OrientatedImages}
 import forms.MemberForm._
+import model.{ContentItemOffer, FlashMessage, Nav, OrientatedImages}
 import play.api.mvc.Controller
 import services.{AuthenticationService, EmailService, GuardianContentService, TouchpointBackend}
-import views.support.{Asset, PageInfo}
-import com.netaporter.uri.dsl._
-import com.netaporter.uri.Uri
 import tracking.RedirectWithCampaignCodes._
+import utils.RequestCountry._
+import views.support.{Asset, PageInfo}
 
 import scala.concurrent.Future
-import utils.RequestCountry._
 
 trait Info extends Controller {
   def supporterRedirect(countryGroup: Option[CountryGroup]) = NoCacheAction { implicit request =>
-    val determinedCountryGroup = (countryGroup orElse request.getFastlyCountry).getOrElse(CountryGroup.RestOfTheWorld)
+    val determinedCountryGroup = (countryGroup orElse request.getFastlyCountryCode).getOrElse(CountryGroup.RestOfTheWorld)
     redirectWithCampaignCodes(redirectToSupporterPage(determinedCountryGroup).url, SEE_OTHER)
   }
 

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -239,7 +239,7 @@ object Joiner extends Controller with ActivityTracking
     implicit val bp: BackendProvider = request
     val idRequest = IdentityRequest(request)
     val campaignCode = CampaignCode.fromRequest
-    val ipAddress = ProxiedIP.getIP(request)
+    val ipAddress = None // Deprected - we do not need to store this [anymore] as we store the ipCountry instead.
     val ipCountry = request.getFastlyCountry
 
     Timing.record(salesforceService.metrics, "createMember") {

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -8,6 +8,7 @@ import com.gu.contentapi.client.model.v1.{MembershipTier => ContentAccess}
 import com.gu.i18n.CountryGroup
 import com.gu.i18n.CountryGroup.UK
 import com.gu.i18n.Currency.GBP
+import com.gu.identity.play.ProxiedIP
 import com.gu.memsub.BillingPeriod
 import com.gu.memsub.promo.{NewUsers, PromoCode}
 import com.gu.memsub.util.Timing
@@ -30,6 +31,7 @@ import services.PromoSessionService.codeFromSession
 import services.{GuardianContentService, _}
 import tracking.ActivityTracking
 import utils.{CampaignCode, TierChangeCookies}
+import utils.RequestCountry._
 import views.support
 import views.support.MembershipCompat._
 import views.support.Pricing._
@@ -78,7 +80,7 @@ object Joiner extends Controller with ActivityTracking
     )
 
     (for {
-      contentURL <- contentRefererOpt if Uri.parse(contentURL).host.exists(_ == "www.theguardian.com")
+      contentURL <- contentRefererOpt if Uri.parse(contentURL).host.contains("www.theguardian.com")
       access <- accessOpt
     } yield {
       Redirect(routes.MemberOnlyContent.membershipContent(contentURL, access.name))
@@ -102,11 +104,11 @@ object Joiner extends Controller with ActivityTracking
         displayName = fullUser.publicFields.displayName
         avatarUrl = fullUser.privateFields.flatMap(_.socialAvatarUrl)
       } yield
-        Ok(views.html.joiner.staff(catalog, new StaffEmails(request.user.email, Some(primaryEmailAddress)), displayName, avatarUrl, flashMsgOpt))
+        Ok(views.html.joiner.staff(catalog, StaffEmails(request.user.email, Some(primaryEmailAddress)), displayName, avatarUrl, flashMsgOpt))
 
       case _ =>
         Future.successful(
-          Ok(views.html.joiner.staff(catalog, new StaffEmails(request.user.email, None), None, None, flashMsgOpt)) )
+          Ok(views.html.joiner.staff(catalog, StaffEmails(request.user.email, None), None, None, flashMsgOpt)) )
     }
   }
 
@@ -237,9 +239,11 @@ object Joiner extends Controller with ActivityTracking
     implicit val bp: BackendProvider = request
     val idRequest = IdentityRequest(request)
     val campaignCode = CampaignCode.fromRequest
+    val ipAddress = ProxiedIP.getIP(request)
+    val ipCountry = request.getFastlyCountry
 
     Timing.record(salesforceService.metrics, "createMember") {
-      memberService.createMember(request.user, formData, idRequest, eventId, campaignCode, tier).map {
+      memberService.createMember(request.user, formData, idRequest, eventId, campaignCode, tier, ipAddress, ipCountry).map {
         case (sfContactId, zuoraSubName) =>
           logger.info(s"User ${request.user.id} successfully became ${tier.name} $zuoraSubName.")
           salesforceService.metrics.putSignUp(tier)

--- a/frontend/app/services/api/MemberService.scala
+++ b/frontend/app/services/api/MemberService.scala
@@ -1,25 +1,26 @@
 package services.api
 
+import java.net.InetAddress
+
 import com.gu.i18n.Country
 import com.gu.identity.play.IdMinimalUser
 import com.gu.memsub.Subscriber._
-import com.gu.memsub.{Subscription => S, _}
-import com.gu.salesforce.{Tier, ContactId, PaidTier}
-import com.gu.memsub.promo.{PromoError, Upgrades, ValidPromotion, PromoCode}
-import com.gu.salesforce.{ContactId, PaidTier}
-import com.gu.memsub.BillingSchedule
+import com.gu.memsub.promo.{PromoError, Upgrades, ValidPromotion}
+import com.gu.memsub.subsv2._
+import com.gu.memsub.{BillingSchedule, Subscription => S}
+import com.gu.salesforce.{ContactId, PaidTier, Tier}
 import com.gu.stripe.Stripe
 import com.gu.zuora.soap.models.Results.{CreateResult, SubscribeResult}
 import controllers.IdentityRequest
 import forms.MemberForm._
 import model.Eventbrite.{EBCode, EBOrder, EBTicketClass}
 import model.RichEvent.RichEvent
-import model.{PlanChoice, GenericSFContact}
+import model.{GenericSFContact, PlanChoice}
+import utils.CampaignCode
 import views.support.ThankyouSummary
-import com.gu.memsub.subsv2._
+
 import scala.concurrent.Future
 import scalaz.\/
-import utils.CampaignCode
 
 trait MemberService {
   import MemberService._
@@ -33,7 +34,9 @@ trait MemberService {
                    identityRequest: IdentityRequest,
                    fromEventId: Option[String],
                    campaignCode: Option[CampaignCode],
-                   tier: Tier): Future[(ContactId, ZuoraSubName)]
+                   tier: Tier,
+                   ipAddress: Option[InetAddress],
+                   ipCountry: Option[Country]): Future[(ContactId, ZuoraSubName)]
 
   def previewUpgradeSubscription(subscriber: PaidMember, newPlan: PlanChoice, code: Option[ValidPromotion[Upgrades]])
                                 (implicit i: IdentityRequest): Future[MemberError \/ BillingSchedule]
@@ -73,11 +76,15 @@ trait MemberService {
                              tier: PaidTier,
                              customer: Stripe.Customer,
                              campaignCode: Option[CampaignCode],
-                             email: String): Future[SubscribeResult]
+                             email: String,
+                             ipAddress: Option[InetAddress],
+                             ipCountry: Option[Country]): Future[SubscribeResult]
 
   def createFreeSubscription(contactId: ContactId,
                              joinData: JoinForm,
-                             email: String): Future[SubscribeResult]
+                             email: String,
+                             ipAddress: Option[InetAddress],
+                             ipCountry: Option[Country]): Future[SubscribeResult]
 }
 
 object MemberService {

--- a/frontend/app/utils/RequestCountry.scala
+++ b/frontend/app/utils/RequestCountry.scala
@@ -8,7 +8,8 @@ import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
 object RequestCountry {
   implicit class RequestWithFastlyCountry(r: Request[_]) {
-    def getFastlyCountry = r.headers.get("X-GU-GeoIP-Country-Code").flatMap(CountryGroup.byFastlyCountryCode)
+    def getFastlyCountryCode = r.headers.get("X-GU-GeoIP-Country-Code").flatMap(CountryGroup.byFastlyCountryCode)
+    def getFastlyCountry = r.headers.get("X-GU-GeoIP-Country-Code").flatMap(CountryGroup.countryByCode)
   }
   implicit class AuthenticatedRequestWithIdentity(r:AuthRequest[_])
   {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "7.2.3"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.7"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.314"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.317"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "7.2.3"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.7"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.312"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.314"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache


### PR DESCRIPTION
- Add extra card info to Zuora enabling us to trigger 'your card is due for renewal comms'. Leveraging membership common: https://github.com/guardian/membership-common/pull/368 and https://github.com/guardian/membership-common/pull/366. For: https://trello.com/c/Hyjpb7eR/90-add-card-number-and-expiry-date-to-zuora-paymentmethod
- Also add the request IP address and the request IP country to the Subscription. This is to help with Tax reporting for VAT: https://trello.com/c/g6RgAqPE/75-new-tax-requirements

This lines membership-frontend up with subscriptions-frontend:

- https://github.com/guardian/subscriptions-frontend/pull/720 and https://github.com/guardian/subscriptions-frontend/pull/715

These are UAT screenshots, using the [Stripe test card](https://stripe.com/docs/testing): 4012 8888 8888 1881

![picture 326](https://cloud.githubusercontent.com/assets/1515970/20921889/13fb2886-bb9e-11e6-9cba-6213a59e59f6.png)
![picture 327](https://cloud.githubusercontent.com/assets/1515970/20921897/176430c6-bb9e-11e6-8f83-b0d850023d34.png)

For Membership sub: A-S00066042 - https://apisandbox-api.zuora.com/rest/v1/payment-methods/credit-cards/accounts/2c92c0f858aa38af0158d39f3b2c209b
```
{
  "creditCards": [
    {
      "id": "2c92c0f858aa38af0158d39f3b42209d",
      "defaultPaymentMethod": true,
      "cardType": "Visa",
      "cardNumber": "1881",
      "expirationMonth": 4,
      "expirationYear": 2019,
      "cardHolderInfo": {
        "cardHolderName": null,
        "addressLine1": null,
        "addressLine2": null,
        "city": null,
        "state": null,
        "zipCode": null,
        "country": "United States",
        "phone": null,
        "email": null
      }
    }
  ],
  "success": true
}
```


cc @rtyley @Ap0c @svillafe @rupertbates @JuliaBellis 