### PR TITLE
Turning on the A/B Test

### DIFF
--- a/frontend/app/abtests/CheckoutFlowVariant.scala
+++ b/frontend/app/abtests/CheckoutFlowVariant.scala
@@ -9,7 +9,7 @@ import scala.util.Random
   */
 object CheckoutFlowVariant {
   val cookieName = "ab-checkout-flow"
-  val runningTest = false
+  val runningTest = true
   val default = A
 
   val all = Seq[CheckoutFlowVariant](A,B)


### PR DESCRIPTION
# Turn on the checkout A/B Test

## This PR should not be merged until the related PRs are merged.

## Trello card: [Here](https://trello.com/c/bVeZ0dC8/206-re-run-identity-a-b-test-with-no-progress-bar-in-the-membersb-option)

## Why?
Surprisingly after we ran the first A/B Test, the old design performed better than the new design. Therefore we decide to remove the progress bar from the new design since our hypothesis is that it distracting the final user.

## Related PRs
* New design for flow B at identity frontend: https://github.com/guardian/identity-frontend/pull/194
* New design for flow B at membership frontend: https://github.com/guardian/membership-frontend/pull/1403

## Images

### Desired
![new-fow-bw 1](https://cloud.githubusercontent.com/assets/825398/20963318/cffeb81a-bc64-11e6-9b17-6d92f913b7ae.png)
