### PR TITLE
[Blocked by business] Added the copy of US and AU

### DIFF
--- a/frontend/app/controllers/Info.scala
+++ b/frontend/app/controllers/Info.scala
@@ -52,7 +52,7 @@ trait Info extends Controller {
 
     val detailImageOrientated = OrientatedImages(portrait = detailImage, landscape = detailImage)
 
-    Ok(views.html.info.elevatedSupporter(
+    Ok(views.html.info.elevatedSupporterUK(
       heroOrientated,
       TouchpointBackend.Normal.catalog.supporter,
       PageInfo(
@@ -69,79 +69,75 @@ trait Info extends Controller {
     val heroImage = ResponsiveImageGroup(
       name=Some("intro"),
       metadata=Some(Grid.Metadata(
-        description = Some("""Same-Sex marriage activists march in the street during a Same-Sex Marriage rally in Sydney, Sunday, Aug. 9, 2015""".stripMargin),
+        description = Some("Montage of The Guardian Headlines"),
         byline = None,
-        credit = Some("Carol Cho/AAP")
+        credit = None
       )),
-      availableImages=ResponsiveImageGenerator("73f50662f5834f4194a448e966637fc88c0b36f6/0_0_5760_3840", Seq(2000, 1000))
+      availableImages=ResponsiveImageGenerator("7b6e7b64f194b1f85bfc0791a23b8a25b72f39ba/0_0_1300_632", Seq(1300, 500), "png")
     )
 
     val heroOrientated = OrientatedImages(portrait = heroImage, landscape = heroImage)
 
-    val pageImages = Seq(
-      ResponsiveImageGroup(
-        name=Some("coral"),
-        metadata=Some(Grid.Metadata(
-          description = Some("The impact of coral bleaching at Lizard Island on the Great Barrier Reef: (left) the coral turns white, known as 'bleaching', in March 2016; (right) the dead coral is blanketed by seaweed in May 2016"),
-          byline = None,
-          credit = None
-        )),
-        availableImages=ResponsiveImageGenerator(
-          id="03d7db325026227b0832bfcd17b2f16f8eb5cfed/0_167_5000_3000",
-          sizes=List(1000,500)
-        )
-      ))
+    val detailImage = ResponsiveImageGroup(
+      name=Some("intro"),
+      metadata=Some(Grid.Metadata(
+        description = Some("A scene in The Guardian editorial office."),
+        byline = None,
+        credit = None
+      )),
+      availableImages=ResponsiveImageGenerator("dcd0f0f703b1e784a3280438806f2feedf27dfab/0_0_1080_648", Seq(1080, 500))
+    )
 
-    Ok(views.html.info.supporterAustralia(
+    val detailImageOrientated = OrientatedImages(portrait = detailImage, landscape = detailImage)
+
+    Ok(views.html.info.elevatedSupporterAU(
       heroOrientated,
       TouchpointBackend.Normal.catalog.supporter,
       PageInfo(
         title = CopyConfig.copyTitleSupporters,
         url = request.path,
-        description = Some(CopyConfig.copyDescriptionSupporters),
-        navigation = Nil
+        description = Some(CopyConfig.copyDescriptionSupporters)
       ),
-      pageImages))
+      detailImageOrientated))
   }
 
 
   def supporterUSA = CachedAndOutageProtected { implicit request =>
     implicit val countryGroup = US
 
-    val pageImages = Seq(
-      ResponsiveImageGroup(
-        name=Some("fearless"),
-        metadata=Some(Grid.Metadata(
-          description = Some("The Counted: people killed by police in the United States in 2015"),
-          byline = Some("The Guardian US"),
-          credit = None
-        )),
-        availableImages=ResponsiveImageGenerator(
-          id="201ae0837f996f47b75395046bdbc30aea587443/0_0_1140_684",
-          sizes=List(1000,500)
-        )
-      )
+    val heroImage = ResponsiveImageGroup(
+      name=Some("intro"),
+      metadata=Some(Grid.Metadata(
+        description = Some("Montage of The Guardian Headlines"),
+        byline = None,
+        credit = None
+      )),
+      availableImages=ResponsiveImageGenerator("7b6e7b64f194b1f85bfc0791a23b8a25b72f39ba/0_0_1300_632", Seq(1300, 500), "png")
     )
 
-    val heroImages = OrientatedImages(
-      portrait = ResponsiveImageGroup(availableImages =
-        ResponsiveImageGenerator("8eea3b3bd80eb2f8826b1cef75799d27a11e56e5/1066_0_1866_2333", Seq(1866, 1600, 800))),
-      landscape = ResponsiveImageGroup(availableImages =
-        ResponsiveImageGenerator("8eea3b3bd80eb2f8826b1cef75799d27a11e56e5/0_613_3500_1500", Seq(3500, 2000, 1000, 500)))
+    val heroOrientated = OrientatedImages(portrait = heroImage, landscape = heroImage)
+
+    val detailImage = ResponsiveImageGroup(
+      name=Some("intro"),
+      metadata=Some(Grid.Metadata(
+        description = Some("A scene in The Guardian editorial office."),
+        byline = None,
+        credit = None
+      )),
+      availableImages=ResponsiveImageGenerator("dcd0f0f703b1e784a3280438806f2feedf27dfab/0_0_1080_648", Seq(1080, 500))
     )
 
-    Ok(
-      views.html.info.supporterUSA(
-        heroImages,
-        TouchpointBackend.Normal.catalog.supporter,
-        PageInfo(
-          title = CopyConfig.copyTitleSupporters,
-          url = request.path,
-          description = Some(CopyConfig.copyDescriptionSupporters),
-          navigation = Nav.internationalLandingPageNavigation
-        ),
-        pageImages
-      )
+    val detailImageOrientated = OrientatedImages(portrait = detailImage, landscape = detailImage)
+
+    Ok(views.html.info.elevatedSupporterUS(
+      heroOrientated,
+      TouchpointBackend.Normal.catalog.supporter,
+      PageInfo(
+        title = CopyConfig.copyTitleSupporters,
+        url = request.path,
+        description = Some(CopyConfig.copyDescriptionSupporters)
+      ),
+      detailImageOrientated)
     )
   }
 

--- a/frontend/app/model/Benefits.scala
+++ b/frontend/app/model/Benefits.scala
@@ -7,6 +7,7 @@ import configuration.Config.zuoraFreeEventTicketsAllowance
 
 
 object Benefits {
+
   def forTier(tier: Tier) = tier match {
     case Staff() => Benefits.staff
     case Friend() => Benefits.friend
@@ -16,58 +17,83 @@ object Benefits {
   }
 
   def promoForCountry(cg: CountryGroup) = cg match {
-    case CountryGroup.Australia => ausSupporter
+    case CountryGroup.Australia => auSupporter
+    case CountryGroup.UK => ukSupporter
+    case CountryGroup.US => usSupporter
     case _ => supporterMinimal
   }
 
   def forTierAndCountry(tier: Tier, cg: CountryGroup) = (tier,cg) match {
-    case (Supporter(), CountryGroup.Australia) => ausSupporter
+    case (Supporter(), CountryGroup.Australia) => auSupporter
     case (tier,CountryGroup.UK) => forTier(tier)
     case (tier,_) => forTier(tier).filterNot(b=>marketedOnlyToUK.contains(b))
   }
+
   val DiscountTicketTiers = Set[Tier](Staff(), Partner(), Patron())
   val PriorityBookingTiers = DiscountTicketTiers
   val ComplimentaryTicketTiers = Set[Tier](Partner(), Patron())
 
-  val welcomePack = Benefit("welcome_pack", "Welcome pack, card and gift")
-  val welcomeDog = Benefit("welcome_pack", "Welcome pack")
+  val adFreeApp = Benefit("ad_free_app","An ad-free experience in our mobile app")
   val accessTicket = Benefit("access_tickets", "Access to tickets")
-  val emailUpdates = Benefit("email_updates", "Regular member emails")
-  var app = Benefit("app","Free access to the premium tier of the Guardian app (includes crosswords and has no adverts)")
-  val priorityBooking = Benefit("priority_booking", "48hrs priority booking")
-  val noBookingFees = Benefit("no_booking_fees", "No booking fees")
-  val guest = Benefit("guest", "Bring a guest")
   val booksOrTickets = Benefit("books_or_tickets", s"$zuoraFreeEventTicketsAllowance tickets or 4 books", isNew = true)
   val booksAndTickets = Benefit("books_and_tickets", s"$zuoraFreeEventTicketsAllowance tickets and 4 books", isNew = true)
-
   val discount = Benefit("discount", "20% discount for you and a guest")
+  val emailsUpdatesJournalists = Benefit("emails_updates_journalists", "Exclusive emails from Guardian journalists")
+  val globalCommunity = Benefit("add_free_app","Joining the global Guardian Members community")
+  val guest = Benefit("guest", "Bring a guest")
+  val liveEvents = Benefit("live_events", "Invitations to Guardian Live events")
+  val noBookingFees = Benefit("no_booking_fees", "No booking fees")
+  val priorityBooking = Benefit("priority_booking", "48hrs priority booking")
+  val regularEmails = Benefit("regular_emails", "Regular behind-the-scenes emails from our newsroom")
+  val regularEmailsUK =  Benefit("regular_emails", "A weekly look \"Inside the Guardian\" for our Members")
   val uniqueExperiences = Benefit("unique_experiences", "Exclusive behind-the-scenes functions")
+  val welcomePack = Benefit("welcome_pack", "Welcome pack, card and gift")
+  val welcomePackAU = Benefit("welcome_pack", "Welcome letter with First Dog on the Moon certificate")
+  val welcomePackUK = Benefit("welcome_pack", "A welcome gift")
+  val welcomePackUS = Benefit("welcome_pack", "A Guardian branded tote bag")
 
   val marketedOnlyToUK = Set[Benefit](accessTicket)
 
   val friend = Seq(
     accessTicket,
-    emailUpdates
+    regularEmails
   )
 
   val supporter = Seq(
     welcomePack,
-    app,
+    adFreeApp,
     accessTicket,
-    emailUpdates
+    regularEmails
   )
 
-  val ausSupporter = Seq(
-    welcomeDog,
-    app,
-    emailUpdates
+  val auSupporter = Seq(
+    adFreeApp,
+    regularEmails,
+    welcomePackAU,
+    liveEvents
+  )
+
+  val usSupporter = Seq(
+    adFreeApp,
+    regularEmails,
+    welcomePackUS,
+    liveEvents
+  )
+
+  val ukSupporter = Seq(
+    emailsUpdatesJournalists,
+    adFreeApp,
+    regularEmailsUK,
+    globalCommunity,
+    welcomePackUK
   )
 
   val supporterMinimal = Seq(
     welcomePack,
-    app,
-    emailUpdates
+    adFreeApp,
+    regularEmails
   )
+
   val partner = Seq(
     booksOrTickets,
     priorityBooking,
@@ -75,9 +101,10 @@ object Benefits {
     discount,
     guest,
     welcomePack,
-    app,
-    emailUpdates
+    adFreeApp,
+    regularEmails
   )
+
   val patron = Seq(
     booksAndTickets,
     uniqueExperiences,
@@ -86,15 +113,15 @@ object Benefits {
     discount,
     guest,
     welcomePack,
-    app,
-    emailUpdates
+    adFreeApp,
+    regularEmails
   )
 
   val comparisonBasicList = Seq(
     welcomePack,
-    app,
+    adFreeApp,
     accessTicket,
-    emailUpdates
+    regularEmails
   )
 
   val staff = (partner ++ supporter).filterNot(_ == booksOrTickets).distinct

--- a/frontend/app/views/fragments/page/elevatedBanner.scala.html
+++ b/frontend/app/views/fragments/page/elevatedBanner.scala.html
@@ -16,7 +16,7 @@
         <div class="elevated-banner__content">
             <h1 class="elevated-banner__title"><h1 class="elevated-banner__title__h1">@mainTitle</h1>
 
-            <p class="elevated-banner__tagline">@tagLine</p>
+            @tagLine
 
             <div class="elevated-banner__button">
             	@fragments.page.elevatedButton(supporterPlans, countryGroup, "Top Button", showCurrencyPrefix)

--- a/frontend/app/views/fragments/page/elevatedCloserTheGuardian.scala.html
+++ b/frontend/app/views/fragments/page/elevatedCloserTheGuardian.scala.html
@@ -5,9 +5,10 @@
 @(  supporterPlans: MonthYearPlans[PaidMember],
     countryGroup: CountryGroup,
     showCurrencyPrefix: Boolean,
-    benefitsTitle: Html)(body: Html)
+    benefitsTitle: Html,
+    lowMargin: Boolean = false)(body: Html)
 
-<section class="elevated-close-guardian-section">
+<section class="elevated-close-guardian-section @if(lowMargin){elevated-close-guardian-section--low-margin}">
     @fragments.page.elevatedCloserGuardianBody(benefitsTitle)(body)
     @fragments.page.elevatedFooterButton(supporterPlans, countryGroup, "Middle Button 2", showCurrencyPrefix, showRightDiagonal = true)
 </section>

--- a/frontend/app/views/info/elevatedSupporterAU.scala.html
+++ b/frontend/app/views/info/elevatedSupporterAU.scala.html
@@ -1,0 +1,87 @@
+@import com.gu.i18n.CountryGroup
+@import configuration.Videos
+@import com.gu.memsub.subsv2.{CatalogPlan, MonthYearPlans}
+@import views.support.PageInfo
+
+@(  heroImage: model.OrientatedImages,
+    supporterPlans: MonthYearPlans[CatalogPlan.Supporter],
+    pageInfo: PageInfo,
+    detailImage: model.OrientatedImages)(implicit token: play.filters.csrf.CSRF.Token, countryGroup: CountryGroup)
+
+@main("Supporters", pageInfo=pageInfo, countryGroup=Some(countryGroup)) {
+
+    <section class="elevated-supporter">
+
+        @* ===== First part ===== *@
+        @fragments.page.elevatedBecomeSupporter(heroImage, supporterPlans, countryGroup, showCurrencyPrefix = false, Html("Become a Guardian<br>Australia Supporter"), Html("Help protect our independent journalism")
+        ){
+            <div class="elevated-become-supporter-body__col u-content-width--left">
+                <p class="u-responsive-p">
+                    We want to make the world a better, fairer place. We want to keep the powerful honest. We aim to keep society informed by producing quality, independent journalism, which discovers and tells readers the truth. At Guardian Australia we shine a light on critical, under-reported stories across Australia and deliver the best of the Guardian’s work from reporters around the globe. Our independent ownership allows us to produce award-winning journalism free from commercial influence.
+                </p>
+                <p class="u-responsive-p">
+                    No-one can edit our editor.
+                </p>
+            </div>
+
+            @fragments.page.elevatedBecomeSupporterBodyVideo(Videos.scottTrustExplained, "Katharine Viner, editor-in-chief, explains the Guardian's unique ownership model")
+
+            <div class="elevated-become-supporter-body__col u-content-width--left">
+                <p class="u-responsive-p">
+                    Your support is crucial for us to maintain this. We operate a lean, local news organisation with offices in Sydney, Melbourne and Canberra, and correspondents in other states. But our commercial environment is increasingly challenging and advertising revenues are in decline. So if you read us, if you like us, if you value our perspective – then it’s only fair to become a Supporter and help make our future in Australia more secure.
+                </p>
+            </div>
+        }
+
+        @* ===== Second Part ===== *@
+        @fragments.page.elevatedCloserTheGuardian(supporterPlans, countryGroup, showCurrencyPrefix = false, Html("Supporters get closer<br>to the Guardian")){
+            <div class="elevated-closer-guardian-body__col elevated-closer-guardian-body__text u-content-width--right">
+                <div class="elevated-closer-guardian-body__list">
+
+                    <p class="u-responsive-p">
+                        As a Guardian Australia Supporter, you can enjoy:
+                    </p>
+
+                    <ul>
+                        <li class="elevated-closer-guardian-body__list_item">
+                            An ad-free experience in our mobile app
+                        </li>
+                        <li class="elevated-closer-guardian-body__list_item">
+                            Regular behind-the-scenes emails from our newsroom
+                        </li>
+                        <li class="elevated-closer-guardian-body__list_item">
+                            Welcome letter with First Dog on the Moon certificate
+                        </li>
+                        <li class="elevated-closer-guardian-body__list_item">
+                            Invitations to Guardian Live events
+                        </li>
+                    </ul>
+
+                    <p class="u-responsive-p">
+                        Most importantly, the knowledge that your contribution is directly funding our journalism in Australia.
+                    <p>
+                </div>
+            </div>
+        }
+
+        @* ===== Third Part ===== *@
+
+        @fragments.page.elevatedWhySupport(detailImage, supporterPlans, countryGroup, showCurrencyPrefix = false, Html("Why do we need<br>our Supporters?")){
+            <p class="u-responsive-p">
+                Like many other media organisations, the Guardian is operating in an incredibly challenging financial climate. Our advertising revenues are falling fast. We have huge numbers of readers, and we are increasingly reliant upon their financial support.
+            </p>
+            <p class="u-responsive-p">
+                We don’t have a wealthy owner pulling the strings. No shareholders, advertisers or billionaire owners can edit our editor.
+            </p>
+            <p class="u-responsive-p">
+                Our owner, the Scott Trust, safeguards our editorial independence from commercial or political interference. It reinvests revenue into our journalism, as opposed to into shareholders' pockets.
+            </p>
+            <p class="u-responsive-p">
+                But while the Scott Trust ensures our independence, we need our Supporters, now more than ever before, to help secure our future.
+            </p>
+            <p class="u-responsive-p">
+                We know that not everyone is in a position to become a Supporter. But if you can, you’ll be an integral part of our mission to make the world a better, fairer place, for everyone.
+            </p>
+        }
+    </section>
+}

--- a/frontend/app/views/info/elevatedSupporterAU.scala.html
+++ b/frontend/app/views/info/elevatedSupporterAU.scala.html
@@ -1,3 +1,4 @@
+@import model.Benefits
 @import com.gu.i18n.CountryGroup
 @import configuration.Videos
 @import com.gu.memsub.subsv2.{CatalogPlan, MonthYearPlans}
@@ -43,18 +44,11 @@
                     </p>
 
                     <ul>
+                    @for(benefit <- Benefits.promoForCountry(countryGroup)){
                         <li class="elevated-closer-guardian-body__list_item">
-                            An ad-free experience in our mobile app
+                        @benefit.title
                         </li>
-                        <li class="elevated-closer-guardian-body__list_item">
-                            Regular behind-the-scenes emails from our newsroom
-                        </li>
-                        <li class="elevated-closer-guardian-body__list_item">
-                            Welcome letter with First Dog on the Moon certificate
-                        </li>
-                        <li class="elevated-closer-guardian-body__list_item">
-                            Invitations to Guardian Live events
-                        </li>
+                    }
                     </ul>
 
                     <p class="u-responsive-p">

--- a/frontend/app/views/info/elevatedSupporterAU.scala.html
+++ b/frontend/app/views/info/elevatedSupporterAU.scala.html
@@ -35,7 +35,7 @@
 
         @* ===== Second Part ===== *@
         @fragments.page.elevatedCloserTheGuardian(supporterPlans, countryGroup, showCurrencyPrefix = false, Html("Supporters get closer<br>to the Guardian")){
-            <div class="elevated-closer-guardian-body__col elevated-closer-guardian-body__text u-content-width--right">
+            <div class="elevated-closer-guardian-body__col elevated-closer-guardian-body__text u-content-width--right au-closer-guardian-body">
                 <div class="elevated-closer-guardian-body__list">
 
                     <p class="u-responsive-p">

--- a/frontend/app/views/info/elevatedSupporterAU.scala.html
+++ b/frontend/app/views/info/elevatedSupporterAU.scala.html
@@ -34,7 +34,7 @@
         }
 
         @* ===== Second Part ===== *@
-        @fragments.page.elevatedCloserTheGuardian(supporterPlans, countryGroup, showCurrencyPrefix = false, Html("Supporters get closer<br>to the Guardian")){
+        @fragments.page.elevatedCloserTheGuardian(supporterPlans, countryGroup, showCurrencyPrefix = false, Html("Supporters get closer<br>to the Guardian"), lowMargin = true){
             <div class="elevated-closer-guardian-body__col elevated-closer-guardian-body__text u-content-width--right au-closer-guardian-body">
                 <div class="elevated-closer-guardian-body__list">
 
@@ -64,24 +64,5 @@
             </div>
         }
 
-        @* ===== Third Part ===== *@
-
-        @fragments.page.elevatedWhySupport(detailImage, supporterPlans, countryGroup, showCurrencyPrefix = false, Html("Why do we need<br>our Supporters?")){
-            <p class="u-responsive-p">
-                Like many other media organisations, the Guardian is operating in an incredibly challenging financial climate. Our advertising revenues are falling fast. We have huge numbers of readers, and we are increasingly reliant upon their financial support.
-            </p>
-            <p class="u-responsive-p">
-                We don’t have a wealthy owner pulling the strings. No shareholders, advertisers or billionaire owners can edit our editor.
-            </p>
-            <p class="u-responsive-p">
-                Our owner, the Scott Trust, safeguards our editorial independence from commercial or political interference. It reinvests revenue into our journalism, as opposed to into shareholders' pockets.
-            </p>
-            <p class="u-responsive-p">
-                But while the Scott Trust ensures our independence, we need our Supporters, now more than ever before, to help secure our future.
-            </p>
-            <p class="u-responsive-p">
-                We know that not everyone is in a position to become a Supporter. But if you can, you’ll be an integral part of our mission to make the world a better, fairer place, for everyone.
-            </p>
-        }
     </section>
 }

--- a/frontend/app/views/info/elevatedSupporterAU.scala.html
+++ b/frontend/app/views/info/elevatedSupporterAU.scala.html
@@ -13,7 +13,7 @@
     <section class="elevated-supporter">
 
         @* ===== First part ===== *@
-        @fragments.page.elevatedBecomeSupporter(heroImage, supporterPlans, countryGroup, showCurrencyPrefix = false, Html("Become a Guardian<br>Australia Supporter"), Html("Help protect our independent journalism")
+        @fragments.page.elevatedBecomeSupporter(heroImage, supporterPlans, countryGroup, showCurrencyPrefix = false, Html("Become a Guardian<br>Australia Supporter"), Html("<p class=\"elevated-banner__tagline\">Help protect our independent journalism</p>")
         ){
             <div class="elevated-become-supporter-body__col u-content-width--left">
                 <p class="u-responsive-p">

--- a/frontend/app/views/info/elevatedSupporterUK.scala.html
+++ b/frontend/app/views/info/elevatedSupporterUK.scala.html
@@ -1,3 +1,4 @@
+@import model.Benefits
 @import com.gu.i18n.CountryGroup
 @import configuration.Videos
 @import com.gu.memsub.subsv2.{CatalogPlan, MonthYearPlans}
@@ -46,21 +47,11 @@
                     <p>
 
                     <ul>
-                        <li class="elevated-closer-guardian-body__list_item">
-                            Exclusive emails from Guardian journalists
-                        </li>
-                        <li class="elevated-closer-guardian-body__list_item">
-                            An ad-free experience on our mobile app
-                        </li>
-                        <li class="elevated-closer-guardian-body__list_item">
-                            A weekly look "Inside the Guardian" for our Members
-                        </li>
-                        <li class="elevated-closer-guardian-body__list_item">
-                            Joining the global Guardian Members community
-                        </li>
-                        <li class="elevated-closer-guardian-body__list_item">
-                            A welcome gift
-                        </li>
+                        @for(benefit <- Benefits.promoForCountry(countryGroup)){
+                            <li class="elevated-closer-guardian-body__list_item">
+                                @benefit.title
+                            </li>
+                        }
                     </ul>
 
                     <p class="u-responsive-p">

--- a/frontend/app/views/info/elevatedSupporterUK.scala.html
+++ b/frontend/app/views/info/elevatedSupporterUK.scala.html
@@ -53,7 +53,7 @@
                             An ad-free experience on our mobile app
                         </li>
                         <li class="elevated-closer-guardian-body__list_item">
-                            A weekly look "Inside the Guardian" for our Members
+                            A weekly look \"Inside the Guardian\" for our Members
                         </li>
                         <li class="elevated-closer-guardian-body__list_item">
                             Joining the global Guardian Members community

--- a/frontend/app/views/info/elevatedSupporterUK.scala.html
+++ b/frontend/app/views/info/elevatedSupporterUK.scala.html
@@ -13,7 +13,7 @@
     <section class="elevated-supporter">
 
         @* ===== First part ===== *@
-        @fragments.page.elevatedBecomeSupporter(heroImage, supporterPlans, countryGroup, showCurrencyPrefix = false, Html("Become a<br>Guardian Supporter"), Html("Be part of the Guardian's future, by helping to secure it")
+        @fragments.page.elevatedBecomeSupporter(heroImage, supporterPlans, countryGroup, showCurrencyPrefix = false, Html("Become a<br>Guardian Supporter"), Html("<p class=\"elevated-banner__tagline\">Be part of the Guardian's future, by helping to secure it</p>")
         ){
             <div class="elevated-become-supporter-body__col u-content-width--left">
                 <p class="u-responsive-p">

--- a/frontend/app/views/info/elevatedSupporterUK.scala.html
+++ b/frontend/app/views/info/elevatedSupporterUK.scala.html
@@ -53,7 +53,7 @@
                             An ad-free experience on our mobile app
                         </li>
                         <li class="elevated-closer-guardian-body__list_item">
-                            A weekly look \"Inside the Guardian\" for our Members
+                            A weekly look "Inside the Guardian" for our Members
                         </li>
                         <li class="elevated-closer-guardian-body__list_item">
                             Joining the global Guardian Members community

--- a/frontend/app/views/info/elevatedSupporterUS.scala.html
+++ b/frontend/app/views/info/elevatedSupporterUS.scala.html
@@ -35,7 +35,7 @@
 
         @* ===== Second Part ===== *@
         @fragments.page.elevatedCloserTheGuardian(supporterPlans, countryGroup, showCurrencyPrefix = false, Html("Join a community of readers<br>who care about independent journalism")){
-            <div class="elevated-closer-guardian-body__col elevated-closer-guardian-body__text u-content-width--right">
+            <div class="elevated-closer-guardian-body__col elevated-closer-guardian-body__text u-content-width--right us-closer-guardian-body">
                 <div class="elevated-closer-guardian-body__list">
 
                     <p class="u-responsive-p">

--- a/frontend/app/views/info/elevatedSupporterUS.scala.html
+++ b/frontend/app/views/info/elevatedSupporterUS.scala.html
@@ -1,3 +1,4 @@
+@import model.Benefits
 @import com.gu.i18n.CountryGroup
 @import configuration.Videos
 @import com.gu.memsub.subsv2.{CatalogPlan, MonthYearPlans}
@@ -43,18 +44,11 @@
                     <p>
 
                     <ul>
-                        <li class="elevated-closer-guardian-body__list_item">
-                            An ad-free experience in our mobile app
-                        </li>
-                        <li class="elevated-closer-guardian-body__list_item">
-                            Regular behind-the-scenes emails from our newsroom
-                        </li>
-                        <li class="elevated-closer-guardian-body__list_item">
-                            A Guardian branded tote bag
-                        </li>
-                        <li class="elevated-closer-guardian-body__list_item">
-                            Invitations to live events
-                        </li>
+                        @for(benefit <- Benefits.promoForCountry(countryGroup)){
+                            <li class="elevated-closer-guardian-body__list_item">
+                            @benefit.title
+                            </li>
+                        }
                     </ul>
 
                     <p class="u-responsive-p">

--- a/frontend/app/views/info/elevatedSupporterUS.scala.html
+++ b/frontend/app/views/info/elevatedSupporterUS.scala.html
@@ -13,7 +13,7 @@
     <section class="elevated-supporter">
 
         @* ===== First part ===== *@
-        @fragments.page.elevatedBecomeSupporter(heroImage, supporterPlans, countryGroup, showCurrencyPrefix = false, Html("Become a<br>Guardian US Supporter"), Html("<p class=\"elevated-banner__tagline--us elevated-banner__tagline\">Help secure the future of our fearless, independent journalism</p>")
+        @fragments.page.elevatedBecomeSupporter(heroImage, supporterPlans, countryGroup, showCurrencyPrefix = false, Html("Become a Guardian<br>US Supporter"), Html("<p class=\"elevated-banner__tagline--us elevated-banner__tagline\">Help secure the future of our fearless, independent journalism</p>")
         ){
             <div class="elevated-become-supporter-body__col u-content-width--left">
                 <p class="u-responsive-p">

--- a/frontend/app/views/info/elevatedSupporterUS.scala.html
+++ b/frontend/app/views/info/elevatedSupporterUS.scala.html
@@ -50,7 +50,7 @@
                             Regular behind-the-scenes emails from our newsroom
                         </li>
                         <li class="elevated-closer-guardian-body__list_item">
-                            A welcome certificate drawn by Guardian artist Mona Chalabi
+                            A Guardian branded tote bag
                         </li>
                         <li class="elevated-closer-guardian-body__list_item">
                             Invitations to live events

--- a/frontend/app/views/info/elevatedSupporterUS.scala.html
+++ b/frontend/app/views/info/elevatedSupporterUS.scala.html
@@ -1,0 +1,84 @@
+@import com.gu.i18n.CountryGroup
+@import configuration.Videos
+@import com.gu.memsub.subsv2.{CatalogPlan, MonthYearPlans}
+@import views.support.PageInfo
+
+@(  heroImage: model.OrientatedImages,
+    supporterPlans: MonthYearPlans[CatalogPlan.Supporter],
+    pageInfo: PageInfo,
+    detailImage: model.OrientatedImages)(implicit token: play.filters.csrf.CSRF.Token, countryGroup: CountryGroup)
+
+@main("Supporters", pageInfo=pageInfo, countryGroup=Some(countryGroup)) {
+
+    <section class="elevated-supporter">
+
+        @* ===== First part ===== *@
+        @fragments.page.elevatedBecomeSupporter(heroImage, supporterPlans, countryGroup, showCurrencyPrefix = false, Html("Become a<br>Guardian US Supporter"), Html("Help secure the future of our fearless, independent journalism")
+        ){
+            <div class="elevated-become-supporter-body__col u-content-width--left">
+                <p class="u-responsive-p">
+                    We want to make the world a better, fairer place. We want to keep the powerful honest.  And we believe that quality, independent journalism is essential for American democracy.
+                </p>
+            </div>
+
+            @fragments.page.elevatedBecomeSupporterBodyVideo(Videos.scottTrustExplained, "Katharine Viner, editor-in-chief, explains the Guardian's unique ownership model")
+
+            <div class="elevated-become-supporter-body__col u-content-width--left">
+                <p class="u-responsive-p">
+                    Guardian US operates outside the American media bubble to bring a global perspective to the most pressing issues facing this country.  Our journalists report with integrity and fairness, but we’re not afraid to take bold stands on the issues we care about most, from civil liberties, to the environment, to free expression. We amplify stories ignored by the establishment media, and elevate underrepresented voices.
+                </p>
+                <p class="u-responsive-p">
+                    This is difficult and expensive work. While more people are reading the Guardian than ever before, far fewer are paying for it. And advertising revenues across the media are falling fast.  So if you read us, and you value our perspective – then become a Supporter and help make our future more secure.
+                </p>
+            </div>
+        }
+
+        @* ===== Second Part ===== *@
+        @fragments.page.elevatedCloserTheGuardian(supporterPlans, countryGroup, showCurrencyPrefix = false, Html("Join a community of readers<br>who care about independent journalism")){
+            <div class="elevated-closer-guardian-body__col elevated-closer-guardian-body__text u-content-width--right">
+                <div class="elevated-closer-guardian-body__list">
+
+                    <p class="u-responsive-p">
+                        As a Guardian US Supporter, you can enjoy:
+                    <p>
+
+                    <ul>
+                        <li class="elevated-closer-guardian-body__list_item">
+                            An ad-free experience in our mobile app
+                        </li>
+                        <li class="elevated-closer-guardian-body__list_item">
+                            Regular behind-the-scenes emails from our newsroom
+                        </li>
+                        <li class="elevated-closer-guardian-body__list_item">
+                            A welcome certificate drawn by Guardian artist Mona Chalabi
+                        </li>
+                        <li class="elevated-closer-guardian-body__list_item">
+                            Invitations to live events
+                        </li>
+                    </ul>
+
+                    <p class="u-responsive-p">
+                        Most importantly, the knowledge that your contribution is directly funding our journalism in America
+                    <p>
+                </div>
+            </div>
+        }
+
+        @* ===== Third Part ===== *@
+
+        @fragments.page.elevatedWhySupport(detailImage, supporterPlans, countryGroup, showCurrencyPrefix = false, Html("Why do we need<br>our Supporters?")){
+            <p class="u-responsive-p">
+                The Guardian’s unique ownership structure guarantees our independence from corporate and political interests. We are owned by The Scott Trust, an independent-UK based organization that reinvests all profits back  into our journalism.
+            </p>
+            <p class="u-responsive-p">
+                We don’t have shareholders to please, or a billionaire owner pulling the strings.
+            </p>
+            <p class="u-responsive-p">
+                But while the Scott Trust ensures our independence, we need our Supporters to help secure our future in this challenging financial climate.
+            </p>
+            <p class="u-responsive-p">
+                We know that not everyone is in a position to become a Supporter. But if you can, you’ll be an integral part of our mission to make the world a better, fairer place, for everyone.
+            </p>
+        }
+    </section>
+}

--- a/frontend/app/views/info/elevatedSupporterUS.scala.html
+++ b/frontend/app/views/info/elevatedSupporterUS.scala.html
@@ -13,7 +13,7 @@
     <section class="elevated-supporter">
 
         @* ===== First part ===== *@
-        @fragments.page.elevatedBecomeSupporter(heroImage, supporterPlans, countryGroup, showCurrencyPrefix = false, Html("Become a<br>Guardian US Supporter"), Html("Help secure the future of our fearless, independent journalism")
+        @fragments.page.elevatedBecomeSupporter(heroImage, supporterPlans, countryGroup, showCurrencyPrefix = false, Html("Become a<br>Guardian US Supporter"), Html("<p class=\"elevated-banner__tagline--us elevated-banner__tagline\">Help secure the future of our fearless, independent journalism</p>")
         ){
             <div class="elevated-become-supporter-body__col u-content-width--left">
                 <p class="u-responsive-p">

--- a/frontend/assets/stylesheets/components/_elevated-banner.scss
+++ b/frontend/assets/stylesheets/components/_elevated-banner.scss
@@ -6,7 +6,7 @@
       clip-path : polygon(0% 100%, 0% 0%, 100% 0%, 100% 95.73%);
   }
 
-  @include mq($from: desktop) { 
+  @include mq($from: desktop) {
     @supports (clip-path : polygon(0% 98%, 0% 0%, 100% 0%, 100% 88.61%)) {
       clip-path : polygon(0% 96%, 0% 0%, 100% 0%, 100% 88.61%);
     }
@@ -17,16 +17,16 @@
     /* In mobile the width of the columns is 100% */
     width: 100%;
     background: guss-colour(news-main-2);
-    
-    @include mq($from: desktop) {   
+
+    @include mq($from: desktop) {
         width: 50%;
         display: inline-block;
-    } 
+    }
 }
 
 .elevated-banner__content {
     padding-top: 3px;
-    
+
     @include mq($from: tablet) {
         padding-top: 6px;
         height: 316px;
@@ -44,7 +44,7 @@
         line-height: 47px;
     }
 }
- 
+
 .elevated-banner__tagline {
     @include fs-header(5);
     line-height: 26px;
@@ -66,9 +66,15 @@
     }
 }
 
+.elevated-banner__tagline--us {
+    @include mq($from: tablet) {
+        max-width: 490px;
+    }
+}
+
 .elevated-banner__button {
     padding-bottom: 34px;
-    
+
     @include mq($from: desktop) {
         margin-top: 35px;
         padding-bottom: 48px;
@@ -76,10 +82,10 @@
 }
 
 .elevated-banner__col--img {
-    display: none;   
+    display: none;
 
-    @include mq($from: desktop) {   
-        display: inline-block;           
+    @include mq($from: desktop) {
+        display: inline-block;
         overflow: hidden;
         height: 316px;
         float: right;
@@ -88,7 +94,7 @@
 
 .elevated-banner__col__img {
 
-    @include mq($from: desktop) {   
+    @include mq($from: desktop) {
         height: 316px;
         overflow: hidden;
     }

--- a/frontend/assets/stylesheets/components/_elevated-banner.scss
+++ b/frontend/assets/stylesheets/components/_elevated-banner.scss
@@ -6,7 +6,7 @@
       clip-path : polygon(0% 100%, 0% 0%, 100% 0%, 100% 95.73%);
   }
 
-  @include mq($from: desktop) {
+  @include mq($from: desktop) { 
     @supports (clip-path : polygon(0% 98%, 0% 0%, 100% 0%, 100% 88.61%)) {
       clip-path : polygon(0% 96%, 0% 0%, 100% 0%, 100% 88.61%);
     }
@@ -17,16 +17,16 @@
     /* In mobile the width of the columns is 100% */
     width: 100%;
     background: guss-colour(news-main-2);
-
-    @include mq($from: desktop) {
+    
+    @include mq($from: desktop) {   
         width: 50%;
         display: inline-block;
-    }
+    } 
 }
 
 .elevated-banner__content {
     padding-top: 3px;
-
+    
     @include mq($from: tablet) {
         padding-top: 6px;
         height: 316px;
@@ -44,7 +44,7 @@
         line-height: 47px;
     }
 }
-
+ 
 .elevated-banner__tagline {
     @include fs-header(5);
     line-height: 26px;
@@ -74,7 +74,7 @@
 
 .elevated-banner__button {
     padding-bottom: 34px;
-
+    
     @include mq($from: desktop) {
         margin-top: 35px;
         padding-bottom: 48px;
@@ -82,10 +82,10 @@
 }
 
 .elevated-banner__col--img {
-    display: none;
+    display: none;   
 
-    @include mq($from: desktop) {
-        display: inline-block;
+    @include mq($from: desktop) {   
+        display: inline-block;           
         overflow: hidden;
         height: 316px;
         float: right;
@@ -94,7 +94,7 @@
 
 .elevated-banner__col__img {
 
-    @include mq($from: desktop) {
+    @include mq($from: desktop) {   
         height: 316px;
         overflow: hidden;
     }

--- a/frontend/assets/stylesheets/components/_elevated-closer-guardian-body.scss
+++ b/frontend/assets/stylesheets/components/_elevated-closer-guardian-body.scss
@@ -4,7 +4,7 @@
 .elevated-closer-guardian-body {
     background: guss-colour(neutral-8);
     padding-bottom: 18px;
-    
+
     @include mq($from: tablet) {
         padding-bottom: 36px;
     }
@@ -29,6 +29,13 @@
     }
 }
 
+.au-closer-guardian-body,
+.us-closer-guardian-body {
+    @include mq($from: desktop) {
+        padding-bottom: 70px;
+    }
+}
+
 .elevated-closer-guardian-body__list {
     p {
         @include mq($from: tablet) {
@@ -44,16 +51,16 @@
 .elevated-closer-guardian-body__col {
     width: 100%;
 
-    @include mq($from: desktop) {   
+    @include mq($from: desktop) {
         display: inline-block;
         vertical-align: middle;
         width: 50%;
-    }    
+    }
 }
 
 .elevated-closer-guardian-body__video {
 	vertical-align: top;
-    
+
     @include mq($from: desktop) {
         float: left;
     }
@@ -89,7 +96,7 @@
     height: 11px;
     vertical-align: baseline;
     width: 11px;
-    
+
     @include mq($from: tablet) {
         height: 14px;
         width: 14px;

--- a/frontend/assets/stylesheets/components/_elevated-closer-guardian-body.scss
+++ b/frontend/assets/stylesheets/components/_elevated-closer-guardian-body.scss
@@ -59,7 +59,7 @@
 }
 
 .elevated-closer-guardian-body__video {
-	vertical-align: top;
+    vertical-align: top;
 
     @include mq($from: desktop) {
         float: left;
@@ -96,7 +96,7 @@
     height: 11px;
     vertical-align: baseline;
     width: 11px;
-    
+
     @include mq($from: tablet) {
         height: 14px;
         width: 14px;

--- a/frontend/assets/stylesheets/components/_elevated-closer-guardian-body.scss
+++ b/frontend/assets/stylesheets/components/_elevated-closer-guardian-body.scss
@@ -96,7 +96,7 @@
     height: 11px;
     vertical-align: baseline;
     width: 11px;
-
+    
     @include mq($from: tablet) {
         height: 14px;
         width: 14px;

--- a/frontend/assets/stylesheets/components/_elevated-closer-guardian-body.scss
+++ b/frontend/assets/stylesheets/components/_elevated-closer-guardian-body.scss
@@ -31,7 +31,7 @@
 
 .au-closer-guardian-body,
 .us-closer-guardian-body {
-    @include mq($from: desktop) {
+    @include mq($from: mem-full) {
         padding-bottom: 70px;
     }
 }

--- a/frontend/assets/stylesheets/components/_elevated-closer-guardian-body.scss
+++ b/frontend/assets/stylesheets/components/_elevated-closer-guardian-body.scss
@@ -4,7 +4,7 @@
 .elevated-closer-guardian-body {
     background: guss-colour(neutral-8);
     padding-bottom: 18px;
-
+    
     @include mq($from: tablet) {
         padding-bottom: 36px;
     }
@@ -31,10 +31,10 @@
 
 .au-closer-guardian-body,
 .us-closer-guardian-body {
-    @include mq($from: mem-full) {
-        padding-bottom: 70px;
-    }
-}
+     @include mq($from: mem-full) {
+         padding-bottom: 70px;
+     }
+ }
 
 .elevated-closer-guardian-body__list {
     p {
@@ -51,16 +51,16 @@
 .elevated-closer-guardian-body__col {
     width: 100%;
 
-    @include mq($from: desktop) {
+    @include mq($from: desktop) {   
         display: inline-block;
         vertical-align: middle;
         width: 50%;
-    }
+    }    
 }
 
 .elevated-closer-guardian-body__video {
     vertical-align: top;
-
+    
     @include mq($from: desktop) {
         float: left;
     }
@@ -96,7 +96,7 @@
     height: 11px;
     vertical-align: baseline;
     width: 11px;
-
+    
     @include mq($from: tablet) {
         height: 14px;
         width: 14px;

--- a/frontend/assets/stylesheets/components/_elevated-closer-guardian-section.scss
+++ b/frontend/assets/stylesheets/components/_elevated-closer-guardian-section.scss
@@ -9,3 +9,7 @@
 
     margin-top: 11px !important;    
 }
+
+.elevated-close-guardian-section--low-margin {
+	margin-bottom: 36px;
+}


### PR DESCRIPTION
# [Blocked by business] Deploy the new landing page for US and AU with the new copy

## Trello card: [Here](https://trello.com/c/ubJrL83n/86-roll-out-supporter-page-designs-on-international-pages)

## Related PR: https://github.com/guardian/membership-frontend/pull/1406

## Why?

The new landing page converts better in the UK. Therefore, we are going to deploy the same design (but we different copy) in the Australian and US version.

## Changes

* `Info.scala` **[Modified]**: Modified the methods which handle the UK, US and AU requests. These modifications include calling the right view and instantiate the correct images required by the views.
* `elevatedSupporterAU.scala.html`**[New]**: The root view for the new landing page view. It contains the Australian copy.
* `elevatedSupporterUS.scala.html`**[New]**: The root view for the new landing page view. It contains the American copy.
* `elevatedSupporter.scala.html → ...views/info/elevatedSupporterUK.scala.html` **[Renamed]**:   The elevatedSupporter file now is called elevatedSupporterUK and it cointains the copy for the UK landing page.
* `_elevated-banner.scss`, `_elevated-closer-guardian-body.scss` **[Modified]**: Incorporated CSS changes for handling the cases of Australia and UK which copy has a different length than the UK's copy. 

## Images

### AU

![all_breakpoints_aus](https://cloud.githubusercontent.com/assets/825398/21189018/2ef9caca-c215-11e6-9a86-76cf3d23ad52.png)

### US

![all_breakpoints_us](https://cloud.githubusercontent.com/assets/825398/21189024/3512599a-c215-11e6-97d0-1f95ea00768c.png)


Please @rtyley @Ap0c,  can you review it?
