### PR TITLE
Benefits class is refactored.

### DIFF
--- a/frontend/app/model/Benefits.scala
+++ b/frontend/app/model/Benefits.scala
@@ -33,8 +33,7 @@ object Benefits {
   val PriorityBookingTiers = DiscountTicketTiers
   val ComplimentaryTicketTiers = Set[Tier](Partner(), Patron())
 
-  var adFreeApp = Benefit("ad_free_app","Free access to the premium tier of the Guardian app (includes crosswords and has no adverts)")
-  val adFreeAppLocalised = Benefit("ad_free_app","An ad-free experience in our mobile app")
+  val adFreeApp = Benefit("ad_free_app","An ad-free experience in our mobile app")
   val accessTicket = Benefit("access_tickets", "Access to tickets")
   val booksOrTickets = Benefit("books_or_tickets", s"$zuoraFreeEventTicketsAllowance tickets or 4 books", isNew = true)
   val booksAndTickets = Benefit("books_and_tickets", s"$zuoraFreeEventTicketsAllowance tickets and 4 books", isNew = true)
@@ -68,14 +67,14 @@ object Benefits {
   )
 
   val auSupporter = Seq(
-    adFreeAppLocalised,
+    adFreeApp,
     regularEmails,
     welcomePackAU,
     liveEvents
   )
 
   val usSupporter = Seq(
-    adFreeAppLocalised,
+    adFreeApp,
     regularEmails,
     welcomePackUS,
     liveEvents
@@ -83,7 +82,7 @@ object Benefits {
 
   val ukSupporter = Seq(
     emailsUpdatesJournalists,
-    adFreeAppLocalised,
+    adFreeApp,
     regularEmailsUK,
     globalCommunity,
     welcomePackUK

--- a/frontend/app/model/Benefits.scala
+++ b/frontend/app/model/Benefits.scala
@@ -7,6 +7,7 @@ import configuration.Config.zuoraFreeEventTicketsAllowance
 
 
 object Benefits {
+
   def forTier(tier: Tier) = tier match {
     case Staff() => Benefits.staff
     case Friend() => Benefits.friend
@@ -16,58 +17,86 @@ object Benefits {
   }
 
   def promoForCountry(cg: CountryGroup) = cg match {
-    case CountryGroup.Australia => ausSupporter
+    case CountryGroup.Australia => auSupporter
+    case CountryGroup.UK => ukSupporter
+    case CountryGroup.US => usSupporter
     case _ => supporterMinimal
   }
 
   def forTierAndCountry(tier: Tier, cg: CountryGroup) = (tier,cg) match {
-    case (Supporter(), CountryGroup.Australia) => ausSupporter
+    case (Supporter(), CountryGroup.Australia) => auSupporter
     case (tier,CountryGroup.UK) => forTier(tier)
     case (tier,_) => forTier(tier).filterNot(b=>marketedOnlyToUK.contains(b))
   }
+
   val DiscountTicketTiers = Set[Tier](Staff(), Partner(), Patron())
   val PriorityBookingTiers = DiscountTicketTiers
   val ComplimentaryTicketTiers = Set[Tier](Partner(), Patron())
 
-  val welcomePack = Benefit("welcome_pack", "Welcome pack, card and gift")
-  val welcomeDog = Benefit("welcome_pack", "Welcome pack")
+  var adFreeApp = Benefit("ad_free_app","Free access to the premium tier of the Guardian app (includes crosswords and has no adverts)")
+  val adFreeAppLocalised = Benefit("ad_free_app","An ad-free experience in our mobile app")
   val accessTicket = Benefit("access_tickets", "Access to tickets")
-  val emailUpdates = Benefit("email_updates", "Regular member emails")
-  var app = Benefit("app","Free access to the premium tier of the Guardian app (includes crosswords and has no adverts)")
-  val priorityBooking = Benefit("priority_booking", "48hrs priority booking")
-  val noBookingFees = Benefit("no_booking_fees", "No booking fees")
-  val guest = Benefit("guest", "Bring a guest")
   val booksOrTickets = Benefit("books_or_tickets", s"$zuoraFreeEventTicketsAllowance tickets or 4 books", isNew = true)
   val booksAndTickets = Benefit("books_and_tickets", s"$zuoraFreeEventTicketsAllowance tickets and 4 books", isNew = true)
-
   val discount = Benefit("discount", "20% discount for you and a guest")
+  val emailsUpdatesJournalists = Benefit("emails_updates_journalists", "Exclusive emails from Guardian journalists")
+  val globalCommunity = Benefit("add_free_app","Joining the global Guardian Members community")
+  val guest = Benefit("guest", "Bring a guest")
+  val liveEvents = Benefit("live_events", "Invitations to Guardian Live events")
+  val noBookingFees = Benefit("no_booking_fees", "No booking fees")
+  val priorityBooking = Benefit("priority_booking", "48hrs priority booking")
+  val regularEmails = Benefit("regular_emails", "Regular member emails")
+  val regularEmailsAU =  Benefit("regular_emails", "Regular behind-the-scenes emails from our newsroom")
+  val regularEmailsUS =  Benefit("regular_emails", "Regular behind-the-scenes emails from our newsroom")
+  val regularEmailsUK =  Benefit("regular_emails", "A weekly look \"Inside the Guardian\" for our Members")
   val uniqueExperiences = Benefit("unique_experiences", "Exclusive behind-the-scenes functions")
+  val welcomePack = Benefit("welcome_pack", "Welcome pack, card and gift")
+  val welcomePackAU = Benefit("welcome_pack", "Welcome letter with First Dog on the Moon certificate")
+  val welcomePackUK = Benefit("welcome_pack", "A welcome gift")
+  val welcomePackUS = Benefit("welcome_pack", "A Guardian branded tote bag")
 
   val marketedOnlyToUK = Set[Benefit](accessTicket)
 
   val friend = Seq(
     accessTicket,
-    emailUpdates
+    regularEmails
   )
 
   val supporter = Seq(
     welcomePack,
-    app,
+    adFreeApp,
     accessTicket,
-    emailUpdates
+    regularEmails
   )
 
-  val ausSupporter = Seq(
-    welcomeDog,
-    app,
-    emailUpdates
+  val auSupporter = Seq(
+    adFreeAppLocalised,
+    regularEmailsAU,
+    welcomePackAU,
+    liveEvents
+  )
+
+  val usSupporter = Seq(
+    adFreeAppLocalised,
+    regularEmailsUS,
+    welcomePackUS,
+    liveEvents
+  )
+
+  val ukSupporter = Seq(
+    emailsUpdatesJournalists,
+    adFreeAppLocalised,
+    regularEmailsUK,
+    globalCommunity,
+    welcomePackUK
   )
 
   val supporterMinimal = Seq(
     welcomePack,
-    app,
-    emailUpdates
+    adFreeApp,
+    regularEmails
   )
+
   val partner = Seq(
     booksOrTickets,
     priorityBooking,
@@ -75,9 +104,10 @@ object Benefits {
     discount,
     guest,
     welcomePack,
-    app,
-    emailUpdates
+    adFreeApp,
+    regularEmails
   )
+
   val patron = Seq(
     booksAndTickets,
     uniqueExperiences,
@@ -86,15 +116,15 @@ object Benefits {
     discount,
     guest,
     welcomePack,
-    app,
-    emailUpdates
+    adFreeApp,
+    regularEmails
   )
 
   val comparisonBasicList = Seq(
     welcomePack,
-    app,
+    adFreeApp,
     accessTicket,
-    emailUpdates
+    regularEmails
   )
 
   val staff = (partner ++ supporter).filterNot(_ == booksOrTickets).distinct

--- a/frontend/app/model/Benefits.scala
+++ b/frontend/app/model/Benefits.scala
@@ -45,9 +45,7 @@ object Benefits {
   val liveEvents = Benefit("live_events", "Invitations to Guardian Live events")
   val noBookingFees = Benefit("no_booking_fees", "No booking fees")
   val priorityBooking = Benefit("priority_booking", "48hrs priority booking")
-  val regularEmails = Benefit("regular_emails", "Regular member emails")
-  val regularEmailsAU =  Benefit("regular_emails", "Regular behind-the-scenes emails from our newsroom")
-  val regularEmailsUS =  Benefit("regular_emails", "Regular behind-the-scenes emails from our newsroom")
+  val regularEmails = Benefit("regular_emails", "Regular behind-the-scenes emails from our newsroom")
   val regularEmailsUK =  Benefit("regular_emails", "A weekly look \"Inside the Guardian\" for our Members")
   val uniqueExperiences = Benefit("unique_experiences", "Exclusive behind-the-scenes functions")
   val welcomePack = Benefit("welcome_pack", "Welcome pack, card and gift")
@@ -71,14 +69,14 @@ object Benefits {
 
   val auSupporter = Seq(
     adFreeAppLocalised,
-    regularEmailsAU,
+    regularEmails,
     welcomePackAU,
     liveEvents
   )
 
   val usSupporter = Seq(
     adFreeAppLocalised,
-    regularEmailsUS,
+    regularEmails,
     welcomePackUS,
     liveEvents
   )

--- a/frontend/app/views/info/elevatedSupporterAU.scala.html
+++ b/frontend/app/views/info/elevatedSupporterAU.scala.html
@@ -1,3 +1,4 @@
+@import model.Benefits
 @import com.gu.i18n.CountryGroup
 @import configuration.Videos
 @import com.gu.memsub.subsv2.{CatalogPlan, MonthYearPlans}
@@ -43,18 +44,11 @@
                     </p>
 
                     <ul>
+                    @for(benefit <- Benefits.promoForCountry(countryGroup)){
                         <li class="elevated-closer-guardian-body__list_item">
-                            An ad-free experience in our mobile app
+                        @benefit.title
                         </li>
-                        <li class="elevated-closer-guardian-body__list_item">
-                            Regular behind-the-scenes emails from our newsroom
-                        </li>
-                        <li class="elevated-closer-guardian-body__list_item">
-                            Welcome letter with First Dog on the Moon certificate
-                        </li>
-                        <li class="elevated-closer-guardian-body__list_item">
-                            Invitations to Guardian Live events
-                        </li>
+                    }
                     </ul>
 
                     <p class="u-responsive-p">

--- a/frontend/app/views/info/elevatedSupporterUK.scala.html
+++ b/frontend/app/views/info/elevatedSupporterUK.scala.html
@@ -1,3 +1,4 @@
+@import model.Benefits
 @import com.gu.i18n.CountryGroup
 @import configuration.Videos
 @import com.gu.memsub.subsv2.{CatalogPlan, MonthYearPlans}
@@ -46,21 +47,11 @@
                     <p>
 
                     <ul>
-                        <li class="elevated-closer-guardian-body__list_item">
-                            Exclusive emails from Guardian journalists
-                        </li>
-                        <li class="elevated-closer-guardian-body__list_item">
-                            An ad-free experience on our mobile app
-                        </li>
-                        <li class="elevated-closer-guardian-body__list_item">
-                            A weekly look "Inside the Guardian" for our Members
-                        </li>
-                        <li class="elevated-closer-guardian-body__list_item">
-                            Joining the global Guardian Members community
-                        </li>
-                        <li class="elevated-closer-guardian-body__list_item">
-                            A welcome gift
-                        </li>
+                        @for(benefit <- Benefits.promoForCountry(countryGroup)){
+                            <li class="elevated-closer-guardian-body__list_item">
+                                @benefit.title
+                            </li>
+                        }
                     </ul>
 
                     <p class="u-responsive-p">

--- a/frontend/app/views/info/elevatedSupporterUS.scala.html
+++ b/frontend/app/views/info/elevatedSupporterUS.scala.html
@@ -1,3 +1,4 @@
+@import model.Benefits
 @import com.gu.i18n.CountryGroup
 @import configuration.Videos
 @import com.gu.memsub.subsv2.{CatalogPlan, MonthYearPlans}
@@ -43,18 +44,11 @@
                     <p>
 
                     <ul>
-                        <li class="elevated-closer-guardian-body__list_item">
-                            An ad-free experience in our mobile app
-                        </li>
-                        <li class="elevated-closer-guardian-body__list_item">
-                            Regular behind-the-scenes emails from our newsroom
-                        </li>
-                        <li class="elevated-closer-guardian-body__list_item">
-                            A Guardian branded tote bag
-                        </li>
-                        <li class="elevated-closer-guardian-body__list_item">
-                            Invitations to live events
-                        </li>
+                        @for(benefit <- Benefits.promoForCountry(countryGroup)){
+                            <li class="elevated-closer-guardian-body__list_item">
+                            @benefit.title
+                            </li>
+                        }
                     </ul>
 
                     <p class="u-responsive-p">


### PR DESCRIPTION
## Why are you doing this?
Currently, the benefits are hard coded on the landing page. In this PR, we are reading those from the `Benefits.scala `

## Trello card: [Here](https://trello.com/c/tgFn2v7u/221-refactor-the-list-of-benefits-of-the-landing-page-to-read-the-benefits-object)

## Changes
* `Benefits.scala` **[Modified]**: Added the new benefits for the specifics landing pages. Defined the benefits object whenever is necessary.
* `elevatedSupporterUS.scala.html`, `elevatedSupporterUK.scala.html` and `elevatedSupporterAU.scala.html` **[Modified]**: Beneftis are being read from `Benefits.scala`

## Screenshots

Not applicable


