### PR TITLE
Turning off the A/B Test.

### DIFF
--- a/frontend/app/abtests/CheckoutFlowVariant.scala
+++ b/frontend/app/abtests/CheckoutFlowVariant.scala
@@ -9,8 +9,8 @@ import scala.util.Random
   */
 object CheckoutFlowVariant {
   val cookieName = "ab-checkout-flow"
-  val runningTest = true
-  val default = A
+  val runningTest = false
+  val default = B
 
   val all = Seq[CheckoutFlowVariant](A,B)
 


### PR DESCRIPTION
## Why are you doing this?
Flow B won the checkout A/B test. Therefore, we are turning it off and selecting flow B as a default.

## Trello card: [Here](https://trello.com/c/6Te8Vvqh/237-turn-off-checkout-a-b-test)

## Changes
* `CheckoutFlowVariant.scala`: turn off the A/B Test and select B as a default case. 

## Screenshots

Not applicable.


Please @Ap0c, can you check this PR?
