### PR TITLE
use new membership common, stop signed in non member errors

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "7.2.3"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.6"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.7"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.327"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.328"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache


### PR DESCRIPTION
In my previous changes to membership common, I tried to log all the errors rather than just discarding them.  Unfortunately I didn't realise that 404 from get user by identity id was actually expected behaviour, so I ended up spamming sentry.

Here is the fix that this pulls in: https://github.com/guardian/membership-common/pull/384

@AWare @paulbrown1982 @pvighi 