### PR TITLE
stop spam to membership feedback

### DIFF
--- a/frontend/app/services/EmailService.scala
+++ b/frontend/app/services/EmailService.scala
@@ -20,12 +20,15 @@ trait EmailService extends LazyLogging {
   }
 
   def sendFeedback(feedback: FeedbackForm, userOpt: Option[IdMinimalUser], uaOpt: Option[String]) = {
-    logger.info(s"Sending feedback for ${feedback.name} - Identity $userOpt")
-    val to = new Destination().withToAddresses(feedbackAddress)
-    val subjectContent = new Content("Membership feedback")
+    if (feedback.email == "davideel@hotmail.com") {
+      logger.info("discarding email we can't do anything useful with")
+    } else {
+      logger.info(s"Sending feedback for ${feedback.name} - Identity $userOpt")
+      val to = new Destination().withToAddresses(feedbackAddress)
+      val subjectContent = new Content("Membership feedback")
 
-    val body =
-      s"""
+      val body =
+        s"""
         Category: ${feedback.category}<br />
         Page: ${feedback.page}<br />
         Comments: ${feedback.feedback}<br />
@@ -36,14 +39,15 @@ trait EmailService extends LazyLogging {
         User agent: ${uaOpt.mkString}
       """.stripMargin
 
-    val message = new Message(subjectContent, new Body().withHtml(new Content(body)))
-    val email = new SendEmailRequest(feedbackAddress, to, message)
+      val message = new Message(subjectContent, new Body().withHtml(new Content(body)))
+      val email = new SendEmailRequest(feedbackAddress, to, message)
 
-    Try {
-      client.sendEmail(email)
-    } match {
-      case Success(details) => //all good
-      case Failure(error) => logger.error(s"Failed to send feedback, got ${error.getMessage}")
+      Try {
+        client.sendEmail(email)
+      } match {
+        case Success(details) => //all good
+        case Failure(error) => logger.error(s"Failed to send feedback, got ${error.getMessage}")
+      }
     }
   }
 }


### PR DESCRIPTION
Note: view with [files?w=0](https://github.com/guardian/membership-frontend/pull/1418/files?w=0) for better diff

## Why are you doing this?
Look at membership feedback and you'll know!!  Loads of emails we can't use in any meaningful way.

## Screenshots



@guardian/membership-and-subscriptions 