### PR TITLE
Adding tracking pixels for off platform re-targetting campaing

### DIFF
--- a/frontend/app/tracking/AppnexusPixel.scala
+++ b/frontend/app/tracking/AppnexusPixel.scala
@@ -1,0 +1,16 @@
+package tracking
+
+import com.gu.salesforce.Tier
+import com.gu.salesforce.Tier.Partner
+import com.gu.salesforce.Tier.Patron
+import com.gu.salesforce.Tier.Supporter
+import com.gu.salesforce.Tier.Friend
+
+object AppnexusPixel {
+
+  val thankYouPageids:Map[Tier, Int] = Map(Partner() -> 793015, Patron() -> 793021, Supporter() ->793016, Friend() -> 793017)
+
+  val landingPageids:Map[Tier, Int] = Map(Supporter() -> 7269289)
+
+  val checkoutPageids:Map[Tier, Int] = Map(Partner() -> 7269292, Patron() -> 7269296, Supporter() -> 7269291)
+}

--- a/frontend/app/views/info/elevatedSupporter.scala.html
+++ b/frontend/app/views/info/elevatedSupporter.scala.html
@@ -2,6 +2,8 @@
 @import configuration.Videos
 @import com.gu.memsub.subsv2.{CatalogPlan, MonthYearPlans}
 @import views.support.PageInfo
+@import tracking.AppnexusPixel
+@import com.gu.salesforce.Tier.Supporter
 
 @(  heroImage: model.OrientatedImages,
     supporterPlans: MonthYearPlans[CatalogPlan.Supporter],
@@ -11,6 +13,10 @@
 @main("Supporters", pageInfo=pageInfo, countryGroup=Some(countryGroup)) {
 
     <section class="elevated-supporter">
+
+        <!-- Conversion Pixel - Jan17 - Partner Conversion pixel - DO NOT MODIFY -->
+            <img src="https://secure.adnxs.com/px?id=@{AppnexusPixel.landingPageids(Supporter())}&t=2" width="1" height="1" />
+        <!-- End of Conversion Pixel -->
 
         @* ===== First part ===== *@
         @fragments.page.elevatedBecomeSupporter(heroImage, supporterPlans, countryGroup, showCurrencyPrefix = false, Html("Become a<br>Guardian Supporter"), Html("Be part of the Guardian's future, by helping to secure it")

--- a/frontend/app/views/info/elevatedSupporter.scala.html
+++ b/frontend/app/views/info/elevatedSupporter.scala.html
@@ -14,9 +14,9 @@
 
     <section class="elevated-supporter">
 
-        <!-- Conversion Pixel - Jan17 - Partner Conversion pixel - DO NOT MODIFY -->
-            <img src="https://secure.adnxs.com/px?id=@{AppnexusPixel.landingPageids(Supporter())}&t=2" width="1" height="1" />
-        <!-- End of Conversion Pixel -->
+        <!-- Segment Pixel - Jan17-Membership Landing Page - DO NOT MODIFY -->
+            <img src="https://secure.adnxs.com/px?add=@{AppnexusPixel.landingPageids(Supporter())}&t=2" width="1" height="1" />
+        <!-- End of Segment Pixel -->
 
         @* ===== First part ===== *@
         @fragments.page.elevatedBecomeSupporter(heroImage, supporterPlans, countryGroup, showCurrencyPrefix = false, Html("Become a<br>Guardian Supporter"), Html("Be part of the Guardian's future, by helping to secure it")

--- a/frontend/app/views/info/supporterAustralia.scala.html
+++ b/frontend/app/views/info/supporterAustralia.scala.html
@@ -7,6 +7,8 @@
 @import com.gu.memsub.subsv2.Catalog._
 @import com.gu.memsub.subsv2.MonthYearPlans
 @import views.support.MembershipCompat._
+@import com.gu.salesforce.Tier.Supporter
+@import tracking.AppnexusPixel
 
 @import com.gu.memsub.subsv2.CatalogPlan
 @(heroImage: model.OrientatedImages, supporterPlans: MonthYearPlans[CatalogPlan.Supporter],
@@ -14,6 +16,11 @@
   pageImages: Seq[com.gu.memsub.images.ResponsiveImageGroup])(implicit token: play.filters.csrf.CSRF.Token, countryGroup: CountryGroup)
 
 @main("Supporters", pageInfo=pageInfo, countryGroup=Some(countryGroup)) {
+
+    <!-- Conversion Pixel - Jan17 - Partner Conversion pixel - DO NOT MODIFY -->
+        <img src="https://secure.adnxs.com/px?id=@{AppnexusPixel.landingPageids(Supporter())}&t=2" width="1" height="1" />
+    <!-- End of Conversion Pixel -->
+
     @* ===== About Supporters ===== *@
     @fragments.page.heroBanner(heroImage) {
         Become a Guardian&nbsp;Supporter

--- a/frontend/app/views/info/supporterAustralia.scala.html
+++ b/frontend/app/views/info/supporterAustralia.scala.html
@@ -17,9 +17,9 @@
 
 @main("Supporters", pageInfo=pageInfo, countryGroup=Some(countryGroup)) {
 
-    <!-- Conversion Pixel - Jan17 - Partner Conversion pixel - DO NOT MODIFY -->
-        <img src="https://secure.adnxs.com/px?id=@{AppnexusPixel.landingPageids(Supporter())}&t=2" width="1" height="1" />
-    <!-- End of Conversion Pixel -->
+    <!-- Segment Pixel - Jan17-Membership Landing Page - DO NOT MODIFY -->
+        <img src="https://secure.adnxs.com/px?add=@{AppnexusPixel.landingPageids(Supporter())}&t=2" width="1" height="1" />
+    <!-- End of Segment Pixel -->
 
     @* ===== About Supporters ===== *@
     @fragments.page.heroBanner(heroImage) {

--- a/frontend/app/views/info/supporterEurope.scala.html
+++ b/frontend/app/views/info/supporterEurope.scala.html
@@ -6,6 +6,8 @@
 @import com.gu.memsub.subsv2.MonthYearPlans
 @import com.gu.memsub.subsv2.CatalogPlan.PaidMember
 @import views.support.MembershipCompat._
+@import com.gu.salesforce.Tier.Supporter
+@import tracking.AppnexusPixel
 
 @(images: model.OrientatedImages, supporterPlans: MonthYearPlans[PaidMember],
     pageInfo: PageInfo,
@@ -14,6 +16,10 @@
 @import configuration.Videos
 @import views.support.Asset
 @main("Supporters", pageInfo=pageInfo, countryGroup=Some(countryGroup)) {
+    <!-- Conversion Pixel - Jan17 - Partner Conversion pixel - DO NOT MODIFY -->
+        <img src="https://secure.adnxs.com/px?id=@{AppnexusPixel.landingPageids(Supporter())}&t=2" width="1" height="1" />
+    <!-- End of Conversion Pixel -->
+
     @fragments.page.heroBanner(images, imageModifierClass = "hero-banner__image--top hero-banner__image--eu") {
         Become a Guardian&nbsp;Supporter
     } {

--- a/frontend/app/views/info/supporterEurope.scala.html
+++ b/frontend/app/views/info/supporterEurope.scala.html
@@ -16,9 +16,10 @@
 @import configuration.Videos
 @import views.support.Asset
 @main("Supporters", pageInfo=pageInfo, countryGroup=Some(countryGroup)) {
-    <!-- Conversion Pixel - Jan17 - Partner Conversion pixel - DO NOT MODIFY -->
-        <img src="https://secure.adnxs.com/px?id=@{AppnexusPixel.landingPageids(Supporter())}&t=2" width="1" height="1" />
-    <!-- End of Conversion Pixel -->
+
+    <!-- Segment Pixel - Jan17-Membership Landing Page - DO NOT MODIFY -->
+        <img src="https://secure.adnxs.com/px?add=@{AppnexusPixel.landingPageids(Supporter())}&t=2" width="1" height="1" />
+    <!-- End of Segment Pixel -->
 
     @fragments.page.heroBanner(images, imageModifierClass = "hero-banner__image--top hero-banner__image--eu") {
         Become a Guardian&nbsp;Supporter

--- a/frontend/app/views/info/supporterInternational.scala.html
+++ b/frontend/app/views/info/supporterInternational.scala.html
@@ -16,9 +16,9 @@
 @import views.support.Asset
 @main("Supporters", pageInfo=pageInfo, countryGroup=Some(countryGroup)) {
 
-    <!-- Conversion Pixel - Jan17 - Partner Conversion pixel - DO NOT MODIFY -->
-        <img src="https://secure.adnxs.com/px?id=@{AppnexusPixel.landingPageids(Supporter())}&t=2" width="1" height="1" />
-    <!-- End of Conversion Pixel -->
+    <!-- Segment Pixel - Jan17-Membership Landing Page - DO NOT MODIFY -->
+        <img src="https://secure.adnxs.com/px?add=@{AppnexusPixel.landingPageids(Supporter())}&t=2" width="1" height="1" />
+    <!-- End of Segment Pixel -->
 
     @fragments.page.heroBanner(heroImage, "hero-banner__image--bottom") {
         Become a Guardian&nbsp;Supporter

--- a/frontend/app/views/info/supporterInternational.scala.html
+++ b/frontend/app/views/info/supporterInternational.scala.html
@@ -3,15 +3,23 @@
 
 @import views.support.PageInfo
 @import com.gu.memsub.subsv2.MonthYearPlans
-@import com.gu.memsub.subsv2.CatalogPlan._
+@import com.gu.memsub.subsv2.CatalogPlan
+@import com.gu.salesforce.Tier.Supporter
 @import views.support.MembershipCompat._
-@(heroImage: model.OrientatedImages, supporterPlans: MonthYearPlans[Supporter],
+@import tracking.AppnexusPixel
+
+@(heroImage: model.OrientatedImages, supporterPlans: MonthYearPlans[CatalogPlan.Supporter],
     pageInfo: PageInfo,
     pageImages: Seq[com.gu.memsub.images.ResponsiveImageGroup])(implicit token: play.filters.csrf.CSRF.Token, countryGroup: CountryGroup)
 
 @import configuration.Videos
 @import views.support.Asset
 @main("Supporters", pageInfo=pageInfo, countryGroup=Some(countryGroup)) {
+
+    <!-- Conversion Pixel - Jan17 - Partner Conversion pixel - DO NOT MODIFY -->
+        <img src="https://secure.adnxs.com/px?id=@{AppnexusPixel.landingPageids(Supporter())}&t=2" width="1" height="1" />
+    <!-- End of Conversion Pixel -->
+
     @fragments.page.heroBanner(heroImage, "hero-banner__image--bottom") {
         Become a Guardian&nbsp;Supporter
     } {

--- a/frontend/app/views/info/supporterUSA.scala.html
+++ b/frontend/app/views/info/supporterUSA.scala.html
@@ -16,9 +16,10 @@
 @import configuration.Videos
 @import views.support.Asset
 @main("Supporters", pageInfo=pageInfo, countryGroup=Some(countryGroup)) {
-    <!-- Conversion Pixel - Jan17 - Partner Conversion pixel - DO NOT MODIFY -->
-        <img src="https://secure.adnxs.com/px?id=@{AppnexusPixel.landingPageids(Supporter())}&t=2" width="1" height="1" />
-    <!-- End of Conversion Pixel -->
+
+    <!-- Segment Pixel - Jan17-Membership Landing Page - DO NOT MODIFY -->
+        <img src="https://secure.adnxs.com/px?add=@{AppnexusPixel.landingPageids(Supporter())}&t=2" width="1" height="1" />
+    <!-- End of Segment Pixel -->
 
     @fragments.page.heroBanner(heroImages) {
         Become a Guardian&nbsp;Supporter

--- a/frontend/app/views/info/supporterUSA.scala.html
+++ b/frontend/app/views/info/supporterUSA.scala.html
@@ -3,16 +3,23 @@
 @import com.gu.salesforce.Tier
 
 @import views.support.MembershipCompat._
-@import com.gu.memsub.subsv2.CatalogPlan._
+@import com.gu.memsub.subsv2.CatalogPlan
 @import views.support.PageInfo
 @import com.gu.memsub.subsv2.MonthYearPlans
-@(heroImages: model.OrientatedImages, supporterPlans: MonthYearPlans[Supporter],
+@import com.gu.salesforce.Tier.Supporter
+@import tracking.AppnexusPixel
+
+@(heroImages: model.OrientatedImages, supporterPlans: MonthYearPlans[CatalogPlan.Supporter],
   pageInfo: PageInfo,
   pageImages: Seq[com.gu.memsub.images.ResponsiveImageGroup])(implicit token: play.filters.csrf.CSRF.Token, countryGroup: CountryGroup)
 
 @import configuration.Videos
 @import views.support.Asset
 @main("Supporters", pageInfo=pageInfo, countryGroup=Some(countryGroup)) {
+    <!-- Conversion Pixel - Jan17 - Partner Conversion pixel - DO NOT MODIFY -->
+        <img src="https://secure.adnxs.com/px?id=@{AppnexusPixel.landingPageids(Supporter())}&t=2" width="1" height="1" />
+    <!-- End of Conversion Pixel -->
+
     @fragments.page.heroBanner(heroImages) {
         Become a Guardian&nbsp;Supporter
     } {

--- a/frontend/app/views/joiner/form/payment.scala.html
+++ b/frontend/app/views/joiner/form/payment.scala.html
@@ -28,9 +28,10 @@
 @main(plans.tier.cta, pageInfo=pageInfo, simpleHeader=true) {
 
     <main class="page-content skin-checkout-b">
-        <!-- Conversion Pixel - Jan17 - Partner Conversion pixel - DO NOT MODIFY -->
-            <img src="https://secure.adnxs.com/px?id=@{AppnexusPixel.checkoutPageids(plans.tier)}&t=2" width="1" height="1" />
-        <!-- End of Conversion Pixel -->
+
+        <!-- Segment Pixel - Jan17 - Become a supporter - DO NOT MODIFY -->
+            <img src="https://secure.adnxs.com/px?add=@{AppnexusPixel.checkoutPageids(plans.tier)}&t=2" width="1" height="1" />
+        <!-- End of Segment Pixel -->
 
         <form action="@routes.Joiner.joinPaid(plans.tier)" method="POST" id="payment-form" class="js-form" novalidate>
             @CSRF.formField

--- a/frontend/app/views/joiner/form/payment.scala.html
+++ b/frontend/app/views/joiner/form/payment.scala.html
@@ -13,6 +13,7 @@
 @import com.gu.memsub.subsv2.MonthYearPlans
 @import com.gu.memsub.subsv2.CatalogPlan.PaidMember
 @import com.gu.i18n.CountryGroup
+@import tracking.AppnexusPixel
 
 
 @(plans: MonthYearPlans[PaidMember],
@@ -27,6 +28,9 @@
 @main(plans.tier.cta, pageInfo=pageInfo, simpleHeader=true) {
 
     <main class="page-content skin-checkout-b">
+        <!-- Conversion Pixel - Jan17 - Partner Conversion pixel - DO NOT MODIFY -->
+            <img src="https://secure.adnxs.com/px?id=@{AppnexusPixel.checkoutPageids(plans.tier)}&t=2" width="1" height="1" />
+        <!-- End of Conversion Pixel -->
 
         <form action="@routes.Joiner.joinPaid(plans.tier)" method="POST" id="payment-form" class="js-form" novalidate>
             @CSRF.formField

--- a/frontend/app/views/joiner/thankyou.scala.html
+++ b/frontend/app/views/joiner/thankyou.scala.html
@@ -10,6 +10,7 @@
 @import com.gu.memsub.PaymentCard
 @import com.gu.memsub.Subscriber
 @import com.gu.memsub.promo.Promotion.AnyPromotion
+@import tracking.AppnexusPixel
 @(member: Subscriber.Member,
   summary: ThankyouSummary,
   cardOpt: Option[PaymentCard],
@@ -60,6 +61,10 @@
    };
 </script>
     <main role="main" class="page-content l-constrained">
+
+        <!-- Conversion Pixel - Jan17 - Partner Conversion pixel - DO NOT MODIFY -->
+            <img src="https://secure.adnxs.com/px?id=@{AppnexusPixel.thankYouPageids(member.subscription.plan.tier)}&t=2" width="1" height="1" />
+        <!-- End of Conversion Pixel -->
 
         @fragments.page.pageHeader(
             pageHeader,


### PR DESCRIPTION
## Why are you doing this?
We need to add tracking pixels to different memberships pages. In order to add a pixel, we should put an img tag in the corresponding view.

`<img src="https://secure.adnxs.com/px?id=PxID&t=2" width="1" height="1" />`

| Page  | Pixel Id  |
|---|---|
| Thank you Page (Partner)  | 793015  |
| Thank you Page (Supporter)  | 793016  |
|  Thank you Page (Friend)  | 793017  |
|  Thank you Page (Patron)  | 793021  |
|  Landing Page (all countries)  | 7269289  |
|  Checkout Page (Supporter)  | 7269291  |
|  Checkout Page (Partner)  | 7269292  |
|  Checkout Page (Patron)  | 7269296  |

## Trello card: [Here](https://trello.com/c/owyPg0FF/210-tracking-pixels-for-off-platform-re-targetting-campaign)

## Changes
* Creating an object which has all the pixels id for different scenarios.
* Adding the pixels to the differents view `*.scala.html`

## Screenshots

### Landing page UK

![picture 56](https://cloud.githubusercontent.com/assets/825398/21451414/ec5de410-c8f6-11e6-9bec-2c21e80fe910.png)

### Landing page US

![picture 57](https://cloud.githubusercontent.com/assets/825398/21451510/828729d8-c8f7-11e6-8a6e-f010c8c714c7.png)

### Landing page AU

![picture 58](https://cloud.githubusercontent.com/assets/825398/21451525/9a77d5ce-c8f7-11e6-8c6e-813d3a68a511.png)

### Landing page Int

![picture 59](https://cloud.githubusercontent.com/assets/825398/21451569/f7d7e8d0-c8f7-11e6-8403-cb99a47f09b5.png)

### Landing page Eu

![picture 60](https://cloud.githubusercontent.com/assets/825398/21451584/10a318a8-c8f8-11e6-9437-a3c61e882394.png)

### Checkout Page (Supporter)

![picture 61](https://cloud.githubusercontent.com/assets/825398/21451670/a5fbc788-c8f8-11e6-905c-b7e40c946de9.png)

### Checkout Page (Partner)

![picture 63](https://cloud.githubusercontent.com/assets/825398/21451746/50cc3904-c8f9-11e6-8de3-b9856d0a1662.png)


### Checkout Page (Patron)

![picture 65](https://cloud.githubusercontent.com/assets/825398/21451807/e5ef67f4-c8f9-11e6-9bc6-f20d8fa9a5e9.png)

### Thank you Page (Supporter)

![picture 62](https://cloud.githubusercontent.com/assets/825398/21451693/d45d3562-c8f8-11e6-812a-5f5b6cc34143.png)

### Thank you Page (Partner)

![picture 64](https://cloud.githubusercontent.com/assets/825398/21451761/8b41539e-c8f9-11e6-894c-618fe3c25b14.png)

### Thank you Page (Patron)

![picture 66](https://cloud.githubusercontent.com/assets/825398/21451819/07d815c8-c8fa-11e6-9672-c774abd27cc7.png)




