### PR TITLE
Fix laggy startup

### DIFF
--- a/frontend/app/filters/AddEC2InstanceHeader.scala
+++ b/frontend/app/filters/AddEC2InstanceHeader.scala
@@ -1,5 +1,6 @@
 package filters
 
+import configuration.Config
 import play.api.Play.current
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.ws.WS
@@ -10,11 +11,18 @@ import scala.concurrent.Future
 object AddEC2InstanceHeader extends Filter {
 
   // http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
-  lazy val instanceIdOptF = WS.url("http://169.254.169.254/latest/meta-data/instance-id").get().map(resp => Some(resp.body).filter(_.nonEmpty)).recover { case _ => None }
+  lazy val instanceIdOptF = getHeader
 
   def apply(nextFilter: RequestHeader => Future[Result])(requestHeader: RequestHeader): Future[Result] = for {
     result <- nextFilter(requestHeader)
     instanceIdOpt <- instanceIdOptF
   } yield instanceIdOpt.fold(result)(instanceId => result.withHeaders("X-EC2-instance-id" -> instanceId))
+
+  def getHeader: Future[Option[String]] = {
+    if (Config.stageProd)
+      WS.url("http://169.254.169.254/latest/meta-data/instance-id").get().map(resp => Some(resp.body).filter(_.nonEmpty)).recover { case _ => None }
+    else
+      Future(None)
+  }
 
 }


### PR DESCRIPTION
## Why are you doing this?
To speed up the start up time of the site when running locally.

The delay was caused by the AddEC2InstanceHeader filter which was unable to complete when running outside of EC2 and so was causing the app to hang until it timed out.

## Trello card: [Here](https://trello.com/c/FPc0b1uO/219-investigate-dev-startup-time-on-membership-frontend)

## Changes
Only attempt to get the EC2 instance header when running in Prod


