### PR TITLE
Update Membership Homepage Video

### DIFF
--- a/frontend/app/configuration/Videos.scala
+++ b/frontend/app/configuration/Videos.scala
@@ -6,20 +6,6 @@ import model.Video
 
 object Videos {
 
-  private val whatIsMembershipPlaceholder = ResponsiveImageGenerator(
-    id="9dc72e35ca1a38f6c02933d48f12de863739ad60/125_0_1873_1124",
-    sizes=List(1000, 500)
-  )
-  val whatIsMembership = Video(
-    srcUrl="//www.youtube.com/embed/9uV35JdlFdM?enablejsapi=1&wmode=transparent",
-    posterImage=Some(
-      ResponsiveImageGroup(
-        altText=Some("What is Guardian Members?"),
-        availableImages=whatIsMembershipPlaceholder
-      )
-    )
-  )
-
   private val supportersPlaceholder = ResponsiveImageGenerator(
     id="9dc72e35ca1a38f6c02933d48f12de863739ad60/125_0_1873_1124",
     sizes=List(1000, 500)

--- a/frontend/app/views/fragments/listing/introducingMembers.scala.html
+++ b/frontend/app/views/fragments/listing/introducingMembers.scala.html
@@ -1,5 +1,5 @@
 @()
 @fragments.media.videoPreview(
-    configuration.Videos.whatIsMembership,
-    "Polly Toynbee, Owen Jones, Ewen MacAskill and Hugh Muir introduce Guardian Members"
+    configuration.Videos.scottTrustExplained,
+    "Katharine Viner, editor-in-chief, explains the Guardian's unique ownership model"
 )

--- a/frontend/app/views/index.scala.html
+++ b/frontend/app/views/index.scala.html
@@ -37,7 +37,7 @@
     @* =========================================== *@
     @* 1. Introducing Guardian Members             *@
     @* =========================================== *@
-    @fragments.page.section("Introducing Guardian Members", isNarrow = false, sectionId = Some("introducing-members")) {
+    @fragments.page.section("Why we are asking for your support", isNarrow = false, sectionId = Some("introducing-members")) {
         @fragments.listing.introducingMembers()
         @fragments.common.jumpLink("Benefits of membership", "#why-join")
     }

--- a/frontend/app/views/patterns/patterns.scala.html
+++ b/frontend/app/views/patterns/patterns.scala.html
@@ -322,7 +322,7 @@
     }
 
     @pattern("Video Player", "Video with poster image overlay") {
-        @fragments.media.videoPlayer(Videos.whatIsMembership)
+        @fragments.media.videoPlayer(Videos.scottTrustExplained)
     }
 
     @pattern("Event Item") {


### PR DESCRIPTION
# Problem

The video currently being used on the homepage is expiring imminently, and needs to be replaced.

[Trello Card](https://trello.com/c/IDaFy7NL/252-remove-membership-video-due-to-copyright-expiry)

# Solution

We're going to replace it with the Scott Trust video, currently being used on the supporter landing page (UK version).

## Changes

- Remove old video from the Videos file, along with placeholder image.
- Replace video on homepage, along with corresponding text.
- Replace video on patterns page.

## Screenshots

**Before**:

![video-before](https://cloud.githubusercontent.com/assets/5131341/21727188/039e43b2-d438-11e6-984d-bee5124e6140.png)

**After**:

![video-after](https://cloud.githubusercontent.com/assets/5131341/21727192/087dba84-d438-11e6-9dc2-682e3c839894.png)

@rupertbates @svillafe @rtyley @JustinPinner 