### PR TITLE
Paypal email to zuora

### DIFF
--- a/frontend/app/controllers/PayPal.scala
+++ b/frontend/app/controllers/PayPal.scala
@@ -1,13 +1,8 @@
 package controllers
 
-import play.api.mvc.{Action, Controller}
-import play.api.mvc.Results.BadRequest
-import play.api.libs.json.{JsError, JsSuccess, Json}
-import okhttp3.{FormBody, OkHttpClient, Request, Response}
-import com.netaporter.uri.Uri.parseQuery
-import configuration.Config
 import com.typesafe.scalalogging.LazyLogging
-import play.api.Logger
+import play.api.libs.json.{JsError, JsSuccess, Json}
+import play.api.mvc.Controller
 import services.PayPalService
 
 object PayPal extends Controller with LazyLogging {
@@ -44,20 +39,20 @@ object PayPal extends Controller with LazyLogging {
 
 	}
 
-	// The endpoint corresponding to the Paypal return url, hit if the user is
+	// The endpoint corresponding to the PayPal return url, hit if the user is
 	// redirected and needs to come back.
 	def returnUrl = NoCacheAction {
 
-		logger.info("User hit the Paypal returnUrl.")
+		logger.info("User hit the PayPal returnUrl.")
 		Ok(views.html.paypal.errorPage())
 
 	}
 
-	// The endpoint corresponding to the Paypal cancel url, hit if the user is
+	// The endpoint corresponding to the PayPal cancel url, hit if the user is
 	// redirected and the payment fails.
 	def cancelUrl = NoCacheAction {
 
-		logger.error("User hit the Paypal cancelUrl, something went wrong.")
+		logger.error("User hit the PayPal cancelUrl, something went wrong.")
 		Ok(views.html.paypal.errorPage())
 
 	}

--- a/frontend/app/controllers/PayPal.scala
+++ b/frontend/app/controllers/PayPal.scala
@@ -14,8 +14,8 @@ object PayPal extends Controller with LazyLogging {
 	implicit val tokenWrites = Json.writes[Token]
 	implicit val tokenReads = Json.reads[Token]
 
-	// Retrieves a payment token from an NVP response, and wraps it in JSON for
-	// sending back to the client.
+	// Wraps the PayPal token and converts it to JSON
+  // for sending back to the client.
 	private def tokenJsonResponse (token : String) = {
 		Json.toJson(Token(token))
 	}

--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -109,7 +109,7 @@ class MemberService(identityService: IdentityService,
       ipAddress: Option[InetAddress],
       ipCountry: Option[Country]): Future[(ContactId, ZuoraSubName)] = {
 
-    def getIdentityUserDetails(): Future[IdUser] =
+    def getIdentityUserDetails: Future[IdUser] =
       identityService.getFullUserDetails(user)(identityRequest).andThen { case Failure(e) =>
         logger.error(s"Could not get Identity user details for user ${user.id}", e)
       }
@@ -130,9 +130,9 @@ class MemberService(identityService: IdentityService,
         identityService.updateUserFieldsBasedOnJoining(user, formData, identityRequest) // Update Identity user details in MongoDB
       }.andThen { case Failure(e) => logger.error(s"Could not update Identity for user ${user.id}", e) }
 
-    def createPaidZuoraSubscription(sfContact: ContactId, paid: PaidMemberJoinForm, email: String, stripeCustomer: Option[Customer]): Future[String] =
+    def createPaidZuoraSubscription(sfContact: ContactId, paid: PaidMemberJoinForm, email: String, payPalEmail: Option[String], stripeCustomer: Option[Customer]): Future[String] =
       (for {
-        zuoraSub <- createPaidSubscription(sfContact, paid, paid.name, paid.tier, stripeCustomer, campaignCode, email, ipAddress, ipCountry)
+        zuoraSub <- createPaidSubscription(sfContact, paid, paid.name, paid.tier, stripeCustomer, campaignCode, email, payPalEmail, ipAddress, ipCountry)
       } yield zuoraSub.subscriptionName).andThen {
         case Failure(e: PaymentGatewayError) => logger.warn(s"Could not create paid Zuora subscription due to payment gateway failure: ID=${user.id}", e)
         case Failure(e) => logger.error(s"Could not create paid Zuora subscription: ID=${user.id}", e)
@@ -158,10 +158,10 @@ class MemberService(identityService: IdentityService,
     formData match {
       case paid@PaidMemberJoinForm(_, _, PaymentForm(_, _, Some(baid)), _, _, _, _, _, _, _, _, _) => //Paid member with PayPal token
         for {
-          idUser <- getIdentityUserDetails()
+          idUser <- getIdentityUserDetails
           sfContact <- createSalesforceContact(idUser)
           email <- retrieveEmail(baid)
-          zuoraSubName <- createPaidZuoraSubscription(sfContact, paid, email, None)
+          zuoraSubName <- createPaidZuoraSubscription(sfContact, paid, idUser.primaryEmailAddress, Some(email), None)
           _ <- updateSalesforceContactWithMembership(None) // FIXME: This should go!
           _ <- updateIdentity()
         } yield (sfContact, zuoraSubName)
@@ -169,16 +169,16 @@ class MemberService(identityService: IdentityService,
       case paid@PaidMemberJoinForm(_, _, PaymentForm(_, Some(stripeToken), _), _, _, _, _, _, _, _, _, _) => //Paid member with Stripe token
         for {
           stripeCustomer <- createStripeCustomer(stripeToken)
-          idUser <- getIdentityUserDetails()
+          idUser <- getIdentityUserDetails
           sfContact <- createSalesforceContact(idUser)
-          zuoraSubName <- createPaidZuoraSubscription(sfContact, paid, idUser.primaryEmailAddress, Some(stripeCustomer))
+          zuoraSubName <- createPaidZuoraSubscription(sfContact, paid, idUser.primaryEmailAddress, None, Some(stripeCustomer))
           _ <- updateSalesforceContactWithMembership(Some(stripeCustomer)) // FIXME: This should go!
           _ <- updateIdentity()
         } yield (sfContact, zuoraSubName)
 
       case _ =>
         for {
-          idUser <- getIdentityUserDetails()
+          idUser <- getIdentityUserDetails
           sfContact <- createSalesforceContact(idUser)
           zuoraSubName <- createFreeZuoraSubscription(sfContact, formData, idUser.primaryEmailAddress)
           _ <- updateSalesforceContactWithMembership(None) // FIXME: This should go!
@@ -418,6 +418,7 @@ class MemberService(identityService: IdentityService,
                                       stripeCustomer: Option[Customer],
                                       campaignCode: Option[CampaignCode],
                                       email: String,
+                                      payPalEmail: Option[String],
                                       ipAddress: Option[InetAddress],
                                       ipCountry: Option[Country]): Future[SubscribeResult] = {
 
@@ -431,7 +432,7 @@ class MemberService(identityService: IdentityService,
 
 
       Subscribe(account = createAccount(contactId, currency, joinData.payment),
-        paymentMethod = createPaymentMethod(contactId, email, joinData.payment, stripeCustomer),
+        paymentMethod = createPaymentMethod(contactId, payPalEmail, joinData.payment, stripeCustomer),
         address = joinData.zuoraAccountAddress,
         email = email,
         ratePlans = NonEmptyList(plan),
@@ -453,13 +454,13 @@ class MemberService(identityService: IdentityService,
         Account.payPal(contactId, currency, autopay = true)
     }
 
-  private def createPaymentMethod(contactId: ContactId, email: String, paymentForm: PaymentForm, stripeCustomer: Option[Customer]) =
+  private def createPaymentMethod(contactId: ContactId, email: Option[String], paymentForm: PaymentForm, stripeCustomer: Option[Customer]) =
     paymentForm match {
       case PaymentForm(_, Some(stripeToken), _) =>
         val card = stripeCustomer.get.card
         CreditCardReferenceTransaction(card.id, stripeCustomer.get.id, card.last4, CountryGroup.countryByCode(card.country), card.exp_month, card.exp_year, card.`type`).some
       case PaymentForm(_, _, Some(payPalBaid)) =>
-        PayPalReferenceTransaction(payPalBaid, email).some
+        PayPalReferenceTransaction(payPalBaid, email.get).some
       case _ => None
     }
 

--- a/frontend/app/services/PayPalService.scala
+++ b/frontend/app/services/PayPalService.scala
@@ -37,8 +37,7 @@ object PayPalService extends LazyLogging {
   private def retrieveNVPParam(response: Response, paramName: String) = {
     val responseBody = response.body().string()
     val queryParams = parseQuery(responseBody)
-    val result = queryParams.paramMap(paramName).head
-    result
+    queryParams.paramMap(paramName).head
   }
 
   def retrieveEmail(baid: String) = {

--- a/frontend/app/services/PayPalService.scala
+++ b/frontend/app/services/PayPalService.scala
@@ -1,0 +1,83 @@
+package services
+
+import com.netaporter.uri.Uri.parseQuery
+import com.typesafe.scalalogging.LazyLogging
+import configuration.Config
+import controllers.{NoCacheAction, routes}
+import controllers.PayPal.{Ok, Token, logger}
+import okhttp3.{FormBody, OkHttpClient, Request, Response}
+import play.api.libs.json.Json
+import play.api.mvc.RequestHeader
+
+object PayPalService extends LazyLogging {
+
+  // The parameters sent with every NVP request.
+  private val defaultNVPParams = Map(
+    "USER" -> Config.paypalUser,
+    "PWD" -> Config.paypalPassword,
+    "SIGNATURE" -> Config.paypalSignature,
+    "VERSION" -> Config.paypalNVPVersion)
+
+  // Takes a series of parameters, send a request to PayPal, returns response.
+  private def nvpRequest(params: Map[String, String]) = {
+
+    val client = new OkHttpClient()
+    val reqBody = new FormBody.Builder()
+    for ((param, value) <- defaultNVPParams) reqBody.add(param, value)
+    for ((param, value) <- params) reqBody.add(param, value)
+
+    val request = new Request.Builder()
+      .url(Config.paypalUrl)
+      .post(reqBody.build())
+      .build()
+
+    client.newCall(request).execute()
+  }
+
+  // Takes an NVP response and retrieves a given parameter as a string.
+  private def retrieveNVPParam(response: Response, paramName: String) = {
+    val responseBody = response.body().string()
+    val queryParams = parseQuery(responseBody)
+    val result = queryParams.paramMap(paramName).head
+    response.close()
+    result
+  }
+
+  def retrieveEmail(baid: String) = {
+    val params = Map(
+      "METHOD" -> "BillAgreementUpdate",
+      "REFERENCEID" -> baid
+    )
+
+    val response = nvpRequest(params)
+    retrieveNVPParam(response, "EMAIL")
+  }
+
+  // Sets up a payment by contacting PayPal, returns the token as JSON.
+  def retrieveToken(request: RequestHeader) = {
+    logger.info("Called setupPayment")
+    val paymentParams = Map(
+      "METHOD" -> "SetExpressCheckout",
+      "PAYMENTREQUEST_0_PAYMENTACTION" -> "SALE",
+      "PAYMENTREQUEST_0_AMT" -> "4.50",
+      "PAYMENTREQUEST_0_CURRENCYCODE" -> "GBP",
+      "RETURNURL" -> routes.PayPal.returnUrl().absoluteURL(secure = true)(request),
+      "CANCELURL" -> routes.PayPal.cancelUrl().absoluteURL(secure = true)(request),
+      "BILLINGTYPE" -> "MerchantInitiatedBilling")
+
+    val response = nvpRequest(paymentParams)
+    retrieveNVPParam(response, "TOKEN")
+  }
+
+  // Sends a request to PayPal to create billing agreement and returns BAID.
+  def retrieveBaid(token: Token) = {
+    logger.info("Called retrieveBaid")
+    val agreementParams = Map(
+      "METHOD" -> "CreateBillingAgreement",
+      "TOKEN" -> token.token)
+
+    val response = nvpRequest(agreementParams)
+    retrieveNVPParam(response, "BILLINGAGREEMENTID")
+  }
+
+}

--- a/frontend/app/services/PayPalService.scala
+++ b/frontend/app/services/PayPalService.scala
@@ -3,10 +3,9 @@ package services
 import com.netaporter.uri.Uri.parseQuery
 import com.typesafe.scalalogging.LazyLogging
 import configuration.Config
-import controllers.{NoCacheAction, routes}
-import controllers.PayPal.{Ok, Token, logger}
+import controllers.PayPal.Token
+import controllers.routes
 import okhttp3.{FormBody, OkHttpClient, Request, Response}
-import play.api.libs.json.Json
 import play.api.mvc.RequestHeader
 
 object PayPalService extends LazyLogging {

--- a/frontend/app/services/PayPalService.scala
+++ b/frontend/app/services/PayPalService.scala
@@ -52,7 +52,7 @@ object PayPalService extends LazyLogging {
     retrieveNVPParam(response, "EMAIL")
   }
 
-  // Sets up a payment by contacting PayPal, returns the token as JSON.
+  // Sets up a payment by contacting PayPal and returns the token.
   def retrieveToken(request: RequestHeader) = {
     logger.info("Called setupPayment")
     val paymentParams = Map(

--- a/frontend/app/services/PayPalService.scala
+++ b/frontend/app/services/PayPalService.scala
@@ -38,7 +38,6 @@ object PayPalService extends LazyLogging {
     val responseBody = response.body().string()
     val queryParams = parseQuery(responseBody)
     val result = queryParams.paramMap(paramName).head
-    response.close()
     result
   }
 

--- a/frontend/app/services/api/MemberService.scala
+++ b/frontend/app/services/api/MemberService.scala
@@ -82,6 +82,7 @@ trait MemberService {
                              stripeCustomer: Option[Customer],
                              campaignCode: Option[CampaignCode],
                              email: String,
+                             payPalEmail: Option[String],
                              ipAddress: Option[InetAddress],
                              ipCountry: Option[Country]): Future[SubscribeResult]
 


### PR DESCRIPTION
## Why are you doing this?
For PayPal users we need to store the email address they use to log in to PayPal as well as the email they have registered with Identity.

This is specifically for if a payment fails when an email will be sent out (to the Identity email address) with the PayPal email address in it.

## Trello card: [Here](https://trello.com/c/VjstsGBH/253-pass-paypal-address-into-zuora)

## Changes
* Refactored the PayPal controller into a controller and a service class
* Added a method in the PayPalService to retrieve the users PayPal email
* Pass in the PayPal email address when creating the users payment method in Zuora

## Screenshots
NA

