### PR TITLE
Hide Address From PayPal Checkout

### DIFF
--- a/frontend/app/services/PayPalService.scala
+++ b/frontend/app/services/PayPalService.scala
@@ -62,7 +62,8 @@ object PayPalService extends LazyLogging {
       "PAYMENTREQUEST_0_CURRENCYCODE" -> "GBP",
       "RETURNURL" -> routes.PayPal.returnUrl().absoluteURL(secure = true)(request),
       "CANCELURL" -> routes.PayPal.cancelUrl().absoluteURL(secure = true)(request),
-      "BILLINGTYPE" -> "MerchantInitiatedBilling")
+      "BILLINGTYPE" -> "MerchantInitiatedBilling",
+      "NOSHIPPING" -> "1")
 
     val response = nvpRequest(paymentParams)
     retrieveNVPParam(response, "TOKEN")


### PR DESCRIPTION
## Why are you doing this?

We don't want the address to appear in the PayPal checkout screen, as we're handling it separately in our checkout. This NVP parameter hides it from the user.

**Trello Card**: [Here](https://trello.com/c/ZsaDUGFo)

## Changes

- Add NVP param to hide address in PayPal checkout.

## Screenshots

**Note**: Ignore the fact that one is a window and the other is an overlay, that's just the PayPal sandbox being flaky.

**Before**:

![paypal-address-before](https://cloud.githubusercontent.com/assets/5131341/21773449/0da8be5e-d687-11e6-8558-1f4559f82011.png)

**After**:

![paypal-address-after](https://cloud.githubusercontent.com/assets/5131341/21773452/129aeb8a-d687-11e6-8a65-f222c0782313.png)

@rupertbates @rtyley @svillafe @JustinPinner 