### PR TITLE
Make paypal checkout blue

### DIFF
--- a/frontend/app/views/fragments/form/cardDetailPayPal.scala.html
+++ b/frontend/app/views/fragments/form/cardDetailPayPal.scala.html
@@ -34,6 +34,9 @@
                 <h3 class="credit-card-note__header">Cancellation</h3>
                 <p>You can cancel your membership online through your profile page.</p>
             </div>
+            <div class="credit-card-note">
+                <h3 class="credit-card-note__header"><a class="js-change-payment-method" href="#">Change payment method</a></h3>
+            </div>
         </div>
     </div>
 
@@ -167,7 +170,7 @@
                 <h3 class="credit-card-note__header">First payment</h3>
                 <p class="credit-card-note__text">will be taken today under the name Guardian News & Media.</p>
             </div>
-            <div class="bottom-credit-card-description--note js-ongoing-card-payments"">
+            <div class="bottom-credit-card-description--note js-ongoing-card-payments">
                 <script type="text/javascript">
                     guardian.membership.checkoutForm.ongoingCardPayments = {
                         annual: '@Dates.dayInMonthWithSuffixAndMonth()',

--- a/frontend/app/views/fragments/form/cardDetailPayPal.scala.html
+++ b/frontend/app/views/fragments/form/cardDetailPayPal.scala.html
@@ -182,6 +182,9 @@
                 <h3 class="credit-card-note__header">Cancellation</h3>
                 <p class="credit-card-note__text">You can cancel your membership online through your profile page.</p>
             </div>
+            <div class="bottom-credit-card-description">
+                <h3 class="credit-card-note__header"><a class="js-change-payment-method" href="#">Change payment method</a></h3>
+            </div>
         </div>
 
     </div>

--- a/frontend/app/views/fragments/form/cardDetailPayPal.scala.html
+++ b/frontend/app/views/fragments/form/cardDetailPayPal.scala.html
@@ -5,8 +5,7 @@
 @import com.gu.memsub.subsv2.MonthYearPlans
 @(
     plans: MonthYearPlans[PaidMember],
-    cardOpt: Option[com.gu.stripe.Stripe.Card] = None,
-    variantA : Boolean = true
+    cardOpt: Option[com.gu.stripe.Stripe.Card] = None
 )
 
 @import views.support.Pricing._
@@ -15,8 +14,7 @@
 <fieldset class="fieldset js-checkout-card-fields is-hidden">
 
     <div class="fieldset__heading">
-        <h2 class="fieldset__headline">Payment method</h2>
-        <a class="js-change-payment-method" href="#">Change</a>
+        <h2 class="fieldset__headline">Card details</h2>
         <div class="fieldset__note js-card-details-note">
             @fragments.form.securityNote()
 
@@ -52,9 +50,9 @@
                             <li class="u-align-middle o-inline-list__item">
                                 We accept
                             </li>
-                            @if(!variantA){
-                                <br>
-                            }
+
+                            <br>
+
                             <li class="u-align-middle o-inline-list__item">
                                 <i class="sprite-card sprite-card--small sprite-card--visa"></i>
                             </li>
@@ -164,26 +162,24 @@
             </div>
         }
 
-
-        @if(!variantA){
-            <div class="bottom-credit-card-description">
-                <div class="bottom-credit-card-description--note">
-                    <h3 class="credit-card-note__header">First payment</h3>
-                    <p class="credit-card-note__text">will be taken today under the name Guardian News & Media.</p>
-                </div>
-                <div class="bottom-credit-card-description--note js-ongoing-card-payments">
-                    <script type="text/javascript">
-                        guardian.membership.checkoutForm.ongoingCardPayments = {
-                            annual: '@Dates.dayInMonthWithSuffixAndMonth()',
-                            monthly: '@Dates.dayInMonthWithSuffix()'
-                        };
-                    </script>
-                </div>
-                <div class="bottom-credit-card-description--note">
-                    <h3 class="credit-card-note__header">Cancellation</h3>
-                    <p class="credit-card-note__text">You can cancel your membership online through your profile page.</p>
-                </div>
+        <div class="bottom-credit-card-description">
+            <div class="bottom-credit-card-description--note">
+                <h3 class="credit-card-note__header">First payment</h3>
+                <p class="credit-card-note__text">will be taken today under the name Guardian News & Media.</p>
             </div>
-        }
+            <div class="bottom-credit-card-description--note js-ongoing-card-payments"">
+                <script type="text/javascript">
+                    guardian.membership.checkoutForm.ongoingCardPayments = {
+                        annual: '@Dates.dayInMonthWithSuffixAndMonth()',
+                        monthly: '@Dates.dayInMonthWithSuffix()'
+                    };
+                </script>
+            </div>
+            <div class="bottom-credit-card-description--note">
+                <h3 class="credit-card-note__header">Cancellation</h3>
+                <p class="credit-card-note__text">You can cancel your membership online through your profile page.</p>
+            </div>
+        </div>
+
     </div>
 </fieldset>

--- a/frontend/app/views/joiner/form/paymentPayPal.scala.html
+++ b/frontend/app/views/joiner/form/paymentPayPal.scala.html
@@ -109,7 +109,7 @@
                                 @fragments.form.securityNote()
                             </div>
                             <div class="fieldset__fields">
-                                <button type="button" class="action">Credit/Debit Card</button>
+                                <button type="button" class="action js-card-payment-method">Credit/Debit Card</button>
                                 <div id="paypal-button-checkout"></div>
                             </div>
                         </fieldset>

--- a/frontend/app/views/joiner/form/paymentPayPal.scala.html
+++ b/frontend/app/views/joiner/form/paymentPayPal.scala.html
@@ -7,19 +7,25 @@
 @import views.support.DisplayText._
 @import views.support.MembershipCompat._
 @import views.support.{CountryWithCurrency, IdentityUser, PageInfo, PaidPlans}
+@import tracking.AppnexusPixel
+
 
 @(plans: MonthYearPlans[PaidMember],
-  countriesWithCurrencies: List[CountryWithCurrency],
-  idUser: IdentityUser,
-  pageInfo: PageInfo,
-  trackingPromoCode: Option[PromoCode],
-  promoCodeToDisplay: Option[PromoCode],
-  countryGroup: Option[CountryGroup]
-)(implicit token: play.filters.csrf.CSRF.Token, request: actions.AuthRequest[_])
+    countriesWithCurrencies: List[CountryWithCurrency],
+    idUser: IdentityUser,
+    pageInfo: PageInfo,
+    trackingPromoCode: Option[PromoCode],
+    promoCodeToDisplay: Option[PromoCode],
+    countryGroup: Option[CountryGroup]
+    )(implicit token: play.filters.csrf.CSRF.Token, request: actions.AuthRequest[_])
 
 @main(plans.tier.cta, pageInfo=pageInfo, simpleHeader=true) {
 
-    <main class="page-content l-constrained">
+    <main class="page-content skin-checkout-b">
+
+        <!-- Segment Pixel - Jan17 - Become a supporter - DO NOT MODIFY -->
+            <img src="https://secure.adnxs.com/px?add=@{AppnexusPixel.checkoutPageids(plans.tier)}&t=2" width="1" height="1" />
+        <!-- End of Segment Pixel -->
 
         <form action="@routes.Joiner.joinPaid(plans.tier)" method="POST" id="payment-form" class="js-form" novalidate>
             @CSRF.formField
@@ -29,32 +35,36 @@
                 <h1 class="form-headline">@plans.tier.cta</h1>
             </section>
 
+
             <section class="form-section form-section--no-padding">
                 <div class="form-section__content">
                 @fragments.form.errorMessageDisplay()
                 </div>
             </section>
 
-            <section class="form-section">
-
-                <div class="form-section__lead-in sign-in-required">
-                    @fragments.joiner.signedInAs(request.uri, inline = false)
-                </div>
+            <section class="form-section form-section--no-padding">
 
                 <div class="form-section__content">
                     @if(plans.tier != Supporter()){
-                    <div class="form-group">
-                        @fragments.form.benefitsFieldset(plans.tier.benefits)
-                        @fragments.form.featureChoiceFieldset(plans.tier)
-                    </div>}
-                    <div class="form-group">
-                        <h2 class="form-group__title">Address</h2>
+                        <div class="form-group">
+                            @fragments.form.benefitsFieldset(plans.tier.benefits)
+                            @fragments.form.featureChoiceFieldset(plans.tier)
+                        </div>}
 
-                        @fragments.form.nameDetail(idUser.privateFields.firstName, idUser.privateFields.secondName, heading = "Name")
+                    <div class="form-group sub-heading">
+                        <h2 class="form-group__title">Name and address</h2>
+
+                        <div class="form-section__lead-in sign-in-required">
+                        @fragments.joiner.signedInAs(request.uri, inline = true)
+                        </div>
+
+                        <div class="form-section__name-detail">
+                        @fragments.form.nameDetail(idUser.privateFields.firstName, idUser.privateFields.secondName, heading = "")
+                        </div>
                         @fragments.form.addressDetail(
                             countriesWithCurrencies = countriesWithCurrencies,
                             heading = "Delivery address",
-                            note = "Once you've joined Guardian Members we'll send you a welcome pack in the post.",
+                            note = "We need your address to send you a welcome pack.",
                             formType = "deliveryAddress",
                             addressRequired = true,
                             address1 = idUser.privateFields.address1,
@@ -70,42 +80,44 @@
                         }
                     </div>
 
-                    @if(plans.tier != Supporter()){
-                        <div class="form-group">
+                    @if(plans.tier != Supporter()) {
+                        <div class="form-group form-section__promotion">
                             <h2 class="form-group__title">Promotion</h2>
                             @fragments.form.promoCode(trackingPromoCode, promoCodeToDisplay)
                         </div>
                     }
 
-                    <div class="form-group">
-                        <h2 class="form-group__title">Billing</h2>
-                        @fragments.form.billingAddress("Billing address")
-                        @fragments.form.addressDetail(
-                            countriesWithCurrencies = countriesWithCurrencies,
-                            formType = "billingAddress",
-                            addressRequired = true,
-                            address1 = idUser.privateFields.billingAddress1,
-                            address2 = idUser.privateFields.billingAddress2,
-                            town = idUser.privateFields.billingAddress3,
-                            postcode = idUser.privateFields.billingPostcode,
-                            county = idUser.privateFields.billingAddress4
-                        )
+                    <div class="form-group form-group--little-padding">
+                        <div class="form-section__billing">
+                            <h2 class="form-group__title">Billing</h2>
+                            @fragments.form.billingAddress("Billing address")
+                            @fragments.form.addressDetail(
+                                countriesWithCurrencies = countriesWithCurrencies,
+                                formType = "billingAddress",
+                                addressRequired = true,
+                                address1 = idUser.privateFields.billingAddress1,
+                                address2 = idUser.privateFields.billingAddress2,
+                                town = idUser.privateFields.billingAddress3,
+                                postcode = idUser.privateFields.billingPostcode,
+                                county = idUser.privateFields.billingAddress4
+                            )
+                        </div>
                         @fragments.form.paymentOptions(plans)
-                        <fieldset class="fieldset js-payment-methods">
+                        <fieldset class="fieldset js-payment-methods actions">
                             <div class="fieldset__heading">
                                 <h2 class="fieldset__headline">Payment method</h2>
                                 @fragments.form.securityNote()
                             </div>
                             <div class="fieldset__fields">
-                                <button type="button" class="action js-card-payment-method">Credit/Debit Card</button>
+                                <button type="button" class="action">Credit/Debit Card</button>
                                 <div id="paypal-button-checkout"></div>
                             </div>
                         </fieldset>
                         @fragments.form.cardDetailPayPal(plans)
                     </div>
-
+                    @fragments.form.terms(countryGroup)
                     @fragments.form.errorMessageDisplay()
-                    @fragments.form.submitPayPal(PaidPlans(plans), countryGroup = countryGroup, dataCategory = Some("checkout page"), dataLabel = Some("payment a-annual"))
+                    @fragments.form.submitPayPal(PaidPlans(plans), membershipTermsAndConditions = false, countryGroup = countryGroup, dataCategory = Some("checkout page"), dataLabel = Some("payment a-annual"))
                 </div>
             </section>
         </form>

--- a/frontend/app/views/joiner/form/paymentPayPal.scala.html
+++ b/frontend/app/views/joiner/form/paymentPayPal.scala.html
@@ -109,7 +109,7 @@
                                 @fragments.form.securityNote()
                             </div>
                             <div class="fieldset__fields">
-                                <button type="button" class="action js-card-payment-method">Credit/Debit Card</button>
+                                <button type="button" class="action choose-payment-method js-card-payment-method">Credit/Debit Card</button>
                                 <div id="paypal-button-checkout"></div>
                             </div>
                         </fieldset>

--- a/frontend/assets/stylesheets/components/_payment-b.scss
+++ b/frontend/assets/stylesheets/components/_payment-b.scss
@@ -161,6 +161,11 @@
       @include mq($from: tablet) {
         display: none;
       }
+      a {
+          color: guss-colour(guardian-brand);
+          display: block;
+          margin-top: 10px;
+      }
     }
 
     .credit-card-note__text {

--- a/frontend/assets/stylesheets/components/_payment-b.scss
+++ b/frontend/assets/stylesheets/components/_payment-b.scss
@@ -220,6 +220,23 @@
             }
         }
 
+        button.choose-payment-method {
+            height: 40px;
+            width: 227px;
+            background: none;
+            background-color : guss-colour(guardian-brand);
+            border-color : guss-colour(guardian-brand);
+            font-size: 16px;
+            padding: 0;
+            text-align: center;
+            margin-bottom: 6px;
+            margin-top: 6px;
+        }
+
+        button.choose-payment-method::after {
+            display: none;
+        }
+
         span {
             width: 90%;
             display: block;

--- a/frontend/assets/stylesheets/components/_payment-b.scss
+++ b/frontend/assets/stylesheets/components/_payment-b.scss
@@ -173,6 +173,12 @@
       @include mq($from: tablet) {
         display: block;
       }
+
+      a {
+        color: guss-colour(guardian-brand);
+        display: block;
+        margin-top: 10px;
+      }
     }
 
     .promo-code {


### PR DESCRIPTION
## Why are you doing this?
The PayPal checkout flow is currently using the old styling whereas the standard flow has been updated to a lovely blue colour.

This PR makes them look the same.

## Trello card: [Here](https://trello.com/c/yTFB78cu/264-switch-paypal-checkout-page-to-new-blue-design)

## Changes
* Copy all the styling changes across the standard flow to the PayPal flow

## Screenshots
Before:
<img width="740" alt="screen shot 2017-01-10 at 15 27 32" src="https://cloud.githubusercontent.com/assets/181371/21811967/640107e4-d749-11e6-9b48-75318cdf92c6.png">
After:
<img width="716" alt="screen shot 2017-01-12 at 16 05 08" src="https://cloud.githubusercontent.com/assets/181371/21897259/f786d8ac-d8e0-11e6-8148-86383a893f77.png">
