### PR TITLE
Add salesforce auth to healthcheck

### DIFF
--- a/frontend/app/controllers/Healthcheck.scala
+++ b/frontend/app/controllers/Healthcheck.scala
@@ -23,7 +23,8 @@ object Healthcheck extends Controller {
     new BoolTest("Events", () => GuardianLiveEventService.events.nonEmpty),
     new BoolTest("CloudWatch", () => CloudWatchHealth.hasPushedMetricSuccessfully),
     new BoolTest("ZuoraPing", () => zuoraSoapClient.lastPingTimeWithin(2.minutes)),
-    new BoolTest("Promotions", () => promos.all.nonEmpty)
+    new BoolTest("Promotions", () => promos.all.nonEmpty),
+    new BoolTest("Salesforce", () => salesforceService.isAuthenticated)
   )
 
   def healthcheck() = Action {

--- a/frontend/app/services/SalesforceService.scala
+++ b/frontend/app/services/SalesforceService.scala
@@ -40,6 +40,8 @@ class SalesforceService(salesforceConfig: SalesforceConfig) extends api.Salesfor
   override def updateMemberStatus(user: IdMinimalUser, tier: Tier, customer: Option[Customer]): Future[ContactId] =
     upsert(user.id, memberData(tier, customer))
 
+  override def isAuthenticated = repository.salesforce.isAuthenticated
+
   private def memberData(tier: Tier, customerOpt: Option[Customer]): JsObject = Json.obj(
     Keys.TIER -> tier.name
   ) ++ customerOpt.map { customer =>

--- a/frontend/app/services/api/SalesforceService.scala
+++ b/frontend/app/services/api/SalesforceService.scala
@@ -15,4 +15,5 @@ trait SalesforceService {
   def metrics: MemberMetrics
   def upsert(user: IdUser, userData: JoinForm): Future[ContactId]
   def updateMemberStatus(user: IdMinimalUser, tier: Tier, customer: Option[Customer]): Future[ContactId]
+  def isAuthenticated: Boolean
 }

--- a/frontend/test/services/DestinationServiceTest.scala
+++ b/frontend/test/services/DestinationServiceTest.scala
@@ -48,7 +48,8 @@ class DestinationServiceTest extends Specification {
           charges = partnerCharge,
           chargedThrough = None, start = new LocalDate("2015-01-01"), end = new LocalDate("2099-01-01"), productName = "")),
         hasPendingFreePlan = false,
-        readerType = ReaderType.Direct
+        readerType = ReaderType.Direct,
+        autoRenew = true
       )
 
       val testSubscriber: Subscriber.Member = Subscriber(testSub, testMember)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "7.2.3"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.7"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.328"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.340"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "7.2.3"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.7"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.340"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.344"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache


### PR DESCRIPTION
See: https://github.com/guardian/membership-common/pull/399/

Subs was getting a weird 500 error due to Salesforce auth not being present for the first few requests on startup. Looking into it: (I think)
1) a request that requires salesforce arrives
2) scalaforce is initialised and blocks req 1 until authentication completes
3) a second request that makes a salesforce request arrives while 1 is authenticating
4) nothing is in the authentication agent and a 500 is thrown.

I've not checked for this in membership, but it looks feasible. Fixing it for subscriptions required a breaking change to membership-common; so I've fixed it here too.

This will slightly change startup behaviour in that any salesforce requests before authentication completes will fail, rather than the first request blocking. 