### PR TITLE
Added billingPeriod re rendering when the country is selected

### DIFF
--- a/frontend/assets/javascripts/src/modules/form/options.js
+++ b/frontend/assets/javascripts/src/modules/form/options.js
@@ -1,10 +1,12 @@
 define([
     '$',
     'bean',
+    'src/modules/form/billingPeriodChoice',
     'src/modules/form/validation/display'
 ], function (
     $,
     bean,
+    billingPeriodChoice,
     validationDisplay
 ) {
     'use strict';
@@ -28,6 +30,7 @@ define([
      */
 
     function renderPrices() {
+        billingPeriodChoice.render();
         hideBillingAddress();
         selectDeliveryCountry();
     }


### PR DESCRIPTION
## Why are you doing this?
There was a bug introduced in https://github.com/guardian/membership-frontend/pull/1387. The bug took place because the promo code was bound and updated that price. When we removed the promo code, that event was not being bound anymore.


Please @paulbrown1982 @rtyley review this change.

