### PR TITLE
Add currency check to acceptance test

### DIFF
--- a/frontend/assets/javascripts/src/templates/checkout/billingPeriodChoice.html
+++ b/frontend/assets/javascripts/src/templates/checkout/billingPeriodChoice.html
@@ -8,7 +8,7 @@
                <% if (guardian.membership.checkoutForm.billingPeriod === choice.inputValue) { %>checked="checked"<% } %>
         />
         <div  id="<%= choice.productRatePlanId %>" class="pseudo-radio <%= choice.classes.join(' ') %>">
-            <div class="pseudo-radio__header">Pay <%= choice.generateDisplayAmount() %></div>
+            <div class="pseudo-radio__header" id="qa-currency-radio">Pay <%= choice.generateDisplayAmount() %></div>
             <% choice.generateNotes().forEach(function(note) { %>
                 <div class="pseudo-radio__note"><%= note %></div>
             <% }); %>

--- a/frontend/build.sbt
+++ b/frontend/build.sbt
@@ -109,4 +109,4 @@ libraryDependencies ++= acceptanceTestDependencies
 
 addCommandAlias("fast-test", "testOnly -- -l Acceptance")
 
-addCommandAlias("acceptance-test", "testOnly acceptance.JoinPartnerSpec")
+addCommandAlias("acceptance-test", "testOnly acceptance.JoinSupporterSpec")

--- a/frontend/test/acceptance/JoinPartnerSpec.scala
+++ b/frontend/test/acceptance/JoinPartnerSpec.scala
@@ -59,6 +59,12 @@ class JoinPartnerSpec extends FeatureSpec with Browser
       And("should be logged in with their Identity account.")
       assert(enterDetails.userIsSignedIn)
 
+      When("users select non-UK country,")
+      enterDetails.changeCountry()
+
+      Then("the currency should change.")
+      assert(enterDetails.currencyHasChanged)
+
       When("Users fill in delivery address details,")
       enterDetails.fillInDeliveryAddress()
 
@@ -72,7 +78,7 @@ class JoinPartnerSpec extends FeatureSpec with Browser
       assert(ThankYou.pageHasLoaded)
 
       And("should be signed in as Partner.")
-      assert(ThankYou.userIsSignedInAsPartner)
+      assert(ThankYou.userIsSignedInAsSupporter)
     }
   }
 }

--- a/frontend/test/acceptance/JoinSupporterSpec.scala
+++ b/frontend/test/acceptance/JoinSupporterSpec.scala
@@ -5,7 +5,7 @@ import acceptance.util._
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfter, FeatureSpec, GivenWhenThen}
 import org.slf4j.LoggerFactory
 
-class JoinPartnerSpec extends FeatureSpec with Browser
+class JoinSupporterSpec extends FeatureSpec with Browser
   with GivenWhenThen with BeforeAndAfter with BeforeAndAfterAll  {
 
   def logger = LoggerFactory.getLogger(this.getClass)
@@ -29,13 +29,13 @@ class JoinPartnerSpec extends FeatureSpec with Browser
         "\nPlease run identity-frontend server before running tests.")
   }
 
-  feature("Become a Partner in UK") {
-    scenario("User joins as Partner by clicking 'Become a Partner' button on Membership homepage", Acceptance) {
+  feature("Become a Supporter in UK") {
+    scenario("User joins as Supporter by clicking 'Become a Supporter' button on Membership homepage", Acceptance) {
       checkDependenciesAreAvailable
 
       val testUser = new TestUser
 
-      Given("users click 'Become a Partner' button on Membership homepage")
+      Given("users click 'Become a Supporter' button on Membership homepage")
 
       When("they land on 'Identity Frontend' page,")
       val register = pages.Register(testUser)
@@ -59,8 +59,8 @@ class JoinPartnerSpec extends FeatureSpec with Browser
       And("should be logged in with their Identity account.")
       assert(enterDetails.userIsSignedIn)
 
-      When("users select non-UK country,")
-      enterDetails.changeCountry()
+      When("users select USA delivery country,")
+      enterDetails.changeCountryToUSA()
 
       Then("the currency should change.")
       assert(enterDetails.currencyHasChanged)
@@ -77,7 +77,7 @@ class JoinPartnerSpec extends FeatureSpec with Browser
       Then("they should land on 'Thank You' page,")
       assert(ThankYou.pageHasLoaded)
 
-      And("should be signed in as Partner.")
+      And("should be signed in as Supporter.")
       assert(ThankYou.userIsSignedInAsSupporter)
     }
   }

--- a/frontend/test/acceptance/JoinSupporterSpec.scala
+++ b/frontend/test/acceptance/JoinSupporterSpec.scala
@@ -60,7 +60,7 @@ class JoinSupporterSpec extends FeatureSpec with Browser
       assert(enterDetails.userIsSignedIn)
 
       When("users select USA delivery country,")
-      enterDetails.changeCountryToUSA()
+      enterDetails.changeCountry("US")
 
       Then("the currency should change.")
       assert(enterDetails.currencyHasChanged)

--- a/frontend/test/acceptance/pages/EnterDetails.scala
+++ b/frontend/test/acceptance/pages/EnterDetails.scala
@@ -25,7 +25,7 @@ case class EnterDetails(val testUser: TestUser) extends Page with Browser {
 
   def fillInCardDeclinedProcessError() { CreditCard.fillInCardDeclinedProcessError() }
 
-  def changeCountry() { DeliveryAddress.selectUSA() }
+  def changeCountryToUSA() { DeliveryAddress.selectUSA() }
 
   def currencyHasChanged(): Boolean = elementHasText(currency, "US$")
 

--- a/frontend/test/acceptance/pages/EnterDetails.scala
+++ b/frontend/test/acceptance/pages/EnterDetails.scala
@@ -5,7 +5,7 @@ import Config.baseUrl
 import org.scalatest.selenium.Page
 
 case class EnterDetails(val testUser: TestUser) extends Page with Browser {
-  val url = s"$baseUrl/join/partner/enter-details"
+  val url = s"$baseUrl/join/supporter/enter-details"
 
   def pageHasLoaded: Boolean = pageHasElement(id("cc-cvc"))
 
@@ -25,6 +25,10 @@ case class EnterDetails(val testUser: TestUser) extends Page with Browser {
 
   def fillInCardDeclinedProcessError() { CreditCard.fillInCardDeclinedProcessError() }
 
+  def changeCountry() { DeliveryAddress.selectUSA() }
+
+  def currencyHasChanged(): Boolean = elementHasText(currency, "US$")
+
   def pay() { clickOn(payButton) }
 
   private object DeliveryAddress {
@@ -39,6 +43,8 @@ case class EnterDetails(val testUser: TestUser) extends Page with Browser {
       setValue(town, "London")
       setValue(postCode, "N1 9GU")
     }
+
+    def selectUSA() { setSingleSelectionValue(country, "US") }
   }
 
   private object CreditCard {
@@ -77,4 +83,6 @@ case class EnterDetails(val testUser: TestUser) extends Page with Browser {
   private val userDisplayName = cssSelector(".js-user-displayname")
 
   private val payButton = className("js-submit-input")
+
+  private val currency = id("qa-currency-radio")
 }

--- a/frontend/test/acceptance/pages/EnterDetails.scala
+++ b/frontend/test/acceptance/pages/EnterDetails.scala
@@ -25,7 +25,7 @@ case class EnterDetails(val testUser: TestUser) extends Page with Browser {
 
   def fillInCardDeclinedProcessError() { CreditCard.fillInCardDeclinedProcessError() }
 
-  def changeCountryToUSA() { DeliveryAddress.selectUSA() }
+  def changeCountry(country: String) { DeliveryAddress.selectCountryCode(country) }
 
   def currencyHasChanged(): Boolean = elementHasText(currency, "US$")
 
@@ -44,7 +44,7 @@ case class EnterDetails(val testUser: TestUser) extends Page with Browser {
       setValue(postCode, "N1 9GU")
     }
 
-    def selectUSA() { setSingleSelectionValue(country, "US") }
+    def selectCountryCode(countryCode:  String) { setSingleSelectionValue(country, countryCode) }
   }
 
   private object CreditCard {

--- a/frontend/test/acceptance/pages/Register.scala
+++ b/frontend/test/acceptance/pages/Register.scala
@@ -6,7 +6,7 @@ import org.scalatest.selenium.Page
 import java.net.URLEncoder
 
 case class Register(testUser: TestUser) extends Page with Browser {
-  private val returnUrlParam = URLEncoder.encode(s"${baseUrl}/join/partner/enter-details", "UTF-8")
+  private val returnUrlParam = URLEncoder.encode(s"${baseUrl}/join/supporter/enter-details", "UTF-8")
   val url = s"${identityFrontendUrl}/register?returnUrl=${returnUrlParam}&skipConfirmation=true&clientId=members"
 
   def fillInPersonalDetails() { RegisterFields.fillIn() }

--- a/frontend/test/acceptance/pages/ThankYou.scala
+++ b/frontend/test/acceptance/pages/ThankYou.scala
@@ -4,9 +4,9 @@ import acceptance.util.{Config, Browser}
 import org.scalatest.selenium.Page
 
 object ThankYou extends Page with Browser {
-  val url = s"${Config.baseUrl}/join/partner/thankyou"
+  val url = s"${Config.baseUrl}/join/supporter/thankyou"
 
-  def userIsSignedInAsPartner: Boolean = elementHasText(cssSelector(".js-user-tier"), "Partner")
+  def userIsSignedInAsSupporter: Boolean = elementHasText(cssSelector(".js-user-tier"), "Supporter")
 
-  def pageHasLoaded: Boolean = (pageHasElement(id("qa-joiner-summary-tier")) && pageHasUrl("join/partner/thankyou"))
+  def pageHasLoaded: Boolean = (pageHasElement(id("qa-joiner-summary-tier")) && pageHasUrl("join/supporter/thankyou"))
 }


### PR DESCRIPTION
# Why are you doing this?
In order to avoid the same type of bug in the future (https://github.com/guardian/membership-frontend/pull/1434), we added an extra check in the membership frontend's acceptance test.

# Changes
* Check currency can change to non-UK currency
* Switch to Supporter flow from Partner flow