### PR TITLE
Revert "Track incomplete supporter checkouts"

### DIFF
--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -128,10 +128,6 @@ object Joiner extends Controller with ActivityTracking
     (for {
       identityUser <- identityService.getIdentityUserView(request.user, identityRequest)
     } yield {
-      tier match {
-        case t: Tier.Supporter => MembersDataAPI.Service.addBehaviour(request.user, "enterPaidDetails.show")
-        case _ =>
-      }
       val plans = catalog.findPaid(tier)
       val supportedCurrencies = plans.allPricing.map(_.currency).toSet
       val pageInfo = PageInfo(
@@ -293,20 +289,14 @@ object Joiner extends Controller with ActivityTracking
       validPromotion = promotion.flatMap(_.validateFor(prpId, country).map(_ => promotion).toOption.flatten)
       destination <- request.touchpointBackend.destinationService.returnDestinationFor(request.session, request.subscriber)
       card <- paymentCard
-    } yield {
-      tier match {
-        case t: Tier.Supporter if !upgrade => MembersDataAPI.Service.removeBehaviour(request)
-        case _ =>
-      }
-      Ok(views.html.joiner.thankyou(
-        request.subscriber,
-        paymentSummary,
-        card,
-        destination,
-        upgrade,
-        validPromotion.filterNot(_.asTracking.isDefined)
-      )).discardingCookies(TierChangeCookies.deletionCookies: _*)
-    }
+    } yield Ok(views.html.joiner.thankyou(
+      request.subscriber,
+      paymentSummary,
+      card,
+      destination,
+      upgrade,
+      validPromotion.filterNot(_.asTracking.isDefined)
+    )).discardingCookies(TierChangeCookies.deletionCookies: _*)
   }
 
   def thankyouStaff = thankyou(Tier.partner)

--- a/frontend/app/services/MembersDataAPI.scala
+++ b/frontend/app/services/MembersDataAPI.scala
@@ -1,7 +1,7 @@
 package services
 
 import actions.ActionRefiners.SubReqWithSub
-import com.gu.identity.play.{AuthenticatedIdUser, AccessCredentials}
+import com.gu.identity.play.AccessCredentials
 import com.gu.memsub.Subscriber.Member
 import com.gu.memsub.util.WebServiceHelper
 import com.gu.okhttp.RequestRunners
@@ -10,8 +10,6 @@ import com.gu.salesforce.Tier
 import configuration.Config
 import monitoring.MembersDataAPIMetrics
 import okhttp3.Request
-import org.joda.time.DateTime
-import org.joda.time.format.ISODateTimeFormat
 import play.api.Logger
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.functional.syntax._
@@ -19,8 +17,10 @@ import play.api.libs.json.Reads._
 import play.api.libs.json._
 import play.api.mvc.Cookie
 import views.support.MembershipCompat._
+
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
+
 
 object MembersDataAPI {
   implicit val tierReads = Reads[Tier] {
@@ -34,7 +34,6 @@ object MembersDataAPI {
   )(Attributes.apply _)
 
   case class Attributes(tier: Tier, membershipNumber: Option[String])
-  case class Behaviour(userId: String, activity: String, lastObserved: String)
 
   object Attributes {
     def fromMember(member: Member) = Attributes(member.subscription.plan.tier, member.contact.regNumber)
@@ -47,32 +46,19 @@ object MembersDataAPI {
     (JsPath \ "details").read[String]
   )(ApiError)
 
-  implicit val behaviourReads: Reads[Behaviour] = (
-    (JsPath \ "userId").read[String] and
-    (JsPath \ "activity").read[String] and
-    (JsPath \ "lastObserved").read[String]
-  )(Behaviour.apply _)
-
-  case class AttributeHelper(cookies: Seq[Option[Cookie]]) extends WebServiceHelper[Attributes, ApiError] {
+  case class Helper(cookies: Seq[Option[Cookie]]) extends WebServiceHelper[Attributes, ApiError] {
     override val wsUrl: String = Config.membersDataAPIUrl
-    override def wsPreExecute(req: Request.Builder): Request.Builder = {
-      req.addHeader("Cookie", cookies.flatten.map(c => s"${c.name}=${c.value}").mkString("; "))
-    }
-    override val httpClient: LoggingHttpClient[Future] = RequestRunners.loggingRunner(MembersDataAPIMetrics)
-  }
+    override def wsPreExecute(req: Request.Builder): Request.Builder = req.addHeader(
+      "Cookie", cookies.flatten.map(c => s"${c.name}=${c.value}").mkString("; "))
 
-  case class BehaviourHelper(cookies: Seq[Option[Cookie]]) extends WebServiceHelper[Behaviour, ApiError] {
-    override val wsUrl: String = Config.membersDataAPIUrl
-    override def wsPreExecute(req: Request.Builder): Request.Builder = {
-      req.addHeader("Cookie", cookies.flatten.map(c => s"${c.name}=${c.value}").mkString("; "))
-    }
     override val httpClient: LoggingHttpClient[Future] = RequestRunners.loggingRunner(MembersDataAPIMetrics)
+
   }
 
   object Service  {
     def checkMatchesResolvedMemberIn(memberRequest: SubReqWithSub[_]) = memberRequest.user.credentials match {
       case cookies: AccessCredentials.Cookies =>
-        getAttributes(Seq(memberRequest.cookies.get("GU_U"), memberRequest.cookies.get("SC_GU_U"))).onComplete {
+        get(Seq(memberRequest.cookies.get("GU_U"), memberRequest.cookies.get("SC_GU_U"))).onComplete {
           case Success(memDataApiAttrs) =>
             val prefix = s"members-data-api-check identity=${memberRequest.user.id} salesforce=${memberRequest.subscriber.contact.salesforceContactId} : "
             val salesforceAttrs = Attributes.fromMember(memberRequest.subscriber)
@@ -86,39 +72,9 @@ object MembersDataAPI {
             }
           case Failure(err) => Logger.error(s"Failed to get membership attributes from membership-data-api for user ${memberRequest.user.id} (OK in dev)", err)
         }
-      case _ => Logger.error(s"Unexpected credentials for getAttributes! ${memberRequest.user.credentials}")
+      case _ => Logger.error(s"Unexpected credentials! ${memberRequest.user.credentials}")
     }
 
-    def addBehaviour(idUser: AuthenticatedIdUser, activity: String) = {
-      idUser.credentials match {
-        case cookies: AccessCredentials.Cookies =>
-          setBehaviour(Seq(Some(Cookie("SC_GU_U", cookies.scGuU))), idUser.id, activity).onComplete {
-            case Success(result) => Logger.info(s"Recorded $activity for ${idUser.id}")
-            case Failure(err) => Logger.error(s"Failed to record behaviour event ($activity) via membership-data-api for user ${idUser.id}", err)
-          }
-        case _ => Logger.error(s"Unexpected credentials for addBehaviour ($activity) for ${idUser.credentials}")
-      }
-    }
-
-    def removeBehaviour(memberRequest: SubReqWithSub[_]) = memberRequest.user.credentials match {
-      case cookies: AccessCredentials.Cookies =>
-        deleteBehaviour(Seq(memberRequest.cookies.get("GU_U"), memberRequest.cookies.get("SC_GU_U")), memberRequest.user.id).onComplete {
-          case Success(result) => Logger.info(s"Cleared behaviours for ${memberRequest.user.user.id}")
-          case Failure(err) => Logger.error(s"Failed to remove behaviour events via membership-data-api for user ${memberRequest.user.id}", err)
-        }
-      case _ => Logger.error(s"Unexpected credentials for removeBehaviour for ${memberRequest.user.credentials}")
-    }
-
-    private def getAttributes(cookies: Seq[Option[Cookie]]) = AttributeHelper(cookies).get[Attributes]("user-attributes/me/membership")
-
-    private def setBehaviour(cookies: Seq[Option[Cookie]], userId: String, activity: String) = {
-      val record = s"""{"userId":"${userId}","activity":"${activity}","dateTime":"${DateTime.now.toString(ISODateTimeFormat.dateTime.withZoneUTC)}"}"""
-      val json = Json.parse(record)
-      BehaviourHelper(cookies).post[Behaviour](s"user-behaviour/me/capture/$activity", json)
-    }
-
-    private def deleteBehaviour(cookies: Seq[Option[Cookie]], userId: String) = {
-      BehaviourHelper(cookies).get[Behaviour]("user-behaviour/me/remove")
-    }
+    private def get(cookies: Seq[Option[Cookie]]) = Helper(cookies).get[Attributes]("user-attributes/me/membership")
   }
 }


### PR DESCRIPTION
Reverts guardian/membership-frontend#1432

The server is throwing internal server errors e.g.;
**ERROR: Failed to record behaviour event (enterPaidDetails.show) via membership-data-api for user...**
```FrontendLogs-PROD 2017-01-17/i-05d81d3299fdd97bd/frontend.log 2017-01-17 14:13:02,389 [application-akka.actor.default] application[MembersDataAPI.scala:97] ERROR: Failed to record behaviour event (enterPaidDetails.show) via membership-data-api for user 1372529
FrontendLogs-PROD 2017-01-17/i-05d81d3299fdd97bd/frontend.log services.MembersDataAPI$ApiError: Internal Server Error - Internal Server Error
	at services.MembersDataAPI$ApiError$.apply(MembersDataAPI.scala:43)
	at services.MembersDataAPI$ApiError$.apply(MembersDataAPI.scala:43)
	at play.api.libs.functional.FunctionalBuilder$CanBuild2$$anonfun$apply$1.apply(Products.scala:35)
FrontendLogs-PROD 2017-01-17/i-05d81d3299fdd97bd/frontend.log services.MembersDataAPI$ApiError: Internal Server Error - Internal Server Error
	at services.MembersDataAPI$ApiError$.apply(MembersDataAPI.scala:43)
	at services.MembersDataAPI$ApiError$.apply(MembersDataAPI.scala:43)
	at play.api.libs.functional.FunctionalBuilder$CanBuild2$$anonfun$apply$1.apply(Products.scala:35)
	at play.api.libs.functional.FunctionalBuilder$CanBuild2$$anonfun$apply$1.apply(Products.scala:35)
	at play.api.libs.json.JsResult$class.map(JsResult.scala:77)
	at play.api.libs.json.JsSuccess.map(JsResult.scala:9)
	at play.api.libs.json.Reads$$anonfun$map$1.apply(Reads.scala:45)
	at play.api.libs.json.Reads$$anonfun$map$1.apply(Reads.scala:45)
	at play.api.libs.json.Reads$$anon$8.reads(Reads.scala:122)
	at play.api.libs.json.JsValue$class.validate(JsValue.scala:18)
	at play.api.libs.json.JsObject.validate(JsValue.scala:76)
	at com.gu.memsub.util.WebServiceHelper$$anonfun$request$1.apply(WebServiceHelper.scala:56)
	at com.gu.memsub.util.WebServiceHelper$$anonfun$request$1.apply(WebServiceHelper.scala:50)
	at scala.util.Success$$anonfun$map$1.apply(Try.scala:237)
	at scala.util.Try$.apply(Try.scala:192)
	at scala.util.Success.map(Try.scala:237)
	at scala.concurrent.Future$$anonfun$map$1.apply(Future.scala:237)
	at scala.concurrent.Future$$anonfun$map$1.apply(Future.scala:237)
	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:32)
	at scala.concurrent.impl.ExecutionContextImpl$AdaptedForkJoinTask.exec(ExecutionContextImpl.scala:121)
	at scala.concurrent.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
	at scala.concurrent.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
	at scala.concurrent.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
	at scala.concurrent.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)
```
and
**ERROR: Failed to remove behaviour events via membership-data-api for user...**
```FrontendLogs-PROD 2017-01-17/i-05d81d3299fdd97bd/frontend.log 2017-01-17 14:14:41,834 [application-akka.actor.default] application[MembersDataAPI.scala:107] ERROR: Failed to remove behaviour events via membership-data-api for user 1372529
FrontendLogs-PROD 2017-01-17/i-05d81d3299fdd97bd/frontend.log services.MembersDataAPI$ApiError: Internal Server Error - Internal Server Error
	at services.MembersDataAPI$ApiError$.apply(MembersDataAPI.scala:43)
	at services.MembersDataAPI$ApiError$.apply(MembersDataAPI.scala:43)
	at play.api.libs.functional.FunctionalBuilder$CanBuild2$$anonfun$apply$1.apply(Products.scala:35)
FrontendLogs-PROD 2017-01-17/i-05d81d3299fdd97bd/frontend.log services.MembersDataAPI$ApiError: Internal Server Error - Internal Server Error
	at services.MembersDataAPI$ApiError$.apply(MembersDataAPI.scala:43)
	at services.MembersDataAPI$ApiError$.apply(MembersDataAPI.scala:43)
	at play.api.libs.functional.FunctionalBuilder$CanBuild2$$anonfun$apply$1.apply(Products.scala:35)
	at play.api.libs.functional.FunctionalBuilder$CanBuild2$$anonfun$apply$1.apply(Products.scala:35)
	at play.api.libs.json.JsResult$class.map(JsResult.scala:77)
	at play.api.libs.json.JsSuccess.map(JsResult.scala:9)
	at play.api.libs.json.Reads$$anonfun$map$1.apply(Reads.scala:45)
	at play.api.libs.json.Reads$$anonfun$map$1.apply(Reads.scala:45)
	at play.api.libs.json.Reads$$anon$8.reads(Reads.scala:122)
	at play.api.libs.json.JsValue$class.validate(JsValue.scala:18)
	at play.api.libs.json.JsObject.validate(JsValue.scala:76)
	at com.gu.memsub.util.WebServiceHelper$$anonfun$request$1.apply(WebServiceHelper.scala:56)
	at com.gu.memsub.util.WebServiceHelper$$anonfun$request$1.apply(WebServiceHelper.scala:50)
	at scala.util.Success$$anonfun$map$1.apply(Try.scala:237)
	at scala.util.Try$.apply(Try.scala:192)
	at scala.util.Success.map(Try.scala:237)
	at scala.concurrent.Future$$anonfun$map$1.apply(Future.scala:237)
	at scala.concurrent.Future$$anonfun$map$1.apply(Future.scala:237)
	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:32)
	at scala.concurrent.impl.ExecutionContextImpl$AdaptedForkJoinTask.exec(ExecutionContextImpl.scala:121)
	at scala.concurrent.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
	at scala.concurrent.forkjoin.ForkJoinPool$WorkQueue.pollAndExecAll(ForkJoinPool.java:1253)
	at scala.concurrent.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1346)
	at scala.concurrent.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
	at scala.concurrent.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)
```

