### PR TITLE
Remove nginx config which is now owned by `identity-platform`

### DIFF
--- a/nginx/membership.conf
+++ b/nginx/membership.conf
@@ -56,29 +56,3 @@ server {
             proxy_set_header Host $http_host;
     }
 }
-
-server {
-    listen                      443;
-    server_name                 idapi-code-proxy.thegulocal.com;
-
-    ssl on;
-    ssl_certificate keys/idapi-code-proxy-thegulocal-com-exp2017-03-31-bundle.crt;
-    ssl_certificate_key keys/idapi-code-proxy-thegulocal-com-exp2017-03-31.key;
-
-    ssl_session_timeout 5m;
-
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-    ssl_ciphers HIGH:!aNULL:!MD5;
-    ssl_prefer_server_ciphers on;
-
-    location / {
-        resolver                8.8.8.8;
-         proxy_pass              https://idapi.code.dev-theguardian.com/;
-        proxy_redirect          default;
-        proxy_set_header        Host                    idapi.code.dev-theguardian.com;
-        proxy_set_header        X-Real-IP               $remote_addr;
-        proxy_set_header        X-Forwarded-For         $proxy_add_x_forwarded_for;
-        proxy_set_header        X-Forwarded-Protocol    $scheme;
-        proxy_set_header        Referer                 "http://m.code.dev-theguardian.com";
-    }
-}


### PR DESCRIPTION
## Why are you doing this?

As of https://github.com/guardian/identity-platform/pull/149, config for the `idapi-code-proxy.thegulocal.com` site is in the `guardian/identity-platform` project:

https://github.com/guardian/identity-platform/blob/814794576/nginx/identity.conf#L159

If you have the config twice, ngninx gives an error:

```
Restarting Nginx
nginx: [warn] conflicting server name "idapi-code-proxy.thegulocal.com" on 0.0.0.0:443, ignored
nginx: [warn] conflicting server name "idapi-code-proxy.thegulocal.com" on 0.0.0.0:443, ignored
```


cc @mario-galic @rupertbates 