### PR TITLE
Track payment method in ga

### DIFF
--- a/frontend/app/views/joiner/thankyou.scala.html
+++ b/frontend/app/views/joiner/thankyou.scala.html
@@ -64,7 +64,12 @@
    guardian.productData = {
        regNumber: '@member.contact.regNumber.getOrElse("")',
        tier: '@member.subscription.plan.tier.name',
-       upgrade: @upgrade
+       upgrade: @upgrade,
+       paymentMethod: '@{paymentMethod match{
+         case Some(_ :PaymentCard) => "CreditCard"
+         case Some(_ :PayPalMethod) => "PayPal"
+         case _ =>
+       }}'
    };
 </script>
     <main role="main" class="page-content l-constrained">

--- a/frontend/app/views/joiner/thankyou.scala.html
+++ b/frontend/app/views/joiner/thankyou.scala.html
@@ -7,13 +7,13 @@
 
 @import views.support.ThankyouSummary
 @import views.support.MembershipCompat._
-@import com.gu.memsub.PaymentCard
 @import com.gu.memsub.Subscriber
 @import com.gu.memsub.promo.Promotion.AnyPromotion
 @import tracking.AppnexusPixel
+@import com.gu.memsub.{PaymentMethod, PaymentCard, PayPalMethod}
 @(member: Subscriber.Member,
   summary: ThankyouSummary,
-  cardOpt: Option[PaymentCard],
+  paymentMethod: Option[PaymentMethod],
   returnDestinationOpt: Option[model.Destination],
   upgrade: Boolean,
   promotion: Option[AnyPromotion])
@@ -50,6 +50,13 @@
             @content
         </div>
     </section>
+}
+
+@paymentRow(title : String, message: String) = {
+    <tr role="row">
+        <th role="rowheader">@title</th>
+        <td id="qa-joiner-summary-card">@message</td>
+    </tr>
 }
 
 @main(title) {
@@ -120,13 +127,13 @@
                         }
                     }
 
-                    @for(card <- cardOpt) {
-
-                    <tr role="row">
-                        <th role="rowheader">Card</th>
-                        <td id="qa-joiner-summary-card">•••• •••• •••• •••• @card.lastFourDigits</td>
-                    </tr>
-                    }
+                    @{paymentMethod match {
+                        case Some(card : PaymentCard) =>
+                            paymentRow("Card", "•••• •••• •••• •••• " + card.lastFourDigits)
+                        case Some(payPal : PayPalMethod) =>
+                            paymentRow("Payment method", "You are paying with PayPal")
+                        case _ =>
+                    }}
                 </table>
             </div>
         </section>

--- a/frontend/assets/javascripts/src/modules/analytics/ga.es6
+++ b/frontend/assets/javascripts/src/modules/analytics/ga.es6
@@ -18,7 +18,8 @@ const dimensions = {
     customerAgent: 'dimension13', // Session
     CamCodeBusinessUnit: 'dimension14', // Session
     CamCodeTeam: 'dimension15', // Session
-    experience: 'dimension16'// Session
+    experience: 'dimension16',// Session
+    paymentMethod: 'dimension17',// User
 
 };
 const metrics = {
@@ -114,6 +115,7 @@ export function init() {
 
         wrappedGa('set',dimensions.membershipNumber,guardian.productData.regNumber);
         wrappedGa('set',dimensions.productPurchased,guardian.productData.tier);
+        wrappedGa('set',dimensions.paymentMethod,guardian.productData.paymentMethod);
         // Send analytics after acquisition (on thank you page).
         acquisitionEvent();
 

--- a/frontend/assets/javascripts/src/modules/analytics/ga.es6
+++ b/frontend/assets/javascripts/src/modules/analytics/ga.es6
@@ -19,7 +19,7 @@ const dimensions = {
     CamCodeBusinessUnit: 'dimension14', // Session
     CamCodeTeam: 'dimension15', // Session
     experience: 'dimension16',// Session
-    paymentMethod: 'dimension17',// User
+    paymentMethod: 'dimension17',// Hit
 
 };
 const metrics = {


### PR DESCRIPTION
## Why are you doing this?
Now that we have more than one way of paying for membership we want to track which payment method users sign up with in Google Analytics.

## Trello card: [Here](https://trello.com/c/tEm0IZed/284-add-payment-method-tracking-into-ga)

## Changes
* Pass a PaymentMethod object through to the 'thank you' page rather than the Card object which was used previously
* Add a new 'paymentMethod' custom dimension into GA

## Screenshots
<img width="1209" alt="screen shot 2017-01-23 at 17 12 32" src="https://cloud.githubusercontent.com/assets/181371/22214346/324d474e-e18f-11e6-947a-f60316e24fa0.png">
Payment method is now shown in the Members aquisition/join event in GA