### PR TITLE
Paypal Error Handling

### DIFF
--- a/frontend/app/views/joiner/form/paymentPayPal.scala.html
+++ b/frontend/app/views/joiner/form/paymentPayPal.scala.html
@@ -121,6 +121,7 @@
                                 <div class="form-field js-payment-type">                                @fragments.form.stripeCheckout(idUser)
                                 </div>
                             </div>
+                            <div class="js-payment-error is-hidden">Sorry, we weren't able to process your payment this time around. Please try again.</div>
                         </fieldset>
                         @fragments.form.cardDetailPayPal(plans)
                     </div>

--- a/frontend/app/views/joiner/form/paymentPayPal.scala.html
+++ b/frontend/app/views/joiner/form/paymentPayPal.scala.html
@@ -121,7 +121,7 @@
                                 <div class="form-field js-payment-type">                                @fragments.form.stripeCheckout(idUser)
                                 </div>
                             </div>
-                            <div class="js-payment-error is-hidden">Sorry, we weren't able to process your payment this time around. Please try again.</div>
+                            <div class="js-payment-error flash-message flash-message--error is-hidden">Sorry, we weren't able to process your payment this time around. Please try again.</div>
                         </fieldset>
                         @fragments.form.cardDetailPayPal(plans)
                     </div>

--- a/frontend/assets/javascripts/src/modules/form/payment/paymentError.es6
+++ b/frontend/assets/javascripts/src/modules/form/payment/paymentError.es6
@@ -46,13 +46,13 @@ export function showMessage (error) {
     const message = getMessage(error);
 
     messageElement.text(message);
-    messageElement.removeClass('is-hidden');
+    messageElement.show();
 
 }
 
 // Hides the error message.
 export function hideMessage () {
 
-    messageElement.addClass('is-hidden');
+    messageElement.hide();
 
 }

--- a/frontend/assets/javascripts/src/modules/form/payment/paymentError.es6
+++ b/frontend/assets/javascripts/src/modules/form/payment/paymentError.es6
@@ -46,13 +46,13 @@ export function showMessage (error) {
     const message = getMessage(error);
 
     messageElement.text(message);
-    messageElement.show();
+    messageElement.removeClass('is-hidden');
 
 }
 
 // Hides the error message.
 export function hideMessage () {
 
-    messageElement.hide();
+    messageElement.addClass('is-hidden');
 
 }

--- a/frontend/assets/javascripts/src/modules/form/payment/paymentError.es6
+++ b/frontend/assets/javascripts/src/modules/form/payment/paymentError.es6
@@ -49,7 +49,7 @@ export function showMessage (error) {
 
     const [sentryMessage, message] = getMessage(error);
 
-    Raven.captureMessage(sentryMessage);
+    logError(sentryMessage)
     messageElement.text(message);
     messageElement.removeClass('is-hidden');
 
@@ -59,5 +59,12 @@ export function showMessage (error) {
 export function hideMessage () {
 
     messageElement.addClass('is-hidden');
+
+}
+
+// Sends an error message to Sentry.
+export function logError (message, level) {
+
+    Raven.captureMessage(message, { level: level || 'error' });
 
 }

--- a/frontend/assets/javascripts/src/modules/form/payment/paymentError.es6
+++ b/frontend/assets/javascripts/src/modules/form/payment/paymentError.es6
@@ -9,12 +9,12 @@ const genericErrorMessage = "Sorry, we weren't able to process your payment this
 
 const errorMessages = {
     PaymentGatewayError: {
-        Fraudulent: 'Sorry we could not take your payment. Please try a different card or contact your bank to find the cause.'
-        TransactionNotAllowed: 'Sorry we could not take your payment because your card does not support this type of purchase. Please try a different card or contact your bank to find the cause.'
-        DoNotHonor: 'Sorry we could not take your payment. Please try a different card or contact your bank to find the cause.'
-        InsufficientFunds: 'Sorry we could not take your payment because your bank indicates insufficient funds. Please try a different card or contact your bank to find the cause.'
-        RevocationOfAuthorization: 'Sorry we could not take your payment. Please try a different card or contact your bank to find the cause.'
-        GenericDecline: 'Sorry we could not take your payment. Please try a different card or contact your bank to find the cause.'
+        Fraudulent: 'Sorry we could not take your payment. Please try a different card or contact your bank to find the cause.',
+        TransactionNotAllowed: 'Sorry we could not take your payment because your card does not support this type of purchase. Please try a different card or contact your bank to find the cause.',
+        DoNotHonor: 'Sorry we could not take your payment. Please try a different card or contact your bank to find the cause.',
+        InsufficientFunds: 'Sorry we could not take your payment because your bank indicates insufficient funds. Please try a different card or contact your bank to find the cause.',
+        RevocationOfAuthorization: 'Sorry we could not take your payment. Please try a different card or contact your bank to find the cause.',
+        GenericDecline: 'Sorry we could not take your payment. Please try a different card or contact your bank to find the cause.',
         UknownPaymentError: 'Sorry we could not take your payment. Please try a different card or contact your bank to find the cause.'
     }
 };
@@ -36,6 +36,9 @@ function getMessage (error) {
     return genericErrorMessage;
 
 }
+
+
+// ----- Exports ----- //
 
 // Displays a message on the page that corresponds to the error passed.
 export function showMessage (error) {

--- a/frontend/assets/javascripts/src/modules/form/payment/paymentError.es6
+++ b/frontend/assets/javascripts/src/modules/form/payment/paymentError.es6
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
 
-import $ from 'src/utils/$'
+import $ from 'src/utils/$';
+import {Raven} from 'src/modules/raven';
 
 
 // ----- Setup ----- //
@@ -30,10 +31,13 @@ function getMessage (error) {
     const specificMessage = error && errorMessages.hasOwnProperty(error.type);
 
     if (specificMessage) {
-        return errorMessages[error.type][error.code];
+
+        return [`${error.type}: ${error.code}`,
+            errorMessages[error.type][error.code]];
+
     }
 
-    return genericErrorMessage;
+    return ['PaymentError', genericErrorMessage];
 
 }
 
@@ -43,8 +47,9 @@ function getMessage (error) {
 // Displays a message on the page that corresponds to the error passed.
 export function showMessage (error) {
 
-    const message = getMessage(error);
+    const [sentryMessage, message] = getMessage(error);
 
+    Raven.captureMessage(sentryMessage);
     messageElement.text(message);
     messageElement.removeClass('is-hidden');
 

--- a/frontend/assets/javascripts/src/modules/form/payment/paymentError.es6
+++ b/frontend/assets/javascripts/src/modules/form/payment/paymentError.es6
@@ -17,6 +17,10 @@ const errorMessages = {
         RevocationOfAuthorization: 'Sorry we could not take your payment. Please try a different card or contact your bank to find the cause.',
         GenericDecline: 'Sorry we could not take your payment. Please try a different card or contact your bank to find the cause.',
         UknownPaymentError: 'Sorry we could not take your payment. Please try a different card or contact your bank to find the cause.'
+    },
+    PayPal: {
+        PaymentError: genericErrorMessage,
+        BAIDCreationFailed: genericErrorMessage
     }
 };
 
@@ -26,18 +30,23 @@ const messageElement = $('.js-payment-error');
 // ----- Functions ----- //
 
 // Decides what the message text should be.
-function getMessage (error) {
+function parseError (error) {
 
     const specificMessage = error && errorMessages.hasOwnProperty(error.type);
 
     if (specificMessage) {
 
-        return [`${error.type}: ${error.code}`,
-            errorMessages[error.type][error.code]];
+        return {
+            sentry: `${error.type}: ${error.code}: ${error.additional || ''}`,
+            user: errorMessages[error.type][error.code]]
+        };
 
     }
 
-    return ['PaymentError', genericErrorMessage];
+    return {
+        sentry: 'UnknownPaymentError',
+        user: genericErrorMessage
+    }
 
 }
 
@@ -47,10 +56,10 @@ function getMessage (error) {
 // Displays a message on the page that corresponds to the error passed.
 export function showMessage (error) {
 
-    const [sentryMessage, message] = getMessage(error);
+    const message = parseError(error);
 
-    logError(sentryMessage)
-    messageElement.text(message);
+    logError(message.sentry);
+    messageElement.text(message.user);
     messageElement.removeClass('is-hidden');
 
 }

--- a/frontend/assets/javascripts/src/modules/form/payment/paymentError.es6
+++ b/frontend/assets/javascripts/src/modules/form/payment/paymentError.es6
@@ -1,0 +1,13 @@
+// ----- Setup ----- //
+
+const errorMessages = {
+    PaymentGatewayError: {
+        Fraudulent: 'Sorry we could not take your payment. Please try a different card or contact your bank to find the cause.'
+        TransactionNotAllowed: 'Sorry we could not take your payment because your card does not support this type of purchase. Please try a different card or contact your bank to find the cause.'
+        DoNotHonor: 'Sorry we could not take your payment. Please try a different card or contact your bank to find the cause.'
+        InsufficientFunds: 'Sorry we could not take your payment because your bank indicates insufficient funds. Please try a different card or contact your bank to find the cause.'
+        RevocationOfAuthorization: 'Sorry we could not take your payment. Please try a different card or contact your bank to find the cause.'
+        GenericDecline: 'Sorry we could not take your payment. Please try a different card or contact your bank to find the cause.'
+        UknownPaymentError: 'Sorry we could not take your payment. Please try a different card or contact your bank to find the cause.'
+    }
+};

--- a/frontend/assets/javascripts/src/modules/form/payment/paymentError.es6
+++ b/frontend/assets/javascripts/src/modules/form/payment/paymentError.es6
@@ -38,7 +38,7 @@ function parseError (error) {
 
         return {
             sentry: `${error.type}: ${error.code}: ${error.additional || ''}`,
-            user: errorMessages[error.type][error.code]]
+            user: errorMessages[error.type][error.code]
         };
 
     }

--- a/frontend/assets/javascripts/src/modules/form/payment/paymentError.es6
+++ b/frontend/assets/javascripts/src/modules/form/payment/paymentError.es6
@@ -27,7 +27,7 @@ const messageElement = $('.js-payment-error');
 // Decides what the message text should be.
 function getMessage (error) {
 
-    const specificMessage = errorMessages.hasOwnProperty(error.type);
+    const specificMessage = error && errorMessages.hasOwnProperty(error.type);
 
     if (specificMessage) {
         return errorMessages[error.type][error.code];

--- a/frontend/assets/javascripts/src/modules/form/payment/paymentError.es6
+++ b/frontend/assets/javascripts/src/modules/form/payment/paymentError.es6
@@ -1,4 +1,11 @@
+// ----- Imports ----- //
+
+import $ from 'src/utils/$'
+
+
 // ----- Setup ----- //
+
+const genericErrorMessage = "Sorry, we weren't able to process your payment this time around. Please try again.";
 
 const errorMessages = {
     PaymentGatewayError: {
@@ -11,3 +18,38 @@ const errorMessages = {
         UknownPaymentError: 'Sorry we could not take your payment. Please try a different card or contact your bank to find the cause.'
     }
 };
+
+const messageElement = $('.js-payment-error');
+
+
+// ----- Functions ----- //
+
+// Decides what the message text should be.
+function getMessage (error) {
+
+    const specificMessage = errorMessages.hasOwnProperty(error.type);
+
+    if (specificMessage) {
+        return errorMessages[error.type][error.code];
+    }
+
+    return genericErrorMessage;
+
+}
+
+// Displays a message on the page that corresponds to the error passed.
+export function showMessage (error) {
+
+    const message = getMessage(error);
+
+    messageElement.text(message);
+    messageElement.removeClass('is-hidden');
+
+}
+
+// Hides the error message.
+export function hideMessage () {
+
+    messageElement.addClass('is-hidden');
+
+}

--- a/frontend/assets/javascripts/src/modules/form/payment/paymentMethod.es6
+++ b/frontend/assets/javascripts/src/modules/form/payment/paymentMethod.es6
@@ -18,7 +18,7 @@ export function showCardFields (event) {
 
 	event.preventDefault();
 
-	[].forEach.call(cardFields.elements, (card) => {
+	[].forEach.call(cardFields.elements, card => {
 		card.removeAttribute('disabled');
 	});
 
@@ -33,7 +33,7 @@ export function hideCardFields (event) {
 
 	event.preventDefault();
 
-	[].forEach.call(cardFields.elements, (card) => {
+	[].forEach.call(cardFields.elements, card => {
 		card.setAttribute('disabled', 'disabled');
 	});
 

--- a/frontend/assets/javascripts/src/modules/form/payment/paymentMethod.es6
+++ b/frontend/assets/javascripts/src/modules/form/payment/paymentMethod.es6
@@ -1,8 +1,17 @@
+// ----- Imports ----- //
+
+import $ from 'src/utils/$'
 import listeners from 'src/modules/form/payment/listeners';
 
-let paymentMethods = document.getElementsByClassName('js-payment-methods')[0];
-let cardFields = document.getElementsByClassName('js-checkout-card-fields')[0];
-let submitButton = document.getElementsByClassName('js-submit-input')[0];
+
+// ----- Setup ----- //
+
+let paymentMethods = $('.js-payment-methods');
+let cardFields = $('.js-checkout-card-fields');
+let submitButton = $('.js-submit-input');
+
+
+// ----- Exports ----- //
 
 // Unhides the credit card fieldset, and enables the form fields.
 export function showCardFields (event) {
@@ -13,9 +22,9 @@ export function showCardFields (event) {
 		card.removeAttribute('disabled');
 	});
 
-	paymentMethods.classList.add('is-hidden');
-	cardFields.classList.remove('is-hidden');
-	submitButton.classList.remove('is-hidden');
+	paymentMethods.addClass('is-hidden');
+	cardFields.removeClass('is-hidden');
+	submitButton.removeClass('is-hidden');
 
 }
 
@@ -28,8 +37,8 @@ export function hideCardFields (event) {
 		card.setAttribute('disabled', 'disabled');
 	});
 
-	paymentMethods.classList.remove('is-hidden');
-	cardFields.classList.add('is-hidden');
-	submitButton.classList.add('is-hidden');
+	paymentMethods.removeClass('is-hidden');
+	cardFields.addClass('is-hidden');
+	submitButton.addClass('is-hidden');
 
 }

--- a/frontend/assets/javascripts/src/modules/form/payment/paymentMethod.es6
+++ b/frontend/assets/javascripts/src/modules/form/payment/paymentMethod.es6
@@ -22,9 +22,9 @@ export function showCardFields (event) {
 		card.removeAttribute('disabled');
 	});
 
-	paymentMethods.addClass('is-hidden');
-	cardFields.removeClass('is-hidden');
-	submitButton.removeClass('is-hidden');
+	paymentMethods.hide();
+	cardFields.show();
+	submitButton.show();
 
 }
 
@@ -37,8 +37,8 @@ export function hideCardFields (event) {
 		card.setAttribute('disabled', 'disabled');
 	});
 
-	paymentMethods.removeClass('is-hidden');
-	cardFields.addClass('is-hidden');
-	submitButton.addClass('is-hidden');
+	paymentMethods.show();
+	cardFields.hide();
+	submitButton.hide();
 
 }

--- a/frontend/assets/javascripts/src/modules/form/paypal.es6
+++ b/frontend/assets/javascripts/src/modules/form/paypal.es6
@@ -14,12 +14,8 @@ function setupPayment (resolve, reject) {
 		const SETUP_PAYMENT_URL = '/paypal/setup-payment';
 
 		paypal.request.post(SETUP_PAYMENT_URL)
-			.then(data => {
-				resolve(data.token);
-			})
-			.catch(err => {
-				reject(err);
-			});
+			.then(({token}) => resolve(token))
+			.catch(reject);
 
 	} else {
 		reject('Form invalid.');

--- a/frontend/assets/javascripts/src/modules/form/paypal.es6
+++ b/frontend/assets/javascripts/src/modules/form/paypal.es6
@@ -20,7 +20,7 @@ function setupPayment (resolve, reject) {
 				if (response.status === 200) {
 					return response.json();
 				} else {
-					throw 'Payment setup failed.';
+					throw new Error('Payment setup failed.');
 				}
 			})
 			.then(({token}) => resolve(token))

--- a/frontend/assets/javascripts/src/modules/form/paypal.es6
+++ b/frontend/assets/javascripts/src/modules/form/paypal.es6
@@ -1,7 +1,10 @@
+// ----- Imports ----- //
 
 import listeners from 'src/modules/form/payment/listeners';
 import * as payment from 'src/modules/payment';
 
+
+// ----- Functions ----- //
 
 // Sends request to server to setup payment, and returns Paypal token.
 function setupPayment (resolve, reject) {
@@ -45,7 +48,11 @@ function postForm (baid) {
 	payment.postForm({ 'payment.payPalBaid': baid.token });
 }
 
+
+// ----- Exports ----- //
+
 export function init () {
+
 	paypal.Button.render({
 
 		// Sets the environment.
@@ -57,13 +64,19 @@ export function init () {
 
 		// Called when user clicks Paypal button.
 		payment: setupPayment,
+		// Called when there is an error with the paypal payment.
         onError: payment.failure,
+
 		// Called when user finishes with Paypal interface (approves payment).
 		onAuthorize: function (data, actions) {
 
 			payment.showSpinner();
+
 			createAgreement(data).then(postForm).catch(err => {
+
+				payment.hideSpinner();
 				alert(err);
+
 			});
 
 	   }

--- a/frontend/assets/javascripts/src/modules/form/paypal.es6
+++ b/frontend/assets/javascripts/src/modules/form/paypal.es6
@@ -43,6 +43,8 @@ function createAgreement (paypalData) {
 		body: JSON.stringify({ token: paypalData.paymentToken })
 	}).then(response => {
 		return response.json();
+	}).catch(err => {
+		return { type: 'PayPal', code: 'BAIDCreationFailed', additional: err };
 	});
 
 }
@@ -69,7 +71,9 @@ export function init () {
 		// Called when user clicks Paypal button.
 		payment: setupPayment,
 		// Called when there is an error with the paypal payment.
-        onError: payment.fail,
+        onError: () => {
+        	payment.fail({ type: 'PayPal', code: 'PaymentError' });
+        },
         // We don't want to do anything here, but if this callback isn't present
         // PayPal throws a bunch of errors and then stops working.
         onCancel: () => {},

--- a/frontend/assets/javascripts/src/modules/form/paypal.es6
+++ b/frontend/assets/javascripts/src/modules/form/paypal.es6
@@ -6,13 +6,21 @@ import * as payment from 'src/modules/payment';
 
 // ----- Functions ----- //
 
+// Handles errors in the PayPal flow, reports a failed payment and throws error.
+function paypalError (err) {
+
+	payment.fail({ type: 'PayPal', code: 'PaymentError', additional: err });
+	throw new Error(err);
+
+}
+
 // Handles the paypal setup response and retrieves the token.
 function handleSetupResponse (response) {
 
 	if (response.status === 200) {
 		return response.json();
 	} else {
-		throw new Error('PayPal payment setup request failed.');
+		paypalError('PayPal payment setup request failed.');
 	}
 
 }
@@ -33,7 +41,7 @@ function setupPayment (resolve, reject) {
 				if (token) {
 					resolve(token);						
 				} else {
-					throw new Error('PayPal token came back blank.');
+					paypalError('PayPal token came back blank.');
 				}
 
 			})
@@ -77,7 +85,7 @@ function createAgreement (paypalData) {
 		if (response.status === 200) {
 			return response.json();
 		} else {
-			throw new Error('Agreement request failed.');
+			paypalError('Agreement request failed.');
 		}
 
 	});
@@ -99,7 +107,7 @@ function makePayment (data, actions) {
 		if (baid && baid.token) {
 			postForm(baid.token);
 		} else {
-			throw new Error('BAID came back blank.');
+			paypalError('BAID came back blank.');
 		}
 
 	}).catch(err => {
@@ -126,6 +134,7 @@ export function init () {
 		payment: setupPayment,
 		// Called when there is an error with the paypal payment.
         onError: () => {
+			console.log('THIS IS A BIG ERROR AND ALL THE THINGS ARE BROKEN');
         	payment.fail({ type: 'PayPal', code: 'PaymentError' });
         },
         // We don't want to do anything here, but if this callback isn't present

--- a/frontend/assets/javascripts/src/modules/form/paypal.es6
+++ b/frontend/assets/javascripts/src/modules/form/paypal.es6
@@ -68,6 +68,9 @@ export function init () {
 		payment: setupPayment,
 		// Called when there is an error with the paypal payment.
         onError: payment.fail,
+        // We don't want to do anything here, but if this callback isn't present
+        // PayPal throws a bunch of errors and then stops working.
+        onCancel: () => {},
 
 		// Called when user finishes with Paypal interface (approves payment).
 		onAuthorize: function (data, actions) {

--- a/frontend/assets/javascripts/src/modules/form/paypal.es6
+++ b/frontend/assets/javascripts/src/modules/form/paypal.es6
@@ -17,17 +17,6 @@ function handleSetupResponse (response) {
 
 }
 
-// Checks that the PayPal token is ok.
-function handleTokenRetrieval ({token}) {
-
-	if (token) {
-		resolve(token);						
-	} else {
-		throw new Error('PayPal token came back blank.');
-	}
-
-}
-
 // Sends request to server to setup payment, and returns Paypal token.
 function setupPayment (resolve, reject) {
 
@@ -39,7 +28,15 @@ function setupPayment (resolve, reject) {
 
 		fetch(SETUP_PAYMENT_URL, { method: 'POST' })
 			.then(handleSetupResponse)
-			.then(handleTokenRetrieval)
+			.then(({token}) => {
+
+				if (token) {
+					resolve(token);						
+				} else {
+					throw new Error('PayPal token came back blank.');
+				}
+
+			})
 			.catch(err => {
 
 				payment.error(err.message);

--- a/frontend/assets/javascripts/src/modules/form/paypal.es6
+++ b/frontend/assets/javascripts/src/modules/form/paypal.es6
@@ -47,7 +47,11 @@ function setupPayment (resolve, reject) {
 			})
 			.catch(err => {
 
-				payment.error(err.message);
+				payment.fail({
+					type: 'PayPal',
+					code: 'PaymentError',
+					additional: err.message
+				});
 				reject(err);
 
 			});

--- a/frontend/assets/javascripts/src/modules/form/paypal.es6
+++ b/frontend/assets/javascripts/src/modules/form/paypal.es6
@@ -9,6 +9,8 @@ import * as payment from 'src/modules/payment';
 // Sends request to server to setup payment, and returns Paypal token.
 function setupPayment (resolve, reject) {
 
+	payment.clearErrors();
+
 	if (payment.validateForm()) {
 
 		const SETUP_PAYMENT_URL = '/paypal/setup-payment';

--- a/frontend/assets/javascripts/src/modules/form/paypal.es6
+++ b/frontend/assets/javascripts/src/modules/form/paypal.es6
@@ -6,6 +6,28 @@ import * as payment from 'src/modules/payment';
 
 // ----- Functions ----- //
 
+// Handles the paypal setup response and retrieves the token.
+function handleSetupResponse (response) {
+
+	if (response.status === 200) {
+		return response.json();
+	} else {
+		throw new Error('PayPal payment setup request failed.');
+	}
+
+}
+
+// Checks that the PayPal token is ok.
+function handleTokenRetrieval ({token}) {
+
+	if (token) {
+		resolve(token);						
+	} else {
+		throw new Error('PayPal token came back blank.');
+	}
+
+}
+
 // Sends request to server to setup payment, and returns Paypal token.
 function setupPayment (resolve, reject) {
 
@@ -16,19 +38,14 @@ function setupPayment (resolve, reject) {
 		const SETUP_PAYMENT_URL = '/paypal/setup-payment';
 
 		fetch(SETUP_PAYMENT_URL, { method: 'POST' })
-			.then(response => {
+			.then(handleSetupResponse)
+			.then(handleTokenRetrieval)
+			.catch(err => {
 
-				if (response.status === 200) {
-					resolve(response.json().token);
-				} else {
+				payment.error(err.message);
+				reject(err);
 
-					payment.error('PayPal payment setup request failed.');
-					reject();
-
-				}
-
-			})
-			.catch(reject);
+			});
 
 	} else {
 		reject('Form invalid.');

--- a/frontend/assets/javascripts/src/modules/form/paypal.es6
+++ b/frontend/assets/javascripts/src/modules/form/paypal.es6
@@ -36,6 +36,35 @@ function setupPayment (resolve, reject) {
 
 }
 
+// Attempts to take the payment and make the user a member.
+function makePayment (data, actions) {
+
+	payment.showSpinner();
+
+	createAgreement(data).then(baid => {
+
+		if (baid) {
+			postForm(baid);
+		}
+
+	}).catch(payment.fail);
+
+}
+
+// Handles the retrieval of the BAID from and AJAX response.
+function handleAgreementResponse (response) {
+
+	if (response.status === 200) {
+		return response.json();
+	} else {
+
+		handleAgreementFail('Agreement request failed.');
+		return null;
+
+	}
+
+}
+
 // Handles failure to create agreement.
 function handleAgreementFail (err) {
 
@@ -55,21 +84,12 @@ function createAgreement (paypalData) {
 	const CREATE_AGREEMENT_URL = '/paypal/create-agreement';
 
 	return fetch(CREATE_AGREEMENT_URL, {
+
 		headers: { 'Content-Type': 'application/json' },
 		method: 'POST',
 		body: JSON.stringify({ token: paypalData.paymentToken })
-	}).then(response => {
 
-		if (response.status === 200) {
-			return response.json();
-		} else {
-
-			handleAgreementFail('Agreement request failed.');
-			return null;
-
-		}
-
-	}).catch(handleAgreementFail);
+	}).then(handleAgreementResponse).catch(handleAgreementFail);
 
 }
 
@@ -103,19 +123,7 @@ export function init () {
         onCancel: () => {},
 
 		// Called when user finishes with Paypal interface (approves payment).
-		onAuthorize: function (data, actions) {
-
-			payment.showSpinner();
-
-			createAgreement(data).then(baid => {
-
-				if (baid) {
-					postForm(baid);
-				}
-
-			}).catch(payment.fail);
-
-	   }
+		onAuthorize: makePayment
 
 	}, '#paypal-button-checkout');
 

--- a/frontend/assets/javascripts/src/modules/form/paypal.es6
+++ b/frontend/assets/javascripts/src/modules/form/paypal.es6
@@ -44,7 +44,6 @@ function createAgreement (paypalData) {
 
 // Creates the new member by posting the form data with the BAID.
 function postForm (baid) {
-
 	payment.postForm({ 'payment.payPalBaid': baid.token });
 }
 
@@ -65,19 +64,13 @@ export function init () {
 		// Called when user clicks Paypal button.
 		payment: setupPayment,
 		// Called when there is an error with the paypal payment.
-        onError: payment.failure,
+        onError: payment.fail,
 
 		// Called when user finishes with Paypal interface (approves payment).
 		onAuthorize: function (data, actions) {
 
 			payment.showSpinner();
-
-			createAgreement(data).then(postForm).catch(err => {
-
-				payment.hideSpinner();
-				alert(err);
-
-			});
+			createAgreement(data).then(postForm).catch(payment.fail);
 
 	   }
 

--- a/frontend/assets/javascripts/src/modules/form/paypal.es6
+++ b/frontend/assets/javascripts/src/modules/form/paypal.es6
@@ -13,7 +13,14 @@ function setupPayment (resolve, reject) {
 
 		const SETUP_PAYMENT_URL = '/paypal/setup-payment';
 
-		paypal.request.post(SETUP_PAYMENT_URL)
+		fetch(SETUP_PAYMENT_URL, { method: 'POST' })
+			.then(response => {
+				if (response.status === 200) {
+					return response.json();
+				} else {
+					throw 'Payment setup failed.';
+				}
+			})
 			.then(({token}) => resolve(token))
 			.catch(reject);
 

--- a/frontend/assets/javascripts/src/modules/form/paypal.es6
+++ b/frontend/assets/javascripts/src/modules/form/paypal.es6
@@ -5,7 +5,9 @@ import * as payment from 'src/modules/payment';
 
 // Sends request to server to setup payment, and returns Paypal token.
 function setupPayment (resolve, reject) {
-    payment.open()
+
+    payment.showSpinner();
+
 	if (payment.validateForm()) {
 
 		const SETUP_PAYMENT_URL = '/paypal/setup-payment';
@@ -15,11 +17,17 @@ function setupPayment (resolve, reject) {
 				resolve(data.token);
 			})
 			.catch(err => {
+
+				payment.hideSpinner();
 				reject(err);
+
 			});
 
 	} else {
+
+		payment.hideSpinner();
 		reject('Form invalid.');
+
 	}
 
 }
@@ -58,7 +66,7 @@ export function init () {
 		// Called when user clicks Paypal button.
 		payment: setupPayment,
         //Oncancel
-        onCancel: payment.close,
+        onCancel: payment.hideSpinner,
         onError: payment.failure,
 		// Called when user finishes with Paypal interface (approves payment).
 		onAuthorize: function (data, actions) {

--- a/frontend/assets/javascripts/src/modules/form/paypal.es6
+++ b/frontend/assets/javascripts/src/modules/form/paypal.es6
@@ -133,8 +133,10 @@ export function init () {
 		// Called when user clicks Paypal button.
 		payment: setupPayment,
 		// Called when there is an error with the paypal payment.
+		// Note that this is only reliably called on the first error, so there
+		// may be some duplicate error logging when this runs alongside
+		// the paypalError function above.
         onError: () => {
-			console.log('THIS IS A BIG ERROR AND ALL THE THINGS ARE BROKEN');
         	payment.fail({ type: 'PayPal', code: 'PaymentError' });
         },
         // We don't want to do anything here, but if this callback isn't present

--- a/frontend/assets/javascripts/src/modules/form/paypal.es6
+++ b/frontend/assets/javascripts/src/modules/form/paypal.es6
@@ -6,8 +6,6 @@ import * as payment from 'src/modules/payment';
 // Sends request to server to setup payment, and returns Paypal token.
 function setupPayment (resolve, reject) {
 
-    payment.showSpinner();
-
 	if (payment.validateForm()) {
 
 		const SETUP_PAYMENT_URL = '/paypal/setup-payment';
@@ -17,17 +15,11 @@ function setupPayment (resolve, reject) {
 				resolve(data.token);
 			})
 			.catch(err => {
-
-				payment.hideSpinner();
 				reject(err);
-
 			});
 
 	} else {
-
-		payment.hideSpinner();
 		reject('Form invalid.');
-
 	}
 
 }
@@ -65,12 +57,11 @@ export function init () {
 
 		// Called when user clicks Paypal button.
 		payment: setupPayment,
-        //Oncancel
-        onCancel: payment.hideSpinner,
         onError: payment.failure,
 		// Called when user finishes with Paypal interface (approves payment).
 		onAuthorize: function (data, actions) {
 
+			payment.showSpinner();
 			createAgreement(data).then(postForm).catch(err => {
 				alert(err);
 			});

--- a/frontend/assets/javascripts/src/modules/form/stripe.es6
+++ b/frontend/assets/javascripts/src/modules/form/stripe.es6
@@ -10,7 +10,7 @@ export function init() {
 
     const open = (e) => {
         if (payment.validateForm()) {
-            payment.open();
+            payment.showSpinner();
             handler.open({
                 description: 'So I could do with some good copy for this, and what it needs to contain like price etc.',
                 panelLabel: 'Approved button copy!',
@@ -23,7 +23,7 @@ export function init() {
                 },
                 closed: () => {
                     if (!success) {
-                        payment.close();
+                        payment.hideSpinner();
                     }
                 }
             })

--- a/frontend/assets/javascripts/src/modules/payment.es6
+++ b/frontend/assets/javascripts/src/modules/payment.es6
@@ -17,14 +17,18 @@ const $spinner = $('.js-payment-processing');
 
 // ----- Exports ----- //
 
+// When a payment method "overlay" is opened.
 export function open() {
-    //When a payment method "overlay" is opened.
+
     $paymentTypes.hide();
+    error.hideMessage();
+
     $spinner.addClass('is-loading');
+
 }
 
+// When a payment method overlay is closed.
 export function close() {
-    //When a payment method overlay is closed.
     $paymentTypes.show();
     $spinner.removeClass('is-loading');
 }

--- a/frontend/assets/javascripts/src/modules/payment.es6
+++ b/frontend/assets/javascripts/src/modules/payment.es6
@@ -37,6 +37,7 @@ export function hideSpinner () {
 // The error object should have a type and a code, see paymentError.es6.
 export function fail (error) {
 
+    hideSpinner();
     error.showMessage(error);
 
 }

--- a/frontend/assets/javascripts/src/modules/payment.es6
+++ b/frontend/assets/javascripts/src/modules/payment.es6
@@ -1,21 +1,40 @@
+// ----- Imports ----- //
+
 import ajax from 'ajax';
 import form from 'src/modules/form/helper/formUtil';
 import validity from 'src/modules/form/validation/validity';
 import serializer from 'src/modules/form/helper/serializer';
 import utilsHelper from 'src/utils/helper';
 import $ from 'src/utils/$'
+import * as error from 'src/modules/form/payment/paymentError';
+
+
+// ----- Setup ----- //
 
 const $paymentTypes = $('.js-payment-type');
 const $spinner = $('.js-payment-processing');
+
+
+// ----- Functions ----- //
+
 export function open() {
     //When a payment method "overlay" is opened.
     $paymentTypes.hide();
     $spinner.addClass('is-loading');
 }
+
 export function close() {
     //When a payment method overlay is closed.
     $paymentTypes.show();
     $spinner.removeClass('is-loading');
+}
+
+// Handles a problem with a payment, takes an error object.
+// The error object should have a type and a code, see paymentError.es6.
+export function fail (error) {
+
+    error.showMessage(error);
+
 }
 
 // Validates the form; returns true if the form is valid, false otherwise.

--- a/frontend/assets/javascripts/src/modules/payment.es6
+++ b/frontend/assets/javascripts/src/modules/payment.es6
@@ -29,8 +29,10 @@ export function showSpinner () {
 
 // When we need to hide the payment processing spinner.
 export function hideSpinner () {
+
     $paymentTypes.show();
     $spinner.removeClass('is-loading');
+
 }
 
 // Handles a problem with a payment, takes an error object.
@@ -43,7 +45,7 @@ export function fail (error) {
 }
 
 // Validates the form; returns true if the form is valid, false otherwise.
-export function validateForm() {
+export function validateForm () {
 
     form.elems.map(function (elem) {
         validity.check(elem);
@@ -55,7 +57,7 @@ export function validateForm() {
 }
 
 // Creates the new member by posting the form data with the provided token object.
-export function postForm(paymentToken) {
+export function postForm (paymentToken) {
 
     let data = serializer(utilsHelper.toArray(form.elem.elements),
         paymentToken);
@@ -64,7 +66,7 @@ export function postForm(paymentToken) {
         url: form.elem.action,
         method: 'post',
         data: data,
-        success: (successData) => window.location.assign(successData.redirect),
+        success: ({redirect}) => window.location.assign(redirect),
         error: fail
     });
 

--- a/frontend/assets/javascripts/src/modules/payment.es6
+++ b/frontend/assets/javascripts/src/modules/payment.es6
@@ -17,8 +17,8 @@ const $spinner = $('.js-payment-processing');
 
 // ----- Exports ----- //
 
-// When a payment method "overlay" is opened.
-export function open() {
+// When we need to show to payment processing spinner.
+export function showSpinner () {
 
     $paymentTypes.hide();
     error.hideMessage();
@@ -27,8 +27,8 @@ export function open() {
 
 }
 
-// When a payment method overlay is closed.
-export function close() {
+// When we need to hide the payment processing spinner.
+export function hideSpinner () {
     $paymentTypes.show();
     $spinner.removeClass('is-loading');
 }

--- a/frontend/assets/javascripts/src/modules/payment.es6
+++ b/frontend/assets/javascripts/src/modules/payment.es6
@@ -25,7 +25,7 @@ function handlePostError (err) {
     try {
         errMessage = JSON.parse(err.response);
     } catch (e) {
-        paymentErr.logError(e.toString);
+        paymentError.logError(e.toString);
     }
 
     fail(errMessage);

--- a/frontend/assets/javascripts/src/modules/payment.es6
+++ b/frontend/assets/javascripts/src/modules/payment.es6
@@ -15,7 +15,7 @@ const $paymentTypes = $('.js-payment-type');
 const $spinner = $('.js-payment-processing');
 
 
-// ----- Functions ----- //
+// ----- Exports ----- //
 
 export function open() {
     //When a payment method "overlay" is opened.

--- a/frontend/assets/javascripts/src/modules/payment.es6
+++ b/frontend/assets/javascripts/src/modules/payment.es6
@@ -15,6 +15,24 @@ const $paymentTypes = $('.js-payment-type');
 const $spinner = $('.js-payment-processing');
 
 
+// ----- Functions ----- /
+
+// Handles problems with the form post.
+function handlePostError (err) {
+
+    let errMessage = null;
+
+    try {
+        errMessage = JSON.parse(err.response);
+    } catch (e) {
+        paymentErr.logError(e.toString);
+    }
+
+    fail(errMessage);
+
+}
+
+
 // ----- Exports ----- //
 
 // Clears any payment error messages.
@@ -51,6 +69,11 @@ export function fail (error) {
 
 }
 
+// Logs an error in the payment flow.
+export function error (msg) {
+    paymentError.logError(msg, 'error');
+}
+
 // Validates the form; returns true if the form is valid, false otherwise.
 export function validateForm () {
 
@@ -74,7 +97,7 @@ export function postForm (paymentToken) {
         method: 'post',
         data: data,
         success: ({redirect}) => window.location.assign(redirect),
-        error: fail
+        error: handlePostError
     });
 
 }

--- a/frontend/assets/javascripts/src/modules/payment.es6
+++ b/frontend/assets/javascripts/src/modules/payment.es6
@@ -17,11 +17,18 @@ const $spinner = $('.js-payment-processing');
 
 // ----- Exports ----- //
 
+// Clears any payment error messages.
+export function clearErrors () {
+
+    paymentError.hideMessage();
+
+}
+
 // When we need to show to payment processing spinner.
 export function showSpinner () {
 
     $paymentTypes.hide();
-    paymentError.hideMessage();
+    clearErrors();
 
     $spinner.addClass('is-loading');
 

--- a/frontend/assets/javascripts/src/modules/payment.es6
+++ b/frontend/assets/javascripts/src/modules/payment.es6
@@ -6,7 +6,7 @@ import validity from 'src/modules/form/validation/validity';
 import serializer from 'src/modules/form/helper/serializer';
 import utilsHelper from 'src/utils/helper';
 import $ from 'src/utils/$'
-import * as error from 'src/modules/form/payment/paymentError';
+import * as paymentError from 'src/modules/form/payment/paymentError';
 
 
 // ----- Setup ----- //
@@ -21,7 +21,7 @@ const $spinner = $('.js-payment-processing');
 export function showSpinner () {
 
     $paymentTypes.hide();
-    error.hideMessage();
+    paymentError.hideMessage();
 
     $spinner.addClass('is-loading');
 
@@ -40,7 +40,7 @@ export function hideSpinner () {
 export function fail (error) {
 
     hideSpinner();
-    error.showMessage(error);
+    paymentError.showMessage(error);
 
 }
 

--- a/frontend/assets/javascripts/src/modules/payment.es6
+++ b/frontend/assets/javascripts/src/modules/payment.es6
@@ -63,12 +63,8 @@ export function postForm(paymentToken) {
         url: form.elem.action,
         method: 'post',
         data: data,
-        success: function (successData) {
-            window.location.assign(successData.redirect);
-        },
-        error: function (errData) {
-            alert(err);
-        }
+        success: (successData) => window.location.assign(successData.redirect),
+        error: fail
     });
 
 }


### PR DESCRIPTION
## Why are you doing this?

There are many places where the PayPal flow might break. It would be nice to present clear messages to users when this happens, and to do lots of logging to figure out why.

There's a fair bit of refactoring going on here, so the diff isn't that clear. Probably the easiest way to figure out what's going on is to look at the flow in the `paypal.es6` module, and trace the calls to the other files.

Also, I think I've caught the places that the flow might fail, but there may still be bugs. I'm hoping that it's set up to catch unexpected crashes, but if anyone notices additional possible sad paths please shout!

[**Trello card**](https://trello.com/c/DfTJi91x/232-client-side-error-handling-for-paypal)

## Changes

- Added error message div to the payment section.
- Added a new module (`paymentError.es6`) to handle displaying error messages to user and logging them to sentry.
- Started using bonzo in `paymentMethod.es6`.
- Refactored `paypal.es6` to handle errors better.
- Tweaked calls in `stripe.es6` to match with new payment API.
- Modified `payment.es6` to use new error module, and to provide an interface to other modules.

## Screenshots

![payment-errors](https://cloud.githubusercontent.com/assets/5131341/22214054/443bd7b4-e18e-11e6-9858-414e9a73b8ad.png)

@JustinPinner @rtyley @svillafe 