### PR TITLE
Pass the correct billing amount to PayPal

### DIFF
--- a/frontend/app/controllers/PayPal.scala
+++ b/frontend/app/controllers/PayPal.scala
@@ -1,8 +1,8 @@
 package controllers
 
 import com.typesafe.scalalogging.LazyLogging
-import play.api.libs.json.{JsError, JsSuccess, Json}
-import play.api.mvc.Controller
+import play.api.libs.json.{JsError, JsSuccess, Json, Reads}
+import play.api.mvc.{AnyContent, Controller, Request}
 import services.PayPalService
 
 object PayPal extends Controller with LazyLogging {
@@ -25,29 +25,25 @@ object PayPal extends Controller with LazyLogging {
 
 	// Sets up a payment by contacting PayPal, returns the token as JSON.
 	def setupPayment = NoCacheAction { request =>
-    request.body.asJson.map{ json =>
-
-      Json.fromJson[PayPalBillingDetails](json) match {
-        case JsSuccess(billingDetails: PayPalBillingDetails, _) =>
-          logger.info("Called setupPayment with billing details: " + billingDetails)
-          Ok(tokenJsonResponse(PayPalService.retrieveToken(request, billingDetails)))
-        case e: JsError => BadRequest(JsError.toJson(e).toString)
-      }
-    }.getOrElse(BadRequest)
+    parseJsonAndRunServiceCall(request)(PayPalService.retrieveToken(request))
 	}
 
 	// Creates a billing agreement using a payment token.
 	def createAgreement = NoCacheAction { request =>
-		request.body.asJson.map { json =>
-
-			Json.fromJson[Token](json) match {
-				case JsSuccess(token: Token, _) => Ok(tokenJsonResponse(PayPalService.retrieveBaid(token)))
-				case e: JsError => BadRequest(JsError.toJson(e).toString)
-			}
-
-		}.getOrElse(BadRequest)
-
+    parseJsonAndRunServiceCall(request)(PayPalService.retrieveBaid)
 	}
+
+  //Takes a request, parses it into a type T, passes this into serviceCall to retrieve a token then returns this as json
+  def parseJsonAndRunServiceCall[T](request:Request[AnyContent])(serviceCall : T => String)(implicit fjs: Reads[T]) = {
+    request.body.asJson.map { json =>
+
+      Json.fromJson[T](json)(fjs) match {
+        case JsSuccess(parsed, _) => Ok(tokenJsonResponse(serviceCall(parsed)))
+        case e: JsError => BadRequest(JsError.toJson(e).toString)
+      }
+
+    }.getOrElse(BadRequest)
+  }
 
 	// The endpoint corresponding to the PayPal return url, hit if the user is
 	// redirected and needs to come back.

--- a/frontend/app/services/PayPalService.scala
+++ b/frontend/app/services/PayPalService.scala
@@ -3,7 +3,7 @@ package services
 import com.netaporter.uri.Uri.parseQuery
 import com.typesafe.scalalogging.LazyLogging
 import configuration.Config
-import controllers.PayPal.Token
+import controllers.PayPal.{PayPalBillingDetails, Token}
 import controllers.routes
 import okhttp3.{FormBody, OkHttpClient, Request, Response}
 import play.api.mvc.RequestHeader
@@ -51,13 +51,12 @@ object PayPalService extends LazyLogging {
   }
 
   // Sets up a payment by contacting PayPal and returns the token.
-  def retrieveToken(request: RequestHeader) = {
-    logger.info("Called setupPayment")
+  def retrieveToken(request: RequestHeader, billingDetails: PayPalBillingDetails) = {
     val paymentParams = Map(
       "METHOD" -> "SetExpressCheckout",
       "PAYMENTREQUEST_0_PAYMENTACTION" -> "SALE",
-      "PAYMENTREQUEST_0_AMT" -> "4.50",
-      "PAYMENTREQUEST_0_CURRENCYCODE" -> "GBP",
+      "PAYMENTREQUEST_0_AMT" -> s"${billingDetails.amount}",
+      "PAYMENTREQUEST_0_CURRENCYCODE" -> s"${billingDetails.currency}",
       "RETURNURL" -> routes.PayPal.returnUrl().absoluteURL(secure = true)(request),
       "CANCELURL" -> routes.PayPal.cancelUrl().absoluteURL(secure = true)(request),
       "BILLINGTYPE" -> "MerchantInitiatedBilling",

--- a/frontend/app/services/PayPalService.scala
+++ b/frontend/app/services/PayPalService.scala
@@ -51,7 +51,7 @@ object PayPalService extends LazyLogging {
   }
 
   // Sets up a payment by contacting PayPal and returns the token.
-  def retrieveToken(request: RequestHeader, billingDetails: PayPalBillingDetails) = {
+  def retrieveToken(request: RequestHeader)(billingDetails: PayPalBillingDetails) = {
     val paymentParams = Map(
       "METHOD" -> "SetExpressCheckout",
       "PAYMENTREQUEST_0_PAYMENTACTION" -> "SALE",

--- a/frontend/assets/javascripts/src/modules/form/paypal.es6
+++ b/frontend/assets/javascripts/src/modules/form/paypal.es6
@@ -32,14 +32,21 @@ function setupPayment (resolve, reject) {
 
 	if (payment.validateForm()) {
 
+        const checkoutForm = guardian.membership.checkoutForm;
+        const amount = checkoutForm.billingPeriods[checkoutForm.billingPeriod].amount[checkoutForm.currency];
+
 		const SETUP_PAYMENT_URL = '/paypal/setup-payment';
 
-		fetch(SETUP_PAYMENT_URL, { method: 'POST' })
+		fetch(SETUP_PAYMENT_URL, {
+		    method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({amount: amount, billingPeriod: checkoutForm.billingPeriod, currency: checkoutForm.currency })
+		})
 			.then(handleSetupResponse)
 			.then(({token}) => {
 
 				if (token) {
-					resolve(token);						
+					resolve(token);
 				} else {
 					paypalError('PayPal token came back blank.');
 				}


### PR DESCRIPTION
## Why are you doing this?
So that PayPal charges users the correct amount  when they purchase membership

## Trello card: [Here](https://trello.com/c/QBy9pUQd/272-pass-through-correct-amount-when-retrieving-paypal-token)

## Changes
* Pass billing data from the checkout page to the server in the setupPayment call
* Pass the billing data through to PayPal when retrieving the initial payment token

## Screenshots

![screen shot 2017-01-24 at 17 00 14](https://cloud.githubusercontent.com/assets/181371/22257722/d1a53212-e256-11e6-80d2-0fb949c32259.png)
*PayPal now shows the correct price of a US membership, not hard coded values*