### PR TITLE
Tweak fix for mem common update

### DIFF
--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -11,7 +11,6 @@ import com.gu.identity.play.{IdMinimalUser, IdUser}
 import com.gu.memsub.Subscriber.{FreeMember, PaidMember}
 import com.gu.memsub.Subscription.{Feature, ProductRatePlanId, RatePlanId}
 import com.gu.memsub.promo.PromotionApplicator._
-import com.gu.memsub.promo.PromotionMatcher._
 import com.gu.memsub.promo._
 import com.gu.memsub.services.PromoService
 import com.gu.memsub.services.api.PaymentService

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "7.2.3"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.7"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.347"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.350"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache


### PR DESCRIPTION
## Why are you doing this?

We are about to make our own update to membership-common, and we want existing versions of mem common released before our own change goes out!

This update [encompasses several versions](https://github.com/guardian/membership-common/compare/v0.347...v0.350) by @paulbrown1982 & @johnduffell, it would be great if you can give your OK for these updates to go out.

Changes made in mem-common [here](https://github.com/guardian/member…ship-common/pull/406) meant we had to remove an (unused?!) import.

## Changes

- Removed (unused?) import in `MemberService.scala` due to the class being removed in https://github.com/guardian/membership-common/pull/406
- Bumped mem-common in dependencies.
