### PR TITLE
Cope with premium Guardian live events which don't have complimentary Members tickets

### DIFF
--- a/frontend/app/model/Eventbrite.scala
+++ b/frontend/app/model/Eventbrite.scala
@@ -245,6 +245,7 @@ object Eventbrite {
     } yield ticket
 
     val limitedAvailabilityText = "Last tickets remaining"
+    val hasComplimentaryTickets = internalTicketing.exists(_.complimentaryTickets.nonEmpty)
     val isLimitedAvailability = internalTicketing.exists(event => event.ticketsNotSold <= Config.eventbriteLimitedAvailabilityCutoff && !event.isSoldOut)
     val ticketsNotSold = internalTicketing.map(_.ticketsNotSold)
     val isSoldOut = internalTicketing.exists(_.isSoldOut)

--- a/frontend/app/views/event/eventDetail.scala.html
+++ b/frontend/app/views/event/eventDetail.scala.html
@@ -55,7 +55,7 @@
         </div>
     </div>
 
-    @if(event.isBookable && event.isInstanceOf[GuLiveEvent]) {
+    @if(event.isBookable && event.hasComplimentaryTickets && event.isInstanceOf[GuLiveEvent]) {
         @fragments.event.remainingTickets("event", List("l-constrained"))
     }
 


### PR DESCRIPTION
## Why are you doing this?
<!-- Remember, PRs are documentation for future contributors -->

We used to have higher-priced Guardian Local events, but the "Guardian Local" brand has now been dropped, and these are events are now folded into Guardian Live. These events are no longer in their own Eventbrite account, they are in our main Guardian Live Eventbrite account- Lyndal says this is a preferable working arrangement for the events team.

Partners and Patrons get 6 tickets at no extra cost which they can use on most Guardian Live events. However, they have never been redeemable against Guardian Local events, because of the much higher price of Guardian Local events. These events are still higher-priced, even if they are now under
the Guardian Live brand!

This change updates our logic to not display this misleading message on the event page:
![image](https://cloud.githubusercontent.com/assets/52038/22302253/dde5caee-e325-11e6-80eb-b9ec296f9b5c.png)

"You can use one of your 6 allocated member tickets for this event."

This message is currently incorrectly appearing on:

https://membership.theguardian.com/event/a-taste-of-home-with-eleonora-galasso-30220454192

...it should still appear on other events like this:

https://membership.theguardian.com/event/a-life-in-politics-harriet-harman-30032764808

The difference is that the first event does not have any ticket classes marked "Member's ticket at no extra cost" in Eventbrite - we can see this in the metadata we get from the Eventbrite API, so we can use it as a cue to ensure we don't show that message.



## Screenshots

After the fix:

An event without "Member's ticket at no extra cost" tickets:
![image](https://cloud.githubusercontent.com/assets/52038/22302476/e8d3bd98-e326-11e6-8ed0-c28e898c1336.png)

An event _with_ "Member's ticket at no extra cost" tickets:
![image](https://cloud.githubusercontent.com/assets/52038/22302472/e0f64802-e326-11e6-9a6c-02d77895fcc3.png)


@Ap0c 
