### PR TITLE
Fix Cloudwatch Thread Spawning

### DIFF
--- a/frontend/app/monitoring/Metrics.scala
+++ b/frontend/app/monitoring/Metrics.scala
@@ -5,7 +5,6 @@ import com.gu.monitoring.CloudWatch
 import configuration.Config
 
 trait Metrics extends CloudWatch {
-  val region = Region.getRegion(Regions.EU_WEST_1)
   val stage = Config.stage
   val application = "membership" // This sets the namespace for Custom Metrics in AWS (see CloudWatch)
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "7.2.3"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.7"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.351-SNAPSHOT"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.352-SNAPSHOT"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "7.2.3"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.7"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.352-SNAPSHOT"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.352"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "7.2.3"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.7"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.350"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.351-SNAPSHOT"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache


### PR DESCRIPTION
# Why are you doing this?

There is currently a problem where there are far too many threads being spawned to handle the CloudWatch client, which is causing membership-frontend to crash regularly when running in dev (out of memory). This bumps membership-common to pick up the fix, which is described in more detail in [the PR in that repository](https://github.com/guardian/membership-common/pull/413).

[**Trello Card**](https://trello.com/c/pTJCTynM/292-fix-aws-client-thread-splurge)

# Changes
- Bump membership common to pick up the fix to the `CloudWatch` trait.
- Removed implementation of region field, as the functionality for this has been moved to a companion object.

@svillafe @JustinPinner @rupertbates @paulbrown1982 @mario-galic