### PR TITLE
Pass item details to paypal

### DIFF
--- a/frontend/app/controllers/PayPal.scala
+++ b/frontend/app/controllers/PayPal.scala
@@ -10,7 +10,7 @@ object PayPal extends Controller with LazyLogging {
 	// Payment token used to tie PayPal requests together.
 	case class Token (token: String)
 
-  case class PayPalBillingDetails(amount: Float, billingPeriod: String, currency: String)
+  case class PayPalBillingDetails(amount: Float, billingPeriod: String, currency: String, tier: String)
 
 	// Json writers.
 	implicit val tokenWrites = Json.writes[Token]
@@ -25,16 +25,16 @@ object PayPal extends Controller with LazyLogging {
 
 	// Sets up a payment by contacting PayPal, returns the token as JSON.
 	def setupPayment = NoCacheAction { request =>
-    parseJsonAndRunServiceCall(request)(PayPalService.retrieveToken(request))
+    parseJsonAndRunServiceCall(request, PayPalService.retrieveToken(request))
 	}
 
 	// Creates a billing agreement using a payment token.
 	def createAgreement = NoCacheAction { request =>
-    parseJsonAndRunServiceCall(request)(PayPalService.retrieveBaid)
+    parseJsonAndRunServiceCall(request, PayPalService.retrieveBaid)
 	}
 
   //Takes a request, parses it into a type T, passes this into serviceCall to retrieve a token then returns this as json
-  def parseJsonAndRunServiceCall[T](request:Request[AnyContent])(serviceCall : T => String)(implicit fjs: Reads[T]) = {
+  def parseJsonAndRunServiceCall[T](request:Request[AnyContent], serviceCall : T => String)(implicit fjs: Reads[T]) = {
     request.body.asJson.map { json =>
 
       Json.fromJson[T](json)(fjs) match {

--- a/frontend/app/services/PayPalService.scala
+++ b/frontend/app/services/PayPalService.scala
@@ -36,6 +36,7 @@ object PayPalService extends LazyLogging {
   // Takes an NVP response and retrieves a given parameter as a string.
   private def retrieveNVPParam(response: Response, paramName: String) = {
     val responseBody = response.body().string()
+    logger.info("NVP response body = " + responseBody)
     val queryParams = parseQuery(responseBody)
     queryParams.paramMap(paramName).head
   }
@@ -55,6 +56,9 @@ object PayPalService extends LazyLogging {
     val paymentParams = Map(
       "METHOD" -> "SetExpressCheckout",
       "PAYMENTREQUEST_0_PAYMENTACTION" -> "SALE",
+      "L_PAYMENTREQUEST_0_NAME0" -> s"Guardian ${billingDetails.tier.capitalize}",
+      "L_PAYMENTREQUEST_0_DESC0" -> s"${billingDetails.billingPeriod.capitalize} payment option",
+      "L_PAYMENTREQUEST_0_AMT0" -> s"${billingDetails.amount}",
       "PAYMENTREQUEST_0_AMT" -> s"${billingDetails.amount}",
       "PAYMENTREQUEST_0_CURRENCYCODE" -> s"${billingDetails.currency}",
       "RETURNURL" -> routes.PayPal.returnUrl().absoluteURL(secure = true)(request),

--- a/frontend/app/services/PayPalService.scala
+++ b/frontend/app/services/PayPalService.scala
@@ -37,7 +37,7 @@ object PayPalService extends LazyLogging {
   private def retrieveNVPParam(response: Response, paramName: String) = {
     val responseBody = response.body().string()
     if (Config.stageDev)
-      logger.info("NVP response body = " + responseBody)
+      logger.debug("NVP response body = " + responseBody)
 
     val queryParams = parseQuery(responseBody)
     queryParams.paramMap(paramName).head
@@ -58,7 +58,6 @@ object PayPalService extends LazyLogging {
     val paymentParams = Map(
       "METHOD" -> "SetExpressCheckout",
       "PAYMENTREQUEST_0_PAYMENTACTION" -> "SALE",
-      "LOGOIMG" -> "https://d24w1tjgih0o9s.cloudfront.net/gu-small.png",
       "L_PAYMENTREQUEST_0_NAME0" -> s"Guardian ${billingDetails.tier.capitalize}",
       "L_PAYMENTREQUEST_0_DESC0" -> s"You have chosen the ${billingDetails.billingPeriod} payment option",
       "L_PAYMENTREQUEST_0_AMT0" -> s"${billingDetails.amount}",

--- a/frontend/app/services/PayPalService.scala
+++ b/frontend/app/services/PayPalService.scala
@@ -74,8 +74,7 @@ object PayPalService extends LazyLogging {
 
   // Sends a request to PayPal to create billing agreement and returns BAID.
   def retrieveBaid(token: Token) = {
-    if (Config.stageDev)
-      logger.info("Called retrieveBaid")
+    logger.debug("Called retrieveBaid")
 
     val agreementParams = Map(
       "METHOD" -> "CreateBillingAgreement",

--- a/frontend/app/services/PayPalService.scala
+++ b/frontend/app/services/PayPalService.scala
@@ -36,7 +36,9 @@ object PayPalService extends LazyLogging {
   // Takes an NVP response and retrieves a given parameter as a string.
   private def retrieveNVPParam(response: Response, paramName: String) = {
     val responseBody = response.body().string()
-    logger.info("NVP response body = " + responseBody)
+    if (Config.stageDev)
+      logger.info("NVP response body = " + responseBody)
+
     val queryParams = parseQuery(responseBody)
     queryParams.paramMap(paramName).head
   }
@@ -56,8 +58,9 @@ object PayPalService extends LazyLogging {
     val paymentParams = Map(
       "METHOD" -> "SetExpressCheckout",
       "PAYMENTREQUEST_0_PAYMENTACTION" -> "SALE",
+      "LOGOIMG" -> "https://d24w1tjgih0o9s.cloudfront.net/gu-small.png",
       "L_PAYMENTREQUEST_0_NAME0" -> s"Guardian ${billingDetails.tier.capitalize}",
-      "L_PAYMENTREQUEST_0_DESC0" -> s"${billingDetails.billingPeriod.capitalize} payment option",
+      "L_PAYMENTREQUEST_0_DESC0" -> s"You have chosen the ${billingDetails.billingPeriod} payment option",
       "L_PAYMENTREQUEST_0_AMT0" -> s"${billingDetails.amount}",
       "PAYMENTREQUEST_0_AMT" -> s"${billingDetails.amount}",
       "PAYMENTREQUEST_0_CURRENCYCODE" -> s"${billingDetails.currency}",
@@ -72,7 +75,9 @@ object PayPalService extends LazyLogging {
 
   // Sends a request to PayPal to create billing agreement and returns BAID.
   def retrieveBaid(token: Token) = {
-    logger.info("Called retrieveBaid")
+    if (Config.stageDev)
+      logger.info("Called retrieveBaid")
+
     val agreementParams = Map(
       "METHOD" -> "CreateBillingAgreement",
       "TOKEN" -> token.token)

--- a/frontend/assets/javascripts/src/modules/form/paypal.es6
+++ b/frontend/assets/javascripts/src/modules/form/paypal.es6
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
 
 import listeners from 'src/modules/form/payment/listeners';
+import form from 'src/modules/form/helper/formUtil';
 import * as payment from 'src/modules/payment';
 
 
@@ -34,13 +35,14 @@ function setupPayment (resolve, reject) {
 
         const checkoutForm = guardian.membership.checkoutForm;
         const amount = checkoutForm.billingPeriods[checkoutForm.billingPeriod].amount[checkoutForm.currency];
+        const tier = form.elem.tier.value;
 
 		const SETUP_PAYMENT_URL = '/paypal/setup-payment';
 
 		fetch(SETUP_PAYMENT_URL, {
 		    method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({amount: amount, billingPeriod: checkoutForm.billingPeriod, currency: checkoutForm.currency })
+            body: JSON.stringify({amount: amount, billingPeriod: checkoutForm.billingPeriod, currency: checkoutForm.currency, tier: tier })
 		})
 			.then(handleSetupResponse)
 			.then(({token}) => {


### PR DESCRIPTION
## Why are you doing this?
To provide more information in the PayPal checkout UI so that the user can tell exactly what they are buying.

## Trello card: [Here](https://trello.com/c/iursJKvB/231-set-correct-message-and-information-in-the-paypal-checkout-page)

## Changes
* Pass the tier to which the user is subscribing into setupPayment call along with the billing details
* Pass line item details through to PayPal in the call to SetExpressCheckout

## Screenshots

![screen shot 2017-01-26 at 13 44 15](https://cloud.githubusercontent.com/assets/181371/22333815/dad28b08-e3cf-11e6-90f5-887e938da93f.png)
