### PR TITLE
Only show the new Stripe checkout in the PayPal flow

### DIFF
--- a/frontend/app/views/fragments/form/stripeCheckout.scala.html
+++ b/frontend/app/views/fragments/form/stripeCheckout.scala.html
@@ -10,4 +10,4 @@
         allowRememberMe: false
     };
 </script>
-<button type="button" class="action choose-payment-method js-stripe-checkout" data-email="@idUser.email">stripe checkout, yeah</button>
+<button type="button" class="action choose-payment-method js-stripe-checkout" data-email="@idUser.email">Credit/Debit Card</button>

--- a/frontend/app/views/joiner/form/paymentPayPal.scala.html
+++ b/frontend/app/views/joiner/form/paymentPayPal.scala.html
@@ -112,13 +112,11 @@
                                 <div class="form-field">
                                     <div class="loader js-payment-processing">Processing.</div>
                                 </div>
-                                <div class="form-field js-payment-type">                                <button type="button" class="action choose-payment-method js-card-payment-method">
-                                    Credit/Debit Card</button>
+                                <div class="form-field js-payment-type">
+                                    @fragments.form.stripeCheckout(idUser)
                                 </div>
                                 <div class="form-field js-payment-type">
                                     <div id="paypal-button-checkout"></div>
-                                </div>
-                                <div class="form-field js-payment-type">                                @fragments.form.stripeCheckout(idUser)
                                 </div>
                             </div>
                             <div class="js-payment-error flash-message flash-message--error is-hidden">Sorry, we weren't able to process your payment this time around. Please try again.</div>


### PR DESCRIPTION
## Why are you doing this?
We only want to show the new Stripe checkout method in the PayPal flow

Unfortunately we need to leave the old Stripe stuff in until we switch over to the new flow completely.

## Trello card: [Here](https://trello.com)

## Changes
* Remove the old Stripe button from the PayPal form
* Change the text of the new Stripe button

## Screenshots
The new checkout page with the new Stripe checkout button
![screen shot 2017-01-26 at 15 27 59](https://cloud.githubusercontent.com/assets/181371/22337095/104c5406-e3dc-11e6-8ec2-3dbbab323422.png)
