### PR TITLE
Improvement in the selectedOption values for tracking purposes

### DIFF
--- a/frontend/app/views/fragments/bundle/bundleOfferingsA.scala.html
+++ b/frontend/app/views/fragments/bundle/bundleOfferingsA.scala.html
@@ -11,7 +11,7 @@
                 <div class="bundle-offering-a__give__content__body">
                     <p class="bundle-offering-a__give__content__body__description">Fund our journalism on your own terms – either a regular or one-off payment. Every penny goes to supporting our fearless, in-depth reporting and keeping our website and apps open to all.</p>
                     <div class="bundle-offering-a__give__monthly-button">
-                        @fragments.bundle.bundleButton("Make a monthly contribution",routes.Bundle.thankYou(bundleVariant, "[A Design] Monthly contribution").url)
+                        @fragments.bundle.bundleButton("Make a monthly contribution",routes.Bundle.thankYou(bundleVariant, "monthly-contribution").url)
                     </div>
                     <div class="bundle-offering-a__give__one-off-button">
                         @fragments.bundle.bundleButton("Make a one-off contribution",s"https://contribute.theguardian.com?INTCMP=${bundleVariant.testId}")
@@ -59,7 +59,7 @@
                             </div>
                         </li>
                     </ul>
-                    @fragments.bundle.bundleButton("Find out more", routes.Bundle.thankYou(bundleVariant, "[A Design] Digital Subscription").url)
+                    @fragments.bundle.bundleButton("Find out more", routes.Bundle.thankYou(bundleVariant, "digital-pack").url)
                 </div>
             </div><div class="bundle-offering-a__subscribe__offer">
                 <div class="bundle-offering-a__subscribe__offer__content">
@@ -117,6 +117,7 @@
                                 </div><div class="bundle-offering-a__print-option__price">
                                         @bundleVariant.prettyMonthlyPrice(Saturday)
                                 </div>
+                                <div class="bundle-offering-b__print-option__id">saturday</div>
                             </li>
                             <li class="bundle-offering-a__subscribe__offer__print-options__option">
                                 <div class="bundle-offering-a__print-option__description">
@@ -125,6 +126,7 @@
                                 </div><div class="bundle-offering-a__print-option__price">
                                     @bundleVariant.prettyMonthlyPrice(GuardianWeekly)
                                 </div>
+                                <div class="bundle-offering-b__print-option__id">guardian-weekly</div>
                             </li>
                             <li class="bundle-offering-a__subscribe__offer__print-options__option">
                                 <div class="bundle-offering-a__print-option__description">
@@ -133,6 +135,7 @@
                                 </div><div class="bundle-offering-a__print-option__price">
                                     @bundleVariant.prettyMonthlyPrice(Weekend)
                                 </div>
+                                <div class="bundle-offering-b__print-option__id">weekend</div>
                             </li>
                             <li class="bundle-offering-a__subscribe__offer__print-options__option">
                                 <div class="bundle-offering-a__print-option__description">
@@ -141,6 +144,7 @@
                                 </div><div class="bundle-offering-a__print-option__price">
                                     @bundleVariant.prettyMonthlyPrice(SatGW)
                                 </div>
+                                <div class="bundle-offering-b__print-option__id">saturday-guardian-weekly</div>
                             </li>
                             <li class="bundle-offering-a__subscribe__offer__print-options__option">
                                 <div class="bundle-offering-a__print-option__description">
@@ -149,6 +153,7 @@
                                 </div><div class="bundle-offering-a__print-option__price">
                                     @bundleVariant.prettyMonthlyPrice(SixDay)
                                 </div>
+                                <div class="bundle-offering-b__print-option__id">six-day</div>
                             </li>
                             <li class="bundle-offering-a__subscribe__offer__print-options__option">
                                 <div class="bundle-offering-a__print-option__description">
@@ -157,9 +162,10 @@
                                 </div><div class="bundle-offering-a__print-option__price">
                                     @bundleVariant.prettyMonthlyPrice(SevenDay)
                                 </div>
+                                <div class="bundle-offering-b__print-option__id">seven-day</div>
                             </li>
                         </ul>
-                        @fragments.bundle.bundleButton(bundleVariant.prettyMonthlyPrice(Saturday), routes.Bundle.thankYou(bundleVariant, "[A Design] Print Digital Subscription-Saturday").url, Option("js-print-button"))
+                        @fragments.bundle.bundleButton(bundleVariant.prettyMonthlyPrice(Saturday), routes.Bundle.thankYou(bundleVariant, "saturday").url, Option("js-print-button"))
                     </div>
                 </div>
             </div>

--- a/frontend/app/views/fragments/bundle/bundleOfferingsA.scala.html
+++ b/frontend/app/views/fragments/bundle/bundleOfferingsA.scala.html
@@ -144,7 +144,7 @@
                                 </div><div class="bundle-offering-a__print-option__price">
                                     @bundleVariant.prettyMonthlyPrice(SatGW)
                                 </div>
-                                <div class="bundle-offering-b__print-option__id">saturday-guardian-weekly</div>
+                                <div class="bundle-offering-b__print-option__id">satgwe</div>
                             </li>
                             <li class="bundle-offering-a__subscribe__offer__print-options__option">
                                 <div class="bundle-offering-a__print-option__description">

--- a/frontend/app/views/fragments/bundle/bundleOfferingsB.scala.html
+++ b/frontend/app/views/fragments/bundle/bundleOfferingsB.scala.html
@@ -158,7 +158,7 @@
                         </div><div class="bundle-offering-b__print-option__price">
                             @bundleVariant.prettyMonthlyPrice(SatGW)
                         </div>
-                        <div class="bundle-offering-b__print-option__id">saturday-guardian-weekly</div>
+                        <div class="bundle-offering-b__print-option__id">satgwe</div>
                     </li>
                     <li class="bundle-offering-b__subscribe__offer__print-options__option">
                         <div class="bundle-offering-b__print-option__description">

--- a/frontend/app/views/fragments/bundle/bundleOfferingsB.scala.html
+++ b/frontend/app/views/fragments/bundle/bundleOfferingsB.scala.html
@@ -35,7 +35,7 @@
                             </div>
                         </li>
                     </ul>
-                    @fragments.bundle.bundleButton("Find out more", routes.Bundle.thankYou(bundleVariant, "[B Design] Supporter").url)
+                    @fragments.bundle.bundleButton("Find out more", routes.Bundle.thankYou(bundleVariant, "supporter").url)
                 </div>
             </div><div class="bundle-offering-b__subscribe__offer">
             <div class="bundle-offering-b__subscribe__offer__content">
@@ -75,7 +75,7 @@
                     </div>
                     </li>
                 </ul>
-                @fragments.bundle.bundleButton("Find out more", routes.Bundle.thankYou(bundleVariant, "[B Design] Digital Subscription").url)
+                @fragments.bundle.bundleButton("Find out more", routes.Bundle.thankYou(bundleVariant, "digital-pack").url)
             </div>
         </div><div class="bundle-offering-b__subscribe__offer">
         <div class="bundle-offering-b__subscribe__offer__content">
@@ -127,18 +127,21 @@
             <div class="bundle-offering-b__subscribe__offer__print-options">
                 <ul>
                     <li class="bundle-offering-b__subscribe__offer__print-options__option subscribe_option--selected">
+
                         <div class="bundle-offering-b__print-option__description">
                             <h1>Saturday</h1>
                         </div><div class="bundle-offering-b__print-option__price">
                             @bundleVariant.prettyMonthlyPrice(Saturday)
-                    </div>
+                        </div>
+                        <div class="bundle-offering-b__print-option__id">saturday</div>
                     </li>
                     <li class="bundle-offering-b__subscribe__offer__print-options__option">
                         <div class="bundle-offering-b__print-option__description">
                             <h1>The Guardian Weekly</h1>
                         </div><div class="bundle-offering-b__print-option__price">
                             @bundleVariant.prettyMonthlyPrice(GuardianWeekly)
-                    </div>
+                        </div>
+                        <div class="bundle-offering-b__print-option__id">guardian-weekly</div>
                     </li>
                     <li class="bundle-offering-b__subscribe__offer__print-options__option">
                         <div class="bundle-offering-b__print-option__description">
@@ -146,14 +149,16 @@
                             <p>Saturday &amp; Sunday</p>
                         </div><div class="bundle-offering-b__print-option__price">
                             @bundleVariant.prettyMonthlyPrice(Weekend)
-                    </div>
+                        </div>
+                        <div class="bundle-offering-b__print-option__id">weekend</div>
                     </li>
                     <li class="bundle-offering-b__subscribe__offer__print-options__option">
                         <div class="bundle-offering-b__print-option__description">
                             <h1>Saturday &amp; The&nbsp;Guardian Weekly</h1>
                         </div><div class="bundle-offering-b__print-option__price">
                             @bundleVariant.prettyMonthlyPrice(SatGW)
-                    </div>
+                        </div>
+                        <div class="bundle-offering-b__print-option__id">saturday-guardian-weekly</div>
                     </li>
                     <li class="bundle-offering-b__subscribe__offer__print-options__option">
                         <div class="bundle-offering-b__print-option__description">
@@ -161,7 +166,8 @@
                             <p>Monday - Saturday</p>
                         </div><div class="bundle-offering-b__print-option__price">
                             @bundleVariant.prettyMonthlyPrice(SixDay)
-                    </div>
+                        </div>
+                        <div class="bundle-offering-b__print-option__id">six-day</div>
                     </li>
                     <li class="bundle-offering-b__subscribe__offer__print-options__option">
                         <div class="bundle-offering-b__print-option__description">
@@ -169,10 +175,11 @@
                             <p>Monday - Sunday</p>
                         </div><div class="bundle-offering-b__print-option__price">
                             @bundleVariant.prettyMonthlyPrice(SevenDay)
-                    </div>
+                        </div>
+                        <div class="bundle-offering-b__print-option__id">seven-day</div>
                     </li>
                 </ul>
-                @fragments.bundle.bundleButton(bundleVariant.prettyMonthlyPrice(Saturday), routes.Bundle.thankYou(bundleVariant, "[B Design] Print Digital Subscription-Saturday").url, Option("js-print-button"))
+                @fragments.bundle.bundleButton(bundleVariant.prettyMonthlyPrice(Saturday), routes.Bundle.thankYou(bundleVariant, "saturday").url, Option("js-print-button"))
             </div>
         </div>
         </div>

--- a/frontend/assets/javascripts/src/modules/landingBundles.es6
+++ b/frontend/assets/javascripts/src/modules/landingBundles.es6
@@ -4,8 +4,8 @@ const PRINT_A_SELECTOR = '.bundle-offering-a__subscribe__offer__print-options';
 const PRINT_B_SELECTOR = '.bundle-offering-b__subscribe__offer__print-options';
 const PRINT_A_PRICE_SELECTOR = '.bundle-offering-a__print-option__price';
 const PRINT_B_PRICE_SELECTOR = '.bundle-offering-b__print-option__price';
-const PRINT_A_NAME_SELECTOR = '.bundle-offering-a__print-option__description >h1';
-const PRINT_B_NAME_SELECTOR = '.bundle-offering-b__print-option__description >h1';
+const PRINT_A_ID_SELECTOR = '.bundle-offering-a__print-option__id';
+const PRINT_B_ID_SELECTOR = '.bundle-offering-b__print-option__id';
 const SEE_MORE_CTA_SELECTOR = '.js-see-more-button';
 const CURRENT_PRINT_SELECTOR = '.subscribe_option--selected';
 const PRINT_CTA_SELECTOR = '.js-print-button';
@@ -46,12 +46,18 @@ function bindOptionsBehaviour() {
         field.addEventListener('click', function(evt){
             let currentSelection = document.querySelector(CURRENT_PRINT_SELECTOR);
             let target = evt.currentTarget;
-            let nameElement = target.querySelector(PRINT_A_NAME_SELECTOR) || target.querySelector(PRINT_B_NAME_SELECTOR);
-            let nameText = nameElement.textContent.trim();
-            let priceElement = target.querySelector(PRINT_A_PRICE_SELECTOR) || target.querySelector(PRINT_B_PRICE_SELECTOR);
-            let priceText = priceElement.textContent.trim();
-            PRINT_CTA.querySelector('p').textContent = priceText;
-            PRINT_CTA.href = PRINT_CTA.href.split('-')[0] + '-' + nameText;
+            let targetIdElement = target.querySelector(PRINT_A_ID_SELECTOR) || target.querySelector(PRINT_B_ID_SELECTOR);
+            let targetId = targetIdElement.textContent.trim();
+            let targetPriceElement = target.querySelector(PRINT_A_PRICE_SELECTOR) || target.querySelector(PRINT_B_PRICE_SELECTOR);
+            let targetPrice = targetPriceElement.textContent.trim();
+
+            //Update the submit button's price
+            PRINT_CTA.querySelector('p').textContent = targetPrice;
+
+            //Update the URL of the button
+            PRINT_CTA.href = updateUrlParameter(PRINT_CTA.href, 'selectedOption', targetId);
+
+            //Update status of the fields
             currentSelection.classList.remove('subscribe_option--selected');
             target.classList.add('subscribe_option--selected');
         });
@@ -62,4 +68,9 @@ function bindOptionsBehaviour() {
 function toggle(section) {
     const shouldShowSection =  getComputedStyle(section).display === 'none';
     section.style.display = shouldShowSection ? 'block' : 'none';
+}
+
+function updateUrlParameter(url, param, value){
+    var regex = new RegExp('('+param+'=)[^\&]+');
+    return url.replace( regex , '$1' + value);
 }

--- a/frontend/assets/stylesheets/components/_bundle-offerings-b.scss
+++ b/frontend/assets/stylesheets/components/_bundle-offerings-b.scss
@@ -163,6 +163,10 @@
     }
 }
 
+.bundle-offering-b__print-option__id {
+    display: none;
+}
+
 .bundle-offering-b__print-option__description {
     width: gs-span(2.275);
     display: inline-block;


### PR DESCRIPTION
## Why are you doing this?
In order to make analytics easier, we decided to simplify the values of the query parameter selectedOption of the Thank You page.

 | Product                        	| selectedOption value     	|
|--------------------------------	|--------------------------	|
| Monthly Contribution           	| monthly-contribution     	|
| Digital Pack                   	| digital-pack             	|
| Saturday                       	| saturday                 	|
| The Guardian Weekly            	| guardian-weekly          	|
| Weekend                        	| weekend                  	|
| Saturday & The Guardian Weekly 	| satgwe 	|
| Sixday                         	| six-day                  	|
| Sevenday                       	| seven-day                	|



## Changes
* Change bundle offering's files and updated the landingBundles.js


## Screenshots
N/A
