### PR TITLE
AdFree field for bundle variants

### DIFF
--- a/frontend/app/abtests/BundleVariant.scala
+++ b/frontend/app/abtests/BundleVariant.scala
@@ -11,7 +11,7 @@ object BundleVariant {
   val all = Seq[BundleVariant](
     BundleVariant(A, 1, Map((Supporter, 6.5), (DigitalPack, 12), (Saturday, 18), (GuardianWeekly, 18), (Weekend, 25), (SatGW, 25), (SixDay, 45), (SevenDay, 50))),
     BundleVariant(B, 1, Map((Supporter, 7.5), (DigitalPack, 14), (Saturday, 18), (GuardianWeekly, 18), (Weekend, 25), (SatGW, 25), (SixDay, 45), (SevenDay, 50))),
-    BundleVariant(B, 2, Map((Supporter, 7.5), (DigitalPack, 14), (Saturday, 18), (GuardianWeekly, 18), (Weekend, 25), (SatGW, 25), (SixDay, 45), (SevenDay, 50)), hasAdFree=false)
+    BundleVariant(B, 2, Map((Supporter, 7.5), (DigitalPack, 14), (Saturday, 18), (GuardianWeekly, 18), (Weekend, 25), (SatGW, 25), (SixDay, 45), (SevenDay, 50)), hasAdFree = false)
   )
 
   def lookup(name: String): Option[BundleVariant] = {

--- a/frontend/app/abtests/BundleVariant.scala
+++ b/frontend/app/abtests/BundleVariant.scala
@@ -11,7 +11,7 @@ object BundleVariant {
   val all = Seq[BundleVariant](
     BundleVariant(A, 1, Map((Supporter, 6.5), (DigitalPack, 12), (Saturday, 18), (GuardianWeekly, 18), (Weekend, 25), (SatGW, 25), (SixDay, 45), (SevenDay, 50))),
     BundleVariant(B, 1, Map((Supporter, 7.5), (DigitalPack, 14), (Saturday, 18), (GuardianWeekly, 18), (Weekend, 25), (SatGW, 25), (SixDay, 45), (SevenDay, 50))),
-    BundleVariant(B, 2, Map((Supporter, 7.5), (DigitalPack, 14), (Saturday, 18), (GuardianWeekly, 18), (Weekend, 25), (SatGW, 25), (SixDay, 45), (SevenDay, 50)))
+    BundleVariant(B, 2, Map((Supporter, 7.5), (DigitalPack, 14), (Saturday, 18), (GuardianWeekly, 18), (Weekend, 25), (SatGW, 25), (SixDay, 45), (SevenDay, 50)), hasAdFree=false)
   )
 
   def lookup(name: String): Option[BundleVariant] = {
@@ -19,7 +19,7 @@ object BundleVariant {
   }
 }
 
-case class BundleVariant(distribution: Distribution, priceIndex: Int, prices: Map[BundleTier, Double]) {
+case class BundleVariant(distribution: Distribution, priceIndex: Int, prices: Map[BundleTier, Double], hasAdFree: Boolean = true) {
   val testId =  s"MEMBERSHIP_AB_THRASHER_UK_${distribution.name}$priceIndex"
 
   def prettyMonthlyPrice(tier: BundleTier) = f"£${prices(tier)}%.2f/month"

--- a/frontend/app/controllers/Bundle.scala
+++ b/frontend/app/controllers/Bundle.scala
@@ -38,7 +38,7 @@ trait Bundle extends Controller {
     val bottomImageOrientated = OrientatedImages(portrait = bottomImage, landscape = bottomImage)
 
     bundleVariant match {
-      case BundleVariant(A , _, _ ) => Ok(views.html.bundle.bundleSetA(
+      case BundleVariant(A , _, _ , _) => Ok(views.html.bundle.bundleSetA(
         heroOrientated,
         TouchpointBackend.Normal.catalog.supporter,
         PageInfo(
@@ -49,7 +49,7 @@ trait Bundle extends Controller {
         bottomImageOrientated,
         bundleVariant))
 
-      case BundleVariant(B , _, _ ) => Ok(views.html.bundle.bundleSetB(
+      case BundleVariant(B , _, _, _ ) => Ok(views.html.bundle.bundleSetB(
         heroOrientated,
         TouchpointBackend.Normal.catalog.supporter,
         PageInfo(

--- a/frontend/app/views/fragments/bundle/bundleOfferingsB.scala.html
+++ b/frontend/app/views/fragments/bundle/bundleOfferingsB.scala.html
@@ -14,16 +14,19 @@
                     <h2>Supporter</h2>
                     <span class="bundle-offering-b__subscribe__offer__price-description">@bundleVariant.prettyMonthlyPrice(Supporter)</span>
                     <ul class="bundle-offering-b__subscribe__offer__list">
-                        <li class="bundle-offering-b__subscribe__offer__list__item">
-                            <div class="bundle-offering-b__subscribe__offer__list__item__icon">
-                            @for(icon <- Asset.inlineSvg("bundle-adfree")) {
-                                @icon
-                            }
-                            </div><div class="bundle-offering-b__subscribe__offer__list__item__content">
-                            <h1>Ad-free</h1>
-                            <p>Enjoy our website and apps without adverts</p>
-                        </div>
-                        </li>
+
+                        @if(bundleVariant.hasAdFree) {
+                            <li class="bundle-offering-b__subscribe__offer__list__item">
+                                <div class="bundle-offering-b__subscribe__offer__list__item__icon">
+                                @for(icon <- Asset.inlineSvg("bundle-adfree")) {
+                                    @icon
+                                }
+                                </div><div class="bundle-offering-b__subscribe__offer__list__item__content">
+                                <h1>Ad-free</h1>
+                                <p>Enjoy our website and apps without adverts</p>
+                            </div>
+                            </li>
+                        }
                         <li class="bundle-offering-b__subscribe__offer__list__item">
                             <div class="bundle-offering-b__subscribe__offer__list__item__icon">
                             @for(icon <- Asset.inlineSvg("bundle-commenting")) {
@@ -42,17 +45,18 @@
                 <h2>Digital Supporter</h2>
                 <span class="bundle-offering-b__subscribe__offer__price-description">@bundleVariant.prettyMonthlyPrice(DigitalPack)</span>
                 <ul class="bundle-offering-b__subscribe__offer__list">
-
-                    <li class="bundle-offering-b__subscribe__offer__list__item">
-                        <div class="bundle-offering-b__subscribe__offer__list__item__icon">
-                        @for(icon <- Asset.inlineSvg("bundle-adfree")) {
-                            @icon
-                        }
-                        </div><div class="bundle-offering-b__subscribe__offer__list__item__content">
-                        <h1>Ad-free</h1>
-                        <p>Enjoy our website and apps without adverts</p>
-                    </div>
-                    </li>
+                    @if(bundleVariant.hasAdFree) {
+                        <li class="bundle-offering-b__subscribe__offer__list__item">
+                            <div class="bundle-offering-b__subscribe__offer__list__item__icon">
+                            @for(icon <- Asset.inlineSvg("bundle-adfree")) {
+                                @icon
+                            }
+                            </div><div class="bundle-offering-b__subscribe__offer__list__item__content">
+                            <h1>Ad-free</h1>
+                            <p>Enjoy our website and apps without adverts</p>
+                        </div>
+                        </li>
+                    }
                     <li class="bundle-offering-b__subscribe__offer__list__item">
                         <div class="bundle-offering-b__subscribe__offer__list__item__icon">
                         @for(icon <- Asset.inlineSvg("bundle-commenting")) {
@@ -82,16 +86,18 @@
             <h2>Print&amp;Digital Supporter</h2>
             <span class="bundle-offering-b__subscribe__offer__price-description">from @bundleVariant.prettyMonthlyPrice(Saturday)</span>
             <ul class="bundle-offering-b__subscribe__offer__list">
-                <li class="bundle-offering-b__subscribe__offer__list__item">
-                    <div class="bundle-offering-b__subscribe__offer__list__item__icon">
-                    @for(icon <- Asset.inlineSvg("bundle-adfree")) {
-                        @icon
-                    }
-                    </div><div class="bundle-offering-b__subscribe__offer__list__item__content">
-                    <h1>Ad-free</h1>
-                    <p>Enjoy our website and apps without adverts</p>
-                </div>
-                </li>
+                @if(bundleVariant.hasAdFree) {
+                    <li class="bundle-offering-b__subscribe__offer__list__item">
+                        <div class="bundle-offering-b__subscribe__offer__list__item__icon">
+                        @for(icon <- Asset.inlineSvg("bundle-adfree")) {
+                            @icon
+                        }
+                        </div><div class="bundle-offering-b__subscribe__offer__list__item__content">
+                        <h1>Ad-free</h1>
+                        <p>Enjoy our website and apps without adverts</p>
+                    </div>
+                    </li>
+                }
                 <li class="bundle-offering-b__subscribe__offer__list__item">
                     <div class="bundle-offering-b__subscribe__offer__list__item__icon">
                     @for(icon <- Asset.inlineSvg("bundle-commenting")) {


### PR DESCRIPTION
## Why are you doing this?
In order to know if we have to show a ad free feature, we add a field marking if the bundle has ad free or not.



## Changes
* Modified BundleVariant model
* Modified Bundle controller.
* Modified offering B template, the only template that takes care about this functionality.

## Screenshots

### A1: 

<img width="1067" alt="picture 84" src="https://cloud.githubusercontent.com/assets/825398/22368650/a5fa8254-e47f-11e6-8ecf-520b9142ce71.png">

### B1:

<img width="994" alt="picture 85" src="https://cloud.githubusercontent.com/assets/825398/22368655/aacab8e4-e47f-11e6-8f27-1ac33a2c0c82.png">

### B2:

<img width="983" alt="picture 86" src="https://cloud.githubusercontent.com/assets/825398/22368658/afbd60f4-e47f-11e6-8868-91be9304fceb.png">


