### PR TITLE
Pricing match

### DIFF
--- a/frontend/app/views/support/Pricing.scala
+++ b/frontend/app/views/support/Pricing.scala
@@ -21,6 +21,7 @@ case class Pricing(yearly: Price, monthly: Price) {
   def getPriceByBillingPeriod(b : BillingPeriod) : Price = b match {
     case Year() => yearly
     case Month() => monthly
+    case _ => monthly
   }
 
   def getPhrase(period : BillingPeriod): String = {


### PR DESCRIPTION
## Why are you doing this?
We want to eliminate a compiler warning about an Inexhaustive Match in Pricing.scala,

## Trello card: [Here](https://trello.com/c/hzSCYAVX/249-inexhaustive-match-in-pricing-scala-compilation-warning)

## Changes
* Added a base case in `Pricing.scala`


## Screenshots

N/A

