### PR TITLE
Better PayPal Error Message In Sentry

### DIFF
--- a/frontend/assets/javascripts/src/modules/form/paypal.es6
+++ b/frontend/assets/javascripts/src/modules/form/paypal.es6
@@ -149,7 +149,11 @@ export function init () {
 		// may be some duplicate error logging when this runs alongside
 		// the paypalError function above.
         onError: () => {
-        	payment.fail({ type: 'PayPal', code: 'PaymentError' });
+        	payment.fail({
+        		type: 'PayPal',
+        		code: 'PaymentError',
+        		additional: 'Catch-all - unknown error in PayPal checkout.'
+        	});
         },
         // We don't want to do anything here, but if this callback isn't present
         // PayPal throws a bunch of errors and then stops working.


### PR DESCRIPTION
## Why are you doing this?

There is currently a catch-all for errors that occur in the PayPal checkout. Unfortunately, PayPal don't really pass through parseable information when this happens, so the existing Sentry message was:

```
PayPal: PaymentError: 
```

This updates it to at least be a little more descriptive, even if we still don't have anything specific about what the problem was:

```
PayPal: PaymentError: Catch-all - unknown error in PayPal checkout.
```

[**Trello Card**](https://trello.com/c/Fr0r8a9i/301-better-paypal-error-message-in-sentry)

## Changes
- Added description to catch-all error message for PayPal.

@rupertbates 