### PR TITLE
Fix TestUser sensitivity to clock drift

### DIFF
--- a/frontend/app/utils/TestUsers.scala
+++ b/frontend/app/utils/TestUsers.scala
@@ -1,6 +1,7 @@
 package utils
 
-import com.github.nscala_time.time.Imports._
+import java.time.Duration.ofDays
+
 import com.gu.identity.play.IdMinimalUser
 import com.gu.identity.testing.usernames.TestUsernames
 import com.gu.salesforce._
@@ -8,11 +9,11 @@ import configuration.Config
 
 object TestUsers {
 
-  val ValidityPeriod = 2.days
+  val ValidityPeriod = ofDays(2)
 
   lazy val testUsers = TestUsernames(
     com.gu.identity.testing.usernames.Encoder.withSecret(Config.config.getString("identity.test.users.secret")),
-    recency = ValidityPeriod.standardDuration
+    recency = ValidityPeriod
   )
 
   def isTestUser(user: IdMinimalUser): Boolean =

--- a/frontend/app/views/testing/testUsers.scala.html
+++ b/frontend/app/views/testing/testUsers.scala.html
@@ -17,7 +17,7 @@
                     <h2>New Test User key: <strong>@userString</strong></h2>
                     <div class="text-intro">
                         <p>
-                            Your user will be valid for the next @ValidityPeriod.pretty.
+                            Your user will be valid for the next @ValidityPeriod.toString.stripPrefix("PT").
                             When registering please populate the following fields with your new test user key.
                         </p>
                     </div>
@@ -50,7 +50,7 @@
                             })();
                         ">
                                 @if(Config.stageDev){Dev } New Identity Signup</a>.
-                            Clicking this on the <em>new</em> identity sign-up page will prompt you for the Test User key, then fill out fields appropriately and submit the form. Unless you're a <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=866522">Firefox user</a>. 
+                            Clicking this on the <em>new</em> identity sign-up page will prompt you for the Test User key, then fill out fields appropriately and submit the form. Unless you're a <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=866522">Firefox user</a>.
                         </li>
                         <li>
                             <a href="javascript:

--- a/frontend/test/acceptance/util/TestUser.scala
+++ b/frontend/test/acceptance/util/TestUser.scala
@@ -1,12 +1,13 @@
 package acceptance.util
 
-import com.github.nscala_time.time.Imports._
+import java.time.Duration.ofDays
+
 import com.gu.identity.testing.usernames.TestUsernames
 
 class TestUser {
   private val testUsers = TestUsernames(
     com.gu.identity.testing.usernames.Encoder.withSecret(Config.testUsersSecret),
-    recency = 2.days.standardDuration
+    recency = ofDays(2)
   )
 
   private def addTestUserCookies(testUsername: String) = {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,10 @@ object Dependencies {
   //libraries
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "7.2.3"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
-  val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.7"
+  val memsubCommonPlayAuth = Seq(
+    "com.gu" %% "memsub-common-play-auth" % "0.8", // v0.8 is the latest version published for Play 2.4...
+    "com.gu" %% "identity-test-users" % "0.6"
+  )
   val membershipCommon = "com.gu" %% "membership-common" % "0.352"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
@@ -27,10 +30,10 @@ object Dependencies {
 
   //projects
 
-  val frontendDependencies = Seq(memsubCommonPlayAuth, scalaUri, membershipCommon,
+  val frontendDependencies = memsubCommonPlayAuth ++ Seq(scalaUri, membershipCommon,
     contentAPI, playWS, playCache, sentryRavenLogback, awsSimpleEmail, snowPlow, bCrypt, scalaz, pegdown,
     PlayImport.specs2 % "test", specs2Extra, dispatch)
 
-  val acceptanceTestDependencies = Seq(scalaTest, selenium, memsubCommonPlayAuth, seleniumHtmlUnitDriver, seleniumManager)
+  val acceptanceTestDependencies = memsubCommonPlayAuth ++ Seq(scalaTest, selenium, seleniumHtmlUnitDriver, seleniumManager)
 
 }


### PR DESCRIPTION
## Why are you doing this?

This is a re-do of https://github.com/guardian/subscriptions-frontend/pull/784 for Membership Frontend.

Acceptance tests on Subscriptions Frontend were [intermittently failing](https://github.com/guardian/subscriptions-frontend/pull/781#issuecomment-276336674) - this was happening when the TestUser token was stamped with a time ahead of the clock time on the `subscriptions-frontend` appserver:

    "IllegalArgumentException: The end instant must be greater the start"

The same fix applies to Membership Frontend (though we don't seem to have the same errors occurring here, probably because we're not using Guest Checkout)

## Changes

See https://github.com/guardian/identity-test-users/commit/410a7fec for the details of the fix, and accompanying tests that check for tolerance of clock drift.

cc @Ap0c 