### PR TITLE
Add Fetch Polyfill

### DIFF
--- a/frontend/assets/javascripts/src/modules/form/paypal.es6
+++ b/frontend/assets/javascripts/src/modules/form/paypal.es6
@@ -2,6 +2,7 @@
 
 import form from 'src/modules/form/helper/formUtil';
 import * as payment from 'src/modules/payment';
+import 'whatwg-fetch';
 
 
 // ----- Functions ----- //

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -66,6 +66,7 @@
     "vinyl-fs": "2.2.1",
     "webpack": "^1.12.15",
     "webpack-dev-server": "^1.14.1",
+    "whatwg-fetch": "^2.0.2",
     "zxcvbn": "3.5.0"
   }
 }


### PR DESCRIPTION
## Why are you doing this?

We're using `fetch` in the PayPal code for our AJAX requests, but it's not supported in all browsers. This adds GitHub's polyfill to handle that.

Note that we could have used `reqwest` here, because we're using it elsewhere under the name `ajax`. However, this library is now outdated, and `fetch` is on the way to being [implemented natively](https://fetch.spec.whatwg.org) in [all browsers](http://caniuse.com/#feat=fetch), so we think using it is preferable. This is probably going to be a precursor to replacing `reqwest` with `fetch` throughout the codebase.

[**Trello Card**](https://trello.com/c/8ZonVpeN/303-fetch-doesn-t-work-in-old-browsers)

## Changes
- Add fetch polyfill to dependencies.
- Import fetch in PayPal module.

@rupertbates @rtyley @JustinPinner 