### PR TITLE
Fix Identity Signup bookmarklet to cope with Identity Frontend changes

### DIFF
--- a/frontend/app/views/testing/testUsers.scala.html
+++ b/frontend/app/views/testing/testUsers.scala.html
@@ -36,32 +36,30 @@
                     <ul>
                         <li>
                             <a href="javascript:
-                            (function() {
-                                if (!document.getElementById('register_field_username')) {
-                                    alert('Element with id register_field_username not found. Are you on the right page?');
-                                    return;
-                                }
-                                var username = prompt('Test User key (first name, last name, username and password will be set to this value):');
-                                if (!username) return;
-                                ['firstname', 'lastname', 'username', 'password', 'email'].forEach(function(field) {
-                                    document.getElementById('register_field_'+field).value = field === 'email' ? username + '@@gu.com' : username;
-                                });
-                                document.querySelector('#register_submit').click();
-                            })();
-                        ">
-                                @if(Config.stageDev){Dev } New Identity Signup</a>.
-                            Clicking this on the <em>new</em> identity sign-up page will prompt you for the Test User key, then fill out fields appropriately and submit the form. Unless you're a <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=866522">Firefox user</a>.
-                        </li>
-                        <li>
-                            <a href="javascript:
-                            (function() {
-                                var s = document.createElement('script');
-                                s.src = '@Asset.bookmarklet("identity-signup.js")';
-                                s.type = 'text/javascript';
-                                document.head.appendChild(s);
-                            })();">
-                                @if(Config.stageDev){Dev }Identity Signup</a>.
-                            Clicking this on the identity sign-up page will prompt you for the Test User key, then fill out fields appropriately and submit the form.
+                                (function() {
+                                    var fieldPrefix = 'register_field_';
+                                    function idFor(field) { return fieldPrefix+field; }
+
+                                    if (!document.getElementById(idFor('email'))) {
+                                        alert('Element with id '+idFor('email')+' not found. Are you on the right page?');
+                                        return;
+                                    }
+                                    var testUserToken = prompt('Test User token:');
+                                    if (!testUserToken) return;
+
+                                    ['firstname', 'lastname', 'password', 'email'].forEach(function(field) {
+                                        var element = document.getElementById(idFor(field));
+                                        element.focus();
+                                        element.value = field === 'email' ? testUserToken + '@@gu.com' : testUserToken;
+                                        element.blur();
+                                    });
+                                    setTimeout(function(){
+                                     document.querySelector('#register_submit').click();
+                                    },500);
+                                })();
+                            ">Identity Signup</a>.
+                            Clicking this on the Identity sign-up page will prompt you for the Test User key, then fill out fields appropriately and submit the form.
+                            Unless you're a <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=866522">Firefox user</a>.
                         </li>
                         <li>
                             <a href="javascript:


### PR DESCRIPTION
## Why are you doing this?

The automatic Identity Signup bookmarklet (available on https://membership.theguardian.com/test-users) wasn't running, complaining that it couldn't find the `register_field_username` field on the [Identity Registration page](https://profile.theguardian.com/register?returnUrl=https://membership.theguardian.com/&skipConfirmation=true&clientId=members).

This was due to the `username` field being hidden and replaced with `displayName` a while ago with these two PRs:

* https://github.com/guardian/identity-frontend/pull/187
* https://github.com/guardian/identity-frontend/pull/195

## Changes

Note that the `displayName` field is still [**present and populated client-side**](https://github.com/guardian/identity-frontend/blob/a6730549/public/components/register-form/register-form.js#L58-L69) on the Identity Registration page, even though it's hidden. I think this is tech-debt, and ideally that field would be completely removed from the client-side, with the display-name calculated on the server-side (cc @markjamesbutler).

This change updates the bookmarklet script so that it triggers a `focus` and  `blur` event on every field it enters - in order to trigger the `updateDisplayName()` call in Identity Frontend - otherwise a nebulous error occurs because the hidden field is not populated (no visible error message is seen, other than the page being refreshed to https://profile-origin.thegulocal.com/register?error=register-error-displayName).

cc @AWare @svillafe  

