### PR TITLE
Upgrade to Play v2.4.10 to take advantage of latest security updates

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ logLevel := Level.Warn
 
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.6")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.10")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")
 


### PR DESCRIPTION
## Why are you doing this?

There's quite a big wodge of stuff in the changelog: https://www.playframework.com/changelog

Obviously, at some point we'll have to upgrade to Play 2.5...

The acceptance tests work locally with the new Play version.

cc @Ap0c 