### PR TITLE
Support non-signed-in Test Users

### DIFF
--- a/frontend/app/controllers/Testing.scala
+++ b/frontend/app/controllers/Testing.scala
@@ -14,6 +14,8 @@ object Testing extends Controller with LazyLogging {
 
   val analyticsOffCookie = Cookie(AnalyticsCookieName, "true", httpOnly = false)
 
+  val PreSigninTestCookieName = "pre-signin-test-user"
+
   /**
    * Make sure to use canonical @guardian.co.uk for addresses
    */
@@ -31,7 +33,8 @@ object Testing extends Controller with LazyLogging {
   def testUser = AuthorisedTester { implicit request =>
     val testUserString = testUsers.generate()
     logger.info(s"Generated test user string $testUserString for ${request.user.email}")
-    Ok(views.html.testing.testUsers(testUserString)).withCookies(analyticsOffCookie)
+    val testUserCookie = Cookie(PreSigninTestCookieName, testUserString, Some(30 * 60), httpOnly = true)
+    Ok(views.html.testing.testUsers(testUserString)).withCookies(testUserCookie, analyticsOffCookie)
   }
 
   def analyticsOff = CachedAction {

--- a/frontend/app/services/TouchpointBackend.scala
+++ b/frontend/app/services/TouchpointBackend.scala
@@ -26,8 +26,9 @@ import monitoring.TouchpointBackendMetrics
 import org.joda.time.LocalDate
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import tracking._
-import utils.TestUsers.isTestUser
+import utils.TestUsers.{TestUserCredentialType, isTestUser}
 import org.joda.time.LocalDate
+import play.api.mvc.RequestHeader
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
@@ -44,32 +45,32 @@ object TouchpointBackend extends LazyLogging {
       config.getString(s"touchpoint.backend.environments.$zuoraEnvName.zuora.api.restUrl")
   }
 
-  def apply(backendType: TouchpointBackendConfig.BackendType): TouchpointBackend = {
-    val touchpointBackendConfig = TouchpointBackendConfig.byType(backendType, Config.config)
-    TouchpointBackend(touchpointBackendConfig, backendType)
+  def apply(backendType: BackendType): TouchpointBackend = {
+    val backendConfig = TouchpointBackendConfig.byType(backendType, Config.config)
+    TouchpointBackend(backendConfig, backendType)
   }
 
-  def apply(backend: TouchpointBackendConfig, backendType: BackendType): TouchpointBackend = {
-    val stripeService = new StripeService(backend.stripe, RequestRunners.loggingRunner(new TouchpointBackendMetrics with StatusMetrics {
-      val backendEnv = backend.stripe.envName
+  def apply(config: TouchpointBackendConfig, backendType: BackendType): TouchpointBackend = {
+    val stripeService = new StripeService(config.stripe, RequestRunners.loggingRunner(new TouchpointBackendMetrics with StatusMetrics {
+      val backendEnv = config.stripe.envName
       val service = "Stripe"
     }))
-    val giraffeStripeService = new StripeService(backend.giraffe, RequestRunners.loggingRunner(new TouchpointBackendMetrics with StatusMetrics {
-      val backendEnv = backend.stripe.envName
+    val giraffeStripeService = new StripeService(config.giraffe, RequestRunners.loggingRunner(new TouchpointBackendMetrics with StatusMetrics {
+      val backendEnv = config.stripe.envName
       val service = "Stripe Giraffe"
     }))
 
-    val restBackendConfig = backend.zuoraRest.copy(url = Uri.parse(backend.zuoraRestUrl(Config.config)))
+    val restBackendConfig = config.zuoraRest.copy(url = Uri.parse(config.zuoraRestUrl(Config.config)))
 
     val memRatePlanIds = Config.membershipRatePlanIds(restBackendConfig.envName)
     val paperRatePlanIds = Config.subsProductIds(restBackendConfig.envName)
     val digipackRatePlanIds = Config.digipackRatePlanIds(restBackendConfig.envName)
-    val runner = RequestRunners.loggingRunner(backend.zuoraMetrics("zuora-soap-client"))
+    val runner = RequestRunners.loggingRunner(config.zuoraMetrics("zuora-soap-client"))
     // extendedRunner sets the configurable read timeout, which is used for the createSubscription call.
-    val extendedRunner = RequestRunners.configurableLoggingRunner(20.seconds, backend.zuoraMetrics("zuora-soap-client"))
-    val zuoraSoapClient = new ClientWithFeatureSupplier(FeatureChoice.codes, backend.zuoraSoap, runner, extendedRunner)
+    val extendedRunner = RequestRunners.configurableLoggingRunner(20.seconds, config.zuoraMetrics("zuora-soap-client"))
+    val zuoraSoapClient = new ClientWithFeatureSupplier(FeatureChoice.codes, config.zuoraSoap, runner, extendedRunner)
 
-    val discounter = new Discounter(Config.discountRatePlanIds(backend.zuoraEnvName))
+    val discounter = new Discounter(Config.discountRatePlanIds(config.zuoraEnvName))
     val promoCollection = DynamoPromoCollection.forStage(Config.config, restBackendConfig.envName)
     val promoService = new PromoService(promoCollection, discounter)
     val zuoraService = new ZuoraServiceImpl(zuoraSoapClient)
@@ -81,13 +82,14 @@ object TouchpointBackend extends LazyLogging {
     val newSubsService = new subsv2.services.SubscriptionService[Future](pids, futureCatalog, client, zuoraService.getAccountIds)
 
     val paymentService = new PaymentService(stripeService, zuoraService, newCatalogService.unsafeCatalog.productMap)
-    val salesforceService = new SalesforceService(backend.salesforce)
+    val salesforceService = new SalesforceService(config.salesforce)
     val identityService = IdentityService(IdentityApi)
     val memberService = new MemberService(
       identityService, salesforceService, zuoraService, stripeService, newSubsService, newCatalogService, promoService, paymentService, discounter,
-        Config.discountRatePlanIds(backend.zuoraEnvName))
+        Config.discountRatePlanIds(config.zuoraEnvName))
 
     TouchpointBackend(
+      config.environmentName,
       salesforceService = salesforceService,
       stripeService = stripeService,
       giraffeStripeService = giraffeStripeService,
@@ -113,6 +115,28 @@ object TouchpointBackend extends LazyLogging {
   lazy val Normal = TouchpointBackend(BackendType.Default)
   lazy val TestUser = TouchpointBackend(BackendType.Testing)
 
+  def backendFor(backendType: BackendType): TouchpointBackend = backendType match {
+    case BackendType.Testing => TestUser
+    case BackendType.Default => Normal
+  }
+
+  case class Resolution(
+    backend: TouchpointBackend,
+    typ: BackendType,
+    validTestUserCredentialOpt: Option[TestUserCredentialType[_]]
+  )
+
+  /**
+    * Alternate credentials are used *only* when the user is not signed in - if you're logged in as
+    * a 'normal' non-test user, it doesn't make any difference what pre-signin-test-cookie you have.
+    */
+  def forRequest[C](permittedAltCredentialType: TestUserCredentialType[C], altCredentialSource: C)(
+    implicit request: RequestHeader): Resolution = {
+    val validTestUserCredentialOpt = isTestUser(permittedAltCredentialType, altCredentialSource)
+    val backendType = if (validTestUserCredentialOpt.isDefined) BackendType.Testing else BackendType.Default
+    Resolution(backendFor(backendType), backendType, validTestUserCredentialOpt)
+  }
+
   Future {
     logger.info(s"TouchpointBackend.TestUser is lazily initialised to ensure bad UAT settings can not block deployment to PROD. Initalisation starting...")
     val amountOfPlans = TestUser.catalog.allMembership.size
@@ -124,20 +148,23 @@ object TouchpointBackend extends LazyLogging {
   def forUser(user: Contact): TouchpointBackend = if (isTestUser(user)) TestUser else Normal
 }
 
-case class TouchpointBackend(salesforceService: api.SalesforceService,
-                             stripeService: StripeService,
-                             giraffeStripeService: StripeService,
-                             zuoraSoapClient: soap.ClientWithFeatureSupplier,
-                             destinationService: DestinationService[Future],
-                             memberService: api.MemberService,
-                             subscriptionService: subsv2.services.SubscriptionService[Future],
-                             catalogService: subsv2.services.CatalogService[Future],
-                             zuoraService: ZuoraService,
-                             membershipRatePlanIds: MembershipRatePlanIds,
-                             promos: PromotionCollection,
-                             promoService: PromoService,
-                             paymentService: PaymentService,
-                             identityService: IdentityService) extends ActivityTracking {
+case class TouchpointBackend(
+  environmentName: String,
+  salesforceService: api.SalesforceService,
+  stripeService: StripeService,
+  giraffeStripeService: StripeService,
+  zuoraSoapClient: soap.ClientWithFeatureSupplier,
+  destinationService: DestinationService[Future],
+  memberService: api.MemberService,
+  subscriptionService: subsv2.services.SubscriptionService[Future],
+  catalogService: subsv2.services.CatalogService[Future],
+  zuoraService: ZuoraService,
+  membershipRatePlanIds: MembershipRatePlanIds,
+  promos: PromotionCollection,
+  promoService: PromoService,
+  paymentService: PaymentService,
+  identityService: IdentityService
+) extends ActivityTracking {
 
   lazy val catalog: Catalog = catalogService.unsafeCatalog
 }

--- a/frontend/app/views/joiner/form/payment.scala.html
+++ b/frontend/app/views/joiner/form/payment.scala.html
@@ -22,10 +22,11 @@
     pageInfo: PageInfo,
     trackingPromoCode: Option[PromoCode],
     promoCodeToDisplay: Option[PromoCode],
-    countryGroup: Option[CountryGroup]
+    countryGroup: Option[CountryGroup],
+    touchpointBackendResolution: services.TouchpointBackend.Resolution
     )(implicit token: play.filters.csrf.CSRF.Token, request: actions.AuthRequest[_])
 
-@main(plans.tier.cta, pageInfo=pageInfo, simpleHeader=true) {
+@main(plans.tier.cta, pageInfo=pageInfo, simpleHeader=true, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
 
     <main class="page-content skin-checkout-b">
 

--- a/frontend/app/views/joiner/thankyou.scala.html
+++ b/frontend/app/views/joiner/thankyou.scala.html
@@ -16,7 +16,9 @@
   paymentMethod: Option[PaymentMethod],
   returnDestinationOpt: Option[model.Destination],
   upgrade: Boolean,
-  promotion: Option[AnyPromotion])
+  promotion: Option[AnyPromotion],
+  touchpointBackendResolution: services.TouchpointBackend.Resolution
+)
 
 @title = @{
     if(upgrade) {
@@ -59,7 +61,10 @@
     </tr>
 }
 
-@main(title) {
+@main(
+    title,
+    touchpointBackendResolutionOpt = Some(touchpointBackendResolution)
+) {
 <script type="text/javascript">
    guardian.productData = {
        regNumber: '@member.contact.regNumber.getOrElse("")',

--- a/frontend/app/views/main.scala.html
+++ b/frontend/app/views/main.scala.html
@@ -1,11 +1,13 @@
 @import views.support.PageInfo
 @import com.gu.i18n.CountryGroup
 @import utils.CountryGroupLang
+@import utils.TestUsers._
 @(  title: String,
     pageInfo: PageInfo = views.support.PageInfo(),
     countryGroup: Option[CountryGroup] = None,
         titleOverride: Option[String] = None,
-    simpleHeader: Boolean = false
+    simpleHeader: Boolean = false,
+    touchpointBackendResolutionOpt: Option[services.TouchpointBackend.Resolution] = None
     )(content: Html)
 @import play.api.libs.json.Json
 @import configuration.{Config, Social}
@@ -86,6 +88,20 @@
     </head>
     <body id="top">
         <a class="u-h skip" href="#container">Skip to main content</a>
+        @for(
+            touchpointBackendResolution <- touchpointBackendResolutionOpt;
+            validTestUserCredential <- touchpointBackendResolution.validTestUserCredentialOpt;
+            backend = touchpointBackendResolution.backend
+        ) {
+            <div class="warning-message">
+                Using @touchpointBackendResolution.typ.name backend: <strong><code>@backend.environmentName</code></strong>
+                because you @validTestUserCredential match {
+                case PreSigninTestCookie => { have a valid <code>@Testing.PreSigninTestCookieName</code> cookie - note you still need to create the user with the Test Username }
+                case NameEnteredInForm => { entered a valid Test Username into the form }
+                case SignedInUsername => { are signed in as a user with a valid Test Username }
+            }
+            </div>
+        }
         <noscript>
             <div class="warning-message copy hidden-print">
                 Please enable JavaScript &ndash; we use it to enhance behaviour for Guardian Members.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
     "com.gu" %% "memsub-common-play-auth" % "0.8", // v0.8 is the latest version published for Play 2.4...
     "com.gu" %% "identity-test-users" % "0.6"
   )
-  val membershipCommon = "com.gu" %% "membership-common" % "0.352"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.354"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache


### PR DESCRIPTION
## Why are you doing this?

Soon we're going to A/B test a flow where the user may not be logged in when they visit the checkout page. Unfortunately the [Test User](https://membership.theguardian.com/test-users) functionality has - up till now - **required the user to be signed in** to work out whether they're a Test User or not -and we need to know whether the user is a Test User or not to choose the correct Touchpoint backend.

Now we need to know if a user is Test User, without them being signed in.

## Changes

This change matches the work in https://github.com/guardian/subscriptions-frontend/pull/165, adding to Membership Frontend new methods for us to tell if a non-signed in user is a Test User. Only the original method is valid for all pages on the site:

- `PreSigninTestCookie` <- valid for viewing correct rateplans pre-purchase. You can get this cookie simply by going to https://membership.theguardian.com/test-users - the cookie will be dropped automatically
- `NameEnteredInForm` <- valid for posting the Checkout form - you will need to enter the Test User token as your First Name
- `SignedInUsername` <- valid for all pages

If the user is signed in, only `SignedInUsername` is used and other credentials are irrelevant.

Because this is all hideously complicated, **this change also adds an informative banner on Checkout and Thank you pages**, that confirms you've been verified as a valid test-user, explaining what credential has been used to work that out: _"Using test backend: UAT because you are signed in as a user with a valid Test Username"_

Note that - at the moment - you still have to be signed-in to view the Checkout and Thank You pages, so the `PreSigninTestCookie` & `NameEnteredInForm` methods can not be exercised.

This change requires https://github.com/guardian/membership-common/pull/417 to be released before this PR will build and pass tests.

## Trello card: [Here](https://trello.com/c/TpuX5Fdb/298-a-b-testing-for-new-checkout-flow-test-merging-registration-into-supporter-checkout)

## Screenshots

https://mem.thegulocal.com/join/supporter/enter-details
![image](https://cloud.githubusercontent.com/assets/52038/22518460/8c1b2a5e-e8a4-11e6-8fd9-1145a0bb01a3.png)

https://mem.thegulocal.com/join/supporter/thankyou
![image](https://cloud.githubusercontent.com/assets/52038/22518518/cb3f6aec-e8a4-11e6-95ed-de7a16ce06be.png)

cc @Ap0c 
