### PR TITLE
Merge Patron Benefits Into Single List

### DIFF
--- a/frontend/app/model/Benefits.scala
+++ b/frontend/app/model/Benefits.scala
@@ -38,7 +38,8 @@ object Benefits {
   val noBookingFees = Benefit("no_booking_fees", "No booking fees")
   val guest = Benefit("guest", "Bring a guest")
   val booksOrTickets = Benefit("books_or_tickets", s"$zuoraFreeEventTicketsAllowance tickets or 4 books", isNew = true)
-  val booksAndTickets = Benefit("books_and_tickets", s"$zuoraFreeEventTicketsAllowance tickets and 4 books", isNew = true)
+  val tickets = Benefit("tickets", s"Get $zuoraFreeEventTicketsAllowance Guardian Live tickets to use throughout the year (use one ticket per event at the event of your choosing)")
+  val books = Benefit("tickets", "We send you 4 carefully selected Guardian published books throughout the year (the exact book remains a mystery until it lands on the doorstep)")
 
   val discount = Benefit("discount", "20% discount for you and a guest")
   val uniqueExperiences = Benefit("unique_experiences", "Exclusive behind-the-scenes functions")
@@ -79,7 +80,8 @@ object Benefits {
     emailUpdates
   )
   val patron = Seq(
-    booksAndTickets,
+    tickets,
+    books,
     uniqueExperiences,
     priorityBooking,
     noBookingFees,

--- a/frontend/app/views/fragments/form/featureChoiceFieldset.scala.html
+++ b/frontend/app/views/fragments/form/featureChoiceFieldset.scala.html
@@ -32,31 +32,12 @@
     </fieldset>
 }
 
-@patronChoice() = {
-    <fieldset class="fieldset">
-        <div class="fieldset__heading">
-            <h3 class="fieldset__headline">Your benefits</h3>
-        </div>
-        <div class="fieldset__fields">
-            @for(choice <- FeatureChoice.all) {
-                <div class="pseudo-radio-faker">
-                    <div class="pseudo-radio-faker__header">@choice.label</div>
-                    <div class="pseudo-radio-faker__note">
-                      @choice.description
-                    </div>
-                </div>
-            }
-        </div>
-    </fieldset>
-}
-
 @tier match {
     case Partner() => {
         @partnerChoice()
     }
     case Patron() => {
         <input type="hidden" name="featureChoice" value="@FeatureChoice.setToString(FeatureChoice.all)" />
-        @patronChoice()
     }
     case _ =>  {}
 }


### PR DESCRIPTION
## Why are you doing this?

On the checkout page, the benefits for patron are split into two separate lists. The books and tickets benefits are listed separately from the rest, as they are for partners. However, while this is necessary for partners, because you have to choose between them with a radio button, it makes no sense for patrons, because you get both.

[**Trello Card**](https://trello.com/c/w07SkHr1/316-merge-patron-benefits-into-single-list)

## Changes

- Modify the benefits model, to split tickets and books and provide fuller description.
- Remove the second list of patron benefits, the tickets and books, from the checkout page.

## Screenshots

**Before:**

![patron-before](https://cloud.githubusercontent.com/assets/5131341/22558256/f668ab3c-e964-11e6-95d8-1267d72a5fa0.png)

**After:**

![patron-after](https://cloud.githubusercontent.com/assets/5131341/22558269/ff2d04d4-e964-11e6-9665-a7a4d0a967d9.png)

**Partner Unchanged:**

![partner-unchanged](https://cloud.githubusercontent.com/assets/5131341/22558282/09049ada-e965-11e6-9b5d-0e443c11b3c0.png)

@svillafe @rupertbates @JustinPinner 