### PR TITLE
update membership common to use rateplan frontendid

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
     "com.gu" %% "memsub-common-play-auth" % "0.8", // v0.8 is the latest version published for Play 2.4...
     "com.gu" %% "identity-test-users" % "0.6"
   )
-  val membershipCommon = "com.gu" %% "membership-common" % "0.355"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.358"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
     "com.gu" %% "memsub-common-play-auth" % "0.8", // v0.8 is the latest version published for Play 2.4...
     "com.gu" %% "identity-test-users" % "0.6"
   )
-  val membershipCommon = "com.gu" %% "membership-common" % "0.354"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.357"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache


### PR DESCRIPTION
see https://github.com/guardian/membership-common/pull/419

This is needed so we can tell 6 for 6 guardian weekly apart from normal yearly guardian weekly.  It also makes the catalog process more deterministic and thus less flaky (and easier to debug when it doesn't work)

@guardian/membership-and-subscriptions we will add 6 for 6 in dev and uat next week, so make sure you merge in master when this is shipped otherwise you will see a "too many plans" error when reading the catalog.