### PR TITLE
Adding disallow statements for the landing pages.

### DIFF
--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -4,7 +4,6 @@ Disallow: /patterns
 Disallow: /whats-on
 Disallow: /join-challenger
 Disallow: /bundles
-Disallow: /bundles/thankyou
 
 Allow: /
 

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -5,6 +5,7 @@ Disallow: /whats-on
 Disallow: /join-challenger
 Disallow: /bundles
 Disallow: /bundles/thankyou
+
 Allow: /
 
 Sitemap: https://membership.theguardian.com/sitemap.xml

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -3,7 +3,8 @@ User-agent: *
 Disallow: /patterns
 Disallow: /whats-on
 Disallow: /join-challenger
-
+Disallow: /bundles
+Disallow: /bundles/thankyou
 Allow: /
 
 Sitemap: https://membership.theguardian.com/sitemap.xml


### PR DESCRIPTION
## Why are you doing this?

We would like to prevent search engines to crawl our site. Therefore, we add a line in the `robots.txt` file.

## Changes
* Modified the `robots.txt`
