### PR TITLE
Deleted some old cache settings. Using Play's aggressively strategy.

### DIFF
--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -42,9 +42,6 @@ logger.application=DEBUG
 
 include "benefits"
 
-# cache static assets for a year
-assets.defaultCache="max-age=31536000"
-
 zuora.free-event-tickets-allowance = 6
 
 # PayPal creds for CI environment.

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -2,8 +2,8 @@
 # This file defines all application routes (Higher priority routes first)
 # ~~~~
 
-GET            /robots.txt                            controllers.CachedAssets.at(path="/public", file="robots.txt", false:Boolean)
-GET            /humans.txt                            controllers.CachedAssets.at(path="/public", file="humans.txt", false:Boolean)
+GET            /robots.txt                            controllers.CachedAssets.at(path="/public", file="robots.txt", aggressiveCaching:Boolean ?= false )
+GET            /humans.txt                            controllers.CachedAssets.at(path="/public", file="humans.txt", aggressiveCaching:Boolean ?= false )
 GET            /favicon.ico                           controllers.CacheBustedAssets.at(path="images/favicons/32x32.ico")
 GET            /sitemap.xml                           controllers.SiteMap.sitemap()
 
@@ -128,7 +128,7 @@ GET            /join                                  controllers.Info.supporter
 GET            /assets/bookmarklets/*bookmarklet      controllers.CachedAssets.bookmarkletAt(path="/public/bookmarklets/", bookmarklet)
 
 # Map static resources from the /public folder to the /assets URL path
-GET            /assets/*assetFile                     controllers.CachedAssets.at(path="/public", assetFile, true: Boolean)
+GET            /assets/*assetFile                     controllers.CachedAssets.at(path="/public", assetFile, aggressiveCaching:Boolean ?= true)
 
 # Promotions
 GET            /p/:promoCodeStr                       controllers.Promotions.promotionPage(promoCodeStr)

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -2,8 +2,8 @@
 # This file defines all application routes (Higher priority routes first)
 # ~~~~
 
-GET            /robots.txt                            controllers.CachedAssets.at(path="/public", file="robots.txt")
-GET            /humans.txt                            controllers.CachedAssets.at(path="/public", file="humans.txt")
+GET            /robots.txt                            controllers.CachedAssets.at(path="/public", file="robots.txt", false:Boolean)
+GET            /humans.txt                            controllers.CachedAssets.at(path="/public", file="humans.txt", false:Boolean)
 GET            /favicon.ico                           controllers.CacheBustedAssets.at(path="images/favicons/32x32.ico")
 GET            /sitemap.xml                           controllers.SiteMap.sitemap()
 
@@ -125,10 +125,10 @@ GET            /founder                               controllers.VanityUrl.redi
 GET            /join-challenger                       controllers.Redirects.homepageRedirect
 GET            /join                                  controllers.Info.supporterRedirect(countryGroup: Option[CountryGroup])
 
-GET            /assets/bookmarklets/*bookmarklet      controllers.CachedAssets.bookmarkletAt(path="/public/bookmarklets/", bookmarklet, true)
+GET            /assets/bookmarklets/*bookmarklet      controllers.CachedAssets.bookmarkletAt(path="/public/bookmarklets/", bookmarklet)
 
 # Map static resources from the /public folder to the /assets URL path
-GET            /assets/*assetFile                     controllers.CachedAssets.at(path="/public", assetFile, true)
+GET            /assets/*assetFile                     controllers.CachedAssets.at(path="/public", assetFile, true: Boolean)
 
 # Promotions
 GET            /p/:promoCodeStr                       controllers.Promotions.promotionPage(promoCodeStr)

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -125,10 +125,10 @@ GET            /founder                               controllers.VanityUrl.redi
 GET            /join-challenger                       controllers.Redirects.homepageRedirect
 GET            /join                                  controllers.Info.supporterRedirect(countryGroup: Option[CountryGroup])
 
-GET            /assets/bookmarklets/*bookmarklet      controllers.CachedAssets.bookmarkletAt(path="/public/bookmarklets/", bookmarklet)
+GET            /assets/bookmarklets/*bookmarklet      controllers.CachedAssets.bookmarkletAt(path="/public/bookmarklets/", bookmarklet, true)
 
 # Map static resources from the /public folder to the /assets URL path
-GET            /assets/*assetFile                     controllers.CachedAssets.at(path="/public", assetFile)
+GET            /assets/*assetFile                     controllers.CachedAssets.at(path="/public", assetFile, true)
 
 # Promotions
 GET            /p/:promoCodeStr                       controllers.Promotions.promotionPage(promoCodeStr)


### PR DESCRIPTION
## Why are you doing this?

The changes introduced in https://github.com/guardian/membership-old/pull/318, didn't use the play's cache strategy correctly. In the `application.conf` file, it was set as a **default cache time** the same amount of time that play use int the aggressive caching strategy. Therefore, we modified the `routes` file to indicate which route should be cache aggressively and which one should be cache for the _default time_.

## Trello card: [Here](https://trello.com/c/HfDgKPSt/323-correctly-setup-the-cache-times-for-the-membership-s-play-app)

## Changes
* Change routes file.
* Change `application.conf`

## Screenshots

### /robots.txt

| Before | After |
|--------|-------|
|![picture 120](https://cloud.githubusercontent.com/assets/825398/22733015/3ea5981a-ede8-11e6-8a28-63c63a008f8c.png) | ![picture 119](https://cloud.githubusercontent.com/assets/825398/22733029/47662500-ede8-11e6-8b1f-3fd3e47e56fb.png) |


### /assets/javascripts/main.js

| Before | After |
|--------|-------|
| ![picture 123](https://cloud.githubusercontent.com/assets/825398/22733337/43f338da-ede9-11e6-84bf-9f6ccb374196.png) | ![picture 122](https://cloud.githubusercontent.com/assets/825398/22733241/ec40b900-ede8-11e6-9e83-40be6f942466.png) |

### /uk/supporter

| Before | After |
|--------|-------|
|![picture 124](https://cloud.githubusercontent.com/assets/825398/22733692/c55e45f8-edea-11e6-8232-5272c9a86cce.png) |  ![picture 125](https://cloud.githubusercontent.com/assets/825398/22733736/f633239c-edea-11e6-8142-45127bd2855c.png) |
