### PR TITLE
set reply to address in feedback form

### DIFF
--- a/frontend/app/services/EmailService.scala
+++ b/frontend/app/services/EmailService.scala
@@ -51,7 +51,7 @@ trait EmailService extends LazyLogging {
       """.stripMargin
       logger.info(body)
       val message = new Message(subjectContent, new Body().withHtml(new Content(body)))
-      val email = new SendEmailRequest(feedback.category.email, to, message)
+      val email = new SendEmailRequest(feedback.category.email, to, message).withReplyToAddresses(feedback.email)
 
       Try {
         client.sendEmail(email)


### PR DESCRIPTION
With reply-to set in the message headers, salesforce assigns the users email to the case that gets auto-created from the email.