### PR TITLE
Deleting bean from comparisonTable.es6

### DIFF
--- a/frontend/assets/javascripts/src/modules/comparisonTable.es6
+++ b/frontend/assets/javascripts/src/modules/comparisonTable.es6
@@ -1,18 +1,17 @@
-import * as bean from 'bean'
 import $ from '$'
 
 'use strict';
 
-const COMPARISON_TABLE_SELECTOR = '.comparison-table';
-const COMPARISON_TABLE = document.querySelector(COMPARISON_TABLE_SELECTOR);
+const COMPARISON_TABLE_CLASS_NAME = 'comparison-table';
+const COMPARISON_TABLE = document.getElementsByClassName(COMPARISON_TABLE_CLASS_NAME);
 
 const HOVER_CLASS = 'is-hover';
 const ACTIVE_CLASS = 'is-active';
-const HOVERED = COMPARISON_TABLE_SELECTOR + ' .is-hover';
-const CLICKABLE = COMPARISON_TABLE_SELECTOR + ' .js-clickable';
+const HOVERED = '.' + COMPARISON_TABLE_CLASS_NAME + ' .is-hover';
+const CLICKABLE = '.' + COMPARISON_TABLE_CLASS_NAME + ' .js-clickable';
 
 export function init() {
-    if (!COMPARISON_TABLE) {
+    if (COMPARISON_TABLE.length == 0) {
         return;
     }
 
@@ -27,19 +26,22 @@ function tierSelector(tier) {
 // because we have no single container which holds a tier column.
 // Instead they are split between rows, so we use data-tier to group them together.
 function addHoverListeners() {
-    bean.on(COMPARISON_TABLE, 'mouseenter', CLICKABLE, e => {
-        let tier = $(e.currentTarget).data('tier');
-        let $elemsInThisTier = $(CLICKABLE + tierSelector(tier));
-        let $elemsInOtherTiers = $(CLICKABLE + ':not(' + tierSelector(tier) + ')');
+    let elems = document.querySelectorAll(CLICKABLE);
+    for(var i = 0 ; i < elems.length ; i++){
+        elems[i].addEventListener('mouseenter', e => {
+            let tier = $(e.currentTarget).data('tier');
+            let $elemsInThisTier = $(CLICKABLE + tierSelector(tier));
+            let $elemsInOtherTiers = $(CLICKABLE + ':not(' + tierSelector(tier) + ')');
 
-        $elemsInThisTier.addClass(HOVER_CLASS);
-        $elemsInThisTier.addClass(ACTIVE_CLASS);
-        $elemsInOtherTiers.removeClass(ACTIVE_CLASS);
-    });
+            $elemsInThisTier.addClass(HOVER_CLASS);
+            $elemsInThisTier.addClass(ACTIVE_CLASS);
+            $elemsInOtherTiers.removeClass(ACTIVE_CLASS);
+        });
 
-    bean.on(COMPARISON_TABLE, 'mouseleave', CLICKABLE, () => {
-        $(HOVERED).removeClass(HOVER_CLASS);
-    });
+        elems[i].addEventListener('mouseleave', () => {
+            $(HOVERED).removeClass(HOVER_CLASS);
+        });
+    }
 }
 
 

--- a/frontend/assets/javascripts/src/modules/comparisonTable.es6
+++ b/frontend/assets/javascripts/src/modules/comparisonTable.es6
@@ -26,12 +26,12 @@ function tierSelector(tier) {
 // because we have no single container which holds a tier column.
 // Instead they are split between rows, so we use data-tier to group them together.
 function addHoverListeners() {
-    let elems = document.querySelectorAll(CLICKABLE);
-    for(var i = 0 ; i < elems.length ; i++){
+    const elems = document.querySelectorAll(CLICKABLE);
+    for(let i = 0 ; i < elems.length ; i++){
         elems[i].addEventListener('mouseenter', e => {
-            let tier = $(e.currentTarget).data('tier');
-            let $elemsInThisTier = $(CLICKABLE + tierSelector(tier));
-            let $elemsInOtherTiers = $(CLICKABLE + ':not(' + tierSelector(tier) + ')');
+            const tier = $(e.currentTarget).data('tier');
+            const $elemsInThisTier = $(CLICKABLE + tierSelector(tier));
+            const $elemsInOtherTiers = $(CLICKABLE + ':not(' + tierSelector(tier) + ')');
 
             $elemsInThisTier.addClass(HOVER_CLASS);
             $elemsInThisTier.addClass(ACTIVE_CLASS);


### PR DESCRIPTION
## Why are you doing this?
We want to delete old js libraries, and this is the first step to do that. In this first PR we delete bean.js from `comparisonTable.es6`. The focus of this PR is to replace the library and not improve the performance of the functions.

In order to minimise the impact of the change, I have just replaced the behaviour of bean.js with built-in functions. In bean.js when a selector is passed to the function .on, it goes trough all the sub-elements of the root that fulfil that selector and attach an element with addEventListener. It is not the most performant thing to do but it was necessary in order to reuse the code of the handler and try to minimise the number of potential new bugs. 

## Trello card: [Here](https://trello.com/c/MDQEOo2d/299-js-clean-code-delete-bean-js-library-from-the-source-code)

## Changes
* Mofidied `comparisonTable.es6`

## Screenshots

N/A
