### PR TITLE
Don't initialise PayPal if we are running in a webview

### DIFF
--- a/frontend/assets/javascripts/src/modules/form/paypal.es6
+++ b/frontend/assets/javascripts/src/modules/form/paypal.es6
@@ -3,6 +3,7 @@
 import form from 'src/modules/form/helper/formUtil';
 import * as payment from 'src/modules/payment';
 import 'whatwg-fetch';
+import isWebView from 'is-webview';
 
 
 // ----- Functions ----- //
@@ -134,6 +135,11 @@ function makePayment (data, actions) {
 // ----- Exports ----- //
 
 export function init () {
+
+    if (isWebView(navigator.userAgent)){
+        console.log("We are running in a Webview, PayPal will not work so don't initialise it");
+        return;
+    }
 
 	paypal.Button.render({
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,6 +42,7 @@
     "grunt-svgstore": "^0.5.0",
     "grunt-webpack": "^1.0.11",
     "gumshoe": "cferdinandi/gumshoe",
+    "is-webview": "^1.0.1",
     "jasmine-core": "^2.4.1",
     "karma": "~0.13.9",
     "karma-chrome-launcher": "^0.1.12",


### PR DESCRIPTION
## Why are you doing this?
Our current implementation of the PayPal checkout will not work in a webview, unfortunately this is how the apps do membership checkout. 

This PR prevents PayPal from being loaded if the checkout page is running in a webview

## Trello card: [Here](https://trello.com/c/y0jjGkTe/325-hide-paypal-button-for-apps-users)

## Screenshots
How the checkout page looks when PayPal is not initialised
<img width="720" alt="screen shot 2017-02-09 at 17 53 40" src="https://cloud.githubusercontent.com/assets/181371/22796030/c16e259c-eef0-11e6-8c84-06ceee7fd99f.png">

