### PR TITLE
Don't show PayPal to apps users (because it won't work)

### DIFF
--- a/frontend/assets/javascripts/src/modules/form/helper/formUtil.js
+++ b/frontend/assets/javascripts/src/modules/form/helper/formUtil.js
@@ -34,8 +34,10 @@ define([
     };
 
     function hasPaypal () {
+        var regex = /^APP_.*_MEMBERSHIP_PAYMENT_SCREEN$/; // matches Android (APP_ANDROID_MEMBERSHIP_PAYMENT), iOS (APP_IOS_MEMBERSHIP_PAYMENT) & Windows app (if they implement it one day)
         var code = url.getQueryParameterByName('INTCMP');
-        var fromApps = code && code.substring(0, 3) ==='APP' && code.substring(code.length - 25) === 'MEMBERSHIP_PAYMENT_SCREEN'; // covers Android, iOS & Windows app (if they implement it one day)
+
+        var fromApps = regex.exec(code);
         return !!document.getElementById('paypal-button-checkout') && !fromApps;
     }
 

--- a/frontend/assets/javascripts/src/modules/form/helper/formUtil.js
+++ b/frontend/assets/javascripts/src/modules/form/helper/formUtil.js
@@ -1,6 +1,7 @@
 define([
-    'src/utils/helper'
-], function (utilsHelper) {
+    'src/utils/helper',
+    'src/utils/url'
+], function (utilsHelper, url) {
     'use strict';
 
     /**
@@ -33,7 +34,9 @@ define([
     };
 
     function hasPaypal () {
-        return !!document.getElementById('paypal-button-checkout');
+        var code = url.getQueryParameterByName('INTCMP');
+        var fromApps = code && code.substring(0, 3) ==='APP' && code.substring(code.length - 25) === 'MEMBERSHIP_PAYMENT_SCREEN'; // covers Android, iOS & Windows app (if they implement it one day)
+        return !!document.getElementById('paypal-button-checkout') && !fromApps;
     }
 
     function hasStripeCheckout () {


### PR DESCRIPTION
## Why are you doing this?
Our current implementation of the PayPal checkout will not work in a webview, unfortunately this is how the apps do membership checkout.

This PR prevents PayPal from being loaded if the checkout page is running in a webview

## Trello card: [Here](https://trello.com/c/y0jjGkTe/325-hide-paypal-button-for-apps-users)

## Screenshots
### How the checkout page looks without PayPal
<img width="720" alt="screen shot 2017-02-09 at 17 53 40" src="https://cloud.githubusercontent.com/assets/181371/22798001/4744a0b8-eef8-11e6-967f-ef4f087c62c8.png">


