### PR TITLE
Membership content 404

### DIFF
--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -80,7 +80,7 @@ object Joiner extends Controller with ActivityTracking
       contentURL <- contentRefererOpt if Uri.parse(contentURL).host.contains("www.theguardian.com")
       access <- accessOpt
     } yield {
-      Redirect(routes.MemberOnlyContent.membershipContent(Some(contentURL), Some(access.name)))
+      Redirect(routes.MemberOnlyContent.membershipContent(Some(contentURL)))
     }).getOrElse(
       Ok(views.html.joiner.tierChooser(TouchpointBackend.Normal.catalog, pageInfo, eventOpt, accessOpt, signInUrl))
     ).withSession(

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -80,7 +80,7 @@ object Joiner extends Controller with ActivityTracking
       contentURL <- contentRefererOpt if Uri.parse(contentURL).host.contains("www.theguardian.com")
       access <- accessOpt
     } yield {
-      Redirect(routes.MemberOnlyContent.membershipContent(contentURL, access.name))
+      Redirect(routes.MemberOnlyContent.membershipContent(Some(contentURL), Some(access.name)))
     }).getOrElse(
       Ok(views.html.joiner.tierChooser(TouchpointBackend.Normal.catalog, pageInfo, eventOpt, accessOpt, signInUrl))
     ).withSession(

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -76,16 +76,8 @@ object Joiner extends Controller with ActivityTracking
       customSignInUrl = Some(signInUrl)
     )
 
-    (for {
-      contentURL <- contentRefererOpt if Uri.parse(contentURL).host.contains("www.theguardian.com")
-      access <- accessOpt
-    } yield {
-      Redirect(routes.MemberOnlyContent.membershipContent(Some(contentURL)))
-    }).getOrElse(
-      Ok(views.html.joiner.tierChooser(TouchpointBackend.Normal.catalog, pageInfo, eventOpt, accessOpt, signInUrl))
-    ).withSession(
-      request.session.copy(data = request.session.data ++ contentRefererOpt.map(JoinReferrer -> _))
-    )
+    Ok(views.html.joiner.tierChooser(TouchpointBackend.Normal.catalog, pageInfo, eventOpt, accessOpt, signInUrl))
+      .withSession(request.session.copy(data = request.session.data ++ contentRefererOpt.map(JoinReferrer -> _)))
   }
 
   def staff = PermanentStaffNonMemberAction.async { implicit request =>

--- a/frontend/app/views/joiner/membershipContent.scala.html
+++ b/frontend/app/views/joiner/membershipContent.scala.html
@@ -8,7 +8,6 @@
 @import com.gu.contentapi.client.model.v1.{MembershipTier=>ContentAccess}
 
 @(pageInfo: PageInfo,
-    accessOpt: Option[ContentAccess],
     signInUrl: String,
     content: CapiContent,
     titleOverride: String

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -32,7 +32,7 @@ GET            /lookupPromotion                       controllers.Promotions.val
 
 GET            /choose-tier                           controllers.Joiner.tierChooser
 
-GET            /membership-content                    controllers.MemberOnlyContent.membershipContent(referringContent: String, membershipAccess: String)
+GET            /membership-content                    controllers.MemberOnlyContent.membershipContent(referringContent: Option[String], membershipAccess: Option[String])
 
 # Normal user signin:
 GET            /signin                                controllers.Login.chooseSigninOrRegister(returnUrl: String)

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -32,7 +32,8 @@ GET            /lookupPromotion                       controllers.Promotions.val
 
 GET            /choose-tier                           controllers.Joiner.tierChooser
 
-GET            /membership-content                    controllers.MemberOnlyContent.membershipContent(referringContent: Option[String], membershipAccess: Option[String])
+GET            /membership-content                    controllers.MemberOnlyContent.membershipContent(referringContent: Option[String] ?= None)
+
 
 # Normal user signin:
 GET            /signin                                controllers.Login.chooseSigninOrRegister(returnUrl: String)


### PR DESCRIPTION
## Why are you doing this?

There are several errors in Sentry ([here](https://sentry.io/the-guardian/membership/issues/123747866/)) about requests to /membership-content which are returning **400 Bad Request**. The main reason for this is because the request doesn't have the necessary query parameters. At the same time, we spotted that are crawlers that are driven traffic to /membership-content also without the required parameters. 
Therefore, in this PR we are deleting one of the parameters and marking the other one as optional and if we don't receive it, we direct that traffic to the supporter landing page.

## Trello card: [Here](https://trello.com/c/lVIZUWz4/176-bad-requests-occurring-for-members-only-content) and [Here](https://trello.com/c/98Iw9jkC/186-modify-robots-txt-to-prevent-web-crawlers-hitting-membership-content)

## Changes
* Deleted the unnecessary **membershipAccess** parameter from membership-content controller.
* Converted membership-content's parameters to Option
* Set a redirect as a default case when we receive None. 

# Screenshots
### /membership-content

| Before | After |
|--------|-------|
|     ![before1](https://cloud.githubusercontent.com/assets/825398/22829876/72ad2816-ef9c-11e6-95be-a28fed9c2194.png)|     ![after1](https://cloud.githubusercontent.com/assets/825398/22829344/097c696c-ef9a-11e6-8e1d-5b4a88baeb05.png) |

### /membership-content?referringContent=membership/audio/2017/feb/02/we-need-to-talk-about-climate-change-guardian-members-exclusive-podcast

| Before | After |
|--------|-------|
| ![before2](https://cloud.githubusercontent.com/assets/825398/22829946/b452ba4c-ef9c-11e6-8852-722a5e334ac1.png)| ![after-2](https://cloud.githubusercontent.com/assets/825398/22829374/2da1058c-ef9a-11e6-84c6-65e4e73d2b34.png)|

### /membership-content?referringContent=membership/audio/2017/feb/02/we-need-to-talk-about-climate-change-guardian-members-exclusive-podcast&membershipAccess=MembersOnly

| Before | After |
|--------|-------|
|![before3](https://cloud.githubusercontent.com/assets/825398/22830013/f38af008-ef9c-11e6-8892-b9e354f2e41f.png)| ![after3](https://cloud.githubusercontent.com/assets/825398/22829452/9f73651a-ef9a-11e6-8863-aea7630b7c73.png)|
