### PR TITLE
Replace commenting with exclusive content for new test.

### DIFF
--- a/frontend/app/abtests/BundleVariant.scala
+++ b/frontend/app/abtests/BundleVariant.scala
@@ -19,7 +19,7 @@ object BundleVariant {
 }
 
 case class BundleVariant(distribution: Distribution, prices: Map[BundleTier, Double], hasAdFree: Boolean = true) {
-  val testId =  s"MEMBERSHIP_A_ADS_THRASHER_UK_${distribution.name}"
+  val testId =  s"MEMBERSHIP_A_ADX_THRASHER_UK_${distribution.name}"
 
   def prettyMonthlyPrice(tier: BundleTier) = f"£${prices(tier)}%.2f/month"
 }

--- a/frontend/app/views/fragments/bundle/bundleOfferingsA.scala.html
+++ b/frontend/app/views/fragments/bundle/bundleOfferingsA.scala.html
@@ -41,12 +41,12 @@
                         }
                         <li class="bundle-offering-a__subscribe__offer__list__item">
                             <div class="bundle-offering-a__subscribe__offer__list__item__icon">
-                                @for(icon <- Asset.inlineSvg("bundle-commenting")) {
+                                @for(icon <- Asset.inlineSvg("bundle-guardian_g")) {
                                     @icon
                                 }
                             </div><div class="bundle-offering-a__subscribe__offer__list__item__content">
-                                <h1>Commenting</h1>
-                                <p>Discussion threads on articles are reserved for paying supporters only</p>
+                                <h1>Exclusive content</h1>
+                                <p>Behind-the-scenes updates from Guardian journalists, a regular newsletter and our new member podcast</p>
                             </div>
                         </li>
 
@@ -84,12 +84,12 @@
 
                         <li class="bundle-offering-a__subscribe__offer__list__item">
                             <div class="bundle-offering-a__subscribe__offer__list__item__icon">
-                                @for(icon <- Asset.inlineSvg("bundle-commenting")) {
+                                @for(icon <- Asset.inlineSvg("bundle-guardian_g")) {
                                     @icon
                                 }
                             </div><div class="bundle-offering-a__subscribe__offer__list__item__content">
-                                <h1>Commenting</h1>
-                                <p>Discussion threads on articles are reserved for paying supporters only</p>
+                                <h1>Exclusive content</h1>
+                                <p>Behind-the-scenes updates from Guardian journalists, a regular newsletter and our new member podcast</p>
                             </div>
                         </li>
                         <li class="bundle-offering-a__subscribe__offer__list__item">


### PR DESCRIPTION
## Why are you doing this?
We're eliminating commenting from the previous A1/A2 test, referring instead to exclusive content.

See companion PR in frontend: https://github.com/guardian/frontend/pull/15832

## Trello card: [Here](https://trello.com/c/1pBVi02T/328-new-a-b-test-for-ad-free-no-comments-included)

## Screenshots
See https://github.com/guardian/frontend/pull/15832
