### PR TITLE
Added a form flush in order to update the validation listeners

### DIFF
--- a/frontend/assets/javascripts/src/modules/form/options.js
+++ b/frontend/assets/javascripts/src/modules/form/options.js
@@ -2,12 +2,14 @@ define([
     '$',
     'bean',
     'src/modules/form/billingPeriodChoice',
-    'src/modules/form/validation/display'
+    'src/modules/form/validation/display',
+    'src/modules/form/helper/formUtil'
 ], function (
     $,
     bean,
     billingPeriodChoice,
-    validationDisplay
+    validationDisplay,
+    form
 ) {
     'use strict';
 
@@ -175,6 +177,7 @@ define([
             checkoutForm.showBillingAddress = true;
 
             renderPrices();
+            form.flush();
         });
 
         bean.on(USE_DELIVERY_ADDRESS_EL, 'click', function() {
@@ -182,6 +185,7 @@ define([
             checkoutForm.billingCountry = checkoutForm.deliveryCountry;
 
             renderPrices();
+            form.flush();
         });
     }
 


### PR DESCRIPTION
## Why are you doing this? 
Currently, in the case of selecting a delivery address which is different from the billing address,  there isn't any validation, triggered by the submit button, on the billing address. As a result, a wrong error message is being displayed. In this PR we are flushing the `form.elems` array in order to keep an update of the elements that we have to test.  

## Trello card: [Here](https://trello.com/c/21rhCU1r/327-bug-in-billing-address-validation)

## Changes
* Modified `options.js` in order to validate the correct field when we press submit.

## Screenshots

### Before
![before-error](https://cloud.githubusercontent.com/assets/825398/22940795/0af6b0ec-f2db-11e6-9224-7da9d62d9183.png)


### After
![after-error](https://cloud.githubusercontent.com/assets/825398/22940728/de45364a-f2da-11e6-9ed7-c6c9cb48f7cf.png)


