### PR TITLE
Simplify and remove many deprecated calls to the PromotionService

### DIFF
--- a/frontend/app/controllers/Healthcheck.scala
+++ b/frontend/app/controllers/Healthcheck.scala
@@ -23,7 +23,7 @@ object Healthcheck extends Controller {
     new BoolTest("Events", () => GuardianLiveEventService.events.nonEmpty),
     new BoolTest("CloudWatch", () => CloudWatchHealth.hasPushedMetricSuccessfully),
     new BoolTest("ZuoraPing", () => zuoraSoapClient.lastPingTimeWithin(2.minutes)),
-    new BoolTest("Promotions", () => promos.all.nonEmpty),
+    new BoolTest("Promotions", () => promos.futureAll.value.exists(_.map(_.nonEmpty).getOrElse(false))),
     new BoolTest("Salesforce", () => salesforceService.isAuthenticated)
   )
 

--- a/frontend/app/controllers/TierController.scala
+++ b/frontend/app/controllers/TierController.scala
@@ -1,17 +1,15 @@
 package controllers
 
-import services.PromoSessionService.codeFromSession
-import actions.BackendProvider
-import com.gu.memsub.promo.{PromoCode, Upgrades}
 import _root_.services.api.MemberService._
+import actions.BackendProvider
 import com.gu.i18n.CountryGroup
-import com.gu.memsub.promo.Formatters.PromotionFormatters._
 import com.gu.i18n.CountryGroup._
 import com.gu.identity.play.PrivateFields
+import com.gu.memsub.BillingPeriod
 import com.gu.memsub.Subscriber.{FreeMember, PaidMember}
+import com.gu.memsub.promo.Formatters.PromotionFormatters._
+import com.gu.memsub.promo.{PromoCode, Upgrades}
 import com.gu.memsub.subsv2.{Catalog, MonthYearPlans}
-import services.{IdentityApi, IdentityService}
-import com.gu.memsub.{BillingPeriod, _}
 import com.gu.salesforce._
 import com.gu.stripe.Stripe
 import com.gu.stripe.Stripe.Serializer._
@@ -24,18 +22,21 @@ import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json.Json
 import play.api.mvc.{Controller, Result}
 import play.filters.csrf.CSRF.Token.getToken
+import services.PromoSessionService.codeFromSession
+import services.{IdentityApi, IdentityService}
 import tracking.ActivityTracking
 import utils.RequestCountry._
 import utils.{CampaignCode, TierChangeCookies}
+import views.support.MembershipCompat._
 import views.support.Pricing._
 import views.support.{CheckoutForm, CountryWithCurrency, PageInfo, PaidToPaidUpgradeSummary}
+
 import scala.concurrent.Future
 import scala.language.implicitConversions
 import scalaz.std.scalaFuture._
 import scalaz.syntax.monad._
 import scalaz.syntax.std.option._
 import scalaz.{EitherT, \/}
-import views.support.MembershipCompat._
 
 object TierController extends Controller with ActivityTracking
                                          with LazyLogging
@@ -172,10 +173,8 @@ object TierController extends Controller with ActivityTracking
         // is the promoCode valid for the page being rendered
         val pageInfo = getPageInfo(privateFields, BillingPeriod.Year)
         val planChoice = PaidPlanChoice(target, BillingPeriod.Year)
-        val validPromoCode = providedPromoCode.flatMap(promoService.validate[Upgrades](_, pageInfo.initialCheckoutForm.defaultCountry.get, planChoice.productRatePlanId).toOption)
-        val validPromotion = validPromoCode.flatMap(validPromo => promoService.findPromotion(validPromo.code))
-        val validTrackingPromoCode = validPromotion.filter(_.asTracking.isDefined).flatMap(p => providedPromoCode)
-        val validDisplayablePromoCode = validPromotion.filterNot(_.asTracking.isDefined).flatMap(p => providedPromoCode)
+        val validPromo =
+          providedPromoCode.flatMap(promoService.validate[Upgrades](_, pageInfo.initialCheckoutForm.defaultCountry.get, planChoice.productRatePlanId).toOption)
 
         Ok(views.html.tier.upgrade.freeToPaid(
           c.friend,
@@ -183,8 +182,7 @@ object TierController extends Controller with ActivityTracking
           countriesWithCurrency,
           privateFields,
           pageInfo,
-          validTrackingPromoCode,
-          validDisplayablePromoCode
+          validPromo
         )(getToken, request))
       })
     }, { paidSubscriber =>

--- a/frontend/app/views/fragments/form/promoCode.scala.html
+++ b/frontend/app/views/fragments/form/promoCode.scala.html
@@ -1,9 +1,8 @@
-@import com.gu.memsub.promo.PromoCode
-
-@(trackingPromoCode: Option[PromoCode], promoCodeToDisplay: Option[PromoCode])
+@import com.gu.memsub.promo.ValidPromotion
+@(validPromotion: Option[ValidPromotion[_]])
 
 <fieldset class="fieldset">
-    @fragments.form.trackingPromoCode(trackingPromoCode)
+    @fragments.form.trackingPromoCode(validPromotion.flatMap(_.trackingCode))
 
     <div class="fieldset__heading">
         <h2 class="fieldset__headline">Do you have a promo code?</h2>
@@ -12,7 +11,7 @@
     <div class="fieldset__fields">
         <div class="form-field">
             <div class="promo-code">
-              <input id="promo-code" name="promoCode" value="@promoCodeToDisplay.map(_.get).getOrElse("")" type="text" class="js-promocode-value input-text js-input promo-code__field"/>
+              <input id="promo-code" name="promoCode" value="@validPromotion.flatMap(_.displayableCode).map(_.get).mkString" type="text" class="js-promocode-value input-text js-input promo-code__field"/>
               <button type="button" class="js-promo-code-apply promo-code__apply action js-promo-code-validate">Apply</button>
             </div>
             <div class="loader js-promo-loader">Validating</div>

--- a/frontend/app/views/joiner/form/friendSignup.scala.html
+++ b/frontend/app/views/joiner/form/friendSignup.scala.html
@@ -5,10 +5,12 @@
 @import views.support.DisplayText._
 @import views.support.{CountryWithCurrency, FreePlan, IdentityUser, PageInfo}
 
+@import com.gu.memsub.promo.ValidPromotion
+@import com.gu.memsub.promo.NewUsers
 @(friendPlan: CatalogPlan.Friend,
   idUser: IdentityUser,
   pageInfo: PageInfo,
-  trackingPromoCode: Option[PromoCode]
+  validPromo: Option[ValidPromotion[NewUsers]]
 )(implicit token: play.filters.csrf.CSRF.Token)
 
 @main("Become a Friend", pageInfo) {
@@ -57,7 +59,7 @@
                             county = idUser.privateFields.address4
                         )
                         @fragments.form.marketingChoices(idUser.marketingChoices.receiveGnmMarketing, idUser.marketingChoices.receive3rdPartyMarketing)
-                        @fragments.form.trackingPromoCode(trackingPromoCode)
+                        @fragments.form.trackingPromoCode(validPromo.flatMap(_.trackingCode))
 
                         @if(!idUser.passwordExists) {
                             @fragments.form.createPassword()

--- a/frontend/app/views/joiner/form/payment.scala.html
+++ b/frontend/app/views/joiner/form/payment.scala.html
@@ -1,27 +1,18 @@
+@import com.gu.i18n.CountryGroup
+@import com.gu.memsub.promo.{NewUsers, ValidPromotion}
+@import com.gu.memsub.subsv2.CatalogPlan.PaidMember
+@import com.gu.memsub.subsv2.MonthYearPlans
+@import com.gu.salesforce.Tier.Supporter
+@import tracking.AppnexusPixel
 @import views.html.helper._
 @import views.support.DisplayText._
-@import views.support.PageInfo
-@import views.support.CountryWithCurrency
-@import views.support.IdentityUser
-
-@import com.gu.memsub.Current
-@import com.gu.salesforce.PaidTier
-@import com.gu.salesforce.Tier.Supporter
-@import com.gu.memsub.promo.PromoCode
-@import views.support.PaidPlans
 @import views.support.MembershipCompat._
-@import com.gu.memsub.subsv2.MonthYearPlans
-@import com.gu.memsub.subsv2.CatalogPlan.PaidMember
-@import com.gu.i18n.CountryGroup
-@import tracking.AppnexusPixel
-
-
+@import views.support.{CountryWithCurrency, IdentityUser, PageInfo, PaidPlans}
 @(plans: MonthYearPlans[PaidMember],
     countriesWithCurrencies: List[CountryWithCurrency],
     idUser: IdentityUser,
     pageInfo: PageInfo,
-    trackingPromoCode: Option[PromoCode],
-    promoCodeToDisplay: Option[PromoCode],
+    validPromo: Option[ValidPromotion[NewUsers]],
     countryGroup: Option[CountryGroup],
     touchpointBackendResolution: services.TouchpointBackend.Resolution
     )(implicit token: play.filters.csrf.CSRF.Token, request: actions.AuthRequest[_])
@@ -88,7 +79,7 @@
                     @if(plans.tier != Supporter()) {
                         <div class="form-group form-section__promotion">
                             <h2 class="form-group__title">Promotion</h2>
-                            @fragments.form.promoCode(trackingPromoCode, promoCodeToDisplay)
+                            @fragments.form.promoCode(validPromo)
                         </div>
                     }
 

--- a/frontend/app/views/tier/upgrade/freeToPaid.scala.html
+++ b/frontend/app/views/tier/upgrade/freeToPaid.scala.html
@@ -1,24 +1,18 @@
+@import com.gu.memsub.subsv2.CatalogPlan.PaidMember
+@import com.gu.memsub.subsv2.{MonthYearPlans, _}
 @import play.api.mvc.RequestHeader
 @import play.filters.csrf
 @import views.support.DisplayText._
-@import views.support.PageInfo
-@import views.support.CountryWithCurrency
-@import com.gu.memsub.{Status, Current}
-@import com.gu.memsub.promo.PromoCode
-@import com.gu.memsub.subsv2._
-@import views.support.PaidPlans
-@import com.gu.memsub.Friend
-@import com.gu.memsub.subsv2.CatalogPlan.PaidMember
-@import com.gu.memsub.subsv2.MonthYearPlans
 @import views.support.MembershipCompat._
-
+@import views.support.{CountryWithCurrency, PageInfo, PaidPlans}
+@import com.gu.memsub.promo.ValidPromotion
+@import com.gu.memsub.promo.Upgrades
 @(currentPlan: CatalogPlan.Member,
   targetPlans: MonthYearPlans[PaidMember],
   countriesWithCurrency: List[CountryWithCurrency],
   userFields: com.gu.identity.play.PrivateFields,
   pageInfo: PageInfo,
-  trackingPromoCode: Option[PromoCode],
-  promoCodeToDisplay: Option[PromoCode]
+    validPromo: Option[ValidPromotion[Upgrades]]
 )(implicit token: csrf.CSRF.Token, request: RequestHeader)
 
 @import views.html.helper._
@@ -71,7 +65,7 @@
 
                   <div class="form-group">
                       <h2 class="form-group__title">Promotion</h2>
-                      @fragments.form.promoCode(trackingPromoCode, promoCodeToDisplay)
+                      @fragments.form.promoCode(validPromo)
                   </div>
 
                   <div class="form-group">

--- a/frontend/app/views/tier/upgrade/paidToPaid.scala.html
+++ b/frontend/app/views/tier/upgrade/paidToPaid.scala.html
@@ -8,7 +8,6 @@
 @import views.support.PageInfo
 @import com.gu.memsub.promo.ValidPromotion
 @import com.gu.memsub.promo.Upgrades
-@import com.gu.memsub.promo.Tracking
 @(
     summary: PaidToPaidUpgradeSummary,
     userFields: com.gu.identity.play.PrivateFields,
@@ -43,7 +42,7 @@
                       <div class="form-group">
                           @fragments.form.benefitsFieldset(summary.target.tier.benefits)
                           @fragments.form.featureChoiceFieldset(summary.target.tier)
-                          @validPromo.filter(_.promotion.promotionType != Tracking).fold(fragments.form.promoCode(validPromo.map(_.code), None))(_ => fragments.form.promoCode(None, validPromo.map(_.code)))
+                          @fragments.form.promoCode(validPromo)
                       </div>
                       <h2 class="h-section">What happens now</h2>
                       <p>When you upgrade we want to make sure you are charged the right amount. We will charge for your <strong>@summary.current.tier.name</strong>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
     "com.gu" %% "memsub-common-play-auth" % "0.8", // v0.8 is the latest version published for Play 2.4...
     "com.gu" %% "identity-test-users" % "0.6"
   )
-  val membershipCommon = "com.gu" %% "membership-common" % "0.361"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.362"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache


### PR DESCRIPTION
## Why are you doing this?

Getting rid of some deprecation warnings is nice (this leaves us with 4, rather than 8, deprecation-warnings related to `PromotionService`), but the main thing is deletion of some ugly lines of code (_44 additions and 69 deletions_) :smiley: 

I'm about to do some work in this area and wanted to tidy up before I started:

## Changes

We now pass around a `Option[ValidPromotion]` rather than a pair of `Option[PromoCode]`, reducing the number of arguments that need to be passed through, and getting rid of some fairly repeated code of the form `.filter(_.asTracking.isDefined).filter(_.asTracking.isDefined).flatMap(p => providedPromoCode)`

This will also require an update from membership-common: https://github.com/guardian/membership-common/pull/427

cc @Ap0c @AWare 