### PR TITLE
Revert "Simplify and remove many deprecated calls to the PromotionService"

### DIFF
--- a/frontend/app/controllers/Healthcheck.scala
+++ b/frontend/app/controllers/Healthcheck.scala
@@ -23,7 +23,7 @@ object Healthcheck extends Controller {
     new BoolTest("Events", () => GuardianLiveEventService.events.nonEmpty),
     new BoolTest("CloudWatch", () => CloudWatchHealth.hasPushedMetricSuccessfully),
     new BoolTest("ZuoraPing", () => zuoraSoapClient.lastPingTimeWithin(2.minutes)),
-    new BoolTest("Promotions", () => promos.futureAll.value.exists(_.map(_.nonEmpty).getOrElse(false))),
+    new BoolTest("Promotions", () => promos.all.nonEmpty),
     new BoolTest("Salesforce", () => salesforceService.isAuthenticated)
   )
 

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -8,12 +8,13 @@ import com.gu.i18n.CountryGroup
 import com.gu.i18n.CountryGroup.UK
 import com.gu.i18n.Currency.GBP
 import com.gu.memsub.BillingPeriod
-import com.gu.memsub.promo._
+import com.gu.memsub.promo.{NewUsers, PromoCode}
 import com.gu.memsub.util.Timing
 import com.gu.salesforce._
 import com.gu.stripe.Stripe
 import com.gu.stripe.Stripe.Serializer._
 import com.gu.zuora.soap.models.errors._
+import com.netaporter.uri.Uri
 import com.netaporter.uri.dsl._
 import com.typesafe.scalalogging.LazyLogging
 import configuration.{Config, CopyConfig}
@@ -139,7 +140,11 @@ object Joiner extends Controller with ActivityTracking
 
       // is the providedPromoCode valid for the page being rendered (year is default billing period)
       val planChoice = PaidPlanChoice(tier, BillingPeriod.Year)
-      val validPromo = providedPromoCode.flatMap(promoService.validate[NewUsers](_, pageInfo.initialCheckoutForm.defaultCountry.get, planChoice.productRatePlanId).toOption)
+      val validPromoCode = providedPromoCode.flatMap(promoService.validate[NewUsers](_, pageInfo.initialCheckoutForm.defaultCountry.get, planChoice.productRatePlanId).toOption)
+      val validPromotion = validPromoCode.flatMap(validPromo => promoService.findPromotion(validPromo.code))
+
+      val validTrackingPromoCode = validPromotion.filter(_.asTracking.isDefined).flatMap(p => providedPromoCode)
+      val validDisplayablePromoCode = validPromotion.filterNot(_.asTracking.isDefined).flatMap(p => providedPromoCode)
 
       val countryCurrencyWhitelist = CountryWithCurrency.whitelisted(supportedCurrencies, GBP)
 
@@ -157,7 +162,8 @@ object Joiner extends Controller with ActivityTracking
           countryCurrencyWhitelist,
           identityUser,
           pageInfo,
-          validPromo,
+          trackingPromoCode = validTrackingPromoCode,
+          promoCodeToDisplay = validDisplayablePromoCode,
           Some(countryGroup),
           resolution)
       })
@@ -173,14 +179,16 @@ object Joiner extends Controller with ActivityTracking
     } yield {
 
       val pageInfo = support.PageInfo(initialCheckoutForm = CheckoutForm.forIdentityUser(identityUser, catalog.friend, None))
-      val validPromo = codeFromSession.flatMap(code => promoService.validate[NewUsers](code, pageInfo.initialCheckoutForm.defaultCountry.get, catalog.friend.id).toOption)
-
+      val providedPromoCode = codeFromSession // only take from the session
+      val validPromoCode = providedPromoCode.flatMap(promoService.validate[NewUsers](_, pageInfo.initialCheckoutForm.defaultCountry.get, catalog.friend.id).toOption)
+      val validPromotion = validPromoCode.flatMap(validPromo => promoService.findPromotion(validPromo.code))
+      val validTrackingPromoCode = validPromotion.filter(_.asTracking.isDefined).flatMap(p => providedPromoCode)
 
       Ok(views.html.joiner.form.friendSignup(
         catalog.friend,
         identityUser,
         pageInfo,
-        validPromo))
+        validTrackingPromoCode))
     }
   }
 

--- a/frontend/app/views/fragments/form/promoCode.scala.html
+++ b/frontend/app/views/fragments/form/promoCode.scala.html
@@ -1,8 +1,9 @@
-@import com.gu.memsub.promo.ValidPromotion
-@(validPromotion: Option[ValidPromotion[_]])
+@import com.gu.memsub.promo.PromoCode
+
+@(trackingPromoCode: Option[PromoCode], promoCodeToDisplay: Option[PromoCode])
 
 <fieldset class="fieldset">
-    @fragments.form.trackingPromoCode(validPromotion.flatMap(_.trackingCode))
+    @fragments.form.trackingPromoCode(trackingPromoCode)
 
     <div class="fieldset__heading">
         <h2 class="fieldset__headline">Do you have a promo code?</h2>
@@ -11,7 +12,7 @@
     <div class="fieldset__fields">
         <div class="form-field">
             <div class="promo-code">
-              <input id="promo-code" name="promoCode" value="@validPromotion.flatMap(_.displayableCode).map(_.get).mkString" type="text" class="js-promocode-value input-text js-input promo-code__field"/>
+              <input id="promo-code" name="promoCode" value="@promoCodeToDisplay.map(_.get).getOrElse("")" type="text" class="js-promocode-value input-text js-input promo-code__field"/>
               <button type="button" class="js-promo-code-apply promo-code__apply action js-promo-code-validate">Apply</button>
             </div>
             <div class="loader js-promo-loader">Validating</div>

--- a/frontend/app/views/joiner/form/friendSignup.scala.html
+++ b/frontend/app/views/joiner/form/friendSignup.scala.html
@@ -5,12 +5,10 @@
 @import views.support.DisplayText._
 @import views.support.{CountryWithCurrency, FreePlan, IdentityUser, PageInfo}
 
-@import com.gu.memsub.promo.ValidPromotion
-@import com.gu.memsub.promo.NewUsers
 @(friendPlan: CatalogPlan.Friend,
   idUser: IdentityUser,
   pageInfo: PageInfo,
-  validPromo: Option[ValidPromotion[NewUsers]]
+  trackingPromoCode: Option[PromoCode]
 )(implicit token: play.filters.csrf.CSRF.Token)
 
 @main("Become a Friend", pageInfo) {
@@ -59,7 +57,7 @@
                             county = idUser.privateFields.address4
                         )
                         @fragments.form.marketingChoices(idUser.marketingChoices.receiveGnmMarketing, idUser.marketingChoices.receive3rdPartyMarketing)
-                        @fragments.form.trackingPromoCode(validPromo.flatMap(_.trackingCode))
+                        @fragments.form.trackingPromoCode(trackingPromoCode)
 
                         @if(!idUser.passwordExists) {
                             @fragments.form.createPassword()

--- a/frontend/app/views/joiner/form/payment.scala.html
+++ b/frontend/app/views/joiner/form/payment.scala.html
@@ -1,18 +1,27 @@
-@import com.gu.i18n.CountryGroup
-@import com.gu.memsub.promo.{NewUsers, ValidPromotion}
-@import com.gu.memsub.subsv2.CatalogPlan.PaidMember
-@import com.gu.memsub.subsv2.MonthYearPlans
-@import com.gu.salesforce.Tier.Supporter
-@import tracking.AppnexusPixel
 @import views.html.helper._
 @import views.support.DisplayText._
+@import views.support.PageInfo
+@import views.support.CountryWithCurrency
+@import views.support.IdentityUser
+
+@import com.gu.memsub.Current
+@import com.gu.salesforce.PaidTier
+@import com.gu.salesforce.Tier.Supporter
+@import com.gu.memsub.promo.PromoCode
+@import views.support.PaidPlans
 @import views.support.MembershipCompat._
-@import views.support.{CountryWithCurrency, IdentityUser, PageInfo, PaidPlans}
+@import com.gu.memsub.subsv2.MonthYearPlans
+@import com.gu.memsub.subsv2.CatalogPlan.PaidMember
+@import com.gu.i18n.CountryGroup
+@import tracking.AppnexusPixel
+
+
 @(plans: MonthYearPlans[PaidMember],
     countriesWithCurrencies: List[CountryWithCurrency],
     idUser: IdentityUser,
     pageInfo: PageInfo,
-    validPromo: Option[ValidPromotion[NewUsers]],
+    trackingPromoCode: Option[PromoCode],
+    promoCodeToDisplay: Option[PromoCode],
     countryGroup: Option[CountryGroup],
     touchpointBackendResolution: services.TouchpointBackend.Resolution
     )(implicit token: play.filters.csrf.CSRF.Token, request: actions.AuthRequest[_])
@@ -79,7 +88,7 @@
                     @if(plans.tier != Supporter()) {
                         <div class="form-group form-section__promotion">
                             <h2 class="form-group__title">Promotion</h2>
-                            @fragments.form.promoCode(validPromo)
+                            @fragments.form.promoCode(trackingPromoCode, promoCodeToDisplay)
                         </div>
                     }
 

--- a/frontend/app/views/tier/upgrade/freeToPaid.scala.html
+++ b/frontend/app/views/tier/upgrade/freeToPaid.scala.html
@@ -1,18 +1,24 @@
-@import com.gu.memsub.subsv2.CatalogPlan.PaidMember
-@import com.gu.memsub.subsv2.{MonthYearPlans, _}
 @import play.api.mvc.RequestHeader
 @import play.filters.csrf
 @import views.support.DisplayText._
+@import views.support.PageInfo
+@import views.support.CountryWithCurrency
+@import com.gu.memsub.{Status, Current}
+@import com.gu.memsub.promo.PromoCode
+@import com.gu.memsub.subsv2._
+@import views.support.PaidPlans
+@import com.gu.memsub.Friend
+@import com.gu.memsub.subsv2.CatalogPlan.PaidMember
+@import com.gu.memsub.subsv2.MonthYearPlans
 @import views.support.MembershipCompat._
-@import views.support.{CountryWithCurrency, PageInfo, PaidPlans}
-@import com.gu.memsub.promo.ValidPromotion
-@import com.gu.memsub.promo.Upgrades
+
 @(currentPlan: CatalogPlan.Member,
   targetPlans: MonthYearPlans[PaidMember],
   countriesWithCurrency: List[CountryWithCurrency],
   userFields: com.gu.identity.play.PrivateFields,
   pageInfo: PageInfo,
-    validPromo: Option[ValidPromotion[Upgrades]]
+  trackingPromoCode: Option[PromoCode],
+  promoCodeToDisplay: Option[PromoCode]
 )(implicit token: csrf.CSRF.Token, request: RequestHeader)
 
 @import views.html.helper._
@@ -65,7 +71,7 @@
 
                   <div class="form-group">
                       <h2 class="form-group__title">Promotion</h2>
-                      @fragments.form.promoCode(validPromo)
+                      @fragments.form.promoCode(trackingPromoCode, promoCodeToDisplay)
                   </div>
 
                   <div class="form-group">

--- a/frontend/app/views/tier/upgrade/paidToPaid.scala.html
+++ b/frontend/app/views/tier/upgrade/paidToPaid.scala.html
@@ -8,6 +8,7 @@
 @import views.support.PageInfo
 @import com.gu.memsub.promo.ValidPromotion
 @import com.gu.memsub.promo.Upgrades
+@import com.gu.memsub.promo.Tracking
 @(
     summary: PaidToPaidUpgradeSummary,
     userFields: com.gu.identity.play.PrivateFields,
@@ -42,7 +43,7 @@
                       <div class="form-group">
                           @fragments.form.benefitsFieldset(summary.target.tier.benefits)
                           @fragments.form.featureChoiceFieldset(summary.target.tier)
-                          @fragments.form.promoCode(validPromo)
+                          @validPromo.filter(_.promotion.promotionType != Tracking).fold(fragments.form.promoCode(validPromo.map(_.code), None))(_ => fragments.form.promoCode(None, validPromo.map(_.code)))
                       </div>
                       <h2 class="h-section">What happens now</h2>
                       <p>When you upgrade we want to make sure you are charged the right amount. We will charge for your <strong>@summary.current.tier.name</strong>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
     "com.gu" %% "memsub-common-play-auth" % "0.8", // v0.8 is the latest version published for Play 2.4...
     "com.gu" %% "identity-test-users" % "0.6"
   )
-  val membershipCommon = "com.gu" %% "membership-common" % "0.362"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.361"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache


### PR DESCRIPTION
Reverts guardian/membership-frontend#1502

<img width="905" alt="picture 9" src="https://cloud.githubusercontent.com/assets/1515970/22998250/d1b52dec-f3cd-11e6-99da-e01096ed37c5.png">

I rolled back to build 10755

cc @rtyley 