### PR TITLE
Send a note when removing behaviour records

### DIFF
--- a/frontend/app/services/MembersDataAPI.scala
+++ b/frontend/app/services/MembersDataAPI.scala
@@ -120,7 +120,8 @@ object MembersDataAPI {
     }
 
     private def deleteBehaviour(cookies: Seq[Option[Cookie]], userId: String, activity: String) = {
-      val record = s"""{"userId":"${userId}","activity":"${activity}","dateTime":"${DateTime.now.toString(ISODateTimeFormat.dateTime.withZoneUTC)}"}"""
+      val removeNote = "remove"
+      val record = s"""{"userId":"${userId}","activity":"${activity}","dateTime":"${DateTime.now.toString(ISODateTimeFormat.dateTime.withZoneUTC)}","note":"${removeNote}"}"""
       val json = Json.parse(record)
       BehaviourHelper(cookies).post[Behaviour]("user-behaviour/remove", json)
     }


### PR DESCRIPTION
## Why are you doing this?
Two reasons: first (and foremost) the absence of a note is causing an error in the data api when reconstructing the json (introduced in https://github.com/guardian/membership-frontend/pull/1505). Second, we will want to send removals for reasons other than completions, and may defer the actual deletion of the record based on those reasons, i.e. to give us an opportunity to communicate with those users.

## Trello card: [Here](https://trello.com/c/ZF8q2EYh/248-abandoned-cart-email-people-who-hit-checkout-page-and-didn-t-convert-2-2)

## Changes
* Place a generic note in the json sent to the behaviour removing endpoint

## Screenshots
```
==> membership-attribute-service.log <==
2017-02-16 12:01:40,047 [application-akka.actor.default] controllers.BehaviourController[BehaviourController.scala:49] INFO: removed enterPaidDetails.show for 2*****5

==> frontend.log <==
2017-02-16 12:01:40,072 [application-akka.actor.default] application[MembersDataAPI.scala:108] INFO: Cleared behaviours for 2******5
```
