### PR TITLE
Remove `InsecureOkHttpClient` as we have proper certs in dev now

### DIFF
--- a/frontend/test/acceptance/util/Dependencies.scala
+++ b/frontend/test/acceptance/util/Dependencies.scala
@@ -26,40 +26,10 @@ object Dependencies {
     val url: String
     def isAvailable: Boolean = {
       val request = new Builder().url(url).build()
-      Try(Await.result(insecureClient.execute(request), 30 second).isSuccessful).getOrElse(false)
+      Try(Await.result(client.execute(request), 30 second).isSuccessful).getOrElse(false)
     }
   }
 
   private val client = new OkHttpClient()
-  private val insecureClient = InsecureOkHttpClient()
 
- /*
-  * Get OkHttpClient which ignores all SSL errors.
-  *
-  * Needed when running against local servers which might not have a valid cert.
-  * https://stackoverflow.com/questions/25509296/trusting-all-certificates-with-okhttp
-  */
-  private object InsecureOkHttpClient {
-
-   def apply() =
-     client.newBuilder().sslSocketFactory(SSL.InsecureSocketFactory).hostnameVerifier(new HostnameVerifier {
-       override def verify(hostname: String, sslSession: SSLSession): Boolean = true
-     }).build()
-
-    private object SSL {
-      val InsecureSocketFactory = {
-        val sslcontext = SSLContext.getInstance("TLS")
-        sslcontext.init(null, Array(TrustEveryoneTrustManager), null)
-        sslcontext.getSocketFactory
-      }
-
-      object TrustEveryoneTrustManager extends X509TrustManager {
-        def checkClientTrusted(chain: Array[X509Certificate], authType: String) {}
-
-        def checkServerTrusted(chain: Array[X509Certificate], authType: String) {}
-
-        val getAcceptedIssuers = new Array[X509Certificate](0)
-      }
-    }
-  }
 }


### PR DESCRIPTION
## Why are you doing this?

The `InsecureOkHttpClient` used in acceptanace tests is unnecessary now, so long as you update your
`identity-platform` to the latest version (including https://github.com/guardian/identity-platform/pull/154 ) and re-run `./ngnix/setup.sh`.

cc @Ap0c @mario-galic 