### PR TITLE
Change Remote Browser to Chrome on Windows 8.1.

### DIFF
--- a/frontend/test/acceptance/util/Driver.scala
+++ b/frontend/test/acceptance/util/Driver.scala
@@ -35,9 +35,8 @@ object Driver {
   }
 
   private def instantiateRemoteBrowser(): WebDriver = {
-    val caps = DesiredCapabilities.internetExplorer()
-    caps.setCapability("platform", "Windows 7")
-    caps.setCapability("version", "11.0")
+    val caps = DesiredCapabilities.chrome()
+    caps.setCapability("platform", "Windows 8.1")
     caps.setCapability("name", "membership-frontend")
     new RemoteWebDriver(new URL(Config.webDriverRemoteUrl), caps)
   }


### PR DESCRIPTION
## Why are you doing this?

The acceptance tests don't work because they were designed against the Stripe DOM as it was observed in Chrome. However, they run remotely against Internet Explorer, for which Stripe appears to load a different DOM. Thus we're changing the remote browser to Chrome.

## Changes

- Update the driver to use Chrome.