### PR TITLE
dont send ip to zuora

### DIFF
--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -226,11 +226,10 @@ object Joiner extends Controller with ActivityTracking
     implicit val bp: BackendProvider = request
     val idRequest = IdentityRequest(request)
     val campaignCode = CampaignCode.fromRequest
-    val ipAddress = None // Deprecated - we do not need to store this [anymore] as we store the ipCountry instead.
     val ipCountry = request.getFastlyCountry
 
     Timing.record(salesforceService.metrics, "createMember") {
-      memberService.createMember(request.user, formData, idRequest, eventId, campaignCode, tier, ipAddress, ipCountry).map {
+      memberService.createMember(request.user, formData, idRequest, eventId, campaignCode, tier, ipCountry).map {
         case (sfContactId, zuoraSubName) =>
           logger.info(s"User ${request.user.id} successfully became ${tier.name} $zuoraSubName.")
           salesforceService.metrics.putSignUp(tier)

--- a/frontend/app/services/api/MemberService.scala
+++ b/frontend/app/services/api/MemberService.scala
@@ -1,7 +1,5 @@
 package services.api
 
-import java.net.InetAddress
-
 import com.gu.i18n.Country
 import com.gu.identity.play.IdMinimalUser
 import com.gu.memsub.Subscriber._
@@ -38,7 +36,6 @@ trait MemberService {
                    fromEventId: Option[String],
                    campaignCode: Option[CampaignCode],
                    tier: Tier,
-                   ipAddress: Option[InetAddress],
                    ipCountry: Option[Country]): Future[(ContactId, ZuoraSubName)]
 
   def previewUpgradeSubscription(subscriber: PaidMember, newPlan: PlanChoice, code: Option[ValidPromotion[Upgrades]])
@@ -83,13 +80,11 @@ trait MemberService {
                              campaignCode: Option[CampaignCode],
                              email: String,
                              payPalEmail: Option[String],
-                             ipAddress: Option[InetAddress],
                              ipCountry: Option[Country]): Future[SubscribeResult]
 
   def createFreeSubscription(contactId: ContactId,
                              joinData: JoinForm,
                              email: String,
-                             ipAddress: Option[InetAddress],
                              ipCountry: Option[Country]): Future[SubscribeResult]
 }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
     "com.gu" %% "memsub-common-play-auth" % "0.8", // v0.8 is the latest version published for Play 2.4...
     "com.gu" %% "identity-test-users" % "0.6"
   )
-  val membershipCommon = "com.gu" %% "membership-common" % "0.365-SNAPSHOT"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.366"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
     "com.gu" %% "memsub-common-play-auth" % "0.8", // v0.8 is the latest version published for Play 2.4...
     "com.gu" %% "identity-test-users" % "0.6"
   )
-  val membershipCommon = "com.gu" %% "membership-common" % "0.362"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.365-SNAPSHOT"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playCache = PlayImport.cache


### PR DESCRIPTION
## Why are you doing this?
Feature removed from common. 
https://github.com/guardian/membership-common/pull/431

## Trello card: [Here](https://trello.com/c/6awOzdpf/92-stop-sending-ipaddress-c-to-zuora-now-that-we-have-ipcountry-c)

## Changes
* removed the ip address field 

## Screenshots
n/a
