### PR TITLE
Better Paypal Return And Cancel Errors

### DIFF
--- a/frontend/app/controllers/PayPal.scala
+++ b/frontend/app/controllers/PayPal.scala
@@ -51,7 +51,7 @@ object PayPal extends Controller with LazyLogging with PayPalServiceProvider {
   // redirected and needs to come back.
   def returnUrl = NoCacheAction {
 
-    logger.info("User hit the PayPal returnUrl.")
+    logger.error("User hit the PayPal returnUrl.")
     Ok(views.html.paypal.errorPage())
 
   }

--- a/frontend/app/views/paypal/errorPage.scala.html
+++ b/frontend/app/views/paypal/errorPage.scala.html
@@ -4,7 +4,7 @@
 
 	<main role="main" class="page-content l-constrained">
 		<div class="paypal-error-page">
-	        <p>Sorry, there was a problem completing your Paypal payment. Please try again:</p>
+	        <p>Sorry, there was a problem completing your PayPal payment. Please try again:</p>
 	        <a class="paypal-error-page__signup-link" href="@routes.Info.supporterRedirect(None)"><button class="action">Become a Supporter</button></a>
 	        <a class="paypal-error-page__signup-link" href="@routes.Joiner.enterPaidDetails(Partner())"><button class="action">Become a Partner</button></a>
 	        <a class="paypal-error-page__signup-link" href="@routes.Info.patron"><button class="action">Become a Patron</button></a>

--- a/frontend/app/views/paypal/errorPage.scala.html
+++ b/frontend/app/views/paypal/errorPage.scala.html
@@ -1,7 +1,14 @@
+@import com.gu.salesforce.Tier.Partner
+
 @main("PayPal Error") {
 
 	<main role="main" class="page-content l-constrained">
-		Sorry, there was a problem completing your Paypal payment.
+		<div class="paypal-error-page">
+	        <p>Sorry, there was a problem completing your Paypal payment. Please try again:</p>
+	        <a class="paypal-error-page__signup-link" href="@routes.Info.supporterRedirect(None)"><button class="action">Become a Supporter</button></a>
+	        <a class="paypal-error-page__signup-link" href="@routes.Joiner.enterPaidDetails(Partner())"><button class="action">Become a Partner</button></a>
+	        <a class="paypal-error-page__signup-link" href="@routes.Info.patron"><button class="action">Become a Patron</button></a>
+        </div>
 	</main>
 
 }

--- a/frontend/assets/stylesheets/components/_paypal-error-page.scss
+++ b/frontend/assets/stylesheets/components/_paypal-error-page.scss
@@ -1,0 +1,14 @@
+.paypal-error-page {
+	text-align: center;
+	margin-top: $gs-baseline * 2;
+
+	.paypal-error-page__signup-link {
+		display: block;
+		margin: $gs-baseline 0;
+	}
+
+	.action {
+		background-color: guss-colour(guardian-brand);
+        border-color: guss-colour(guardian-brand);
+	}
+}

--- a/frontend/assets/stylesheets/style.scss
+++ b/frontend/assets/stylesheets/style.scss
@@ -113,6 +113,7 @@
 @import 'components/video';
 @import 'components/patterns';
 @import 'components/promo-code';
+@import 'components/paypal-error-page';
 
 // =============================================================================
 // Scopes


### PR DESCRIPTION
## Why are you doing this?

The return and cancel URLs are never expected to be hit in production, so we would like to log any contact with them as errors. However, that doesn't mean the error pages can't be at least somewhat user-friendly...

[**Trello Card**](https://trello.com/c/QCR6Kgeh/239-monitor-return-and-cancel-urls-possibly-do-full-implementation)

## Changes

- Upgraded return URL to an error.
- Modified the PayPal error page to make it more user-friendly, with links back to the different tiers:
    + Supporter goes to Supporter landing page.
    + Partner goes to the Partner checkout page (because we don't have a landing page).
    + Patron goes to the Patron landing page.

## Screenshots

Yes, it's ugly, but we're expecting this page never to be reached...

![paypal-new-errors](https://cloud.githubusercontent.com/assets/5131341/23134252/fe4eb640-f78b-11e6-8a96-4397af45d288.png)
