### PR TITLE
Paypal Acceptance Tests

### DIFF
--- a/frontend/test/acceptance/JoinSupporterSpec.scala
+++ b/frontend/test/acceptance/JoinSupporterSpec.scala
@@ -38,7 +38,7 @@ class JoinSupporterSpec extends FeatureSpec with Browser
 
       Given("users click 'Become a Supporter' button on Membership homepage")
 
-      When("they land on 'Identity Frontend' page,")
+      When("They land on 'Identity Frontend' page,")
       val register = pages.Register(testUser)
       go.to(register)
       assert(register.pageHasLoaded)
@@ -60,7 +60,7 @@ class JoinSupporterSpec extends FeatureSpec with Browser
       And("should be logged in with their Identity account.")
       assert(enterDetails.userIsSignedIn)
 
-      When("users select USA delivery country,")
+      When("Users select USA delivery country,")
       enterDetails.changeCountry("US")
 
       Then("the currency should change.")
@@ -73,28 +73,31 @@ class JoinSupporterSpec extends FeatureSpec with Browser
       enterDetails.clickContinue()
 
       And("click 'Pay' button,")
-      enterDetails.pay()
+      enterDetails.payStripe()
 
       Then("the Stripe Checkout iframe should display")
       assert(enterDetails.stripeCheckoutHasLoaded())
 
-      When("the checkout iframe is present")
+      When("The checkout iframe is present")
       enterDetails.switchToStripe()
 
       Then("credit card field is present")
       assert(enterDetails.stripeCheckoutHasCC())
 
-      Then("expiry date field is present")
+      And("expiry date field is present")
       assert(enterDetails.stripeCheckoutHasExph())
 
-      Then("CVC field is present")
+      And("CVC field is present")
       assert(enterDetails.stripeCheckoutHasCVC())
 
-      Then("submit button is present")
+      And("submit button is present")
       assert(enterDetails.stripeCheckoutHasSubmit())
 
-      And("they fill in credit card payment details,")
-      enterDetails.fillInCreditCardPaymentDetailsStripe()
+      When("They fill in credit card payment details,")
+      enterDetails.fillInCreditCardPaymentDetailsStripe
+
+      And("accept the payment")
+      enterDetails.acceptStripePayment
 
       Then("they should land on 'Thank You' page,")
       assert(ThankYou.pageHasLoaded)
@@ -111,7 +114,7 @@ class JoinSupporterSpec extends FeatureSpec with Browser
 
       Given("users click 'Become a Supporter' button on Membership homepage")
 
-      When("they land on 'Identity Frontend' page,")
+      When("They land on 'Identity Frontend' page,")
       val register = pages.Register(testUser)
       go.to(register)
       assert(register.pageHasLoaded)
@@ -126,7 +129,7 @@ class JoinSupporterSpec extends FeatureSpec with Browser
       val enterDetails = pages.EnterDetails(testUser)
       assert(enterDetails.pageHasLoaded)
 
-      When("we switch to the PayPal AB variant")
+      When("We switch to the PayPal AB variant")
       enterDetails.switchToPayPalVariant
 
       Then("they should have Identity cookies,")
@@ -137,7 +140,7 @@ class JoinSupporterSpec extends FeatureSpec with Browser
       And("should be logged in with their Identity account.")
       assert(enterDetails.userIsSignedIn)
 
-      When("users select USA delivery country,")
+      When("Users select USA delivery country,")
       enterDetails.changeCountry("US")
 
       Then("the currency should change.")

--- a/frontend/test/acceptance/JoinSupporterSpec.scala
+++ b/frontend/test/acceptance/JoinSupporterSpec.scala
@@ -30,6 +30,7 @@ class JoinSupporterSpec extends FeatureSpec with Browser
   }
 
   feature("Become a Supporter in UK") {
+
     scenario("User joins as Supporter by clicking 'Become a Supporter' button on Membership homepage", Acceptance) {
       checkDependenciesAreAvailable
 
@@ -101,6 +102,83 @@ class JoinSupporterSpec extends FeatureSpec with Browser
       And("should be signed in as Supporter.")
       assert(ThankYou.userIsSignedInAsSupporter)
     }
+
+    scenario("User joins as Supporter using PayPal", Acceptance) {
+
+      checkDependenciesAreAvailable
+
+      val testUser = new TestUser
+
+      Given("users click 'Become a Supporter' button on Membership homepage")
+
+      When("they land on 'Identity Frontend' page,")
+      val register = pages.Register(testUser)
+      go.to(register)
+      assert(register.pageHasLoaded)
+
+      And("fill in personal details,")
+      register.fillInPersonalDetails()
+
+      And("submit the form to create their Identity account,")
+      register.submit()
+
+      Then("they should land on 'Enter Details' page,")
+      val enterDetails = pages.EnterDetails(testUser)
+      assert(enterDetails.pageHasLoaded)
+
+      When("we switch to the PayPal AB variant")
+      enterDetails.switchToPayPalVariant
+
+      Then("they should have Identity cookies,")
+      Seq("GU_U", "SC_GU_U", "SC_GU_LA").foreach { idCookie =>
+        assert(Driver.cookiesSet.map(_.getName).contains(idCookie))
+      }
+
+      And("should be logged in with their Identity account.")
+      assert(enterDetails.userIsSignedIn)
+
+      When("users select USA delivery country,")
+      enterDetails.changeCountry("US")
+
+      Then("the currency should change.")
+      assert(enterDetails.currencyHasChanged)
+
+      When("Users fill in delivery address details,")
+      enterDetails.fillInDeliveryAddress()
+
+      And("click Continue")
+      enterDetails.clickContinue()
+
+      And("click PayPal button,")
+      enterDetails.payPal
+
+      Then("the PayPal Express Checkout mini-browser should display")
+      enterDetails.switchToPayPal
+      assert(enterDetails.payPalCheckoutHasLoaded)
+
+      When("Users fill in their PayPal credentials")
+      enterDetails.payPalFillInDetails
+
+      And("click 'Log In'")
+      enterDetails.payPalLogin
+
+      Then("payment summary appears")
+      assert(enterDetails.payPalHasPaymentSummary)
+
+      And("it displays the correct amount")
+      assert(enterDetails.payPalSummaryHasCorrectAmount)
+
+      When("User agrees to payment")
+      enterDetails.acceptPayPalPayment
+
+      Then("they should land on 'Thank You' page,")
+      assert(ThankYou.pageHasLoaded)
+
+      And("should be signed in as Supporter.")
+      assert(ThankYou.userIsSignedInAsSupporter)
+
+    }
+
   }
 }
 

--- a/frontend/test/acceptance/JoinSupporterSpec.scala
+++ b/frontend/test/acceptance/JoinSupporterSpec.scala
@@ -64,7 +64,7 @@ class JoinSupporterSpec extends FeatureSpec with Browser
       enterDetails.changeCountry("US")
 
       Then("the currency should change.")
-      assert(enterDetails.currencyHasChanged)
+      assert(enterDetails.currencyHasChangedTo("US$"))
 
       When("Users fill in delivery address details,")
       enterDetails.fillInDeliveryAddress()
@@ -144,7 +144,7 @@ class JoinSupporterSpec extends FeatureSpec with Browser
       enterDetails.changeCountry("US")
 
       Then("the currency should change.")
-      assert(enterDetails.currencyHasChanged)
+      assert(enterDetails.currencyHasChangedTo("US$"))
 
       When("Users fill in delivery address details,")
       enterDetails.fillInDeliveryAddress()

--- a/frontend/test/acceptance/JoinSupporterSpec.scala
+++ b/frontend/test/acceptance/JoinSupporterSpec.scala
@@ -31,7 +31,7 @@ class JoinSupporterSpec extends FeatureSpec with Browser
 
   feature("Become a Supporter in UK") {
 
-    scenario("User joins as Supporter by clicking 'Become a Supporter' button on Membership homepage", Acceptance) {
+    scenario("User joins as Supporter by clicking 'Become a Supporter' button on Membership homepage, and pays using Stripe", Acceptance) {
       checkDependenciesAreAvailable
 
       val testUser = new TestUser

--- a/frontend/test/acceptance/pages/EnterDetails.scala
+++ b/frontend/test/acceptance/pages/EnterDetails.scala
@@ -15,13 +15,14 @@ case class EnterDetails(val testUser: TestUser) extends Page with Browser {
 
   def clickContinue() = clickOn(className("js-continue-name-address"))
 
-  def fillInCreditCardPaymentDetailsStripe(): Unit = StripeCheckout.fillIn()
-
   def changeCountry(country: String) = { DeliveryAddress.selectCountryCode(country) }
 
   def currencyHasChanged(): Boolean = hiddenElementHasText(currency, "US$")
 
-  def pay() = clickOn(className("js-stripe-checkout"))
+
+  // ----- Stripe Methods ----- //
+
+  def payStripe() = clickOn(className("js-stripe-checkout"))
 
   def switchToStripe() = switchFrame(StripeCheckout.container)
 
@@ -34,6 +35,13 @@ case class EnterDetails(val testUser: TestUser) extends Page with Browser {
   def stripeCheckoutHasExph(): Boolean = pageHasElement(StripeCheckout.cardExp)
 
   def stripeCheckoutHasSubmit(): Boolean = pageHasElement(StripeCheckout.submitButton)
+
+  def fillInCreditCardPaymentDetailsStripe(): Unit = StripeCheckout.fillIn
+
+  def acceptStripePayment() = StripeCheckout.acceptPayment
+
+
+  // ----- PayPal Methods ----- //
 
   def switchToPayPalVariant() = changeUrl(s"$url?countryGroup=uk&paypalTest=with_paypal")
 
@@ -59,6 +67,10 @@ case class EnterDetails(val testUser: TestUser) extends Page with Browser {
     switchToParentWindow
   }
 
+
+  // ----- Page Sections ----- //
+
+  // Handles interaction with the delivery address fields.
   private object DeliveryAddress {
     val country = id("country-deliveryAddress")
     val addressLine1 = id("address-line-one-deliveryAddress")
@@ -75,9 +87,11 @@ case class EnterDetails(val testUser: TestUser) extends Page with Browser {
     def selectCountryCode(countryCode:  String) { setSingleSelectionValue(country, countryCode) }
   }
 
-  // Temporary hack to identify elements on Stripe Checkout form using xpath, since the ids are no longer consistently set.
+  // Handles interaction with the Stripe Checkout overlay.
   private object StripeCheckout {
+
     val container = name("stripe_checkout_app")
+    // Temporary hack to identify elements on Stripe Checkout form using xpath, since the ids are no longer consistently set.
     val cardNumber = xpath("//div[label/text() = \"Card number\"]/input")
     val cardExp = xpath("//div[label/text() = \"Expiry\"]/input")
     val cardCvc = xpath("//div[label/text() = \"CVC\"]/input")
@@ -88,8 +102,7 @@ case class EnterDetails(val testUser: TestUser) extends Page with Browser {
       setValueSlowly(cardNumber, cardNum)
       setValueSlowly(cardExp, "1019")
       setValueSlowly(cardCvc, "111")
-      continue()
-      Thread.sleep(5000)
+      
     }
 
     def fillIn(): Unit = fillInHelper("4242 4242 4242 4242")
@@ -111,9 +124,11 @@ case class EnterDetails(val testUser: TestUser) extends Page with Browser {
     // Charge will be declined with a processing_error code.
     def fillInCardDeclinedProcessError(): Unit = fillInHelper("4000000000000119")
 
-    def continue(): Unit = clickOn(submitButton)
+    def acceptPayment(): Unit = clickOn(submitButton)
+
   }
 
+  // Handles interaction with the PayPal Express Checkout overlay.
   private object PayPalCheckout {
 
     val container = name("injectedUl")
@@ -123,6 +138,7 @@ case class EnterDetails(val testUser: TestUser) extends Page with Browser {
     val agreeAndPay = id("confirmButtonTop")
     val paymentAmount = className("formatCurrency")
 
+    // Fills in the sandbox user credentials.
     def fillIn() = {
 
       setValueSlowly(emailInput, Config.paypalBuyerEmail)

--- a/frontend/test/acceptance/pages/EnterDetails.scala
+++ b/frontend/test/acceptance/pages/EnterDetails.scala
@@ -17,7 +17,7 @@ case class EnterDetails(val testUser: TestUser) extends Page with Browser {
 
   def changeCountry(country: String) = { DeliveryAddress.selectCountryCode(country) }
 
-  def currencyHasChanged(): Boolean = hiddenElementHasText(currency, "US$")
+  def currencyHasChangedTo(currencySymbol: String): Boolean = hiddenElementHasText(currency, currencySymbol)
 
 
   // ----- Stripe Methods ----- //

--- a/frontend/test/acceptance/pages/Register.scala
+++ b/frontend/test/acceptance/pages/Register.scala
@@ -22,10 +22,10 @@ case class Register(testUser: TestUser) extends Page with Browser {
     val password = id("register_field_password")
 
     def fillIn() {
-      setValue(firstName, testUser.username)
-      setValue(lastName, testUser.username)
-      setValue(email, s"${testUser.username}@gu.com")
-      setValue(password, testUser.username)
+      setValue(firstName, testUser.username, clear=true)
+      setValue(lastName, testUser.username, clear=true)
+      setValue(email, s"${testUser.username}@gu.com", clear=true)
+      setValue(password, testUser.username, clear=true)
     }
   }
 

--- a/frontend/test/acceptance/util/Browser.scala
+++ b/frontend/test/acceptance/util/Browser.scala
@@ -2,7 +2,9 @@ package acceptance.util
 
 import org.openqa.selenium.support.ui.{ExpectedCondition, ExpectedConditions, WebDriverWait}
 import org.openqa.selenium.By
+import org.openqa.selenium.support.ui.ExpectedConditions.numberOfWindowsToBe
 import org.scalatest.selenium.WebBrowser
+
 import scala.util.Try
 import scala.collection.JavaConverters.asScalaSetConverter
 
@@ -90,6 +92,7 @@ trait Browser extends WebBrowser {
    * the parent window.
    * */
   def switchWindow() {
+    waitUntil(numberOfWindowsToBe(2))
 
     for {
       winHandle <- driver.getWindowHandles.asScala

--- a/frontend/test/acceptance/util/Browser.scala
+++ b/frontend/test/acceptance/util/Browser.scala
@@ -9,6 +9,7 @@ import scala.collection.JavaConverters.asScalaSetConverter
 trait Browser extends WebBrowser {
 
   lazy implicit val driver = Driver()
+  // Stores a handle to the first window opened by the driver.
   lazy val parentWindow = driver.getWindowHandle
 
   def pageHasText(text: String): Boolean =
@@ -38,8 +39,10 @@ trait Browser extends WebBrowser {
 
   def setValue(q: Query, value: String, clear: Boolean = false) {
     if (pageHasElement(q)) {
+
       if (clear) q.webElement.clear
       q.webElement.sendKeys(value)
+
     } else
       throw new MissingPageElementException(q)
   }
@@ -47,7 +50,9 @@ trait Browser extends WebBrowser {
   /*
     * Stripe wants you to pause between month and year and between each quartet in the cc
     * This causes pain when you use Selenium. There are a few stack overflow posts- but nothing really useful.
-    * This also seems to be necessary to make PayPal work properly.
+    * This pausing also seems to be necessary to make PayPal work properly,
+    * without this it starts to complain about invalid credentials after only
+    * a few characters.
     * */
   def setValueSlowly(q: Query, value: String): Unit = {
     for {
@@ -72,6 +77,7 @@ trait Browser extends WebBrowser {
       throw new MissingPageElementException(q)
   }
 
+  // Switches to a new iframe specified by the Query, q.
   def switchFrame(q: Query) {
     if (pageHasElement(q))
       driver.switchTo().frame(q.webElement)
@@ -79,6 +85,10 @@ trait Browser extends WebBrowser {
       throw new MissingPageElementException(q)
   }
 
+  /*
+   * Switches to the first window in the list of windows that doesn't match
+   * the parent window.
+   * */
   def switchWindow() {
 
     for {
@@ -88,6 +98,7 @@ trait Browser extends WebBrowser {
 
   }
 
+  // Switches back to the first window opened by the driver.
   def switchToParentWindow() = driver.switchTo().window(parentWindow)
 
   def changeUrl(url: String) = driver.get(url)

--- a/frontend/test/acceptance/util/Config.scala
+++ b/frontend/test/acceptance/util/Config.scala
@@ -24,6 +24,10 @@ object Config {
 
   val waitTimout: Int = conf.getString("waitTimeout").toInt
 
+  val paypalBuyerEmail = conf.getString("paypal.sandbox.buyer.email")
+
+  val paypalBuyerPassword = conf.getString("paypal.sandbox.buyer.password")
+
   def debug() { conf.root().render() }
 
   def printSummary(): Unit = {


### PR DESCRIPTION
## Why are you doing this?

It would be good if we could have acceptance tests for PayPal ready before releasing it, to make sure we don't break it by accident.

These changes also involve adding the PayPal sandbox credentials to the membership config. In order to run the acceptance tests locally you will have to pull down the new DEV private config (instructions are in the **Download private keys** section of the membership-frontend [README](https://github.com/guardian/membership-frontend/blob/master/README.md)).

I've also used this PR as an opportunity to make some refactors suggested by @mario-galic in #1511.

[**Trello Card**](https://trello.com/c/WjyHHjYB/302-paypal-monitoring-testing)

## Changes

- Added a new scenario to the `JoinSupporterSpec` for PayPal.
- Modified `EnterDetails` page to include new methods for PayPal, including a new `PayPalCheckout` object.
- Pulled the `setValueSlowly` method out into the Browser module, as it's needed by both Stripe and PayPal.
- Added new config for the membership PayPal sandbox creds.
- Modified the `setValue` method to add a 'clear' option, because autofill was messing with the registration fields.
- Added methods for switching between windows and frames, and changing the URL, to the `Browser` module.