### PR TITLE
Switch on PayPal!

### DIFF
--- a/frontend/app/abtests/PayPalTestVariants.scala
+++ b/frontend/app/abtests/PayPalTestVariants.scala
@@ -6,5 +6,5 @@ object PayPalTestVariants {
   val withPayPal = "with_paypal"
   val stripeOnly = "stripe_only"
   val variants = List(withPayPal, stripeOnly)
-  def allocateVariant() = None //Some(variants(Random.nextInt(2))) //uncomment to go live
+  def allocateVariant() = Some(variants(Random.nextInt(2))) //uncomment to go live
 }


### PR DESCRIPTION
## Why are you doing this?
To enable PayPal

### Notes 
* Currently only enabled via an A/B test query parameter so will only appear in supporter flow
* Whether a user sees the PayPal payment option is tracked in GA via the 'experience' custom dimension. The payment method they finally choose is tracked via the 'paymentMethod' custom dimension.


