### PR TITLE
Update Acceptance Test Config For PayPal Sandbox

### DIFF
--- a/frontend/test/acceptance/conf/acceptance-test.conf
+++ b/frontend/test/acceptance/conf/acceptance-test.conf
@@ -16,3 +16,10 @@ webDriverRemoteUrl = ${?WEBDRIVER_REMOTE_URL}
 
 // maximum amount of time to wait for a condition in seconds
 waitTimeout = 30
+
+// Credentials for the PayPal sandbox, uses private conf when running locally
+// and environment when running in Travis.
+paypal.sandbox {
+  buyer.email = ${?PAYPAL_SANDBOX_EMAIL}
+  buyer.password = ${?PAYPAL_SANDBOX_PASSWORD}
+}


### PR DESCRIPTION
## Why are you doing this?

So the acceptance tests failed on #1517 because Saucelabs doesn't have access to the private config where they are stored. The solution to this is to make them available as Travis environment variables for the Saucelabs tests, and fall back to the private config when testing locally.

## Changes

- Updated acceptance test config to use optional environment variables, and fall back to those present in the private config (which it imports).
