### PR TITLE
Decrease use of `AuthRequest` in the checkout flow

### DIFF
--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -126,7 +126,7 @@ object Joiner extends Controller with ActivityTracking
       tier match {
         case t: Tier.Supporter => {
           MembersDataAPI.Service.upsertBehaviour(
-            request,
+            request.user,
             activity = Some("enterPaidDetails.show"),
             note = Some(t.name))
         }
@@ -274,7 +274,7 @@ object Joiner extends Controller with ActivityTracking
       paymentMethod <- paymentService.getPaymentMethod(request.subscriber.subscription.accountId)
     } yield {
       tier match {
-        case t: Tier.Supporter if !upgrade => MembersDataAPI.Service.removeBehaviour(request)
+        case t: Tier.Supporter if !upgrade => MembersDataAPI.Service.removeBehaviour(request.user)
         case _ =>
       }
       Ok(views.html.joiner.thankyou(
@@ -311,7 +311,7 @@ object Joiner extends Controller with ActivityTracking
 
   private def setBehaviourNote(tier: String, errorCode: String)(implicit request: AuthRequest[_]) = {
     if (tier.toLowerCase == "supporter") {
-      MembersDataAPI.Service.upsertBehaviour(request, note = Some(errorCode))
+      MembersDataAPI.Service.upsertBehaviour(request.user, note = Some(errorCode))
     }
   }
 


### PR DESCRIPTION

## Why are you doing this?

This is a small part of a bigger change working on the Merge Registration & Checkout story.

To cope with the checkout page no longer being behind an `AuthRequest`, we need to use `AuthenticatedIdUser` & `AccessCredentials.Cookies` in preference to `AuthRequest` where possible in that flow. Incidentally, note the `AuthenticatedIdUser` object provides a reference to the access credentials.

Note that this change depends on this update to `identity-play-auth`: https://github.com/guardian/identity-play-auth/commit/02b40d1ebaf98ecc5ec5f44b8b8480b9409f556a ...that update made it into Membership Frontend with https://github.com/guardian/membership-frontend/pull/1522

## Trello card: [Here](https://trello.com/c/TpuX5Fdb/298-a-b-testing-for-new-checkout-flow-test-merging-registration-into-supporter-checkout)

cc @JustinPinner @svillafe 