### PR TITLE
Improve Logging For Payment Methods

### DIFF
--- a/frontend/app/monitoring/MemberMetrics.scala
+++ b/frontend/app/monitoring/MemberMetrics.scala
@@ -1,6 +1,8 @@
 package monitoring
 
 import com.gu.salesforce.Tier
+import com.gu.zuora.soap.models.Commands.PaymentMethod
+import com.amazonaws.services.cloudwatch.model.Dimension
 
 class MemberMetrics(val backendEnv: String) extends TouchpointBackendMetrics {
 
@@ -24,6 +26,20 @@ class MemberMetrics(val backendEnv: String) extends TouchpointBackendMetrics {
 
   def putFailSignUp(tier: Tier) {
     put(s"failed-sign-up-${tier.name}")
+  }
+
+  def putCreationOfPaidSubscription(paymentMethod: Option[PaymentMethod]) = {
+
+    val methodName = paymentMethod match {
+      case Some(method) => method.getClass.getSimpleName
+      case None => "UnknownPaymentMethod"
+    }
+
+    val paymentDimension = new Dimension().withName("PaymentMethod")
+      .withValue(methodName)
+
+    put(s"create-paid-subscription", 1, paymentDimension)
+
   }
 
   private def put(metricName: String) {

--- a/frontend/app/monitoring/MemberMetrics.scala
+++ b/frontend/app/monitoring/MemberMetrics.scala
@@ -32,7 +32,7 @@ class MemberMetrics(val backendEnv: String) extends TouchpointBackendMetrics {
 
     for {
       method <- paymentMethod
-    } yield {
+    } {
 
       val paymentDimension = new Dimension().withName("PaymentMethod")
         .withValue(method.getClass.getSimpleName)

--- a/frontend/app/monitoring/MemberMetrics.scala
+++ b/frontend/app/monitoring/MemberMetrics.scala
@@ -30,15 +30,16 @@ class MemberMetrics(val backendEnv: String) extends TouchpointBackendMetrics {
 
   def putCreationOfPaidSubscription(paymentMethod: Option[PaymentMethod]) = {
 
-    val methodName = paymentMethod match {
-      case Some(method) => method.getClass.getSimpleName
-      case None => "UnknownPaymentMethod"
+    for {
+      method <- paymentMethod
+    } yield {
+
+      val paymentDimension = new Dimension().withName("PaymentMethod")
+        .withValue(method.getClass.getSimpleName)
+
+      put(s"create-paid-subscription", 1, paymentDimension)
+
     }
-
-    val paymentDimension = new Dimension().withName("PaymentMethod")
-      .withValue(methodName)
-
-    put(s"create-paid-subscription", 1, paymentDimension)
 
   }
 

--- a/frontend/app/services/PayPalService.scala
+++ b/frontend/app/services/PayPalService.scala
@@ -74,8 +74,7 @@ class PayPalService(apiConfig: PayPalConfig) extends LazyLogging {
       "REFERENCEID" -> baid
     )
 
-    val response = nvpRequest(params)
-    retrieveNVPParam(response, "EMAIL")
+    retrieveNVPParam(nvpRequest(params), "EMAIL")
   }
 
   // Sets up a payment by contacting PayPal and returns the token.
@@ -93,8 +92,7 @@ class PayPalService(apiConfig: PayPalConfig) extends LazyLogging {
       "BILLINGTYPE" -> "MerchantInitiatedBilling",
       "NOSHIPPING" -> "1")
 
-    val response = nvpRequest(paymentParams)
-    retrieveNVPParam(response, "TOKEN")
+    retrieveNVPParam(nvpRequest(paymentParams), "TOKEN")
   }
 
   // Sends a request to PayPal to create billing agreement and returns BAID.
@@ -105,7 +103,6 @@ class PayPalService(apiConfig: PayPalConfig) extends LazyLogging {
       "METHOD" -> "CreateBillingAgreement",
       "TOKEN" -> token.token)
 
-    val response = nvpRequest(agreementParams)
-    retrieveNVPParam(response, "BILLINGAGREEMENTID")
+    retrieveNVPParam(nvpRequest(agreementParams), "BILLINGAGREEMENTID")
   }
 }

--- a/frontend/app/services/PayPalService.scala
+++ b/frontend/app/services/PayPalService.scala
@@ -3,6 +3,7 @@ package services
 import com.gu.okhttp.RequestRunners
 import com.gu.paypal.PayPalConfig
 import com.netaporter.uri.Uri.parseQuery
+import com.netaporter.uri.QueryString
 import com.typesafe.scalalogging.LazyLogging
 import configuration.Config
 import controllers.PayPal.{PayPalBillingDetails, Token}
@@ -18,6 +19,35 @@ class PayPalService(apiConfig: PayPalConfig) extends LazyLogging {
     "SIGNATURE" -> config.signature,
     "VERSION" -> config.NVPVersion)
 
+  // Logs the result of the PayPal NVP request.
+  private def logNVPResponse(response: QueryString) = {
+
+    def msg(status: String) = s"PayPal: ${status} (NVPResponse: ${response})"
+
+    retrieveNVPParam(response, "ACK") match {
+      case "Success" => logger.info("Successful PayPal NVP request")
+      case "SuccessWithWarning" => logger.warn(msg("Warning"))
+      case "Failure" => logger.error(msg("Error"))
+      case "FailureWithWarning" => logger.error(msg("Error With Warning"))
+    }
+
+  }
+
+  // Extracts response params as a map.
+  private def extractResponse(response: Response) = {
+
+    val responseBody = response.body().string()
+
+    if (Config.stageDev)
+      logger.info("NVP response body = " + responseBody)
+
+    val parsedResponse = parseQuery(responseBody)
+
+    logNVPResponse(parsedResponse)
+    parsedResponse
+
+  }
+
   // Takes a series of parameters, send a request to PayPal, returns response.
   private def nvpRequest(params: Map[String, String]) = {
 
@@ -30,18 +60,13 @@ class PayPalService(apiConfig: PayPalConfig) extends LazyLogging {
       .post(reqBody.build())
       .build()
 
-    RequestRunners.client.newCall(request).execute()
+    extractResponse(RequestRunners.client.newCall(request).execute)
+
   }
 
   // Takes an NVP response and retrieves a given parameter as a string.
-  private def retrieveNVPParam(response: Response, paramName: String) = {
-    val responseBody = response.body().string()
-    if (Config.stageDev)
-      logger.info("NVP response body = " + responseBody)
-
-    val queryParams = parseQuery(responseBody)
-    queryParams.paramMap(paramName).head
-  }
+  private def retrieveNVPParam(response: QueryString, paramName: String) =
+    response.paramMap(paramName).head
 
   def retrieveEmail(baid: String) = {
     val params = Map(


### PR DESCRIPTION
## Why are you doing this?

There are two main aims for this PR:

1. Start logging the payment method using CloudWatch metrics, so that we can improve monitoring of the platform health (and allow @rtyley to make pretty graphs).
2. Start logging the success or failure of NVP requests to PayPal, so we have a better idea of why payments fail.

[**Trello Card**](https://trello.com/c/nRzemYIN/360-record-stripe-vs-paypal-sign-ups-in-aws)

## Changes

- Added new method for recording payment methods in `MemberMetrics`, recording the method itself as a dimension.
- Called this new metric logging method once sign-up is complete in `MemberService`.
- Restructured the handling of NVP response from PayPal in `PayPalService`. Instead of passing the `Response` object around, we now decode it immediately and passed the decoded `QueryString` around instead. This means that we can extract the status of the response for logging straight away, and then extract further parameters further down the line.
