### PR TITLE
Fix race condition while acceptance test is waiting for thank-you

### DIFF
--- a/frontend/test/acceptance/pages/ThankYou.scala
+++ b/frontend/test/acceptance/pages/ThankYou.scala
@@ -8,5 +8,10 @@ object ThankYou extends Page with Browser {
 
   def userIsSignedInAsSupporter: Boolean = elementHasText(cssSelector(".js-user-tier"), "Supporter")
 
-  def pageHasLoaded: Boolean = (pageHasElement(id("qa-joiner-summary-tier")) && pageHasUrl("join/supporter/thankyou"))
+  def pageHasLoaded: Boolean = {
+    // ensure that we are looking at the main page, and not the Stripe/Paypal iframe that may have just closed
+    driver.switchTo().defaultContent()
+
+    pageHasElement(id("qa-joiner-summary-tier")) && pageHasUrl("join/supporter/thankyou")
+  }
 }

--- a/frontend/test/acceptance/util/Browser.scala
+++ b/frontend/test/acceptance/util/Browser.scala
@@ -107,7 +107,7 @@ trait Browser extends WebBrowser {
   def changeUrl(url: String) = driver.get(url)
 
   private def waitUntil[T](pred: ExpectedCondition[T]): Boolean =
-    Try(new WebDriverWait(driver, Config.waitTimout).until(pred)).isSuccess
+    Try(new WebDriverWait(driver, Config.waitTimeout).until(pred)).isSuccess
 
   private case class MissingPageElementException(q: Query)
     extends Exception(s"Could not find WebElement with locator: ${q.queryString}")

--- a/frontend/test/acceptance/util/Config.scala
+++ b/frontend/test/acceptance/util/Config.scala
@@ -22,7 +22,7 @@ object Config {
 
   val screencastIdFile = conf.getString("screencastId.file")
 
-  val waitTimout: Int = conf.getString("waitTimeout").toInt
+  val waitTimeout: Int = conf.getInt("waitTimeout")
 
   val paypalBuyerEmail = conf.getString("paypal.sandbox.buyer.email")
 


### PR DESCRIPTION
## Why are you doing this?

We got a acceptance test failure with this run, after https://github.com/guardian/membership-frontend/pull/1523 was merged to master (tho' the problem was unrelated to that PR):

https://travis-ci.org/guardian/membership-frontend/builds/204939484#L275
https://saucelabs.com/beta/tests/daab714dab654af19559e3530ae99fd3/commands#210

The Stripe payment had been accepted, the stripe overlay was about to disappear, the checkout page was soon to be replaced by the Thank You page, and the WebDriver code was waiting for the `qa-joiner-summary-tier` element of the Thank You page to appear. It logged 5 failed attempts to see the element over a total of 2.5 seconds, each message looking like this:

```
{"using":"id","value":"qa-joiner-summary-tier"}
RESPONSE

=> {"message":"no such element: Unable to locate element: {\"method\":\"id\",\"selector\":\"qa-joiner-summary-tier\"}\n (Session info: chrome=56.0.2924.76)\n (Driver info: chromedriver=2.27.440174 (e97a722caafc2d3a8b807ee115bfb307f7d2cfd9),platform=Windows NT 6.3.9600 x86_64)"}
```

This is normal, and normally the `WebDriverWait` would persist for up to 30 seconds, waiting for that element to appear. It is configured to swallow those `org.openqa.selenium.NotFoundException`s:

https://seleniumhq.github.io/selenium/docs/api/java/org/openqa/selenium/support/ui/WebDriverWait.html#WebDriverWait-org.openqa.selenium.WebDriver-long-

However, on the 6th attempt, it got a different error:

```
{"using":"id","value":"qa-joiner-summary-tier"}
RESPONSE

=> {"message":"unknown error: unhandled inspector error: {\"code\":-32000,\"message\":\"Cannot find context with specified id\"}\n (Session info: chrome=56.0.2924.76)\n (Driver info: chromedriver=2.27.440174 (e97a722caafc2d3a8b807ee115bfb307f7d2cfd9),platform=Windows NT 6.3.9600 x86_64)"}
```

This `Cannot find context with specified id` error was propagated, immediately killing and failing that test.


We believe that the error was caused by the `driver` attempting to look at the Stripe iframe context, which had just closed (because the test payment had been accepted) - the context no longer existed, so attempting to examine items within it was fatal.

We switch the driver to the context of the Stripe iframe earlier in test, in order to be able to fill the fields out:

https://github.com/guardian/membership-frontend/blob/940fe2a95/frontend/test/acceptance/JoinSupporterSpec.scala#L81-L103

...up until now, we had not explicitly switched back. We probably didn't need to for most runs, because the page-load of the Thank You page probably trigger the driver to switch context automatically.


## Changes

This change explicitly switches the context of the driver to the default content, so that we don't attempt to operate on the Stripe iframe which is about to disappear.

Also fixing small typo of `waitTimout`.



## Screenshots

![image](https://cloud.githubusercontent.com/assets/52038/23307077/120be3a0-fa9e-11e6-868f-d9821a86e110.png)

cc @Ap0c @mario-galic 
