### PR TITLE
Use Address case-class to avoid referring to 10 address fields by name

### DIFF
--- a/frontend/app/views/fragments/form/addressDetailFields.scala.html
+++ b/frontend/app/views/fragments/form/addressDetailFields.scala.html
@@ -1,12 +1,9 @@
 @import com.gu.i18n.Country
 @import views.support.CountryWithCurrency
+@import com.gu.memsub.Address
 @(countriesWithCurrencies: List[CountryWithCurrency],
   formType: String,
-  address1: Option[String],
-  address2: Option[String],
-  town: Option[String],
-  postcode: Option[String],
-  county: Option[String],
+  address: Address,
   addressRequired: Boolean = true,
   heading: String = "",
   note: String = "",
@@ -21,7 +18,7 @@
                 required
                 aria-required="true">
         @for(countyOrState <- countyOrStateList) {
-            <option value="@countyOrState"@if(county.getOrElse("") == countyOrState){ selected}>@countyOrState</option>
+            <option value="@address.countyOrState"@if(address.countyOrState == countyOrState){ selected}>@countyOrState</option>
         }
         </select>
         @fragments.form.errorMessage(s"Please enter your ${countyOrStateLabel.capitalize}")
@@ -60,7 +57,7 @@
                    for="address-line-one-@(formType)">Address line 1</label>
             <input type="text"
                    name="@(formType).lineOne"
-                   value="@address1"
+                   value="@address.lineOne"
                    id="address-line-one-@(formType)"
                    @* Salesforce accepts up to 255 chars but this field gets concatenated with address line 2 *@
                    maxlength="126"
@@ -73,7 +70,7 @@
             <label class="label optional-marker" for="address-line-two-@(formType)">Address line 2</label>
             <input type="text"
                    name="@(formType).lineTwo"
-                   value="@address2"
+                   value="@address.lineTwo"
                    id="address-line-two-@(formType)"
                    @* Salesforce accepts up to 255 chars but this field gets concatenated with address line 1 *@
                    maxlength="126"
@@ -84,7 +81,7 @@
             <label class="label js-town-label @if(!addressRequired){optional-marker}" for="town-@(formType)">Town</label>
             <input type="text"
                    name="@(formType).town"
-                   value="@town"
+                   value="@address.town"
                    id="town-@(formType)"
                    maxlength="40"
                    class="input-text js-town"
@@ -100,7 +97,7 @@
                 <label class="label optional-marker" for="county-or-state-@(formType)">County</label>
                 <input type="text"
                        name="@(formType).countyOrState"
-                       value="@county"
+                       value="@address.countyOrState"
                        id="county-or-state-@(formType)"
                        @* This length is limited by Zuora. Salesforce accepts up to 40 chars *@
                        maxlength="32"
@@ -112,7 +109,7 @@
             <label class="label optional-marker js-postcode-label" for="postCode-@(formType)">Post code</label>
             <input type="text"
                    name="@(formType).postCode"
-                   value="@postcode"
+                   value="@address.postCode"
                    id="postCode-@(formType)"
                    maxlength="10"
                    class="input-text js-postcode form-field__postcode"

--- a/frontend/app/views/joiner/form/payment.scala.html
+++ b/frontend/app/views/joiner/form/payment.scala.html
@@ -72,11 +72,7 @@
                             note = "We need your address to send you a welcome pack",
                             formType = "deliveryAddress",
                             addressRequired = true,
-                            address1 = idUser.privateFields.address1,
-                            address2 = idUser.privateFields.address2,
-                            town = idUser.privateFields.address3,
-                            postcode = idUser.privateFields.postcode,
-                            county = idUser.privateFields.address4
+                            address = idUser.deliveryAddress
                         )
                         <!-- Billing Address -->
                         @fragments.form.billingAddressFields("Billing address")
@@ -84,11 +80,7 @@
                             countriesWithCurrencies = countriesWithCurrencies,
                             formType = "billingAddress",
                             addressRequired = true,
-                            address1 = idUser.privateFields.billingAddress1,
-                            address2 = idUser.privateFields.billingAddress2,
-                            town = idUser.privateFields.billingAddress3,
-                            postcode = idUser.privateFields.billingPostcode,
-                            county = idUser.privateFields.billingAddress4,
+                            address = idUser.billingAddress,
                             showHeading = false
                         )
 

--- a/frontend/app/views/support/IdentityUser.scala
+++ b/frontend/app/views/support/IdentityUser.scala
@@ -2,10 +2,10 @@ package views.support
 
 import com.gu.i18n.{Country, CountryGroup}
 import com.gu.identity.model.PublicFields
-import com.gu.identity.play.{StatusFields, PrivateFields}
+import com.gu.identity.play.{PrivateFields, StatusFields}
 import com.gu.identity.play.IdUser
+import com.gu.memsub.Address
 import utils.TestUsers
-
 
 case class IdentityUser(privateFields: PrivateFields, marketingChoices: StatusFields, passwordExists: Boolean, email: String) {
   private val countryName: Option[String] = privateFields.billingCountry orElse privateFields.country
@@ -15,6 +15,24 @@ case class IdentityUser(privateFields: PrivateFields, marketingChoices: StatusFi
 
   val countryGroup: Option[CountryGroup] =
     countryName.flatMap(CountryGroup.byCountryNameOrCode)
+
+  val deliveryAddress = Address(
+    lineOne =       privateFields.address1.mkString,
+    lineTwo =       privateFields.address2.mkString,
+    town =          privateFields.address3.mkString,
+    countyOrState = privateFields.address4.mkString,
+    postCode =      privateFields.postcode.mkString,
+    countryName =   privateFields.country.mkString
+  )
+
+  val billingAddress = Address(
+    lineOne =       privateFields.billingAddress1.mkString,
+    lineTwo =       privateFields.billingAddress2.mkString,
+    town =          privateFields.billingAddress3.mkString,
+    countyOrState = privateFields.billingAddress4.mkString,
+    postCode =      privateFields.billingPostcode.mkString,
+    countryName =   privateFields.billingCountry.mkString
+  )
 
   def isTestUser: Boolean = privateFields.firstName.exists(TestUsers.isTestUser)
 }


### PR DESCRIPTION

## Why are you doing this?
Related to https://trello.com/c/TpuX5Fdb/298-a-b-testing-for-new-checkout-flow-test-merging-registration-into-supporter-checkout ...in the code, when you _may_ not have an Identity user, having a single case class you can refer to is a lot nicer than referring to 10 address fields by name and handling them individually.


## Screenshots

Testing locally, I first added this information to a new Identity profile:

![image](https://cloud.githubusercontent.com/assets/52038/23309383/61b0ac4e-faa6-11e6-9701-d4d12932337d.png)

...arriving at the Supporter checkout, the details were populated as expected:

![image](https://cloud.githubusercontent.com/assets/52038/23309418/82525c22-faa6-11e6-86bb-bf1b7e186506.png)


If I created a blank Identity account without populating the fields, this displayed fine as you would expect:

![image](https://cloud.githubusercontent.com/assets/52038/23309569/0bf7fdc4-faa7-11e6-88cc-c37d188eb277.png)

cc @Ap0c 