### PR TITLE
Set the correct value for elements in the 'State' dropdown

### DIFF
--- a/frontend/app/views/fragments/form/addressDetailFields.scala.html
+++ b/frontend/app/views/fragments/form/addressDetailFields.scala.html
@@ -18,7 +18,7 @@
                 required
                 aria-required="true">
         @for(countyOrState <- countyOrStateList) {
-            <option value="@address.countyOrState"@if(address.countyOrState == countyOrState){ selected}>@countyOrState</option>
+            <option value="@countyOrState" @if(address.countyOrState == countyOrState){ selected}>@countyOrState</option>
         }
         </select>
         @fragments.form.errorMessage(s"Please enter your ${countyOrStateLabel.capitalize}")


### PR DESCRIPTION
## Why are you doing this?
To fix a bug which is preventing US and Canadian users checking out


