### PR TITLE
Set State/Province label correctly for US/Canadian users

### DIFF
--- a/frontend/assets/javascripts/src/modules/form/address/subdivision.js
+++ b/frontend/assets/javascripts/src/modules/form/address/subdivision.js
@@ -8,6 +8,7 @@ define(['$'], function ($) {
     var POST_CODE_STRING = 'Post code';
     var COUNTY_STRING = 'County';
     var STATE_STRING = 'State';
+    var PROVINCE_STRING = 'Province';
     var COUNTY_CONTAINER_SELECTOR = '.js-county-container';
     var POSTCODE_LABEL_SELECTOR = '.js-postcode-label';
     var AUSTRALIA_STRING = 'australia';
@@ -44,14 +45,14 @@ define(['$'], function ($) {
             $townLabel.text(TOWN_STRING);
             $countyContainer.append($stateSelectParent.removeClass(HIDE_CONTENT_VISUALLY_CLASSNAME));
             $postcodeLabel.text(ZIP_CODE_STRING);
-            $countyLabel.text(COUNTY_STRING);
-            $countyLabel.addClass(OPTIONAL_CLASSNAME);
+            $countyLabel.text(STATE_STRING);
+            $countyLabel.removeClass(OPTIONAL_CLASSNAME);
         } else if (optionTxt === CANADA_STRING) {
             $townLabel.text(TOWN_STRING);
             $countyContainer.append($provinceSelectParent.removeClass(HIDE_CONTENT_VISUALLY_CLASSNAME));
             $postcodeLabel.text(ZIP_CODE_STRING);
-            $countyLabel.text(COUNTY_STRING);
-            $countyLabel.addClass(OPTIONAL_CLASSNAME);
+            $countyLabel.text(PROVINCE_STRING);
+            $countyLabel.removeClass(OPTIONAL_CLASSNAME);
         } else if (optionTxt === AUSTRALIA_STRING){
             $townLabel.text(SUBURB_STRING);
             $countyLabel.text(STATE_STRING);


### PR DESCRIPTION
## Why are you doing this?
Currently US and Canadian users are seeing the label 'County (optional)' for their State or Province select box. This is incorrect both because the terminology is wrong and also because this field is not optional for them.

This PR fixes both of these issues

## Trello card: [Here](https://trello.com/c/5KU7XioZ/366-fix-labelling-on-us-canada-state-province-select-dropdown)

## Screenshots
### Before Canada:
![screen shot 2017-02-27 at 11 47 19](https://cloud.githubusercontent.com/assets/181371/23360537/caee328c-fce3-11e6-8e49-964d5746acb2.png)
### Before US:
![screen shot 2017-02-27 at 11 47 02](https://cloud.githubusercontent.com/assets/181371/23360538/caf00cf6-fce3-11e6-8ee1-c0599508df76.png)

### After Canada:
![screen shot 2017-02-27 at 11 48 04](https://cloud.githubusercontent.com/assets/181371/23360535/caed01fa-fce3-11e6-85df-04a5e19e7dd2.png)
### After US:
![screen shot 2017-02-27 at 11 47 53](https://cloud.githubusercontent.com/assets/181371/23360536/caed3648-fce3-11e6-94e7-5519f5572af4.png)
