### PR TITLE
update membership common

### DIFF
--- a/frontend/test/services/DestinationServiceTest.scala
+++ b/frontend/test/services/DestinationServiceTest.scala
@@ -39,7 +39,7 @@ class DestinationServiceTest extends Specification {
         accountId = com.gu.memsub.Subscription.AccountId(""),
         startDate = new LocalDate("2015-01-01"),
         termStartDate = new LocalDate("2015-01-01"),
-        firstPaymentDate = new LocalDate("2015-01-01"),
+        acceptanceDate = new LocalDate("2015-01-01"),
         termEndDate = new LocalDate("2016-01-01"),
         promoCode = None,
         casActivationDate = None,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "7.2.3"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.9" // v0.9 is the latest version published for Play 2.4...
-  val membershipCommon = "com.gu" %% "membership-common" % "0.367"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.368"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playFilters = PlayImport.filters


### PR DESCRIPTION
## Why are you doing this?
updating membership common so that the next person who needs to update it doesn't have to deal with my breaking changes

The firstPaymentDate in the subscription object really contains the customer acceptance date. It is no longer true that this is always the first payment date for all subs. 

@paulbrown1982 @johnduffell 