### PR TITLE
use the new tidied up catalog structure

### DIFF
--- a/frontend/app/controllers/TierController.scala
+++ b/frontend/app/controllers/TierController.scala
@@ -5,11 +5,12 @@ import actions.BackendProvider
 import com.gu.i18n.CountryGroup
 import com.gu.i18n.CountryGroup._
 import com.gu.identity.play.PrivateFields
+import com.gu.memsub.Benefit.PaidMemberTier
 import com.gu.memsub.BillingPeriod
 import com.gu.memsub.Subscriber.{FreeMember, PaidMember}
 import com.gu.memsub.promo.Formatters.PromotionFormatters._
 import com.gu.memsub.promo.{PromoCode, Upgrades}
-import com.gu.memsub.subsv2.{Catalog, MonthYearPlans}
+import com.gu.memsub.subsv2.{Catalog, PaidMembershipPlans}
 import com.gu.salesforce._
 import com.gu.stripe.Stripe
 import com.gu.stripe.Stripe.Serializer._
@@ -113,7 +114,7 @@ object TierController extends Controller with ActivityTracking
     Ok(views.html.tier.cancel.summaryPaid(request.subscriber.subscription)).discardingCookies(TierChangeCookies.deletionCookies: _*)
   }
 
-  def paymentSummary(subscriber: PaidMember, targetPlans: MonthYearPlans[com.gu.memsub.subsv2.CatalogPlan.PaidMember], code: Option[PromoCode])
+  def paymentSummary(subscriber: PaidMember, targetPlans: PaidMembershipPlans[PaidMemberTier], code: Option[PromoCode])
                     (implicit b: BackendProvider, c: Catalog, r: IdentityRequest): Future[MemberError \/ PaidToPaidUpgradeSummary] = {
 
     val targetPlan = targetPlans.get(subscriber.subscription.plan.charges.billingPeriod)

--- a/frontend/app/views/bundle/bundleSetA.scala.html
+++ b/frontend/app/views/bundle/bundleSetA.scala.html
@@ -1,13 +1,12 @@
 @import com.gu.i18n.CountryGroup
 @import configuration.Videos
-@import com.gu.memsub.subsv2.{CatalogPlan, MonthYearPlans}
 @import views.support.PageInfo
 @import tracking.AppnexusPixel
-@import com.gu.salesforce.Tier.Supporter
 
 @import abtests.BundleVariant
+@import com.gu.memsub.subsv2.PaidMembershipPlans
 @(  heroImage: model.OrientatedImages,
-    supporterPlans: MonthYearPlans[CatalogPlan.Supporter],
+    supporterPlans: PaidMembershipPlans[com.gu.memsub.Benefit.Supporter.type],
     pageInfo: PageInfo,
     whySupportImage: model.OrientatedImages,
     bundleVariant: BundleVariant)(implicit token: play.filters.csrf.CSRF.Token)

--- a/frontend/app/views/bundle/thankYou.scala.html
+++ b/frontend/app/views/bundle/thankYou.scala.html
@@ -1,6 +1,6 @@
 @import com.gu.i18n.CountryGroup
 @import configuration.Videos
-@import com.gu.memsub.subsv2.{CatalogPlan, MonthYearPlans}
+@import com.gu.memsub.subsv2.CatalogPlan
 @import views.support.PageInfo
 @import tracking.AppnexusPixel
 @import com.gu.salesforce.Tier.Supporter

--- a/frontend/app/views/fragments/bundle/bundleHeader.scala.html
+++ b/frontend/app/views/fragments/bundle/bundleHeader.scala.html
@@ -1,7 +1,6 @@
 @import model.OrientatedImages
 @import com.gu.i18n.CountryGroup
-@import com.gu.memsub.subsv2.MonthYearPlans
-@import com.gu.memsub.subsv2.CatalogPlan.PaidMember
+@import com.gu.memsub.Benefit.PaidMemberTier
 
 @(image: OrientatedImages, mainTitle: Html, tagLine: Html, paragraph: Html)
 

--- a/frontend/app/views/fragments/form/cardDetail.scala.html
+++ b/frontend/app/views/fragments/form/cardDetail.scala.html
@@ -1,10 +1,8 @@
 
-@import com.gu.salesforce.PaidTier
-@import com.gu.memsub.Current
-@import com.gu.memsub.subsv2.CatalogPlan.PaidMember
-@import com.gu.memsub.subsv2.MonthYearPlans
+@import com.gu.memsub.subsv2.PaidMembershipPlans
+@import com.gu.memsub.Benefit
 @(
-    plans: MonthYearPlans[PaidMember],
+    plans: PaidMembershipPlans[Benefit.PaidMemberTier],
     cardOpt: Option[com.gu.stripe.Stripe.Card] = None
 )
 

--- a/frontend/app/views/fragments/form/paymentOptions.scala.html
+++ b/frontend/app/views/fragments/form/paymentOptions.scala.html
@@ -1,6 +1,6 @@
-@import com.gu.memsub.subsv2.MonthYearPlans
-@import com.gu.memsub.subsv2.CatalogPlan.PaidMember
-@(plans: MonthYearPlans[PaidMember])
+@import com.gu.memsub.subsv2.PaidMembershipPlans
+@import com.gu.memsub.Benefit.PaidMemberTier
+@(plans: PaidMembershipPlans[PaidMemberTier])
 
 <fieldset class="fieldset js-payment-options-container">
 

--- a/frontend/app/views/fragments/form/paymentOptionsFields.scala.html
+++ b/frontend/app/views/fragments/form/paymentOptionsFields.scala.html
@@ -1,6 +1,6 @@
-@import com.gu.memsub.subsv2.MonthYearPlans
-@import com.gu.memsub.subsv2.CatalogPlan.PaidMember
-@(plans: MonthYearPlans[PaidMember])
+@import com.gu.memsub.subsv2.PaidMembershipPlans
+@import com.gu.memsub.Benefit
+@(plans: PaidMembershipPlans[Benefit.PaidMemberTier])
 
 <fieldset class="fieldset js-payment-options-container">
 

--- a/frontend/app/views/fragments/page/elevatedBanner.scala.html
+++ b/frontend/app/views/fragments/page/elevatedBanner.scala.html
@@ -1,10 +1,10 @@
 @import model.OrientatedImages
-@import com.gu.memsub.subsv2.MonthYearPlans
+@import com.gu.memsub.subsv2.PaidMembershipPlans
 @import com.gu.i18n.CountryGroup
-@import com.gu.memsub.subsv2.CatalogPlan.PaidMember
 
+@import com.gu.memsub.Benefit.PaidMemberTier
 @(  image: OrientatedImages,
-    supporterPlans: MonthYearPlans[PaidMember],
+    supporterPlans: PaidMembershipPlans[PaidMemberTier],
     countryGroup: CountryGroup,
     mainTitle:Html,
     tagLine: Html

--- a/frontend/app/views/fragments/page/elevatedBecomeSupporter.scala.html
+++ b/frontend/app/views/fragments/page/elevatedBecomeSupporter.scala.html
@@ -1,10 +1,11 @@
 @import model.OrientatedImages
 @import com.gu.i18n.CountryGroup
-@import com.gu.memsub.subsv2.MonthYearPlans
-@import com.gu.memsub.subsv2.CatalogPlan.PaidMember
+@import com.gu.memsub.subsv2.PaidMembershipPlans
+@import com.gu.memsub.Benefit.PaidMemberTier
+@import com.gu.memsub.Benefit.PaidMemberTier
 
 @(  image: OrientatedImages,
-    supporterPlans: MonthYearPlans[PaidMember],
+    supporterPlans: PaidMembershipPlans[PaidMemberTier],
     countryGroup: CountryGroup,
     mainTitle: Html,
     tagLine: Html

--- a/frontend/app/views/fragments/page/elevatedButton.scala.html
+++ b/frontend/app/views/fragments/page/elevatedButton.scala.html
@@ -1,13 +1,13 @@
 @import com.gu.i18n.CountryGroup
-@import com.gu.memsub.subsv2.CatalogPlan.PaidMember
-@import com.gu.memsub.subsv2.MonthYearPlans
+@import com.gu.memsub.Benefit.PaidMemberTier
+@import com.gu.memsub.subsv2.PaidMembershipPlans
 @import abtests.PayPalTestVariants
 @import views.support.Asset
 @import views.support.MembershipCompat._
 @import views.support.Pricing._
 @import com.gu.memsub.BillingPeriod.{ Month, Year}
 
-@(  supporterPlans: MonthYearPlans[PaidMember],
+@(  supporterPlans: PaidMembershipPlans[PaidMemberTier],
     countryGroup: CountryGroup,
     dataLabel : String)
 

--- a/frontend/app/views/fragments/page/elevatedCloserTheGuardian.scala.html
+++ b/frontend/app/views/fragments/page/elevatedCloserTheGuardian.scala.html
@@ -1,8 +1,8 @@
 @import com.gu.i18n.CountryGroup
-@import com.gu.memsub.subsv2.MonthYearPlans
-@import com.gu.memsub.subsv2.CatalogPlan.PaidMember
+@import com.gu.memsub.subsv2.PaidMembershipPlans
+@import com.gu.memsub.Benefit.PaidMemberTier
 
-@(  supporterPlans: MonthYearPlans[PaidMember],
+@(  supporterPlans: PaidMembershipPlans[PaidMemberTier],
     countryGroup: CountryGroup,
     showCurrencyPrefix: Boolean,
     benefitsTitle: Html)(body: Html)

--- a/frontend/app/views/fragments/page/elevatedFooterButton.scala.html
+++ b/frontend/app/views/fragments/page/elevatedFooterButton.scala.html
@@ -1,8 +1,8 @@
 @import com.gu.i18n.CountryGroup
-@import com.gu.memsub.subsv2.MonthYearPlans
-@import com.gu.memsub.subsv2.CatalogPlan.PaidMember
+@import com.gu.memsub.subsv2.PaidMembershipPlans
+@import com.gu.memsub.Benefit.PaidMemberTier
 
-@(	supporterPlans: MonthYearPlans[PaidMember],
+@(	supporterPlans: PaidMembershipPlans[PaidMemberTier],
     countryGroup: CountryGroup,
     dataLabel: String,
     showRightDiagonal: Boolean = false

--- a/frontend/app/views/fragments/page/elevatedWhySupport.scala.html
+++ b/frontend/app/views/fragments/page/elevatedWhySupport.scala.html
@@ -1,10 +1,10 @@
 @import com.gu.i18n.CountryGroup
-@import com.gu.memsub.subsv2.MonthYearPlans
-@import com.gu.memsub.subsv2.CatalogPlan.PaidMember
+@import com.gu.memsub.subsv2.PaidMembershipPlans
+@import com.gu.memsub.Benefit.PaidMemberTier
 @import model.OrientatedImages
 
 @(  image: OrientatedImages,
-	supporterPlans: MonthYearPlans[PaidMember],
+	supporterPlans: PaidMembershipPlans[PaidMemberTier],
     countryGroup: CountryGroup,
     showCurrencyPrefix: Boolean,
     title: Html

--- a/frontend/app/views/fragments/pricing/billingPeriodChoice.scala.html
+++ b/frontend/app/views/fragments/pricing/billingPeriodChoice.scala.html
@@ -1,11 +1,10 @@
 @import com.gu.salesforce.PaidTier
-@import com.gu.memsub.Current
 @import views.support.Pricing._
 @import com.gu.memsub.BillingPeriod._
-@import com.gu.memsub.subsv2.CatalogPlan.PaidMember
-@import com.gu.memsub.subsv2.MonthYearPlans
+@import com.gu.memsub.subsv2.PaidMembershipPlans
 
-@(plans: MonthYearPlans[PaidMember])
+@import com.gu.memsub.Benefit.PaidMemberTier
+@(plans: PaidMembershipPlans[PaidMemberTier])
 
 
 <script type="text/javascript">

--- a/frontend/app/views/fragments/pricing/billingPeriodChoiceFields.scala.html
+++ b/frontend/app/views/fragments/pricing/billingPeriodChoiceFields.scala.html
@@ -1,11 +1,10 @@
 @import com.gu.salesforce.PaidTier
-@import com.gu.memsub.Current
 @import views.support.Pricing._
 @import com.gu.memsub.BillingPeriod._
-@import com.gu.memsub.subsv2.CatalogPlan.PaidMember
-@import com.gu.memsub.subsv2.MonthYearPlans
+@import com.gu.memsub.subsv2.PaidMembershipPlans
 
-@(plans: MonthYearPlans[PaidMember])
+@import com.gu.memsub.Benefit.PaidMemberTier
+@(plans: PaidMembershipPlans[PaidMemberTier])
 
 
 <script type="text/javascript">

--- a/frontend/app/views/fragments/pricing/paidPriceInfo.scala.html
+++ b/frontend/app/views/fragments/pricing/paidPriceInfo.scala.html
@@ -4,10 +4,10 @@
 @import com.gu.memsub.Current
 @import views.support.Pricing._
 @import views.support.MembershipCompat._
-@import com.gu.memsub.subsv2.MonthYearPlans
-@import com.gu.memsub.subsv2.CatalogPlan.PaidMember
+@import com.gu.memsub.subsv2.PaidMembershipPlans
+@import com.gu.memsub.Benefit.PaidMemberTier
 @(
-    plans: MonthYearPlans[PaidMember],
+    plans: PaidMembershipPlans[PaidMemberTier],
     currency: Currency,
     isReversible: Boolean = false,
     canFlex: Boolean = true,

--- a/frontend/app/views/fragments/tier/packagePromoMinimal.scala.html
+++ b/frontend/app/views/fragments/tier/packagePromoMinimal.scala.html
@@ -4,9 +4,9 @@
 @import com.gu.memsub.Current
 @import views.support.Pricing._
 @import views.support.MembershipCompat._
-@import com.gu.memsub.subsv2.MonthYearPlans
-@import com.gu.memsub.subsv2.CatalogPlan.PaidMember
-@(paidPlan: MonthYearPlans[PaidMember],
+@import com.gu.memsub.subsv2.PaidMembershipPlans
+@import com.gu.memsub.Benefit.PaidMemberTier
+@(paidPlan: PaidMembershipPlans[PaidMemberTier],
   cg: CountryGroup,
   showDescription: Boolean = true,
   descriptionAnchor: Option[String] = None,

--- a/frontend/app/views/fragments/tier/packagePromoSupporter.scala.html
+++ b/frontend/app/views/fragments/tier/packagePromoSupporter.scala.html
@@ -4,9 +4,9 @@
 
 @import views.support.MembershipCompat._
 @import com.gu.i18n.CountryGroup
-@import com.gu.memsub.subsv2.MonthYearPlans
-@import com.gu.memsub.subsv2.CatalogPlan.PaidMember
-@(supporterPlans: MonthYearPlans[PaidMember], cg: CountryGroup, metricLabel: String)
+@import com.gu.memsub.subsv2.PaidMembershipPlans
+@import com.gu.memsub.Benefit.PaidMemberTier
+@(supporterPlans: PaidMembershipPlans[PaidMemberTier], cg: CountryGroup, metricLabel: String)
 
 @import com.gu.salesforce.Tier._
 

--- a/frontend/app/views/info/elevatedSupporter.scala.html
+++ b/frontend/app/views/info/elevatedSupporter.scala.html
@@ -1,12 +1,13 @@
 @import com.gu.i18n.CountryGroup
 @import configuration.Videos
-@import com.gu.memsub.subsv2.{CatalogPlan, MonthYearPlans}
+@import com.gu.memsub.subsv2.PaidMembershipPlans
 @import views.support.PageInfo
+@import com.gu.memsub.Benefit
 @import tracking.AppnexusPixel
 @import com.gu.salesforce.Tier.Supporter
 
 @(  heroImage: model.OrientatedImages,
-    supporterPlans: MonthYearPlans[CatalogPlan.Supporter],
+    supporterPlans: PaidMembershipPlans[Benefit.Supporter.type],
     pageInfo: PageInfo,
     detailImage: model.OrientatedImages)(implicit token: play.filters.csrf.CSRF.Token, countryGroup: CountryGroup)
 

--- a/frontend/app/views/info/patron.scala.html
+++ b/frontend/app/views/info/patron.scala.html
@@ -3,13 +3,13 @@
 @import com.gu.memsub.Current
 @import views.support.{Asset, PageInfo, PaidPlans}
 @import com.gu.salesforce.Tier
-@import com.gu.memsub.subsv2.Catalog._
+@import com.gu.memsub.Benefit
 
-@import com.gu.memsub.subsv2.MonthYearPlans
+@import com.gu.memsub.subsv2.PaidMembershipPlans
 @import com.gu.memsub.subsv2.CatalogPlan
-@(patronPlans: MonthYearPlans[CatalogPlan.Patron],
-  supporterPlans: MonthYearPlans[CatalogPlan.Supporter],
-  partnerPlans: MonthYearPlans[CatalogPlan.Partner],
+@(patronPlans: PaidMembershipPlans[Benefit.Patron.type],
+  supporterPlans: PaidMembershipPlans[Benefit.Supporter.type],
+  partnerPlans: PaidMembershipPlans[Benefit.Partner.type],
   pageInfo: PageInfo,
   countryGroup: CountryGroup,
   pageImages: Seq[com.gu.memsub.images.ResponsiveImageGroup])(implicit token: play.filters.csrf.CSRF.Token)

--- a/frontend/app/views/info/supporter.scala.html
+++ b/frontend/app/views/info/supporter.scala.html
@@ -3,13 +3,13 @@
 
 @import com.gu.memsub.Current
 @import configuration.Videos
-@import com.gu.memsub.subsv2.Catalog._
+@import com.gu.memsub.Benefit
 @import views.support.Asset
-@import com.gu.memsub.subsv2.MonthYearPlans
+@import com.gu.memsub.subsv2.PaidMembershipPlans
 @import views.support.MembershipCompat._
 
 @import com.gu.memsub.subsv2.CatalogPlan
-@(heroImage: model.OrientatedImages, supporterPlans: MonthYearPlans[CatalogPlan.Supporter],
+@(heroImage: model.OrientatedImages, supporterPlans: PaidMembershipPlans[Benefit.Supporter.type],
   pageInfo: PageInfo,
   pageImages: Seq[com.gu.memsub.images.ResponsiveImageGroup])(implicit token: play.filters.csrf.CSRF.Token, countryGroup: CountryGroup)
 

--- a/frontend/app/views/info/supporterAustralia.scala.html
+++ b/frontend/app/views/info/supporterAustralia.scala.html
@@ -4,14 +4,14 @@
 @import com.gu.memsub.Current
 @import views.support.Asset
 @import configuration.Videos
-@import com.gu.memsub.subsv2.Catalog._
-@import com.gu.memsub.subsv2.MonthYearPlans
+@import com.gu.memsub.Benefit
+@import com.gu.memsub.subsv2.PaidMembershipPlans
 @import views.support.MembershipCompat._
 @import com.gu.salesforce.Tier.Supporter
 @import tracking.AppnexusPixel
 
 @import com.gu.memsub.subsv2.CatalogPlan
-@(heroImage: model.OrientatedImages, supporterPlans: MonthYearPlans[CatalogPlan.Supporter],
+@(heroImage: model.OrientatedImages, supporterPlans: PaidMembershipPlans[Benefit.Supporter.type],
   pageInfo: PageInfo,
   pageImages: Seq[com.gu.memsub.images.ResponsiveImageGroup])(implicit token: play.filters.csrf.CSRF.Token, countryGroup: CountryGroup)
 

--- a/frontend/app/views/info/supporterEurope.scala.html
+++ b/frontend/app/views/info/supporterEurope.scala.html
@@ -3,13 +3,13 @@
 @import com.gu.salesforce.Tier.Supporter
 
 @import views.support.PageInfo
-@import com.gu.memsub.subsv2.MonthYearPlans
-@import com.gu.memsub.subsv2.CatalogPlan.PaidMember
+@import com.gu.memsub.subsv2.PaidMembershipPlans
+@import com.gu.memsub.Benefit.PaidMemberTier
 @import views.support.MembershipCompat._
 @import com.gu.salesforce.Tier.Supporter
 @import tracking.AppnexusPixel
 
-@(images: model.OrientatedImages, supporterPlans: MonthYearPlans[PaidMember],
+@(images: model.OrientatedImages, supporterPlans: PaidMembershipPlans[PaidMemberTier],
     pageInfo: PageInfo,
     pageImages: Seq[com.gu.memsub.images.ResponsiveImageGroup])(implicit token: play.filters.csrf.CSRF.Token, countryGroup: CountryGroup)
 

--- a/frontend/app/views/info/supporterInternational.scala.html
+++ b/frontend/app/views/info/supporterInternational.scala.html
@@ -2,13 +2,14 @@
 @import com.gu.memsub.Current
 
 @import views.support.PageInfo
-@import com.gu.memsub.subsv2.MonthYearPlans
+@import com.gu.memsub.subsv2.PaidMembershipPlans
 @import com.gu.memsub.subsv2.CatalogPlan
 @import com.gu.salesforce.Tier.Supporter
 @import views.support.MembershipCompat._
 @import tracking.AppnexusPixel
+@import com.gu.memsub.Benefit
 
-@(heroImage: model.OrientatedImages, supporterPlans: MonthYearPlans[CatalogPlan.Supporter],
+@(heroImage: model.OrientatedImages, supporterPlans: PaidMembershipPlans[Benefit.Supporter.type],
     pageInfo: PageInfo,
     pageImages: Seq[com.gu.memsub.images.ResponsiveImageGroup])(implicit token: play.filters.csrf.CSRF.Token, countryGroup: CountryGroup)
 

--- a/frontend/app/views/info/supporterUSA.scala.html
+++ b/frontend/app/views/info/supporterUSA.scala.html
@@ -5,11 +5,12 @@
 @import views.support.MembershipCompat._
 @import com.gu.memsub.subsv2.CatalogPlan
 @import views.support.PageInfo
-@import com.gu.memsub.subsv2.MonthYearPlans
+@import com.gu.memsub.subsv2.PaidMembershipPlans
 @import com.gu.salesforce.Tier.Supporter
 @import tracking.AppnexusPixel
+@import com.gu.memsub.Benefit
 
-@(heroImages: model.OrientatedImages, supporterPlans: MonthYearPlans[CatalogPlan.Supporter],
+@(heroImages: model.OrientatedImages, supporterPlans: PaidMembershipPlans[Benefit.Supporter.type],
   pageInfo: PageInfo,
   pageImages: Seq[com.gu.memsub.images.ResponsiveImageGroup])(implicit token: play.filters.csrf.CSRF.Token, countryGroup: CountryGroup)
 

--- a/frontend/app/views/joiner/form/payment.scala.html
+++ b/frontend/app/views/joiner/form/payment.scala.html
@@ -1,14 +1,14 @@
 @import abtests.PayPalTestVariants
 @import com.gu.i18n.CountryGroup
-@import com.gu.memsub.subsv2.CatalogPlan.PaidMember
-@import com.gu.memsub.subsv2.MonthYearPlans
+@import com.gu.memsub.Benefit.PaidMemberTier
+@import com.gu.memsub.subsv2.PaidMembershipPlans
 @import com.gu.salesforce.Tier.{Partner, Supporter}
 @import tracking.AppnexusPixel
 @import views.html.helper._
 @import views.support.DisplayText._
 @import views.support.MembershipCompat._
 @import views.support.{CountryWithCurrency, IdentityUser, PageInfo}
-@(plans: MonthYearPlans[PaidMember],
+@(plans: PaidMembershipPlans[PaidMemberTier],
     countriesWithCurrencies: List[CountryWithCurrency],
     idUser: IdentityUser,
     pageInfo: PageInfo,

--- a/frontend/app/views/promotions/singlePricePlanDiscountLandingPage.scala.html
+++ b/frontend/app/views/promotions/singlePricePlanDiscountLandingPage.scala.html
@@ -27,15 +27,15 @@
 @import com.gu.memsub.promo.HeroImageAlignment
 @import views.support.HeroImageAlignment._
 @import org.pegdown.PegDownProcessor
-@import com.gu.memsub.subsv2.CatalogPlan.PaidMember
-@import com.gu.memsub.subsv2.MonthYearPlans
+@import com.gu.memsub.Benefit.PaidMemberTier
+@import com.gu.memsub.subsv2.PaidMembershipPlans
 @import views.support.MembershipCompat._
 
 @import com.gu.memsub.subsv2.CatalogPlan
 @(  heroImages: model.OrientatedImages,
     heroImageAlignment: HeroImageAlignment,
     pricePlan: CatalogPlan.PaidMember[BillingPeriod],
-    pricePlans: MonthYearPlans[PaidMember],
+    pricePlans: PaidMembershipPlans[PaidMemberTier],
     pageInfo: PageInfo,
     promotionImage: ResponsiveImageGroup,
     promoCode: PromoCode,

--- a/frontend/app/views/promotions/singleTierLandingPage.scala.html
+++ b/frontend/app/views/promotions/singleTierLandingPage.scala.html
@@ -17,11 +17,11 @@
 
 @import com.gu.memsub.promo.MembershipLandingPage
 @import org.pegdown.PegDownProcessor
-@import com.gu.memsub.subsv2.MonthYearPlans
-@import com.gu.memsub.subsv2.CatalogPlan.PaidMember
+@import com.gu.memsub.subsv2.PaidMembershipPlans
+@import com.gu.memsub.Benefit.PaidMemberTier
 @import views.support.MembershipCompat._
 
-@(pricePlans: MonthYearPlans[PaidMember],
+@(pricePlans: PaidMembershipPlans[PaidMemberTier],
     pageInfo: PageInfo,
     headerImage: model.OrientatedImages,
     heroImageAlignment: HeroImageAlignment,

--- a/frontend/app/views/support/DisplayText.scala
+++ b/frontend/app/views/support/DisplayText.scala
@@ -3,8 +3,8 @@ package views.support
 import com.gu.i18n.CountryGroup
 import com.gu.i18n.CountryGroup.UK
 import com.gu.memsub.Current
-import com.gu.memsub.subsv2.CatalogPlan.PaidMember
-import com.gu.memsub.subsv2.MonthYearPlans
+import com.gu.memsub.Benefit.PaidMemberTier
+import com.gu.memsub.subsv2.PaidMembershipPlans
 import com.gu.salesforce.Tier._
 import com.gu.salesforce.{PaidTier, Tier}
 import model.Benefits.marketedOnlyToUK
@@ -46,7 +46,7 @@ object DisplayText {
     val chooseTierPatron = List(Highlight("Get all partner benefits, 6 tickets and 4 books plus invitations  to exclusive behind-the-scenes functions"))
   }
 
-  implicit class PaidTierDetailsCopy(paidPlans: MonthYearPlans[PaidMember]) {
+  implicit class PaidTierDetailsCopy(paidPlans: PaidMembershipPlans[PaidMemberTier]) {
     private val pricing = paidPlans.gbpPricing
 
     val yearlySavingNote: Option[String] = paidPlans.tier match {

--- a/frontend/app/views/support/MembershipCompat.scala
+++ b/frontend/app/views/support/MembershipCompat.scala
@@ -8,6 +8,7 @@ import com.gu.memsub.Subscription.ProductRatePlanId
 import com.gu.memsub.subsv2.{CatalogPlan, _}
 import com.gu.memsub.{Subscription => _, _}
 import com.gu.salesforce.{FreeTier, PaidTier, Tier}
+import Benefit._
 
 import scala.language.higherKinds
 import scala.util.Try
@@ -18,7 +19,7 @@ import scala.util.Try
   */
 object MembershipCompat {
 
-  implicit class MonthYearMembership(in: MonthYearPlans[CatalogPlan.PaidMember]) {
+  implicit class MonthYearMembership(in: PaidMembershipPlans[Benefit.PaidMemberTier]) {
     def tier: PaidTier = in.month.tier
   }
 
@@ -50,7 +51,7 @@ object MembershipCompat {
     }
   }
 
-  implicit class YMPlans(in: MonthYearPlans[CatalogPlan.PaidMember]) {
+  implicit class YMPlans(in: PaidMembershipPlans[Benefit.PaidMemberTier]) {
 
     def get(b: BillingPeriod): CatalogPlan.PaidMember[BillingPeriod] = b match {
       case Month => in.month
@@ -88,7 +89,7 @@ object MembershipCompat {
     def unsafeFindFree(prpId: ProductRatePlanId): CatalogPlan.FreeMember = Seq(in.friend, in.staff)
         .find(_.id == prpId).getOrElse(throw new Exception(s"no free plan with id $prpId"))
 
-    def findPaid(p: PaidTier): MonthYearPlans[CatalogPlan.PaidMember] = p match {
+    def findPaid(p: PaidTier): PaidMembershipPlans[Benefit.PaidMemberTier] = p match {
       case Tier.Supporter() => in.supporter
       case Tier.Partner() => in.partner
       case Tier.Patron() => in.patron

--- a/frontend/app/views/support/Pricing.scala
+++ b/frontend/app/views/support/Pricing.scala
@@ -3,8 +3,8 @@ package views.support
 import com.gu.i18n.Currency
 import com.gu.memsub.BillingPeriod.{Month, Year}
 import com.gu.memsub.{BillingPeriod, Price}
-import com.gu.memsub.subsv2.CatalogPlan.PaidMember
-import com.gu.memsub.subsv2.MonthYearPlans
+import com.gu.memsub.Benefit.PaidMemberTier
+import com.gu.memsub.subsv2.PaidMembershipPlans
 
 case class Pricing(yearly: Price, monthly: Price) {
   require(yearly.currency == monthly.currency, "The yearly and monthly prices should have the same currency")
@@ -33,7 +33,7 @@ case class Pricing(yearly: Price, monthly: Price) {
 }
 
 object Pricing {
-  implicit class WithPricing(plans: MonthYearPlans[PaidMember]) {
+  implicit class WithPricing(plans: PaidMembershipPlans[PaidMemberTier]) {
     lazy val allPricing: List[Pricing] = Currency.all.flatMap(pricing)
 
     def unsafePriceByCurrency(currency: Currency) = pricing(currency).getOrElse {

--- a/frontend/app/views/support/TierPlans.scala
+++ b/frontend/app/views/support/TierPlans.scala
@@ -1,10 +1,12 @@
 package views.support
 import com.gu.i18n.{Country, CountryGroup, Currency}
+import com.gu.memsub.Benefit.PaidMemberTier
 import com.gu.memsub._
 import com.gu.memsub.subsv2.CatalogPlan.{PaidMember, Partner}
 import com.gu.memsub.subsv2._
 import com.gu.salesforce.Tier
 import views.support.MembershipCompat._
+
 import scala.language.implicitConversions
 /**
   * Hack to unify FreeMembershipPlan and PaidMembershipPlans in views
@@ -23,7 +25,7 @@ case class FreePlan(plan: CatalogPlan.FreeMember) extends TierPlans {
   override def currency(country: Country): Option[Currency] = CountryGroup.availableCurrency(currencies)(country)
 }
 
-case class PaidPlans[M <: MonthYearPlans[PaidMember]](plans: M) extends TierPlans {
+case class PaidPlans[M <: PaidMembershipPlans[PaidMemberTier]](plans: M) extends TierPlans {
   override def tier = plans.month.tier
   override def currencies = plans.month.charges.price.currencies.intersect(plans.year.charges.price.currencies)
   override def currency(country: Country): Option[Currency] = CountryGroup.availableCurrency(currencies)(country)
@@ -33,7 +35,7 @@ object TierPlans {
   implicit def fromFreeMembershipPlan(plan: CatalogPlan.FreeMember): TierPlans =
     FreePlan(plan)
 
-  implicit def fromPaidMembershipPlan(plans: MonthYearPlans[CatalogPlan.PaidMember]): TierPlans = {
+  implicit def fromPaidMembershipPlan(plans: PaidMembershipPlans[Benefit.PaidMemberTier]): TierPlans = {
     PaidPlans(plans)
   }
 }

--- a/frontend/app/views/tier/downgrade/summary.scala.html
+++ b/frontend/app/views/tier/downgrade/summary.scala.html
@@ -5,7 +5,6 @@
 @import com.gu.memsub.Status
 @import com.gu.memsub.subsv2._
 @import com.gu.memsub.Current
-@import com.gu.memsub.Friend
 @import views.support.MembershipCompat._
 
 @(subscription: Subscription[SubscriptionPlan.PaidMember],

--- a/frontend/app/views/tier/upgrade/freeToPaid.scala.html
+++ b/frontend/app/views/tier/upgrade/freeToPaid.scala.html
@@ -1,6 +1,6 @@
 @import abtests.PayPalTestVariants
 @import com.gu.memsub.promo.{Upgrades, ValidPromotion}
-@import com.gu.memsub.subsv2.CatalogPlan.PaidMember
+@import com.gu.memsub.Benefit.PaidMemberTier
 @import com.gu.memsub.subsv2._
 @import com.gu.salesforce.Tier.{Partner, Supporter}
 @import play.api.mvc.RequestHeader
@@ -10,7 +10,7 @@
 @import views.support.MembershipCompat._
 @import views.support.{CountryWithCurrency, IdentityUser, PageInfo}
 @(currentPlan: CatalogPlan.Member,
-    targetPlans: MonthYearPlans[PaidMember],
+    targetPlans: PaidMembershipPlans[PaidMemberTier],
     countriesWithCurrency: List[CountryWithCurrency],
     idUser: IdentityUser,
     pageInfo: PageInfo,

--- a/frontend/test/services/DestinationServiceTest.scala
+++ b/frontend/test/services/DestinationServiceTest.scala
@@ -2,12 +2,11 @@ package services
 import com.github.nscala_time.time.Imports._
 import com.gu.contentapi.client.parser.JsonParser
 import com.gu.i18n.Currency.GBP
+import com.gu.memsub.Benefit._
 import com.gu.memsub.BillingPeriod.Month
 import com.gu.memsub.Subscription.{ProductRatePlanId, RatePlanId}
 import com.gu.memsub._
-import com.gu.memsub.services
-import com.gu.memsub.subsv2.Subscription
-import com.gu.memsub.subsv2._
+import com.gu.memsub.subsv2.{Subscription, _}
 import com.gu.salesforce._
 import model.Eventbrite.EBAccessCode
 import model.EventbriteTestObjects._
@@ -32,7 +31,7 @@ class DestinationServiceTest extends Specification {
     def createRequestWithSession(newSessions: (String, String)*) = {
 
       val testMember = Contact("id", None, None, Some("fn"), "ln", Some("email"), new DateTime(), "contactId", "accountId", None, None, None, None, None)
-      val partnerCharge: PaidCharge[com.gu.memsub.Partner.type, Month.type] = PaidCharge[com.gu.memsub.Partner.type, Month.type](com.gu.memsub.Partner, Month, PricingSummary(Map(GBP -> Price(0.1f, GBP))))
+      val partnerCharge: PaidCharge[Partner.type, Month.type] = PaidCharge[Partner.type, Month.type](Partner, Month, PricingSummary(Map(GBP -> Price(0.1f, GBP))))
       val testSub: Subscription[SubscriptionPlan.Member] = new Subscription[SubscriptionPlan.Partner](
         id = com.gu.memsub.Subscription.Id(""),
         name = com.gu.memsub.Subscription.Name(""),
@@ -44,7 +43,7 @@ class DestinationServiceTest extends Specification {
         promoCode = None,
         casActivationDate = None,
         isCancelled = false,
-        plans = scalaz.NonEmptyList(new PaidSubscriptionPlan[Product.Membership, PaidCharge[com.gu.memsub.Partner.type, Month.type]](
+        plans = scalaz.NonEmptyList(new PaidSubscriptionPlan[Product.Membership, PaidCharge[Partner.type, Month.type]](
           id = RatePlanId(""), productRatePlanId = ProductRatePlanId(""), name = "name", product = Product.Membership, description = "", features = Nil,
           charges = partnerCharge,
           chargedThrough = None, start = new LocalDate("2015-01-01"), end = new LocalDate("2099-01-01"), productName = "")),

--- a/frontend/test/views/support/CheckoutFormTest.scala
+++ b/frontend/test/views/support/CheckoutFormTest.scala
@@ -3,9 +3,10 @@ package views.support
 import com.gu.i18n.Currency._
 import com.gu.i18n._
 import com.gu.identity.play.{PrivateFields, StatusFields}
+import com.gu.memsub.Benefit._
 import com.gu.memsub.Subscription.ProductRatePlanId
 import com.gu.memsub._
-import com.gu.memsub.subsv2.{CatalogPlan, MonthYearPlans, PaidCharge}
+import com.gu.memsub.subsv2.{CatalogPlan, PaidCharge, PaidMembershipPlans}
 import org.specs2.mutable.Specification
 
 
@@ -39,7 +40,7 @@ class CheckoutFormTest extends Specification {
     EUR -> Price(3.5f, EUR)
   ))
 
-  val plans = MonthYearPlans[CatalogPlan.Partner](
+  val plans = PaidMembershipPlans[Partner.type](
     month = CatalogPlan(ProductRatePlanId(""), Product.Membership, "Partner", "Partner", None, PaidCharge(Partner, BillingPeriod.Month, pricingSummary), Status.current),
     year = CatalogPlan(ProductRatePlanId(""), Product.Membership, "Partner", "Partner", None, PaidCharge(Partner, BillingPeriod.Year, pricingSummary), Status.current)
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "7.2.3"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.9" // v0.9 is the latest version published for Play 2.4...
-  val membershipCommon = "com.gu" %% "membership-common" % "0.372"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.374-SNAPSHOT"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playFilters = PlayImport.filters

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "7.2.3"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.9" // v0.9 is the latest version published for Play 2.4...
-  val membershipCommon = "com.gu" %% "membership-common" % "0.374-SNAPSHOT"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.375"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playFilters = PlayImport.filters


### PR DESCRIPTION
The new catalog has weekly in 3 subsections, catalog.weekly.zoneX rather than catalog.weeklyZoneX
This PR makes it all compile!

Also the Benefits are now in the Benefit object rather than sitting around loose in com.gu.memsub

Relies on guardian/membership-common#444

@paulbrown1982 @svillafe
