### PR TITLE
Add the 'Backend' dimension to all Touchpoint metrics.

### DIFF
--- a/frontend/app/monitoring/TouchpointBackendMetrics.scala
+++ b/frontend/app/monitoring/TouchpointBackendMetrics.scala
@@ -5,10 +5,5 @@ import configuration.Config
 
 trait TouchpointBackendMetrics extends Metrics {
   val backendEnv: String
-
-  val standardBackend = Config.stage == backendEnv
-
-  override def mandatoryDimensions = if (standardBackend) super.mandatoryDimensions else {
-    super.mandatoryDimensions :+ new Dimension().withName("Backend").withValue(backendEnv)
-  }
+  override def mandatoryDimensions = super.mandatoryDimensions :+ new Dimension().withName("Backend").withValue(backendEnv)
 }


### PR DESCRIPTION
## Why are you doing this?
Currently we only add the Backend dimension to CloudWatch metrics if the value is different to the Stage eg. Test users use the UAT backend in Prod.
It would be useful for the purposes of filtering events to record the Backend whatever the value, this change does that.

## Trello card: [Here](https://trello.com/c/CuJR5k32/373-add-the-backend-dimension-to-all-touchpoint-metrics)

