### PR TITLE
Remove promo codes

### DIFF
--- a/frontend/app/actions/Fallbacks.scala
+++ b/frontend/app/actions/Fallbacks.scala
@@ -17,7 +17,7 @@ object Fallbacks {
     redirectTo(controllers.routes.FrontPage.welcome)
 
   def tierChangeEnterDetails(tier: PaidTier)(implicit req: RequestHeader) =
-    redirectTo(controllers.routes.TierController.upgrade(tier, None))
+    redirectTo(controllers.routes.TierController.upgrade(tier))
 
   def contributorJoinRedirect(implicit request: RequestHeader) =
     redirectTo(controllers.routes.Contributor.enterMonthlyContributionsDetails())

--- a/frontend/app/controllers/TierController.scala
+++ b/frontend/app/controllers/TierController.scala
@@ -152,7 +152,6 @@ object TierController extends Controller with ActivityTracking
     request.paidOrFreeSubscriber.fold({ freeSubscriber =>
       idUserFuture.map(idUser => {
 
-        // is the promoCode valid for the page being rendered
         val pageInfo = getPageInfo(idUser.privateFields, BillingPeriod.Year)
 
         Ok(views.html.tier.upgrade.freeToPaid(

--- a/frontend/app/forms/MemberForm.scala
+++ b/frontend/app/forms/MemberForm.scala
@@ -52,14 +52,14 @@ object MemberForm {
 
   trait JoinForm extends CommonForm {
     val deliveryAddress: Address
-    val trackingPromoCode: Option[PromoCode]
+    val marketingChoices: MarketingChoicesForm
+    val password: Option[String]
     val planChoice: PlanChoice
   }
 
   trait PaidMemberForm {
     val featureChoice: Set[FeatureChoice]
     val zuoraAccountAddress : Address
-    val trackingPromoCode: Option[PromoCode]
     val payment: PaymentForm
   }
 
@@ -69,13 +69,12 @@ object MemberForm {
   }
 
   case class FriendJoinForm(name: NameForm, deliveryAddress: Address, marketingChoices: MarketingChoicesForm,
-                            password: Option[String], trackingPromoCode: Option[PromoCode]) extends JoinForm {
+                            password: Option[String]) extends JoinForm {
     override val planChoice: FreePlanChoice = FreePlanChoice(friend)
   }
 
   case class StaffJoinForm(name: NameForm, deliveryAddress: Address, marketingChoices: MarketingChoicesForm,
                             password: Option[String]) extends JoinForm {
-    val trackingPromoCode = None
     override val planChoice: FreePlanChoice = FreePlanChoice(staff)
   }
 
@@ -89,8 +88,7 @@ object MemberForm {
                                 password: Option[String],
                                 casId: Option[String],
                                 subscriberOffer: Boolean,
-                                featureChoice: Set[FeatureChoice],
-                                trackingPromoCode: Option[PromoCode]
+                                featureChoice: Set[FeatureChoice]
                                ) extends JoinForm with PaidMemberForm {
 
     lazy val zuoraAccountAddress = billingAddress.getOrElse(deliveryAddress)
@@ -116,18 +114,16 @@ object MemberForm {
   trait MemberChangeForm {
     val featureChoice: Set[FeatureChoice]
     val addressDetails: Option[AddressDetails]
-    val trackingPromoCode: Option[PromoCode]
   }
 
-  case class PaidMemberChangeForm(password: String, featureChoice: Set[FeatureChoice], trackingPromoCode: Option[PromoCode]) extends MemberChangeForm {
+  case class PaidMemberChangeForm(password: String, featureChoice: Set[FeatureChoice]) extends MemberChangeForm {
     val addressDetails = None
   }
 
   case class FreeMemberChangeForm(payment: PaymentForm,
                                   deliveryAddress: Address,
                                   billingAddress: Option[Address],
-                                  featureChoice: Set[FeatureChoice],
-                                  trackingPromoCode: Option[PromoCode]
+                                  featureChoice: Set[FeatureChoice]
                                   ) extends MemberChangeForm with PaidMemberForm {
     val addressDetails = Some(AddressDetails(deliveryAddress, billingAddress))
     lazy val zuoraAccountAddress = billingAddress.getOrElse(deliveryAddress)
@@ -192,8 +188,6 @@ object MemberForm {
       Map(key -> value.identifier)
   }
 
-  val trackingPromoCode = of[PromoCode] as promoCodeFormatter
-
   val nonPaidAddressMapping: Mapping[Address] = mapping(
     "lineOne" -> text,
     "lineTwo" -> text,
@@ -240,8 +234,7 @@ object MemberForm {
       "name" -> nameMapping,
       "deliveryAddress" -> nonPaidAddressMapping,
       "marketingChoices" -> marketingChoicesMapping,
-      "password" -> optional(nonEmptyText),
-      "trackingPromoCode" -> optional(trackingPromoCode)
+      "password" -> optional(nonEmptyText)
     )(FriendJoinForm.apply)(FriendJoinForm.unapply)
   )
 
@@ -266,8 +259,7 @@ object MemberForm {
       "password" -> optional(nonEmptyText),
       "casId" -> optional(nonEmptyText),
       "subscriberOffer" -> default(boolean, false),
-      "featureChoice" -> productFeature,
-      "trackingPromoCode" -> optional(trackingPromoCode)
+      "featureChoice" -> productFeature
     )(PaidMemberJoinForm.apply)(PaidMemberJoinForm.unapply)
   )
 
@@ -288,16 +280,14 @@ object MemberForm {
       "payment" -> paymentMapping,
       "deliveryAddress" -> paidAddressMapping,
       "billingAddress" -> optional(paidAddressMapping),
-      "featureChoice" -> productFeature,
-      "trackingPromoCode" -> optional(trackingPromoCode)
+      "featureChoice" -> productFeature
   )(FreeMemberChangeForm.apply)(FreeMemberChangeForm.unapply)
   )
 
   val paidMemberChangeForm: Form[PaidMemberChangeForm] = Form(
     mapping(
       "password" -> nonEmptyText,
-      "featureChoice" -> productFeature,
-      "trackingPromoCode" -> optional(trackingPromoCode)
+      "featureChoice" -> productFeature
     )(PaidMemberChangeForm.apply)(PaidMemberChangeForm.unapply)
   )
 

--- a/frontend/app/forms/MemberForm.scala
+++ b/frontend/app/forms/MemberForm.scala
@@ -60,7 +60,6 @@ object MemberForm {
     val featureChoice: Set[FeatureChoice]
     val zuoraAccountAddress : Address
     val trackingPromoCode: Option[PromoCode]
-    val promoCode: Option[PromoCode]
     val payment: PaymentForm
   }
 
@@ -91,8 +90,7 @@ object MemberForm {
                                 casId: Option[String],
                                 subscriberOffer: Boolean,
                                 featureChoice: Set[FeatureChoice],
-                                trackingPromoCode: Option[PromoCode],
-                                promoCode: Option[PromoCode]
+                                trackingPromoCode: Option[PromoCode]
                                ) extends JoinForm with PaidMemberForm {
 
     lazy val zuoraAccountAddress = billingAddress.getOrElse(deliveryAddress)
@@ -119,10 +117,9 @@ object MemberForm {
     val featureChoice: Set[FeatureChoice]
     val addressDetails: Option[AddressDetails]
     val trackingPromoCode: Option[PromoCode]
-    val promoCode: Option[PromoCode]
   }
 
-  case class PaidMemberChangeForm(password: String, featureChoice: Set[FeatureChoice], trackingPromoCode: Option[PromoCode], promoCode: Option[PromoCode]) extends MemberChangeForm {
+  case class PaidMemberChangeForm(password: String, featureChoice: Set[FeatureChoice], trackingPromoCode: Option[PromoCode]) extends MemberChangeForm {
     val addressDetails = None
   }
 
@@ -130,8 +127,7 @@ object MemberForm {
                                   deliveryAddress: Address,
                                   billingAddress: Option[Address],
                                   featureChoice: Set[FeatureChoice],
-                                  trackingPromoCode: Option[PromoCode],
-                                  promoCode: Option[PromoCode]
+                                  trackingPromoCode: Option[PromoCode]
                                   ) extends MemberChangeForm with PaidMemberForm {
     val addressDetails = Some(AddressDetails(deliveryAddress, billingAddress))
     lazy val zuoraAccountAddress = billingAddress.getOrElse(deliveryAddress)
@@ -197,7 +193,6 @@ object MemberForm {
   }
 
   val trackingPromoCode = of[PromoCode] as promoCodeFormatter
-  val promoCode = of[PromoCode] as promoCodeFormatter
 
   val nonPaidAddressMapping: Mapping[Address] = mapping(
     "lineOne" -> text,
@@ -272,8 +267,7 @@ object MemberForm {
       "casId" -> optional(nonEmptyText),
       "subscriberOffer" -> default(boolean, false),
       "featureChoice" -> productFeature,
-      "trackingPromoCode" -> optional(trackingPromoCode),
-      "promoCode" -> optional(promoCode)
+      "trackingPromoCode" -> optional(trackingPromoCode)
     )(PaidMemberJoinForm.apply)(PaidMemberJoinForm.unapply)
   )
 
@@ -295,8 +289,7 @@ object MemberForm {
       "deliveryAddress" -> paidAddressMapping,
       "billingAddress" -> optional(paidAddressMapping),
       "featureChoice" -> productFeature,
-      "trackingPromoCode" -> optional(trackingPromoCode),
-      "promoCode" -> optional(promoCode)
+      "trackingPromoCode" -> optional(trackingPromoCode)
   )(FreeMemberChangeForm.apply)(FreeMemberChangeForm.unapply)
   )
 
@@ -304,8 +297,7 @@ object MemberForm {
     mapping(
       "password" -> nonEmptyText,
       "featureChoice" -> productFeature,
-      "trackingPromoCode" -> optional(trackingPromoCode),
-      "promoCode" -> optional(promoCode)
+      "trackingPromoCode" -> optional(trackingPromoCode)
     )(PaidMemberChangeForm.apply)(PaidMemberChangeForm.unapply)
   )
 

--- a/frontend/app/forms/MemberForm.scala
+++ b/frontend/app/forms/MemberForm.scala
@@ -5,7 +5,6 @@ import java.nio.charset.StandardCharsets
 
 import com.gu.i18n._
 import com.gu.memsub.BillingPeriod._
-import com.gu.memsub.promo.PromoCode
 import com.gu.memsub.{Address, BillingPeriod, FullName}
 import com.gu.salesforce.PaidTier
 import com.gu.salesforce.Tier._
@@ -171,14 +170,6 @@ object MemberForm {
       .transform(
         { code => CountryGroup.countryByCode(code).fold("")(_.name)},
         { name => CountryGroup.countryByNameOrCode(name).fold("")(_.alpha2)})
-
-
-  implicit val promoCodeFormatter: Formatter[PromoCode] = new Formatter[PromoCode] {
-    override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], PromoCode] =
-      data.get(key).filter(_.nonEmpty).map(PromoCode).toRight(Seq(FormError(key, "Cannot find a promo code")))
-
-    override def unbind(key: String, value: PromoCode) = Map(key -> value.get)
-  }
 
   implicit val currencyFormatter = new Formatter[Currency] {
     type Result = Either[Seq[FormError], Currency]

--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -127,7 +127,7 @@ class MemberService(identityService: IdentityService,
       }
 
     formData match {
-      case paid@PaidMemberJoinForm(_, _, _, PaymentForm(_, _, Some(baid)), _, _, _, _, _, _, _, _) => //Paid member with PayPal token
+      case paid@PaidMemberJoinForm(_, _, _, PaymentForm(_, _, Some(baid)), _, _, _, _, _, _, _) => //Paid member with PayPal token
         for {
           idUser <- getIdentityUserDetails(user, identityRequest)
           sfContact <- createSalesforceContact(idUser, formData)
@@ -137,7 +137,7 @@ class MemberService(identityService: IdentityService,
           _ <- updateIdentity(formData, identityRequest, user)
         } yield (sfContact, zuoraSubName)
 
-      case paid@PaidMemberJoinForm(_, _, _, PaymentForm(_, Some(stripeToken), _), _, _, _, _, _, _, _, _) => //Paid member with Stripe token
+      case paid@PaidMemberJoinForm(_, _, _, PaymentForm(_, Some(stripeToken), _), _, _, _, _, _, _, _) => //Paid member with Stripe token
         for {
           stripeCustomer <- createStripeCustomer(stripeToken, user)
           idUser <- getIdentityUserDetails(user, identityRequest)
@@ -438,7 +438,7 @@ class MemberService(identityService: IdentityService,
         name = joinData.name,
         address = joinData.deliveryAddress,
         email = email,
-        promoCode = joinData.trackingPromoCode,
+        promoCode = None,
         contractAcceptance = today,
         contractEffective = today
       ))

--- a/frontend/app/services/api/MemberService.scala
+++ b/frontend/app/services/api/MemberService.scala
@@ -40,7 +40,7 @@ trait MemberService {
                    identityRequest: IdentityRequest,
                    campaignCode: Option[CampaignCode]): Future[(ContactId, ZuoraSubName)]
 
-  def previewUpgradeSubscription(subscriber: PaidMember, newPlan: PlanChoice, code: Option[ValidPromotion[Upgrades]])
+  def previewUpgradeSubscription(subscriber: PaidMember, newPlan: PlanChoice)
                                 (implicit i: IdentityRequest): Future[MemberError \/ BillingSchedule]
 
   def upgradeFreeSubscription(sub: FreeMember, newTier: PaidTier, form: FreeMemberChangeForm, code: Option[CampaignCode])

--- a/frontend/app/views/fragments/form/trackingPromoCode.scala.html
+++ b/frontend/app/views/fragments/form/trackingPromoCode.scala.html
@@ -1,4 +1,0 @@
-@import com.gu.memsub.promo.PromoCode
-
-@(trackingPromoCode: Option[PromoCode])
-<input id="promo-code-hidden" type="hidden" name="trackingPromoCode" value="@trackingPromoCode.map(_.get).getOrElse("")"/>

--- a/frontend/app/views/fragments/tier/packageChanger.scala.html
+++ b/frontend/app/views/fragments/tier/packageChanger.scala.html
@@ -9,7 +9,7 @@
 
 @actionPath = {
   @tierPlans match {
-        case PaidPlans(plans) => { @routes.TierController.upgrade(plans.tier, None) }
+        case PaidPlans(plans) => { @routes.TierController.upgrade(plans.tier) }
         case FreePlan(_) => { @routes.TierController.downgradeToFriend() }
     }
  }

--- a/frontend/app/views/joiner/form/friendSignup.scala.html
+++ b/frontend/app/views/joiner/form/friendSignup.scala.html
@@ -9,8 +9,7 @@
 @import com.gu.memsub.promo.NewUsers
 @(friendPlan: CatalogPlan.Friend,
   idUser: IdentityUser,
-  pageInfo: PageInfo,
-  validPromo: Option[ValidPromotion[NewUsers]]
+  pageInfo: PageInfo
 )(implicit token: play.filters.csrf.CSRF.Token)
 
 @main("Become a Friend", pageInfo) {
@@ -59,7 +58,6 @@
                             county = idUser.privateFields.address4
                         )
                         @fragments.form.marketingChoices(Some(idUser.marketingChoices))
-                        @fragments.form.trackingPromoCode(validPromo.flatMap(_.trackingCode))
 
                         @if(!idUser.passwordExists) {
                             @fragments.form.createPassword()

--- a/frontend/app/views/joiner/thankyou.scala.html
+++ b/frontend/app/views/joiner/thankyou.scala.html
@@ -16,7 +16,6 @@
   paymentMethod: Option[PaymentMethod],
   returnDestinationOpt: Option[model.Destination],
   upgrade: Boolean,
-  promotion: Option[AnyPromotion],
   touchpointBackendResolution: services.TouchpointBackend.Resolution
 )
 
@@ -145,17 +144,6 @@
                 </table>
             </div>
         </section>
-        @for(promo <- promotion) {
-            <section class="page-section page-section--bordered">
-                <div class="page-section__lead-in">
-                    <h2 class="page-section__headline">Promotion applied</h2>
-                </div>
-                <div class="page-section__content">
-                    <p>@if(promo.description.isEmpty) { @promo.name } else { @promo.description }</p>
-                    @promo.asIncentive.map {a => <p>@a.promotionType.redemptionInstructions</p> }
-                </div>
-            </section>
-        }
 
         <section class="page-section page-section--bordered">
             <div class="page-section__lead-in">

--- a/frontend/app/views/tier/upgrade/freeToPaid.scala.html
+++ b/frontend/app/views/tier/upgrade/freeToPaid.scala.html
@@ -13,8 +13,7 @@
     targetPlans: PaidMembershipPlans[PaidMemberTier],
     countriesWithCurrency: List[CountryWithCurrency],
     idUser: IdentityUser,
-    pageInfo: PageInfo,
-    validPromo: Option[ValidPromotion[Upgrades]]
+    pageInfo: PageInfo
 )(implicit token: csrf.CSRF.Token, request: RequestHeader)
 
 @main(
@@ -31,7 +30,7 @@
         </section>
 
             <!-- CHECKOUT FORM -->
-        <form action="@routes.TierController.upgrade(targetPlans.tier, None)" method="POST" id="payment-form" class="js-form" data-change-to-tier="@targetPlans.tier.name">
+        <form action="@routes.TierController.upgrade(targetPlans.tier)" method="POST" id="payment-form" class="js-form" data-change-to-tier="@targetPlans.tier.name">
             @CSRF.formField
             <input type="hidden" name="tier" disabled value="@targetPlans.tier.slug"/>
             <input type="hidden" name="email" id="email" disabled value="@idUser.email"/>

--- a/frontend/app/views/tier/upgrade/paidToPaid.scala.html
+++ b/frontend/app/views/tier/upgrade/paidToPaid.scala.html
@@ -6,21 +6,18 @@
 @import views.html.helper.CSRF
 
 @import views.support.PageInfo
-@import com.gu.memsub.promo.ValidPromotion
-@import com.gu.memsub.promo.Upgrades
 @import com.gu.memsub.PaymentCard
 @import com.gu.memsub.PayPalMethod
 @(
     summary: PaidToPaidUpgradeSummary,
     userFields: com.gu.identity.play.PrivateFields,
     pageInfo: PageInfo,
-    flashMessage: Option[model.FlashMessage],
-    validPromo: Option[ValidPromotion[Upgrades]]
+    flashMessage: Option[model.FlashMessage]
 )(implicit token: play.filters.csrf.CSRF.Token, request: RequestHeader)
 
 @main("Upgrade to " + summary.target.tier.name, pageInfo=pageInfo) {
       <main role="main" class="page-content l-constrained">
-          <form action="@routes.TierController.upgrade(summary.target.tier,None)" method="POST" class="js-form" id="payment-form">
+          <form action="@routes.TierController.upgrade(summary.target.tier)" method="POST" class="js-form" id="payment-form">
               @CSRF.formField
 
               @fragments.page.pageHeader("Great, glad to see you've decided to become a " + summary.target.tier.name, Some("Join as an annual Partner or Patron Member and get 2 months free"))
@@ -49,7 +46,7 @@
                       <p>When you upgrade we want to make sure you are charged the right amount. We will charge for your <strong>@summary.current.tier.name</strong>
                           membership up until today and the amount remaining will be deducted from your first payment as a <strong>@summary.target.tier.name</strong>
                           .</p>
-                      <p><strong>@summary.target.tier.name</strong> payments start today and will recur @{summary.billingPeriod.adverb}.</p>
+                      <p><strong>@summary.target.tier.name</strong> payments start today and will recur @{summary.billingPeriod.adverb}. </p>
                   </div>
                   <div class="page-section__supplementary">
 

--- a/frontend/assets/javascripts/src/main.js
+++ b/frontend/assets/javascripts/src/main.js
@@ -24,7 +24,6 @@ require([
     'src/modules/comparisonTable',
     'src/modules/metrics',
     'src/modules/patterns',
-    'src/modules/paidToPaid',
     'src/modules/memstatus',
     'src/modules/faq',
     'src/modules/landingBundles'
@@ -54,7 +53,6 @@ require([
     comparisonTable,
     metrics,
     patterns,
-    paidToPaid,
     memstatus,
     faq,
     landingBundles
@@ -102,8 +100,6 @@ require([
 
     // Pattern library
     patterns.init();
-
-    paidToPaid.init();
 
     memstatus.init();
 

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -22,7 +22,7 @@ GET            /feature/:feature/:onOrOff             controllers.FeatureOptIn.s
 GET            /join/staff                            controllers.Joiner.staff
 GET            /join/staff/enter-details              controllers.Joiner.enterStaffDetails
 GET            /join/friend/enter-details             controllers.Joiner.enterFriendDetails
-GET            /join/:tier/enter-details              controllers.Joiner.enterPaidDetails(tier: PaidTier, countryGroup: CountryGroup ?= CountryGroup.UK, promoCode: Option[PromoCode] ?= None)
+GET            /join/:tier/enter-details              controllers.Joiner.enterPaidDetails(tier: PaidTier, countryGroup: CountryGroup ?= CountryGroup.UK)
 
 
 POST           /join/friend/enter-details             controllers.Joiner.joinFriend
@@ -97,7 +97,7 @@ GET            /tier/cancel/free/summary    controllers.TierController.cancelFre
 GET            /tier/change/friend                    controllers.TierController.downgradeToFriend
 POST           /tier/change/friend                    controllers.TierController.downgradeToFriendConfirm
 GET            /tier/change/friend/summary            controllers.TierController.downgradeToFriendSummary
-GET            /tier/change/:tier                     controllers.TierController.upgrade(tier: PaidTier, promoCode: Option[PromoCode])
+GET            /tier/change/:tier                     controllers.TierController.upgrade(tier: PaidTier)
 POST           /tier/change/:tier                     controllers.TierController.upgradeConfirm(tier: PaidTier)
 GET            /tier/change/:tier/summary             controllers.TierController.upgradeThankyou(tier: PaidTier)
 

--- a/frontend/test/services/IdentityServiceTest.scala
+++ b/frontend/test/services/IdentityServiceTest.scala
@@ -39,7 +39,6 @@ class IdentityServiceTest extends Specification with Mockito {
         NameForm("Joe", "Bloggs"),
         Address("line one", "line 2", "town", "country", "postcode", Country.UK.name),
         MarketingChoicesForm(Some(false), Some(false)),
-        None,
         None
       )
 
@@ -65,9 +64,7 @@ class IdentityServiceTest extends Specification with Mockito {
         None,
         None,
         subscriberOffer = false,
-        Set.empty,
-        None,
-        None
+        Set.empty
       )
 
       identityService.updateUserFieldsBasedOnJoining(user, paidForm, identityRequest)

--- a/frontend/test/services/PromoSessionServiceTest.scala
+++ b/frontend/test/services/PromoSessionServiceTest.scala
@@ -5,7 +5,6 @@ import org.specs2.mutable.Specification
 import play.api.mvc.Cookie
 import play.api.test.FakeRequest
 import scalaz.syntax.std.option._
-import services.PromoSessionService._
 
 class PromoSessionServiceTest extends Specification {
 

--- a/frontend/test/services/PromoSessionServiceTest.scala
+++ b/frontend/test/services/PromoSessionServiceTest.scala
@@ -5,6 +5,7 @@ import org.specs2.mutable.Specification
 import play.api.mvc.Cookie
 import play.api.test.FakeRequest
 import scalaz.syntax.std.option._
+import services.PromoSessionService._
 
 class PromoSessionServiceTest extends Specification {
 


### PR DESCRIPTION
## Why are you doing this?
We no longer use promo codes on the site, however there is still a lot of code which deals with them, this makes the code base more complicated and slower to work with. Conversely removing this redundant code will make the code base simpler and easier to work with.

## Trello card: [Here](https://trello.com/c/J6j9tcxk/355-remove-promo-codes-from-the-codebase)
