### PR TITLE
Allow unauthenticated users to view checkout (not for general public!)

### DIFF
--- a/frontend/app/actions/ActionRefiners.scala
+++ b/frontend/app/actions/ActionRefiners.scala
@@ -13,7 +13,7 @@ import com.typesafe.scalalogging.LazyLogging
 import controllers.IdentityRequest
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.mvc.Results._
-import play.api.mvc.Security.AuthenticatedBuilder
+import play.api.mvc.Security.{AuthenticatedBuilder, AuthenticatedRequest}
 import play.api.mvc._
 import utils.PlannedOutage
 import views.support.MembershipCompat._
@@ -47,16 +47,18 @@ object ActionRefiners extends LazyLogging {
   type SubReqWithFree[A] = SubscriptionRequest[A] with FreeSubscriber
   type SubReqWithSub[A] = SubscriptionRequest[A] with Subscriber
 
-  private def getSubRequest[A](request: AuthRequest[A]): Future[Option[SubReqWithSub[A]]] = {
+  private def getSubRequest[A](request: Request[A]): Future[Option[SubReqWithSub[A]]] = {
     implicit val pf = Membership
-    val tp = request.touchpointBackend
     val FreeSubscriber = Subscriber[Subscription[SubscriptionPlan.FreeMember]] _
     val PaidSubscriber = Subscriber[Subscription[SubscriptionPlan.PaidMember]] _
 
     (for {
-      member <- OptionT(request.forMemberOpt(identity))
+      user <- OptionT(Future.successful(AuthenticationService.authenticatedIdUserProvider(request)))
+      authRequest = new AuthenticatedRequest(user, request)
+      tp = authRequest.touchpointBackend
+      member <- OptionT(authRequest.forMemberOpt(identity))
       subscription <- OptionT(tp.subscriptionService.either[SubscriptionPlan.FreeMember, SubscriptionPlan.PaidMember](member))
-    } yield new SubscriptionRequest[A](tp, request) with Subscriber {
+    } yield new SubscriptionRequest[A](tp, authRequest) with Subscriber {
       override def paidOrFreeSubscriber = subscription.bimap(FreeSubscriber(_, member), PaidSubscriber(_, member))
     }).run
   }
@@ -114,6 +116,10 @@ object ActionRefiners extends LazyLogging {
       }
       Ok(views.html.tier.upgrade.unavailableUpgradePath(req.subscriber.subscription.plan.tier, selectedTier))
     }
+  }
+
+  def noAuthenticatedMemberFilter(onMember: SubReqWithSub[_] => Result = memberHome(_)) = new ActionFilter[Request] {
+    override def filter[A](request: Request[A]) = getSubRequest(request).map(_.map(onMember))
   }
 
   def onlyNonMemberFilter(onMember: SubReqWithSub[_] => Result = memberHome(_)) = new ActionFilter[AuthRequest] {

--- a/frontend/app/controllers/FeatureOptIn.scala
+++ b/frontend/app/controllers/FeatureOptIn.scala
@@ -1,0 +1,20 @@
+package controllers
+
+
+import com.typesafe.scalalogging.LazyLogging
+import play.api.mvc.Controller
+import utils.{Feature, OnOrOff}
+
+object FeatureOptIn extends Controller with LazyLogging {
+
+  def state(feature: Feature) = NoCacheAction { request =>
+    val s = feature.stateFor(request)
+    Ok(s"$feature: $s")
+  }
+
+  def setFeatureOnOrOff(feature: Feature, onOrOff: OnOrOff) = NoCacheAction {
+    Ok(s"$feature $onOrOff : cookie dropped").withCookies(feature.cookieFor(onOrOff))
+  }
+
+
+}

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import actions.ActionRefiners._
+import actions.Fallbacks.chooseRegister
 import actions.{RichAuthRequest, _}
 import com.github.nscala_time.time.Imports._
 import com.gu.contentapi.client.model.v1.{MembershipTier => ContentAccess}
@@ -24,9 +25,11 @@ import play.api.i18n.Messages.Implicits._
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json.Json
 import play.api.mvc._
+import services.AuthenticationService.authenticatedIdUserProvider
 import services.PromoSessionService.codeFromSession
 import services.{GuardianContentService, _}
 import tracking.ActivityTracking
+import utils.Feature.MergedRegistration
 import utils.RequestCountry._
 import utils.TestUsers.PreSigninTestCookie
 import utils.{CampaignCode, TierChangeCookies}
@@ -34,7 +37,7 @@ import views.support
 import views.support.MembershipCompat._
 import views.support.Pricing._
 import views.support.TierPlans._
-import views.support.{CheckoutForm, CountryWithCurrency, PageInfo}
+import views.support.{CheckoutForm, CountryWithCurrency, IdentityUser, PageInfo}
 
 import scala.concurrent.Future
 import scala.util.Failure
@@ -100,13 +103,25 @@ object Joiner extends Controller with ActivityTracking
     }
   }
 
-  def NonMemberAction(tier: Tier) = NoCacheAction andThen PlannedOutageProtection andThen authenticated() andThen onlyNonMemberFilter(onMember = redirectMemberAttemptingToSignUp(tier))
+  def authenticatedIfNotMergingRegistration(onUnauthenticated: RequestHeader => Result = chooseRegister(_)) = new ActionFilter[Request] {
+    override def filter[A](request: Request[A]) = Future.successful {
+      val userSignedIn = authenticatedIdUserProvider(request).isDefined
+      if (userSignedIn || MergedRegistration.turnedOnFor(request)) None else Some(onUnauthenticated(request))
+    }
+  }
+
+  def OptionallyAuthenticatedNonMemberAction(tier: Tier) =
+    NoCacheAction andThen PlannedOutageProtection andThen authenticatedIfNotMergingRegistration() andThen noAuthenticatedMemberFilter(onMember = redirectMemberAttemptingToSignUp(tier))
+
+  def NonMemberAction(tier: Tier) =
+    NoCacheAction andThen PlannedOutageProtection andThen authenticated() andThen onlyNonMemberFilter(onMember = redirectMemberAttemptingToSignUp(tier))
 
   def enterPaidDetails(
     tier: PaidTier,
     countryGroup: CountryGroup,
-    promoCode: Option[PromoCode]) = NonMemberAction(tier).async { implicit request =>
+    promoCode: Option[PromoCode]) = OptionallyAuthenticatedNonMemberAction(tier).async { implicit request =>
 
+    val userOpt = authenticatedIdUserProvider(request)
     implicit val resolution: TouchpointBackend.Resolution =
       TouchpointBackend.forRequest(PreSigninTestCookie, request.cookies)
 
@@ -120,12 +135,12 @@ object Joiner extends Controller with ActivityTracking
     val identityRequest = IdentityRequest(request)
 
     (for {
-      identityUser <- identityService.getIdentityUserView(request.user, identityRequest)
+      identityUserOpt <- userOpt.map(user => identityService.getIdentityUserView(user, identityRequest).map(Option(_))).getOrElse(Future.successful[Option[IdentityUser]](None))
     } yield {
       tier match {
-        case t: Tier.Supporter => {
+        case t: Tier.Supporter => for (user <- userOpt) {
           MembersDataAPI.Service.upsertBehaviour(
-            request.user,
+            user,
             activity = Some("enterPaidDetails.show"),
             note = Some(t.name))
         }
@@ -136,7 +151,7 @@ object Joiner extends Controller with ActivityTracking
       val pageInfo = PageInfo(
         stripePublicKey = Some(stripeService.publicKey),
         payPalEnvironment = Some(tpBackend.payPalService.config.payPalEnvironment),
-        initialCheckoutForm = CheckoutForm.forIdentityUser(identityUser, plans, Some(countryGroup))
+        initialCheckoutForm = CheckoutForm.forIdentityUser(identityUserOpt.flatMap(_.country), plans, Some(countryGroup))
       )
 
       val providedPromoCode = promoCode orElse codeFromSession
@@ -150,11 +165,11 @@ object Joiner extends Controller with ActivityTracking
       Ok(views.html.joiner.form.payment(
         plans,
         countryCurrencyWhitelist,
-        identityUser,
+        identityUserOpt,
         pageInfo,
         Some(countryGroup),
         resolution))
-    }).andThen { case Failure(e) => logger.error(s"User ${request.user.user.id} could not enter details for paid tier ${tier.name}: ${identityRequest.trackingParameters}", e)}
+    }).andThen { case Failure(e) => logger.error(s"User ${userOpt.map(_.id)} could not enter details for paid tier ${tier.name}: ${identityRequest.trackingParameters}", e)}
   }
 
   def enterFriendDetails = NonMemberAction(Tier.friend).async { implicit request =>
@@ -165,7 +180,7 @@ object Joiner extends Controller with ActivityTracking
       identityUser <- identityService.getIdentityUserView(request.user, IdentityRequest(request))
     } yield {
 
-      val pageInfo = support.PageInfo(initialCheckoutForm = CheckoutForm.forIdentityUser(identityUser, catalog.friend, None))
+      val pageInfo = support.PageInfo(initialCheckoutForm = CheckoutForm.forIdentityUser(identityUser.country, catalog.friend, None))
       val validPromo = codeFromSession.flatMap(code => promoService.validate[NewUsers](code, pageInfo.initialCheckoutForm.defaultCountry.get, catalog.friend.id).toOption)
 
       Ok(views.html.joiner.form.friendSignup(

--- a/frontend/app/forms/MemberForm.scala
+++ b/frontend/app/forms/MemberForm.scala
@@ -68,6 +68,7 @@ object MemberForm {
 
   case class PaidMemberJoinForm(tier: PaidTier,
                                 name: NameForm,
+                                email: String,
                                 payment: PaymentForm,
                                 deliveryAddress: Address,
                                 billingAddress: Option[Address],
@@ -231,6 +232,7 @@ object MemberForm {
     mapping(
       "tier" -> nonEmptyText.transform[PaidTier](PaidTier.slugMap, _.slug),
       "name" -> nameMapping,
+      "email" -> nonEmptyText,
       "payment" -> paymentMapping,
       "deliveryAddress" -> paidAddressMapping,
       "billingAddress" -> optional(paidAddressMapping),

--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -153,7 +153,7 @@ class MemberService(identityService: IdentityService,
 
 
     formData match {
-      case paid@PaidMemberJoinForm(_, _, PaymentForm(_, _, Some(baid)), _, _, _, _, _, _, _, _, _) => //Paid member with PayPal token
+      case paid@PaidMemberJoinForm(_, _, _, PaymentForm(_, _, Some(baid)), _, _, _, _, _, _, _, _, _) => //Paid member with PayPal token
         for {
           idUser <- getIdentityUserDetails
           sfContact <- createSalesforceContact(idUser)
@@ -163,7 +163,7 @@ class MemberService(identityService: IdentityService,
           _ <- updateIdentity()
         } yield (sfContact, zuoraSubName)
 
-      case paid@PaidMemberJoinForm(_, _, PaymentForm(_, Some(stripeToken), _), _, _, _, _, _, _, _, _, _) => //Paid member with Stripe token
+      case paid@PaidMemberJoinForm(_, _, _, PaymentForm(_, Some(stripeToken), _), _, _, _, _, _, _, _, _, _) => //Paid member with Stripe token
         for {
           stripeCustomer <- createStripeCustomer(stripeToken)
           idUser <- getIdentityUserDetails

--- a/frontend/app/utils/Features.scala
+++ b/frontend/app/utils/Features.scala
@@ -1,0 +1,42 @@
+package utils
+
+import enumeratum._
+import play.api.mvc.{Cookie, RequestHeader}
+import utils.OnOrOff.On
+
+sealed trait Feature extends EnumEntry {
+  val cookieName = s"feature-$entryName"
+
+  def cookieFor(onOrOff: OnOrOff) = Cookie(cookieName, onOrOff.entryName, httpOnly = false)
+
+  def turnedOnFor(request: RequestHeader): Boolean = stateFor(request) == On
+
+  def stateFor(request: RequestHeader): OnOrOff = {
+    request.cookies.get(cookieName).flatMap(cookie => OnOrOff.withNameOption(cookie.value)).getOrElse(OnOrOff.Off)
+  }
+}
+
+object Feature extends PlayEnum[Feature] {
+
+  val values = findValues
+
+  case object MergedRegistration extends Feature
+
+}
+
+sealed trait OnOrOff extends EnumEntry {
+  val opposite: OnOrOff
+}
+
+object OnOrOff extends PlayEnum[OnOrOff] {
+
+  val values = findValues
+
+  case object On extends OnOrOff {
+    val opposite = Off
+  }
+  case object Off extends OnOrOff {
+    val opposite = On
+  }
+
+}

--- a/frontend/app/views/fragments/form/createPassword.scala.html
+++ b/frontend/app/views/fragments/form/createPassword.scala.html
@@ -1,10 +1,3 @@
-<fieldset class="fieldset">
-
-    <div class="fieldset__heading">
-        <h2 class="fieldset__headline">Create password</h2>
-        <div class="fieldset__note">Password required to keep your information secure.</div>
-    </div>
-
     <div class="fieldset__fields js-password-container">
 
         <div class="form-field form-field--no-margin">
@@ -39,5 +32,3 @@
         </div>
 
     </div>
-
-</fieldset>

--- a/frontend/app/views/fragments/form/marketingChoices.scala.html
+++ b/frontend/app/views/fragments/form/marketingChoices.scala.html
@@ -1,12 +1,12 @@
-@(gnm: Option[Boolean], thirdParty: Option[Boolean])
+@(marketingChoices: Option[com.gu.identity.play.StatusFields])
 
 <fieldset class="u-h">
 
     <input type="hidden"
            name="marketingChoices.gnnMarketing"
-           value="@gnm" />
+           value="@marketingChoices.map(_.receiveGnmMarketing)" />
 
     <input type="hidden"
            name="marketingChoices.thirdParty"
-           value="@thirdParty" />
+           value="@marketingChoices.map(_.receive3rdPartyMarketing)" />
 </fieldset>

--- a/frontend/app/views/fragments/form/nameDetailFields.scala.html
+++ b/frontend/app/views/fragments/form/nameDetailFields.scala.html
@@ -1,9 +1,4 @@
-@(firstName: Option[String], lastName: Option[String])(implicit request: RequestHeader)
-@import utils.TestUsers.testUsers
-
-@if(firstName.exists(testUsers.isValid)) {
-    <!-- VALID TEST USER -->
-}
+@(privateFields: Option[com.gu.identity.play.PrivateFields])(implicit request: RequestHeader)
 
 <fieldset class="fieldset">
 
@@ -21,7 +16,7 @@
                    * same size limit is imposed here.
                    *@
                    maxlength="30"
-                   value="@firstName"
+                   value="@privateFields.flatMap(_.firstName)"
                    class="input-text js-name-first"
                    required
                    aria-required="true"/>
@@ -34,7 +29,7 @@
                    name="name.last"
                    id="name-last"
                    maxlength="50"
-                   value="@lastName"
+                   value="@privateFields.flatMap(_.secondName)"
                    class="input-text js-name-last"
                    required
                    aria-required="true"/>

--- a/frontend/app/views/fragments/form/stripeCheckout.scala.html
+++ b/frontend/app/views/fragments/form/stripeCheckout.scala.html
@@ -1,5 +1,5 @@
 @import views.support.IdentityUser
-@(idUser: IdentityUser)
+@(idUser: Option[IdentityUser])
 <script>
     guardian.stripeCheckout = {
         key: guardian.stripePublicKey,
@@ -10,4 +10,4 @@
         allowRememberMe: false
     };
 </script>
-<button type="button" class="action choose-payment-method js-stripe-checkout" data-email="@idUser.email">Credit/Debit Card</button>
+<button type="button" class="action choose-payment-method js-stripe-checkout" data-email="@idUser.map(_.email).mkString">Credit/Debit Card</button>

--- a/frontend/app/views/fragments/form/stripeCheckout.scala.html
+++ b/frontend/app/views/fragments/form/stripeCheckout.scala.html
@@ -10,4 +10,4 @@
         allowRememberMe: false
     };
 </script>
-<button type="button" class="action choose-payment-method js-stripe-checkout" data-email="@idUser.map(_.email).mkString">Credit/Debit Card</button>
+<button type="button" class="action choose-payment-method js-stripe-checkout">Credit/Debit Card</button>

--- a/frontend/app/views/joiner/form/addressWithWelcomePack.scala.html
+++ b/frontend/app/views/joiner/form/addressWithWelcomePack.scala.html
@@ -51,10 +51,7 @@
                         postcode = idUser.privateFields.postcode,
                         county = idUser.privateFields.address4
                     )
-                    @fragments.form.marketingChoices(
-                        idUser.marketingChoices.receiveGnmMarketing,
-                        idUser.marketingChoices.receive3rdPartyMarketing
-                    )
+                    @fragments.form.marketingChoices(Some(idUser.marketingChoices))
 
                     @if(!idUser.passwordExists) {
                         @fragments.form.createPassword()

--- a/frontend/app/views/joiner/form/friendSignup.scala.html
+++ b/frontend/app/views/joiner/form/friendSignup.scala.html
@@ -58,7 +58,7 @@
                             postcode = idUser.privateFields.postcode,
                             county = idUser.privateFields.address4
                         )
-                        @fragments.form.marketingChoices(idUser.marketingChoices.receiveGnmMarketing, idUser.marketingChoices.receive3rdPartyMarketing)
+                        @fragments.form.marketingChoices(Some(idUser.marketingChoices))
                         @fragments.form.trackingPromoCode(validPromo.flatMap(_.trackingCode))
 
                         @if(!idUser.passwordExists) {

--- a/frontend/app/views/joiner/form/payment.scala.html
+++ b/frontend/app/views/joiner/form/payment.scala.html
@@ -8,13 +8,14 @@
 @import views.support.DisplayText._
 @import views.support.MembershipCompat._
 @import views.support.{CountryWithCurrency, IdentityUser, PageInfo}
+@import views.support.IdentityUser.BlankAddress
 @(plans: PaidMembershipPlans[PaidMemberTier],
     countriesWithCurrencies: List[CountryWithCurrency],
-    idUser: IdentityUser,
+    idUser: Option[IdentityUser],
     pageInfo: PageInfo,
     countryGroup: Option[CountryGroup],
     touchpointBackendResolution: services.TouchpointBackend.Resolution
-)(implicit token: play.filters.csrf.CSRF.Token, request: actions.AuthRequest[_])
+)(implicit token: play.filters.csrf.CSRF.Token, request: RequestHeader)
 
 @main(
     plans.tier.cta,
@@ -62,20 +63,37 @@
                     <div class="form-panel__content js-form-panel-name-address @if(plans.tier == Partner()) {is-hidden}">
                             <!-- Name -->
                         <div class="form-section__name-detail">
-                        @fragments.form.nameDetailFields(
-                            idUser.privateFields.firstName,
-                            idUser.privateFields.secondName
-                        )
+                            @fragments.form.nameDetailFields(idUser.map(_.privateFields))
                         </div>
 
-                            <!-- Address -->
+
+                        <div class="fieldset__fields @if(idUser.isDefined) {is-hidden}">
+                            <div class="form-field">
+                                <label class="label" for="email">Email address</label>
+                                <input type="email"
+                                name="email"
+                                id="email"
+                                maxlength="80"
+                                value="@idUser.map(_.email)"
+                                class="input-text js-name-first"
+                                required
+                                aria-required="true"/>
+                                @fragments.form.errorMessage("Please enter your email")
+                            </div>
+                        </div>
+
+                        @if(!idUser.exists(_.passwordExists)) {
+                            @fragments.form.createPassword()
+                        }
+
+                        <!-- Address -->
                         @fragments.form.addressDetailFields(
                             countriesWithCurrencies = countriesWithCurrencies,
                             heading = "Delivery address",
                             note = "We need your address to send you a welcome pack",
                             formType = "deliveryAddress",
                             addressRequired = true,
-                            address = idUser.deliveryAddress
+                            address = idUser.map(_.deliveryAddress).getOrElse(BlankAddress)
                         )
                             <!-- Billing Address -->
                         @fragments.form.billingAddressFields("Billing address")
@@ -83,15 +101,11 @@
                             countriesWithCurrencies = countriesWithCurrencies,
                             formType = "billingAddress",
                             addressRequired = true,
-                            address = idUser.billingAddress,
+                            address = idUser.map(_.billingAddress).getOrElse(BlankAddress),
                             showHeading = false
                         )
 
-                        @fragments.form.marketingChoices(idUser.marketingChoices.receiveGnmMarketing, idUser.marketingChoices.receive3rdPartyMarketing)
-
-                        @if(!idUser.passwordExists) {
-                            @fragments.form.createPassword()
-                        }
+                        @fragments.form.marketingChoices(idUser.map(_.marketingChoices))
 
                         <button class="action form-panel__continue js-continue-name-address" type="button">Continue</button>
                         <div class="flash-message flash-message--error is-hidden js-payment-errors qa-form-error">

--- a/frontend/app/views/support/IdentityUser.scala
+++ b/frontend/app/views/support/IdentityUser.scala
@@ -38,6 +38,8 @@ case class IdentityUser(privateFields: PrivateFields, marketingChoices: StatusFi
 }
 
 object IdentityUser {
+  val BlankAddress = Address("", "", "", "", "", "")
+
   /**
   * An Identity user, for view purposes, with default empty private and status fields
   */

--- a/frontend/app/views/tier/upgrade/freeToPaid.scala.html
+++ b/frontend/app/views/tier/upgrade/freeToPaid.scala.html
@@ -111,7 +111,7 @@
                                     <div class="loader js-payment-processing">Processing.</div>
                                 </div>
                                 <div class="form-field js-payment-type">
-                                @fragments.form.stripeCheckout(idUser)
+                                @fragments.form.stripeCheckout(Some(idUser))
                                 </div>
                                 <div class="form-field js-payment-type">
                                     <div id="paypal-button-checkout"></div>

--- a/frontend/assets/javascripts/src/modules/form/stripe.es6
+++ b/frontend/assets/javascripts/src/modules/form/stripe.es6
@@ -5,7 +5,6 @@ export function init() {
     let handler = window.StripeCheckout.configure(guardian.stripeCheckout);
     let success = false;
     const button = $('.js-stripe-checkout');
-    const email = button.data('email');
     bean.on(window, 'popstate', handler.close);
     const amount = () => {
         let billingPeriod = guardian.membership.checkoutForm.billingPeriods[guardian.membership.checkoutForm.billingPeriod];
@@ -15,6 +14,7 @@ export function init() {
     };
     const open = (e) => {
         if (payment.validateForm()) {
+            const email = document.querySelector('#email').value;
             payment.showSpinner();
             handler.open({
                 description: 'Please enter your card details.',

--- a/frontend/build.sbt
+++ b/frontend/build.sbt
@@ -87,6 +87,7 @@ riffRaffUploadManifestBucket := Option("riffraff-builds")
 
 
 play.sbt.routes.RoutesKeys.routesImport ++= Seq(
+    "utils.{Feature,OnOrOff}",
     "com.gu.salesforce.Tier",
     "com.gu.salesforce.FreeTier",
     "com.gu.salesforce.PaidTier",

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -15,6 +15,8 @@ GET            /welcome                               controllers.FrontPage.welc
 GET            /healthcheck                           controllers.Healthcheck.healthcheck
 GET            /test-users                            controllers.Testing.testUser
 GET            /analytics-off                         controllers.Testing.analyticsOff
+GET            /feature/:feature                      controllers.FeatureOptIn.state(feature: Feature)
+GET            /feature/:feature/:onOrOff             controllers.FeatureOptIn.setFeatureOnOrOff(feature: Feature, onOrOff: OnOrOff)
 
 # Join
 GET            /join/staff                            controllers.Joiner.staff

--- a/frontend/test/services/IdentityServiceTest.scala
+++ b/frontend/test/services/IdentityServiceTest.scala
@@ -57,6 +57,7 @@ class IdentityServiceTest extends Specification with Mockito {
       val paidForm = PaidMemberJoinForm(
         partner,
         NameForm("Joe", "Bloggs"),
+        "joe@example.com",
         PaymentForm(Year, Some("stripeToken"), None),
         Address("line one", "line 2", "town", "country", "postcode", Country.UK.name),
         Some(Address("line one", "line 2", "town", "country", "postcode", Country.UK.name)),

--- a/frontend/test/views/support/CheckoutFormTest.scala
+++ b/frontend/test/views/support/CheckoutFormTest.scala
@@ -55,7 +55,7 @@ class CheckoutFormTest extends Specification {
         "and the country group currency is available" should {
           "set country/currency from the request" in {
             CheckoutForm.forIdentityUser(
-              idUser, PaidPlans(plans), Some(CountryGroup.Europe)
+              None, PaidPlans(plans), Some(CountryGroup.Europe)
             ).tupled2 ===(None, EUR)
           }
         }
@@ -63,7 +63,7 @@ class CheckoutFormTest extends Specification {
         "and the country group currency is not available" should {
           "fallback to the request country group and set currency to GBP" in {
             CheckoutForm.forIdentityUser(
-              idUserWithBlankCountry, PaidPlans(plans), Some(CountryGroup.Australia)
+              None, PaidPlans(plans), Some(CountryGroup.Australia)
             ).tupled2 === (Some(Country.Australia), GBP)
           }
         }
@@ -72,13 +72,13 @@ class CheckoutFormTest extends Specification {
       "when no country group is set" should {
         "set country/currency from the identity user" in {
           CheckoutForm.forIdentityUser(
-            idUser, PaidPlans(plans), None
+            Some(Country.US), PaidPlans(plans), None
           ).tupled2 === (Some(Country.US), USD)
         }
 
         "fallback to the UK country group if the identity user has no address info" in {
           CheckoutForm.forIdentityUser(
-            idUserWithBlankCountry, PaidPlans(plans), None
+            None, PaidPlans(plans), None
           ).tupled2 === (Some(Country.UK), GBP)
         }
       }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,10 +25,11 @@ object Dependencies {
   val specs2Extra = "org.specs2" %% "specs2-matcher-extra" % "3.6" % "test"
   val dispatch = "net.databinder.dispatch" %% "dispatch-core" % "0.11.3"
   val pegdown = "org.pegdown" % "pegdown" % "1.6.0"
+  val enumPlay = "com.beachape" %% "enumeratum-play" % "1.3.7"
 
   //projects
 
-  val frontendDependencies =  Seq(memsubCommonPlayAuth, scalaUri, membershipCommon,
+  val frontendDependencies =  Seq(memsubCommonPlayAuth, scalaUri, membershipCommon, enumPlay,
     contentAPI, playWS, playFilters, playCache, sentryRavenLogback, awsSimpleEmail, snowPlow, bCrypt, scalaz, pegdown,
     PlayImport.specs2 % "test", specs2Extra, dispatch)
 


### PR DESCRIPTION
## Why are you doing this?

We're testing whether Merging Registration into the Supporter checkout will improve conversion.

Note that it is still not possible for an unauthenticated user to complete checkout - this just lets them get as far as the checkout page: https://membership.theguardian.com/join/supporter/enter-details - further steps **will fail**.

## Trello card: [Here](https://trello.com/c/TpuX5Fdb/298-a-b-testing-for-new-checkout-flow-test-merging-registration-into-supporter-checkout)

## Changes

Regular users will still authenticate, but it's possible to enable the unauthenticated behaviour by opting-in to the 'MergedRegistration feature (I've added a very small amount of scaffolding for opt-in
features):

https://membership.theguardian.com/feature/MergedRegistration
https://membership.theguardian.com/feature/MergedRegistration/On
https://membership.theguardian.com/feature/MergedRegistration/Off

The code that respects this is in `OptionallyAuthenticatedNonMemberAction`
and `authenticatedIfNotMergingRegistration()`.

## Screenshots

#### with https://mem.thegulocal.com/feature/MergedRegistration/On : 

![image](https://cloud.githubusercontent.com/assets/52038/23709975/0f54b71c-0413-11e7-8b73-5834025b9170.png)

#### with https://mem.thegulocal.com/feature/MergedRegistration/Off : 

...user is forced to sign-in, and then:

![image](https://cloud.githubusercontent.com/assets/52038/23710020/33c0c92e-0413-11e7-8502-604ac25ab1ea.png)


cc @Ap0c  @dominickendrick 