### PR TITLE
Behaviour upsert should contain lastObserved, not dateTime value

### DIFF
--- a/frontend/app/services/MembersDataAPI.scala
+++ b/frontend/app/services/MembersDataAPI.scala
@@ -117,7 +117,7 @@ object MembersDataAPI {
       val json: JsValue = Json.obj(
         "userId" -> userId,
         "activity" -> activity,
-        "dateTime" -> DateTime.now.toString(ISODateTimeFormat.dateTime.withZoneUTC),
+        "lastObserved" -> DateTime.now.toString(ISODateTimeFormat.dateTime.withZoneUTC),
         "note" -> note
       )
       BehaviourHelper(cookies).post[Behaviour]("user-behaviour/capture", json)


### PR DESCRIPTION
I thought I had fixed this before, but it must have slipped through the net.

We were dropping the wrong name into the json when sending behaviour upsert requests to our data-api. This meant that no `lastObserved` date values were being recorded in the behaviour table, and thus no emails would have been generated after the requisite number of days for those users.

This is all in test mode at the moment so no real harm done.
