### PR TITLE
Updating to latest membership-common

### DIFF
--- a/frontend/test/services/DestinationServiceTest.scala
+++ b/frontend/test/services/DestinationServiceTest.scala
@@ -4,7 +4,7 @@ import com.gu.contentapi.client.parser.JsonParser
 import com.gu.i18n.Currency.GBP
 import com.gu.memsub.Benefit._
 import com.gu.memsub.BillingPeriod.Month
-import com.gu.memsub.Subscription.{ProductRatePlanId, RatePlanId}
+import com.gu.memsub.Subscription.{ProductRatePlanChargeId, ProductRatePlanId, RatePlanId}
 import com.gu.memsub._
 import com.gu.memsub.subsv2.{Subscription, _}
 import com.gu.salesforce._
@@ -31,7 +31,7 @@ class DestinationServiceTest extends Specification {
     def createRequestWithSession(newSessions: (String, String)*) = {
 
       val testMember = Contact("id", None, None, Some("fn"), "ln", Some("email"), new DateTime(), "contactId", "accountId", None, None, None, None, None)
-      val partnerCharge: PaidCharge[Partner.type, Month.type] = PaidCharge[Partner.type, Month.type](Partner, Month, PricingSummary(Map(GBP -> Price(0.1f, GBP))))
+      val partnerCharge: PaidCharge[Partner.type, Month.type] = PaidCharge[Partner.type, Month.type](Partner, Month, PricingSummary(Map(GBP -> Price(0.1f, GBP))), ProductRatePlanChargeId("prpcId"))
       val testSub: Subscription[SubscriptionPlan.Member] = new Subscription[SubscriptionPlan.Partner](
         id = com.gu.memsub.Subscription.Id(""),
         name = com.gu.memsub.Subscription.Name(""),

--- a/frontend/test/views/support/CheckoutFormTest.scala
+++ b/frontend/test/views/support/CheckoutFormTest.scala
@@ -4,7 +4,7 @@ import com.gu.i18n.Currency._
 import com.gu.i18n._
 import com.gu.identity.play.{PrivateFields, StatusFields}
 import com.gu.memsub.Benefit._
-import com.gu.memsub.Subscription.ProductRatePlanId
+import com.gu.memsub.Subscription.{ProductRatePlanChargeId, ProductRatePlanId}
 import com.gu.memsub._
 import com.gu.memsub.subsv2.{CatalogPlan, PaidCharge, PaidMembershipPlans}
 import org.specs2.mutable.Specification
@@ -41,8 +41,8 @@ class CheckoutFormTest extends Specification {
   ))
 
   val plans = PaidMembershipPlans[Partner.type](
-    month = CatalogPlan(ProductRatePlanId(""), Product.Membership, "Partner", "Partner", None, PaidCharge(Partner, BillingPeriod.Month, pricingSummary), Status.current),
-    year = CatalogPlan(ProductRatePlanId(""), Product.Membership, "Partner", "Partner", None, PaidCharge(Partner, BillingPeriod.Year, pricingSummary), Status.current)
+    month = CatalogPlan(ProductRatePlanId(""), Product.Membership, "Partner", "Partner", None, PaidCharge(Partner, BillingPeriod.Month, pricingSummary, ProductRatePlanChargeId("prpcId")), Status.current),
+    year = CatalogPlan(ProductRatePlanId(""), Product.Membership, "Partner", "Partner", None, PaidCharge(Partner, BillingPeriod.Year, pricingSummary, ProductRatePlanChargeId("prpcId")), Status.current)
   )
 
   implicit class checkoutForm2Tuple2(form: CheckoutForm) {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "7.2.3"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.9" // v0.9 is the latest version published for Play 2.4...
-  val membershipCommon = "com.gu" %% "membership-common" % "0.381-SNAPSHOT"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.381"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playFilters = PlayImport.filters

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "7.2.3"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.9" // v0.9 is the latest version published for Play 2.4...
-  val membershipCommon = "com.gu" %% "membership-common" % "0.375"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.381-SNAPSHOT"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playFilters = PlayImport.filters


### PR DESCRIPTION
## Why are you doing this?
Updating to [latest membership common](https://github.com/guardian/membership-common/pull/450) (v0.381) which contains a breaking change to the fields in case class PaidCharge.

## Trello card: [Here](https://trello.com/c/RETXPNdh/169-bug-six-weeks-rate-plans-use-the-contract-effective-date-incorrectly)

## Changes
* Update 2 test classes

## Screenshots
N/A


cc @svillafe @rupertbates @johnduffell 