### PR TITLE
Paid comments AB test

### DIFF
--- a/frontend/app/abtests/BundleVariant.scala
+++ b/frontend/app/abtests/BundleVariant.scala
@@ -10,7 +10,9 @@ object BundleVariant {
 
   val all = Seq[BundleVariant](
     BundleVariant(CONTROL, Map((Supporter, 6.5), (DigitalPack, 12), (Saturday, 18), (GuardianWeekly, 18), (Weekend, 25), (SatGW, 25), (SixDay, 45), (SevenDay, 50))),
-    BundleVariant(VARIANT, Map((Supporter, 6.5), (DigitalPack, 12), (Saturday, 18), (GuardianWeekly, 18), (Weekend, 25), (SatGW, 25), (SixDay, 45), (SevenDay, 50)), hasAdFree = false)
+    BundleVariant(VARIANT, Map((Supporter, 6.5), (DigitalPack, 12), (Saturday, 18), (GuardianWeekly, 18), (Weekend, 25), (SatGW, 25), (SixDay, 45), (SevenDay, 50)), hasAdFree = false),
+    BundleVariant(PDCPRE, Map((Supporter, 6.5), (DigitalPack, 12), (Saturday, 18), (GuardianWeekly, 18), (Weekend, 25), (SatGW, 25), (SixDay, 45), (SevenDay, 50))),
+    BundleVariant(PDCPOST, Map((Supporter, 6.5), (DigitalPack, 12), (Saturday, 18), (GuardianWeekly, 18), (Weekend, 25), (SatGW, 25), (SixDay, 45), (SevenDay, 50)))
   )
 
   def lookup(name: String): Option[BundleVariant] = {
@@ -19,7 +21,7 @@ object BundleVariant {
 }
 
 case class BundleVariant(distribution: Distribution, prices: Map[BundleTier, Double], hasAdFree: Boolean = true) {
-  val testId =  s"MEMBERSHIP_A_ADX_THRASHER_UK_${distribution.name}"
+  val testId =  distribution.name
 
   def prettyMonthlyPrice(tier: BundleTier) = f"£${prices(tier)}%.2f/month"
 }
@@ -48,8 +50,10 @@ object BundleTier {
 
 
 object Distribution {
-  val CONTROL = Distribution("CONTROL")
-  val VARIANT = Distribution("VARIANT")
+  val CONTROL = Distribution("MEMBERSHIP_A_ADX_THRASHER_UK_CONTROL")
+  val VARIANT = Distribution("MEMBERSHIP_A_ADX_THRASHER_UK_VARIANT")
+  val PDCPRE = Distribution("MEMBERSHIP_A_PDCOM_PRE")
+  val PDCPOST = Distribution("MEMBERSHIP_A_PDCOM_POST")
 }
 
 case class Distribution(name: String)

--- a/frontend/app/abtests/BundleVariant.scala
+++ b/frontend/app/abtests/BundleVariant.scala
@@ -11,8 +11,8 @@ object BundleVariant {
   val all = Seq[BundleVariant](
     BundleVariant(CONTROL, Map((Supporter, 6.5), (DigitalPack, 12), (Saturday, 18), (GuardianWeekly, 18), (Weekend, 25), (SatGW, 25), (SixDay, 45), (SevenDay, 50))),
     BundleVariant(VARIANT, Map((Supporter, 6.5), (DigitalPack, 12), (Saturday, 18), (GuardianWeekly, 18), (Weekend, 25), (SatGW, 25), (SixDay, 45), (SevenDay, 50)), hasAdFree = false),
-    BundleVariant(PDCPRE, Map((Supporter, 6.5), (DigitalPack, 12), (Saturday, 18), (GuardianWeekly, 18), (Weekend, 25), (SatGW, 25), (SixDay, 45), (SevenDay, 50))),
-    BundleVariant(PDCPOST, Map((Supporter, 6.5), (DigitalPack, 12), (Saturday, 18), (GuardianWeekly, 18), (Weekend, 25), (SatGW, 25), (SixDay, 45), (SevenDay, 50)))
+    BundleVariant(PDCPRE, Map((Supporter, 6.5), (DigitalPack, 12), (Saturday, 18), (GuardianWeekly, 18), (Weekend, 25), (SatGW, 25), (SixDay, 45), (SevenDay, 50)), hasPaidComments = true, hasContributions = false),
+    BundleVariant(PDCPOST, Map((Supporter, 6.5), (DigitalPack, 12), (Saturday, 18), (GuardianWeekly, 18), (Weekend, 25), (SatGW, 25), (SixDay, 45), (SevenDay, 50)), hasPaidComments = true, hasContributions = false)
   )
 
   def lookup(name: String): Option[BundleVariant] = {
@@ -20,7 +20,11 @@ object BundleVariant {
   }
 }
 
-case class BundleVariant(distribution: Distribution, prices: Map[BundleTier, Double], hasAdFree: Boolean = true) {
+case class BundleVariant(distribution: Distribution,
+                         prices: Map[BundleTier, Double],
+                         hasAdFree: Boolean = true,
+                         hasPaidComments: Boolean = false,
+                         hasContributions: Boolean = true) {
   val testId =  distribution.name
 
   def prettyMonthlyPrice(tier: BundleTier) = f"£${prices(tier)}%.2f/month"

--- a/frontend/app/controllers/Bundle.scala
+++ b/frontend/app/controllers/Bundle.scala
@@ -38,7 +38,7 @@ trait Bundle extends Controller {
     val bottomImageOrientated = OrientatedImages(portrait = bottomImage, landscape = bottomImage)
 
     bundleVariant match {
-      case BundleVariant(_, _, _) => Ok(views.html.bundle.bundleSetA(
+      case BundleVariant(_, _, _, _, _) => Ok(views.html.bundle.bundleSetA(
         heroOrientated,
         TouchpointBackend.Normal.catalog.supporter,
         PageInfo(
@@ -46,6 +46,7 @@ trait Bundle extends Controller {
           url = request.path,
           description = Some(CopyConfig.copyDescriptionSupporters)
         ),
+        request.getQueryString("returnUrl"),
         bottomImageOrientated,
         bundleVariant))
     }
@@ -69,7 +70,10 @@ trait Bundle extends Controller {
           url = request.path,
           description = Some(CopyConfig.copyDescriptionSupporters)
         ),
-        bundleVariant, selectedOption, heroOrientated))
+        bundleVariant,
+        selectedOption,
+        heroOrientated,
+        request.getQueryString("returnUrl")))
     }
 }
 

--- a/frontend/app/views/bundle/bundleSetA.scala.html
+++ b/frontend/app/views/bundle/bundleSetA.scala.html
@@ -19,7 +19,7 @@
         heroImage,
         Html("Support<br/>the Guardian"),
         Html("We\'re introducing <strong>new ways</strong> to support the&nbsp;Guardian\'s quality journalism and independent voice"),
-        Html("Our most important relationship is with our readers. Please help to fund our journalism by becoming a Supporter, and together we can keep the world informed. You can do this with a regular one-off payment, or by signing up to our Digital or Paper packages.")
+        Html("Our most important relationship is with our readers. Please help to fund our journalism by becoming a Supporter, and together we can keep the world informed. You can do this by signing up to one of our Digital or Paper packages shown below.")
     )
 
     @* ===== Offerings ===== *@

--- a/frontend/app/views/bundle/bundleSetA.scala.html
+++ b/frontend/app/views/bundle/bundleSetA.scala.html
@@ -8,6 +8,7 @@
 @(  heroImage: model.OrientatedImages,
     supporterPlans: PaidMembershipPlans[com.gu.memsub.Benefit.Supporter.type],
     pageInfo: PageInfo,
+    returnUrl: Option[String] = None,
     whySupportImage: model.OrientatedImages,
     bundleVariant: BundleVariant)(implicit token: play.filters.csrf.CSRF.Token)
 
@@ -22,7 +23,7 @@
     )
 
     @* ===== Offerings ===== *@
-    @fragments.bundle.bundleOfferingsA(bundleVariant)
+    @fragments.bundle.bundleOfferingsA(bundleVariant, returnUrl)
 
     @* ===== Why do we need supporters? ===== *@
     @fragments.bundle.bundleSupportUs(whySupportImage, bundleVariant,

--- a/frontend/app/views/bundle/thankYou.scala.html
+++ b/frontend/app/views/bundle/thankYou.scala.html
@@ -9,19 +9,18 @@
 @(  pageInfo: PageInfo,
     bundleVariant: BundleVariant,
     selectedOption: String,
-    heroImage: model.OrientatedImages)(implicit token: play.filters.csrf.CSRF.Token)
+    heroImage: model.OrientatedImages,
+    returnUrl: Option[String] = None)(implicit token: play.filters.csrf.CSRF.Token)
 
 @main("Supporters", pageInfo=pageInfo) {
     @* ===== First part ===== *@
     @fragments.bundle.bundleHeader(
         heroImage,
         Html("Thank you for<br/>your interest"),
-        Html("This product is something we’ve<br>been working on that isn’t available<br/>at the moment"),
-        Html("We are still evaluating the interest and feasibility of this type of offer.</p><p>If you would like more information about this product and would like to be contacted if it becomes available, please give us your email address.</p><p>If you have any feedback, do let us know below.</p>")
+        Html("We are currently evaluating the feasibility of this product, and as such, it isn’t available at this time"),
+        Html("Your participation in this test has helped us with this evaluation, and from now on you won't be directed here again.<br><br>Thank you.</p>")
     )
     <div class="l-constrained">
-        <div class="bundle-thankyou__email-form  bundle-thankyou-js">
-            <script type="text/javascript" src="https://guardiannewsampampmedia.formstack.com/forms/js.php/membership_team__feedback_form?bundle_variant=@bundleVariant.testId&selected_option=@selectedOption"></script><noscript><a href="https://guardiannewsampampmedia.formstack.com/forms/membership_team__feedback_form?bundle_variant=@bundleVariant.testId&selected_option=@selectedOption" title="Online Form">Online Form - Membership team - feedback form</a></noscript><div style="text-align:right; font-size:x-small;"><a href="http://www.formstack.com?utm_source=jsembed&utm_medium=product&utm_campaign=product+branding&fa=h,2583327" title="Web Form Generator">Web Form Generator</a></div>
-        </div>
+        @fragments.bundle.bundleButton("Return to comments", returnUrl.getOrElse("https://www.theguardian.com"))
     </div>
 }

--- a/frontend/app/views/bundle/thankYou.scala.html
+++ b/frontend/app/views/bundle/thankYou.scala.html
@@ -17,10 +17,10 @@
     @fragments.bundle.bundleHeader(
         heroImage,
         Html("Thank you for<br/>your interest"),
-        Html("We are currently evaluating the feasibility of this product, and as such, it isn’t available at this time"),
-        Html("Your participation in this test has helped us with this evaluation, and from now on you won't be directed here again.<br><br>Thank you.</p>")
+        Html("We are currently evaluating the demand for the feature you selected"),
+        Html("We have a number of tests underway that help us determine which products our readers are interested in. Your participation has helped us with this evaluation, and from now on you won't be directed here again.<br><br>Thank you.</p>")
     )
     <div class="l-constrained">
-        @fragments.bundle.bundleButton("Return to comments", returnUrl.getOrElse("https://www.theguardian.com"))
+        @fragments.bundle.bundleButton("Continue to comment", returnUrl.getOrElse("https://www.theguardian.com"))
     </div>
 }

--- a/frontend/app/views/fragments/bundle/bundleButton.scala.html
+++ b/frontend/app/views/fragments/bundle/bundleButton.scala.html
@@ -3,7 +3,7 @@
 @(buttonLabel: String, target: String, className: Option[String] = None, chevron: Boolean = false, secondary: Boolean = false, returnUrl: Option[String] = None)
 
 <div class="bundle-button">
-    <a class="@if(secondary){ bundle-button__content--secondary } else { bundle-button__content } @className.mkString"
+    <a class="@if(secondary){bundle-button__content--secondary} else {bundle-button__content} @className.mkString"
         href="@if(returnUrl.nonEmpty){ @if(target.indexOf("?") > 0) { @target&returnUrl=@returnUrl.get } else { @target?returnUrl=@returnUrl.get } } else { @target }">
         <p>@buttonLabel</p>
         <div class="bundle-button__content__arrow">

--- a/frontend/app/views/fragments/bundle/bundleButton.scala.html
+++ b/frontend/app/views/fragments/bundle/bundleButton.scala.html
@@ -1,9 +1,10 @@
 @import views.support.Asset
 
-@(buttonLabel: String, target: String, className: Option[String] = None, chevron: Boolean = false, secondary: Boolean = false)
+@(buttonLabel: String, target: String, className: Option[String] = None, chevron: Boolean = false, secondary: Boolean = false, returnUrl: Option[String] = None)
 
 <div class="bundle-button">
-    <a class="@if(secondary){ bundle-button__content--secondary } else { bundle-button__content } @className.mkString" href="@target">
+    <a class="@if(secondary){ bundle-button__content--secondary } else { bundle-button__content } @className.mkString"
+        href="@if(returnUrl.nonEmpty){ @if(target.indexOf("?") > 0) { @target&returnUrl=@returnUrl.get } else { @target?returnUrl=@returnUrl.get } } else { @target }">
         <p>@buttonLabel</p>
         <div class="bundle-button__content__arrow">
             @if(chevron){

--- a/frontend/app/views/fragments/bundle/bundleOfferingsA.scala.html
+++ b/frontend/app/views/fragments/bundle/bundleOfferingsA.scala.html
@@ -2,10 +2,10 @@
 @import views.support.Asset
 @import abtests.BundleTier._
 
-@(bundleVariant: BundleVariant)
+@(bundleVariant: BundleVariant, returnUrl: Option[String])
 <section class="bundle-section">
     <div class="bundle-offering-a l-constrained">
-        @if(!bundleVariant.distribution.name.contains("_PDCOM_")) {
+        @if(bundleVariant.hasContributions) {
             <div class="bundle-offering-a__give">
                 <div class="bundle-offering-a__give__content">
                     <h1>Support through giving</h1>
@@ -43,7 +43,7 @@
                             </div>
                             </li>
                         }
-                        @if(bundleVariant.distribution.name.contains("_PDCOM_")) {
+                        @if(bundleVariant.hasPaidComments) {
                             <li class="bundle-offering-a__subscribe__offer__list__item">
                                 <div class="bundle-offering-a__subscribe__offer__list__item__icon">
                                 @for(icon <- Asset.inlineSvg("bundle-commenting")) {
@@ -78,7 +78,7 @@
                             </div>
                         </li>
                     </ul>
-                    @fragments.bundle.bundleButton("Find out more", routes.Bundle.thankYou(bundleVariant, "digital-pack").url)
+                    @fragments.bundle.bundleButton("Find out more", routes.Bundle.thankYou(bundleVariant, "digital-pack").url, returnUrl = Some(java.net.URLEncoder.encode(returnUrl.getOrElse("https://www.theguardian.com"), "utf-8")))
                 </div>
             </div><div class="bundle-offering-a__subscribe__offer">
                 <div class="bundle-offering-a__subscribe__offer__content">
@@ -98,7 +98,7 @@
                            </div>
                         </li>
                     }
-                    @if(bundleVariant.distribution.name.contains("_PDCOM_")) {
+                    @if(bundleVariant.hasPaidComments) {
                         <li class="bundle-offering-a__subscribe__offer__list__item">
                             <div class="bundle-offering-a__subscribe__offer__list__item__icon">
                             @for(icon <- Asset.inlineSvg("bundle-commenting")) {
@@ -201,7 +201,7 @@
                                 <div class="bundle-offering-a__print-option__id">seven-day</div>
                             </li>
                         </ul>
-                        @fragments.bundle.bundleButton(bundleVariant.prettyMonthlyPrice(Saturday), routes.Bundle.thankYou(bundleVariant, "saturday").url, Option("js-print-button"))
+                        @fragments.bundle.bundleButton(bundleVariant.prettyMonthlyPrice(Saturday), routes.Bundle.thankYou(bundleVariant, "saturday").url, Option("js-print-button"), returnUrl = Some(java.net.URLEncoder.encode(returnUrl.getOrElse("https://www.theguardian.com"), "utf-8")))
                     </div>
                 </div>
             </div>

--- a/frontend/app/views/fragments/bundle/bundleOfferingsA.scala.html
+++ b/frontend/app/views/fragments/bundle/bundleOfferingsA.scala.html
@@ -5,20 +5,24 @@
 @(bundleVariant: BundleVariant)
 <section class="bundle-section">
     <div class="bundle-offering-a l-constrained">
-        <div class="bundle-offering-a__give">
-            <div class="bundle-offering-a__give__content">
-                <h1>Support through giving</h1>
-                <div class="bundle-offering-a__give__content__body">
-                    <p class="bundle-offering-a__give__content__body__description">Fund our journalism on your own terms – either a regular or one-off payment. Every penny goes to supporting our fearless, in-depth reporting and keeping our website and apps open to all.</p>
-                    <div class="bundle-offering-a__give__monthly-button">
-                        @fragments.bundle.bundleButton("Make a monthly contribution",routes.Bundle.thankYou(bundleVariant, "monthly-contribution").url)
-                    </div>
-                    <div class="bundle-offering-a__give__one-off-button">
-                        @fragments.bundle.bundleButton("Make a one-off contribution",s"https://contribute.theguardian.com?INTCMP=${bundleVariant.testId}")
+        @if(!bundleVariant.distribution.name.contains("_PDCOM_")) {
+            <div class="bundle-offering-a__give">
+                <div class="bundle-offering-a__give__content">
+                    <h1>Support through giving</h1>
+                    <div class="bundle-offering-a__give__content__body">
+                        <p class="bundle-offering-a__give__content__body__description">
+                            Fund our journalism on your own terms – either a regular or one-off payment. Every penny goes to supporting our fearless, in-depth reporting and keeping our website and apps open to all.</p>
+                        <div class="bundle-offering-a__give__monthly-button">
+                        @fragments.bundle.bundleButton("Make a monthly contribution", routes.Bundle.thankYou(bundleVariant, "monthly-contribution").url)
+                        </div>
+                        <div class="bundle-offering-a__give__one-off-button">
+                        @fragments.bundle.bundleButton("Make a one-off contribution", s"https://contribute.theguardian.com?INTCMP=${bundleVariant.testId}")
+                        </div>
                     </div>
                 </div>
             </div>
-        </div><div class="bundle-offering-a__subscribe">
+        }
+        <div class="bundle-offering-a__subscribe">
             <h1>Support through subscribing</h1>
             <div class="bundle-offering-a__subscribe__offer">
                 <div class="bundle-offering-a__subscribe__offer__content">
@@ -37,6 +41,19 @@
                                 <h1>Ad-free</h1>
                                 <p>Enjoy our website and apps without adverts</p>
                             </div>
+                            </li>
+                        }
+                        @if(bundleVariant.distribution.name.contains("_PDCOM_")) {
+                            <li class="bundle-offering-a__subscribe__offer__list__item">
+                                <div class="bundle-offering-a__subscribe__offer__list__item__icon">
+                                @for(icon <- Asset.inlineSvg("bundle-commenting")) {
+                                    @icon
+                                }
+                                </div>
+                                <div class="bundle-offering-a__subscribe__offer__list__item__content">
+                                    <h1>Commenting</h1>
+                                    <p>Discussion threads on articles are reserved for paying supporters only</p>
+                                </div>
                             </li>
                         }
                         <li class="bundle-offering-a__subscribe__offer__list__item">
@@ -79,6 +96,19 @@
                             <h1>Ad-free</h1>
                             <p>Enjoy our website and apps without adverts</p>
                            </div>
+                        </li>
+                    }
+                    @if(bundleVariant.distribution.name.contains("_PDCOM_")) {
+                        <li class="bundle-offering-a__subscribe__offer__list__item">
+                            <div class="bundle-offering-a__subscribe__offer__list__item__icon">
+                            @for(icon <- Asset.inlineSvg("bundle-commenting")) {
+                                @icon
+                            }
+                            </div>
+                            <div class="bundle-offering-a__subscribe__offer__list__item__content">
+                                <h1>Commenting</h1>
+                                <p>Discussion threads on articles are reserved for paying supporters only</p>
+                            </div>
                         </li>
                     }
 

--- a/frontend/app/views/fragments/bundle/bundleOfferingsA.scala.html
+++ b/frontend/app/views/fragments/bundle/bundleOfferingsA.scala.html
@@ -78,7 +78,7 @@
                             </div>
                         </li>
                     </ul>
-                    @fragments.bundle.bundleButton("Find out more", routes.Bundle.thankYou(bundleVariant, "digital-pack").url, returnUrl = Some(java.net.URLEncoder.encode(returnUrl.getOrElse("https://www.theguardian.com"), "utf-8")))
+                    @fragments.bundle.bundleButton("Find out more", routes.Bundle.thankYou(bundleVariant, "digital-pack").url, className = Option("js-commit-button"), returnUrl = Some(java.net.URLEncoder.encode(returnUrl.getOrElse("https://www.theguardian.com"), "utf-8")))
                 </div>
             </div><div class="bundle-offering-a__subscribe__offer">
                 <div class="bundle-offering-a__subscribe__offer__content">

--- a/frontend/assets/javascripts/src/modules/landingBundles.es6
+++ b/frontend/assets/javascripts/src/modules/landingBundles.es6
@@ -8,6 +8,7 @@ const PRINT_A_ID_SELECTOR = '.bundle-offering-a__print-option__id';
 const PRINT_B_ID_SELECTOR = '.bundle-offering-b__print-option__id';
 const SEE_MORE_CTA_SELECTOR = '.js-see-more-button';
 const CURRENT_PRINT_SELECTOR = '.subscribe_option--selected';
+const COMMIT_BUTTON_SELECTOR = '.js-commit-button';
 const PRINT_CTA_SELECTOR = '.js-print-button';
 const PRINT_OPTIONS_SELECTOR = '.bundle-offering-a__subscribe__offer__print-options__option, .bundle-offering-b__subscribe__offer__print-options__option';
 
@@ -16,7 +17,16 @@ const PRINT_B = document.querySelectorAll(PRINT_B_SELECTOR);
 const SEE_MORE_CTA = document.querySelector(SEE_MORE_CTA_SELECTOR);
 const PRINT_OPTIONS = document.querySelectorAll(PRINT_OPTIONS_SELECTOR);
 const PRINT_CTA = document.querySelector(PRINT_CTA_SELECTOR);
+const COMMIT_CTA = document.querySelector(COMMIT_BUTTON_SELECTOR);
+const COMMIT_COOKIE_NAME = 'GU_PDCOMCTA';
 
+const cookieDomain = () => {
+    return document.location.host.substr(document.location.host.indexOf('.') ? document.location.host.indexOf('.') + 1 : 0);
+};
+const setCookie = (name, value, days = 7, path = '/', domain = cookieDomain()) => {
+    const expires = new Date(Date.now() + days * 864e5).toGMTString();
+    document.cookie = name + `=${encodeURIComponent(value)}; expires=${expires}; path=${path}; domain=${domain}`;
+};
 
 export function init() {
 
@@ -38,6 +48,14 @@ function bindButtonBehaviour() {
         toggle(printSection);
         toggle(SEE_MORE_CTA);
         evt.preventDefault();
+    });
+
+    PRINT_CTA.addEventListener('click', function(evt){
+        setCookie(COMMIT_COOKIE_NAME, 1, 60);
+    });
+
+    COMMIT_CTA.addEventListener('click', function(evt){
+        setCookie(COMMIT_COOKIE_NAME, 1, 60);
     });
 }
 

--- a/frontend/assets/stylesheets/components/_bundle-header.scss
+++ b/frontend/assets/stylesheets/components/_bundle-header.scss
@@ -80,10 +80,10 @@
     }
     h1 {
         @include text-title();
-        @include mq($from: tablet) {
+        @include mq($from: tablet, $until: desktop) {
             font-size: 46px;
         }
-        @include mq($from: desktop) {
+        @include mq($from: desktop, $until: mem-full) {
             font-size: 50px;
         }
         @include mq($from: mem-full) {
@@ -93,12 +93,11 @@
 
     p {
         @include text-tag-line();
-
-        @include mq($from: tablet) {
+        @include mq($from: tablet, $until: desktop) {
             font-size: 20px;
             width: gs-span(5.25);
         }
-        @include mq($from: desktop) {
+        @include mq($from: desktop, $until: mem-full) {
             font-size: 22px;
             width: gs-span(3.75);
         }
@@ -113,13 +112,13 @@
     @include bundle-column-narrow();
     img {
         position: absolute;
-        @include mq($from: tablet) {
+        @include mq($from: tablet, $until: desktop) {
             width: 288px;
             height: 240px;
             top: 87px;
             margin-left: 430px;
         }
-        @include mq($from: desktop) {
+        @include mq($from: desktop, $until: mem-full) {
             width: 288px;
             height: 240px;
             top: 117px;
@@ -142,6 +141,9 @@
         padding-left: $gs-gutter * 5;
     }
     p {
+        @include mq($from: mem-full) {
+            width: gs-span(6);
+        }
         margin-bottom: 0;
         @include text-paragraph();
         padding-top: $gs-baseline;

--- a/frontend/assets/stylesheets/components/_bundle-header.scss
+++ b/frontend/assets/stylesheets/components/_bundle-header.scss
@@ -2,13 +2,30 @@
 /* Header */
 .global-header-bundles {
 
-    height: 96px;
+    @include mq($from: tablet) {
+        height: 76px;
+    }
+    @include mq($from: desktop) {
+        height: 96px;
+    }
 
     .global-header__logo__image {
         margin-top: 2px;
-        margin-right: 20px;
-        width: 320px;
-        height: 60px;
+        @include mq($from: tablet) {
+            margin-right: 10px;
+            width: 280px;
+            height: 50px;
+        }
+        @include mq($from: desktop) {
+            margin-right: 330px;
+            width: 320px;
+            height: 60px;
+        }
+        @include mq($from: mem-full) {
+            margin-right: 20px;
+            width: 320px;
+            height: 60px;
+        }
     }
 
     .global-header__inner {
@@ -52,37 +69,79 @@
 
 .bundle-header__main__content {
     @include bundle-column-wide();
-    padding-left: 100px;
-
+    @include mq($from: tablet) {
+        padding-left: $gs-gutter;
+    }
+    @include mq($from: desktop) {
+        padding-left: $gs-gutter * 2;
+    }
+    @include mq($from: mem-full) {
+        padding-left: 100px;
+    }
     h1 {
         @include text-title();
-        padding-top: $gs-baseline * 2;
+        @include mq($from: tablet) {
+            font-size: 46px;
+        }
+        @include mq($from: desktop) {
+            font-size: 50px;
+        }
+        @include mq($from: mem-full) {
+            padding-top: $gs-baseline * 2;
+        }
     }
 
     p {
-         @include text-tag-line();
-         padding-bottom: $gs-baseline * 3;
-         width: gs-span(6);
-     }
+        @include text-tag-line();
+
+        @include mq($from: tablet) {
+            font-size: 20px;
+            width: gs-span(5.25);
+        }
+        @include mq($from: desktop) {
+            font-size: 22px;
+            width: gs-span(3.75);
+        }
+        @include mq($from: mem-full) {
+            padding-bottom: $gs-baseline * 3;
+            width: gs-span(6);
+        }
+    }
 }
 
 .bundle-header__main__img {
-
     @include bundle-column-narrow();
-
     img {
         position: absolute;
-        width: 480px;
-        height: 400px;
-        top: 117px;
+        @include mq($from: tablet) {
+            width: 288px;
+            height: 240px;
+            top: 87px;
+            margin-left: 430px;
+        }
+        @include mq($from: desktop) {
+            width: 288px;
+            height: 240px;
+            top: 117px;
+            margin-left: 336px;
+        }
+        @include mq($from: mem-full) {
+            width: 480px;
+            height: 400px;
+            top: 117px;
+        }
     }
 }
 
 .bundle-header__secondary__content {
     @include bundle-column-wide();
-    padding-left: $gs-gutter * 5;
+    @include mq($until: mem-full) {
+        padding-left: $gs-gutter;
+    }
+    @include mq($from: mem-full) {
+        padding-left: $gs-gutter * 5;
+    }
     p {
-        width: gs-span(6);
         margin-bottom: 0;
         @include text-paragraph();
         padding-top: $gs-baseline;

--- a/frontend/assets/stylesheets/components/_bundle-offerings-a.scss
+++ b/frontend/assets/stylesheets/components/_bundle-offerings-a.scss
@@ -1,12 +1,20 @@
 /* Give */
 .bundle-offering-a__give {
-    @include bundle-column-narrow();
-    padding-left: $gs-gutter * 5;
+    @include mq($from: desktop) {
+        @include bundle-column-narrow();
+        padding-left: $gs-gutter * 5;
+    }
 }
 
 .bundle-offering-a__give__content {
     margin-top: $gs-baseline * 3;
-    max-width: gs-span(4.75);
+
+    @include mq($from: tablet) {
+        max-width: gs-span(3.75);
+    }
+    @include mq($from: desktop) {
+        max-width: gs-span(4.75);
+    }
 
     >h1 {
         margin-top: $gs-baseline * 3;
@@ -19,18 +27,21 @@
         margin-bottom: $gs-baseline;
         margin-left: $gs-gutter/2;
     }
+
 }
 
 .bundle-offering-a__give__content__body {
     background-color: #d4ebf8;
-    margin-top: $gs-baseline * 2;
+    @include mq($from: desktop) {
+        margin-top: $gs-baseline * 2;
 
-    >p {
-        @include fs-headline(2);
-        font-size: 18px;
-        line-height: 22px;
-        margin-bottom: $gs-baseline * 2;
-        padding: 8px $gs-gutter/2 0;
+        > p {
+            @include fs-headline(2);
+            font-size: 18px;
+            line-height: 22px;
+            margin-bottom: $gs-baseline * 2;
+            padding: 8px $gs-gutter/2 0;
+        }
     }
 }
 
@@ -46,15 +57,22 @@
 .bundle-offering-a__subscribe {
     @include bundle-column-wide();
     padding-right: $gs-gutter;
+    padding-top: $gs-baseline * 2;
+    margin-left: $gs-gutter;
+    @include mq($from: tablet) {
+        width: gs-span(9);
+    }
+    @include mq($from: desktop) {
+        width: gs-span(8);
+    }
 
-    >h1 {
-        margin-top: $gs-baseline * 3;
+    > h1 {
         padding-top: 2px;
         @include text-offering-title();
         border-top: 1px guss-colour(news-main-2) solid;
     }
 
-    >div:first-of-type {
+    > div:first-of-type {
         padding-right: 1px;
 
         .bundle-button__content {
@@ -64,7 +82,12 @@
 }
 
 .bundle-offering-a__subscribe__offer {
-    width: gs-span(4.125);
+    @include mq($from: tablet) {
+        width: gs-span(4.5);
+    }
+    @include mq($from: desktop) {
+        width: gs-span(3.85);
+    }
     display: inline-block;
     vertical-align: top;
     margin-top: $gs-baseline * 2;
@@ -75,6 +98,9 @@
 
     >h2 {
         @include fs-headline(4);
+        @include mq($from: desktop) {
+            font-size: 22px;
+        }
         padding: 8px $gs-gutter/2 0;
         font-weight: 900;
     }
@@ -88,6 +114,9 @@
 .bundle-offering-a__subscribe__offer__price-description {
     padding-left: $gs-gutter / 2;
     @include fs-headline(4);
+    @include mq($from: desktop) {
+        font-size: 22px;
+    }
     font-weight: 200;
     color: guss-colour(neutral-1);
 }
@@ -118,6 +147,10 @@
 
 .bundle-offering-a__subscribe__offer__list__item__content {
     width: 251px;
+    @include mq($from: desktop) {
+        width: 224px;
+    }
+
     display: inline-block;
     vertical-align: top;
     >h1 {

--- a/frontend/assets/stylesheets/components/_bundle-offerings-a.scss
+++ b/frontend/assets/stylesheets/components/_bundle-offerings-a.scss
@@ -1,5 +1,8 @@
 /* Give */
 .bundle-offering-a__give {
+    margin: auto;
+    display: inherit;
+    float: left;
     @include mq($from: desktop) {
         @include bundle-column-narrow();
         padding-left: $gs-gutter * 5;
@@ -27,12 +30,11 @@
         margin-bottom: $gs-baseline;
         margin-left: $gs-gutter/2;
     }
-
 }
 
 .bundle-offering-a__give__content__body {
     background-color: #d4ebf8;
-    @include mq($from: desktop) {
+    @include mq($from: mem-full) {
         margin-top: $gs-baseline * 2;
 
         > p {
@@ -55,24 +57,27 @@
 /* Subscribe */
 
 .bundle-offering-a__subscribe {
+    margin: auto;
+    @include mq($from: desktop) {
+        display: inherit;
+        //float: right;
+    }
     @include bundle-column-wide();
     padding-right: $gs-gutter;
-    padding-top: $gs-baseline * 2;
-    margin-left: $gs-gutter;
-    @include mq($from: tablet) {
-        width: gs-span(9);
+    @include mq($until: mem-full) {
+        padding-top: $gs-baseline * 2;
     }
-    @include mq($from: desktop) {
-        width: gs-span(8);
-    }
-
-    > h1 {
+    width: gs-span(9);
+    >h1 {
+        @include mq($from: mem-full) {
+            margin-top: $gs-baseline * 3;
+        }
         padding-top: 2px;
         @include text-offering-title();
         border-top: 1px guss-colour(news-main-2) solid;
     }
 
-    > div:first-of-type {
+    >div:first-of-type {
         padding-right: 1px;
 
         .bundle-button__content {
@@ -82,12 +87,7 @@
 }
 
 .bundle-offering-a__subscribe__offer {
-    @include mq($from: tablet) {
-        width: gs-span(4.5);
-    }
-    @include mq($from: desktop) {
-        width: gs-span(3.85);
-    }
+    width: gs-span(4.25);
     display: inline-block;
     vertical-align: top;
     margin-top: $gs-baseline * 2;
@@ -98,7 +98,7 @@
 
     >h2 {
         @include fs-headline(4);
-        @include mq($from: desktop) {
+        @include mq($until: mem-full) {
             font-size: 22px;
         }
         padding: 8px $gs-gutter/2 0;
@@ -114,7 +114,7 @@
 .bundle-offering-a__subscribe__offer__price-description {
     padding-left: $gs-gutter / 2;
     @include fs-headline(4);
-    @include mq($from: desktop) {
+    @include mq($until: mem-full) {
         font-size: 22px;
     }
     font-weight: 200;
@@ -146,9 +146,11 @@
 }
 
 .bundle-offering-a__subscribe__offer__list__item__content {
-    width: 251px;
-    @include mq($from: desktop) {
+    @include mq($until: mem-full) {
         width: 224px;
+    }
+    @include mq($from: mem-full) {
+        width: 251px;
     }
 
     display: inline-block;

--- a/frontend/assets/stylesheets/components/_bundle-offerings-a.scss
+++ b/frontend/assets/stylesheets/components/_bundle-offerings-a.scss
@@ -60,7 +60,6 @@
     margin: auto;
     @include mq($from: desktop) {
         display: inherit;
-        //float: right;
     }
     @include bundle-column-wide();
     padding-right: $gs-gutter;

--- a/frontend/assets/stylesheets/components/_bundle-support-us.scss
+++ b/frontend/assets/stylesheets/components/_bundle-support-us.scss
@@ -3,7 +3,7 @@
     padding-left: 20px;
 
     >img {
-        @include mq($until: mem-full){
+        @include mq($until: mem-full) {
             display: none;
         }
         position: absolute;
@@ -28,7 +28,9 @@
 .bundle-support__main__title {
     @include bundle-column-wide();
     padding-right: $gs-gutter;
-    margin-left: $gs-gutter;
+    @include mq($until: mem-full) {
+        margin-left: $gs-gutter;
+    }
 
     >h1 {
         padding-top: 2px;
@@ -71,7 +73,9 @@
         max-width: gs-span(6);
     }
     color: guss-colour(neutral-1);
-    margin-left: $gs-gutter;
+    @include mq($until: mem-full){
+        margin-left: $gs-gutter;
+    }
     >p {
         margin-bottom: $gs-baseline;
     }

--- a/frontend/assets/stylesheets/components/_bundle-support-us.scss
+++ b/frontend/assets/stylesheets/components/_bundle-support-us.scss
@@ -3,6 +3,9 @@
     padding-left: 20px;
 
     >img {
+        @include mq($until: mem-full){
+            display: none;
+        }
         position: absolute;
         margin-top: $gs-baseline * 4;
         width: 460px;
@@ -25,6 +28,7 @@
 .bundle-support__main__title {
     @include bundle-column-wide();
     padding-right: $gs-gutter;
+    margin-left: $gs-gutter;
 
     >h1 {
         padding-top: 2px;
@@ -63,9 +67,11 @@
 .bundle-support__content__body__text {
     @include text-paragraph();
     padding-top: 8px;
-    max-width: gs-span(6);
+    @include mq($from: mem-full) {
+        max-width: gs-span(6);
+    }
     color: guss-colour(neutral-1);
-
+    margin-left: $gs-gutter;
     >p {
         margin-bottom: $gs-baseline;
     }

--- a/frontend/assets/stylesheets/components/_bundle-thank-you.scss
+++ b/frontend/assets/stylesheets/components/_bundle-thank-you.scss
@@ -50,3 +50,9 @@
         margin-left: $gs-gutter * 3;
     }
 }
+
+.bundle-button {
+    margin-top: $gs-baseline;
+    margin-bottom: $gs-baseline;
+    margin-left: $gs-gutter * 5;
+}


### PR DESCRIPTION
## Why are you doing this?
We're testing paid commenting and have opened a PR in frontend to introduce a 0% AB test. This is the back-end of that test.

## Trello card: [Here](https://trello.com/c/mq93Nry8/374-set-up-a-0-ab-test-for-first-pass-of-paid-commenting-trial)

## Changes
-Add a new bundle variant
-Drop the 'give' section from the landing page
-Allow for more breakpoints than just `mem-full` (this still needs some effort)
-Drop a cookie when the user selects one of the paid options
-Changes the copy a little, to better reflect what the user expects

## Screenshots
See the [frontend PR](https://github.com/guardian/frontend/pull/16149) (there's a big GIF there!)

cc @Ap0c @svillafe 