### PR TITLE
Fix Stripe payment on free-to-paid-upgrade

### DIFF
--- a/frontend/app/views/tier/upgrade/freeToPaid.scala.html
+++ b/frontend/app/views/tier/upgrade/freeToPaid.scala.html
@@ -34,6 +34,7 @@
         <form action="@routes.TierController.upgrade(targetPlans.tier, None)" method="POST" id="payment-form" class="js-form" data-change-to-tier="@targetPlans.tier.name">
             @CSRF.formField
             <input type="hidden" name="tier" disabled value="@targetPlans.tier.slug"/>
+            <input type="hidden" name="email" id="email" disabled value="@idUser.email"/>
 
             <section class="form-content">
 


### PR DESCRIPTION
## Why are you doing this?

Friend members trying to upgrade to become a paying member can currently not pay by Stripe (PayPal is OK) - clicking on the _'Credit/Debit Card'_ button does nothing, due to javascript crashing in [`stripe.es6`](https://github.com/guardian/membership-frontend/blob/eb1f69ec/frontend/assets/javascripts/src/modules/form/stripe.es6#L17). 

![image](https://cloud.githubusercontent.com/assets/52038/23963712/18e9e102-09aa-11e7-9f75-cf6090c376bd.png)

This is due to a breaking change in https://github.com/guardian/membership-frontend/pull/1539, specifically commit https://github.com/guardian/membership-frontend/pull/1539/commits/67384bd7, where the user's email was removed as a data-property of the 'Stripe' button, and instead read from the `email` field. When making this change I completely forgot about the free-to-paid upgrade form, where payment is entered - but the user is already logged in, so no email field is present, and the javascript crashes.

Here's a screenshot of the successful completion of a free-to-paid-upgrade with this fix:

![image](https://cloud.githubusercontent.com/assets/52038/23964048/1768b41a-09ab-11e7-92ce-91acc2831e48.png)


As a side note- it was necessary to use a test-user in Dev to reproduce this issue, because I can't sign-up as a Friend using a 'Normal' user in Dev. The logs show:

```
com.gu.zuora.soap.models.errors.ZuoraPartialError: INVALID_VALUE: The subscription cannot be activated, because we cannot determine the bill cycle day from the charges in the subscription. We need a recurring charge to be present in order to auto-set the bill cycle day for the account.
        at com.gu.zuora.soap.models.errors.ErrorHandler$.handleZuoraPartialErrors(Errors.scala:142)
        at com.gu.zuora.soap.models.errors.ErrorHandler$.apply(Errors.scala:84)
        at com.gu.zuora.soap.readers.Result$class.extractEither(Result.scala:13)
        at com.gu.zuora.soap.readers.Result$$anon$1.extractEither(Result.scala:21)
        at com.gu.zuora.soap.readers.Reader$$anonfun$read$1.apply(Reader.scala:24)
        at com.gu.zuora.soap.readers.Reader$$anonfun$read$1.apply(Reader.scala:20)
```

cc @svillafe 


