### PR TITLE
Default test cookie to theguardian.com domain

### DIFF
--- a/frontend/assets/javascripts/src/modules/landingBundles.es6
+++ b/frontend/assets/javascripts/src/modules/landingBundles.es6
@@ -20,10 +20,7 @@ const PRINT_CTA = document.querySelector(PRINT_CTA_SELECTOR);
 const COMMIT_CTA = document.querySelector(COMMIT_BUTTON_SELECTOR);
 const COMMIT_COOKIE_NAME = 'GU_PDCOMCTA';
 
-const cookieDomain = () => {
-    return document.location.host.substr(document.location.host.indexOf('.') ? document.location.host.indexOf('.') + 1 : 0);
-};
-const setCookie = (name, value, days = 7, path = '/', domain = cookieDomain()) => {
+const setCookie = (name, value, days = 7, path = '/', domain = 'theguardian.com') => {
     const expires = new Date(Date.now() + days * 864e5).toGMTString();
     document.cookie = name + `=${encodeURIComponent(value)}; expires=${expires}; path=${path}; domain=${domain}`;
 };


### PR DESCRIPTION
## Why are you doing this?
Follows on from https://github.com/guardian/membership-frontend/pull/1544. Testing on CODE showed that the domain name generated for the cookie wasn't good enough when the bundles test is completed by the user.

As this was only written to allow testing on thegulocal.com, we can just use theguardian.com now (and will have to override it manually when testing locally in future).

cc @rupertbates @Ap0c @svillafe 