### PR TITLE
Fix To Hide PayPal In Apps

### DIFF
--- a/frontend/assets/javascripts/src/modules/form/helper/formUtil.js
+++ b/frontend/assets/javascripts/src/modules/form/helper/formUtil.js
@@ -34,11 +34,20 @@ define([
     };
 
     function hasPaypal () {
-        var regex = /^APP_.*_MEMBERSHIP_PAYMENT_SCREEN$/; // matches Android (APP_ANDROID_MEMBERSHIP_PAYMENT), iOS (APP_IOS_MEMBERSHIP_PAYMENT) & Windows app (if they implement it one day)
-        var code = url.getQueryParameterByName('INTCMP');
 
-        var fromApps = regex.exec(code);
+        var platform = url.getQueryParameterByName('platform');
+        var campaignCode = url.getQueryParameterByName('INTCMP');
+        var androidCampCodes = [
+            'APP_ANDROID_MEMBERSHIP_PAYMENT_SCREEN',
+            'gdnwb_copts_memco_kr3_app_epic_ask4',
+            'gdnwb_copts_memco_app_epic_always_ask'
+        ];
+
+        var fromApps = platform === 'ios' || platform === 'android' ||
+            androidCampCodes.indexOf(campaignCode) > -1;
+
         return !!document.getElementById('paypal-button-checkout') && !fromApps;
+
     }
 
     function hasStripeCheckout () {


### PR DESCRIPTION
## Why are you doing this?

PayPal does not work in the app web views, so we need to hide the button for users in the apps. Previously we were doing this by checking for the presence of the iOS or Android campaign codes in the INTCMP query param. However, the apps are now passing through a much wider range of campaign codes, depending on where the user has come from. Therefore we need to switch to using a `platform` query param to figure out whether we are in the apps or not.

The iOS app has not gone into production with the INTCMP changes, so all we need to do there is check for `platform=ios`, which has been implemented in [this PR](https://github.com/guardian/ios-live/pull/3095). However, the Android app went into production with these changes yesterday, so until we can get the fix deployed next week, we need to temporarily check for the most common of the INTCMP codes it is now sending through to us.

[**Trello Card**](https://trello.com/c/ipFJgiI1/402-fix-paypal-in-apps-check-for-platform)

## Changes

- Check for platform query param, and don't show PayPal if it matches 'ios' or 'android'.
- Check for three most common android INTCMPs, and don't show PayPal if they are present.

## Screenshots

**Platform: iOS**

![paypal-ios](https://cloud.githubusercontent.com/assets/5131341/24052170/6a5b34cc-0b2c-11e7-8174-5d152fab585d.png)

**Android Campaign Code**

![paypal-android](https://cloud.githubusercontent.com/assets/5131341/24052186/799ffaa8-0b2c-11e7-9d94-70724b42d5ba.png)

**Anything Else**

![paypal-normal](https://cloud.githubusercontent.com/assets/5131341/24052197/8650d2e0-0b2c-11e7-8d5b-d3c062f29e69.png)

cc @alfavata @maxspencer