### PR TITLE
Remove the "| Guardian members" part of the page title

### DIFF
--- a/frontend/app/views/joiner/form/monthlyContribution.scala.html
+++ b/frontend/app/views/joiner/form/monthlyContribution.scala.html
@@ -10,7 +10,7 @@
     touchpointBackendResolution: services.TouchpointBackend.Resolution,
     contributionValue: Int)(implicit token: play.filters.csrf.CSRF.Token, request: actions.AuthRequest[_])
 
-@main("Become a contributor", pageInfo=pageInfo, header = SimpleHeader, margins=false, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
+@main("", pageInfo = pageInfo, titleOverride = Some("Become a contributor"), header = SimpleHeader, margins = false, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
     <script>
         (function() {
             'use strict';

--- a/frontend/app/views/joiner/thankyouMonthly.scala.html
+++ b/frontend/app/views/joiner/thankyouMonthly.scala.html
@@ -12,7 +12,7 @@
 )
 
 @title = @{
-    s"Thank you for your support"
+    s"Thank you for your contribution"
 }
 
 @pageHeader = @{
@@ -39,7 +39,8 @@
 }
 
 @main(
-    title,
+    "",
+    titleOverride = Some(title),
     touchpointBackendResolutionOpt = Some(touchpointBackendResolution),
     header = SimpleHeader
 ) {


### PR DESCRIPTION
## Why are you doing this?
The new monthly contribution product should not have any mention of membership in it so we need to remove it from the page title where it gets appended by default.

## Screenshots
The new pages (note title in the browser tab)
![screen shot 2017-03-21 at 14 35 11](https://cloud.githubusercontent.com/assets/181371/24152487/b2a71416-0e43-11e7-88a1-c2f8a2897fb5.png)
![screen shot 2017-03-21 at 14 33 47](https://cloud.githubusercontent.com/assets/181371/24152486/b28c97f8-0e43-11e7-94b8-61b164febdf8.png)
