### PR TITLE
Replacing caret with tilde for webpack 2

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -64,7 +64,7 @@
     "time-grunt": "^1.2.1",
     "url-search-params": "^0.6.1",
     "vinyl-fs": "2.2.1",
-    "webpack": "^2.2.1",
+    "webpack": "~2.2.1",
     "webpack-dev-server": "^1.14.1",
     "zxcvbn": "3.5.0"
   }


### PR DESCRIPTION
## Why are you doing this?
This is to avoid npm bump our version of webpack, only the patches.

## Changes
* Update package.json

cc: @Ap0c 