### PR TITLE
Refactor PayPal App Check

### DIFF
--- a/frontend/assets/javascripts/src/modules/form/helper/formUtil.js
+++ b/frontend/assets/javascripts/src/modules/form/helper/formUtil.js
@@ -37,14 +37,16 @@ define([
 
         var platform = url.getQueryParameterByName('platform');
         var campaignCode = url.getQueryParameterByName('INTCMP');
-        var androidCampCodes = [
+        var appCampCodes = [
             'APP_ANDROID_MEMBERSHIP_PAYMENT_SCREEN',
+            'APP_IOS_MEMBERSHIP_PAYMENT_SCREEN',
             'gdnwb_copts_memco_kr3_app_epic_ask4',
             'gdnwb_copts_memco_app_epic_always_ask'
         ];
 
+        // Platform for new versions of the apps, camp codes for old versions.
         var fromApps = platform === 'ios' || platform === 'android' ||
-            androidCampCodes.indexOf(campaignCode) > -1;
+            appCampCodes.indexOf(campaignCode) > -1;
 
         return !!document.getElementById('paypal-button-checkout') && !fromApps;
 


### PR DESCRIPTION
## Why are you doing this?

The aim of this is to prevent PayPal being seen in the apps, because it's broken in web views, and handles and oversight concerning the iOS app.

In #1550 we switched to using the `platform` query param to check for the apps, which iOS added to their beta. However, their beta wasn't actually out at the time (should be going out today), which means we should have still been checking for `APP_IOS_MEMBERSHIP_PAYMENT_SCREEN` in the `INTCMP` param in order to hide PayPal.

This is bad, because theoretically it meant that all iOS users on the live version of the iOS app would have been seeing a broken PayPal implementation. *Except that* fortunately the iOS app was using the same `INTCMP` codes that we were checking for in the Android app, so PayPal would still have been hidden for most users.

Unfortunately, there are still situations where the current live version iOS app doesn't send through an `INTCMP` at all, and there is nothing we can do about this. However, we can still add in the old `APP_IOS_MEMBERSHIP_PAYMENT_SCREEN` for the people who are on much older versions.

## Summary

That's all a bit complicated, so to summarise:

**Old Versions of iOS App**:

Sends through `INTCMP=APP_IOS_MEMBERSHIP_PAYMENT_SCREEN`. We have added a check for this now in this PR.

**Current Live iOS App**:

Sends through `INTCMP`s of `gdnwb_copts_memco_kr3_app_epic_ask4`, `gdnwb_copts_memco_app_epic_always_ask` or nothing. We caught these campaign codes by accident in #1550 because we were checking for them in Android. We are now explicitly checking for them in both apps. We unfortunately can't do anything in the case of no campaign code.

**New Version of iOS App Going Out Today**:

Sends through `platform=ios`, which we now check for.

[**Trello Card**](https://trello.com/c/g5kDkUxd/422-fix-paypal-in-ios-app)

## Changes

- Renamed `androidCampCodes` to `appCampCodes` to reflect the fact that they may come from either app.
- Added `APP_IOS_MEMBERSHIP_PAYMENT_SCREEN` to checked campaign codes for older versions of the iOS app.

cc @alfavata