### PR TITLE
New checkout flow design for monthly contribution

### DIFF
--- a/frontend/app/controllers/Binders.scala
+++ b/frontend/app/controllers/Binders.scala
@@ -63,4 +63,8 @@ object Binders {
   implicit object bindableBundleVariant extends QueryParsing[BundleVariant](
     x => BundleVariant.lookup(x).get, _.testId,  (key: String, _: Exception) => s"Cannot parse parameter $key as a Bundle Variant"
   )
+
+  implicit object bindableBigDecimal extends QueryParsing[BigDecimal](
+    x => BigDecimal(x), x => "%.2f".format(x),  (key: String, _: Exception) => s"Cannot parse parameter $key as a BigDecimal"
+  )
 }

--- a/frontend/app/controllers/Contributor.scala
+++ b/frontend/app/controllers/Contributor.scala
@@ -38,7 +38,7 @@ object Contributor extends Controller with ActivityTracking with PaymentGatewayE
 
   def NonContributorAction = NoCacheAction andThen PlannedOutageProtection andThen authenticated() andThen onlyNonContributorFilter()
 
-  def enterMonthlyContributionsDetails(countryGroup: CountryGroup = UK, contributionValue: Option[Int] = None) = NonContributorAction.async { implicit request =>
+  def enterMonthlyContributionsDetails(countryGroup: CountryGroup = UK, contributionValue: Option[Double] = None) = NonContributorAction.async { implicit request =>
 
     implicit val resolution: TouchpointBackend.Resolution =
       TouchpointBackend.forRequest(PreSigninTestCookie, request.cookies)

--- a/frontend/app/controllers/Contributor.scala
+++ b/frontend/app/controllers/Contributor.scala
@@ -9,7 +9,7 @@ import com.gu.stripe.Stripe
 import com.gu.stripe.Stripe.Serializer._
 import com.gu.zuora.soap.models.errors._
 import com.typesafe.scalalogging.LazyLogging
-import controllers.Joiner.{paymentService, _}
+import controllers.Joiner._
 import forms.MemberForm._
 import org.joda.time.LocalDate
 import play.api.Play.current
@@ -22,7 +22,7 @@ import tracking.ActivityTracking
 import utils.CampaignCode
 import utils.RequestCountry._
 import utils.TestUsers.PreSigninTestCookie
-import views.support.{PageInfo, ThankYouMonthlySummary}
+import views.support.{PageInfo, Pricing, ThankYouMonthlySummary}
 
 import scala.concurrent.Future
 import scala.util.Failure
@@ -38,7 +38,7 @@ object Contributor extends Controller with ActivityTracking with PaymentGatewayE
 
   def NonContributorAction = NoCacheAction andThen PlannedOutageProtection andThen authenticated() andThen onlyNonContributorFilter()
 
-  def enterMonthlyContributionsDetails(countryGroup: CountryGroup = UK, contributionValue: Option[Double] = None) = NonContributorAction.async { implicit request =>
+  def enterMonthlyContributionsDetails(countryGroup: CountryGroup = UK, contributionValue: Option[BigDecimal] = None) = NonContributorAction.async { implicit request =>
 
     implicit val resolution: TouchpointBackend.Resolution =
       TouchpointBackend.forRequest(PreSigninTestCookie, request.cookies)
@@ -69,7 +69,7 @@ object Contributor extends Controller with ActivityTracking with PaymentGatewayE
         pageInfo,
         Some(countryGroup),
         resolution,
-        contributionValue.getOrElse(5)))
+        Pricing.bigDecimalToPrice(contributionValue.getOrElse(5))))
     }).andThen { case Failure(e) => logger.error(s"User ${request.user.user.id} could not enter details for paid tier supporter: ${identityRequest.trackingParameters}", e) }
   }
 

--- a/frontend/app/views/fragments/form/stripeCheckout.scala.html
+++ b/frontend/app/views/fragments/form/stripeCheckout.scala.html
@@ -10,4 +10,4 @@
         allowRememberMe: false
     };
 </script>
-<button type="button" class="action choose-payment-method js-stripe-checkout">Credit/Debit Card</button>
+<button type="button" class="action choose-payment-method js-stripe-checkout">Credit/Debit card</button>

--- a/frontend/app/views/joiner/form/monthlyContribution.scala.html
+++ b/frontend/app/views/joiner/form/monthlyContribution.scala.html
@@ -100,7 +100,7 @@
 
                             <div class="form-field monthly-contribution__section">
                                 <label class="label" for="monthly-contribution">Your monthly contribution</label>
-                                <input type="hidden" name="payment.amount" id="monthly-contribution" value="@contributionValue" class="js-monthly-contribution" data-validation="validContributionValue"/>
+                                <input type="hidden" name="payment.amount" id="monthly-contribution" value="@("%.2f".format(contributionValue).replace(".00",""))" class="js-monthly-contribution" data-validation="validContributionValue"/>
                                 <span class="monthly-contribution__amount">£@("%.2f".format(contributionValue).replace(".00",""))</span><span class="monthly-contribution__edit"><a class="text-link">Edit</a></span>
                                 @fragments.form.errorMessage("The minimum monthly contribution is £5.")
                             </div>

--- a/frontend/app/views/joiner/form/monthlyContribution.scala.html
+++ b/frontend/app/views/joiner/form/monthlyContribution.scala.html
@@ -98,10 +98,10 @@
                     <div class="form-panel__content">
                         <div class="fieldset__fields  js-form-panel-payment form-panel--no-margin">
 
-                            <div class="form-field js-monthly-contribution monthly-contribution__section">
+                            <div class="form-field monthly-contribution__section">
                                 <label class="label" for="monthly-contribution">Your monthly contribution</label>
-                                <input type="hidden" name="payment.amount" id="monthly-contribution" value="@contributionValue" data-validation="validContributionValue"/>
-                                <span class="monthly-contribution__amount">£@contributionValue</span>
+                                <input type="hidden" name="payment.amount" id="monthly-contribution" value="@contributionValue" class="js-monthly-contribution" data-validation="validContributionValue"/>
+                                <span class="monthly-contribution__amount">£@contributionValue</span><span class="monthly-contribution__edit"><a class="text-link">Edit</a></span>
                                 @fragments.form.errorMessage("The minimum monthly contribution is £5.")
                             </div>
 

--- a/frontend/app/views/joiner/form/monthlyContribution.scala.html
+++ b/frontend/app/views/joiner/form/monthlyContribution.scala.html
@@ -8,7 +8,7 @@
     pageInfo: PageInfo,
     countryGroup: Option[CountryGroup],
     touchpointBackendResolution: services.TouchpointBackend.Resolution,
-    contributionValue: Int)(implicit token: play.filters.csrf.CSRF.Token, request: actions.AuthRequest[_])
+    contributionValue: Double)(implicit token: play.filters.csrf.CSRF.Token, request: actions.AuthRequest[_])
 
 @main("", pageInfo = pageInfo, titleOverride = Some("Become a contributor"), header = SimpleHeader, margins = false, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
     <script>
@@ -101,7 +101,7 @@
                             <div class="form-field monthly-contribution__section">
                                 <label class="label" for="monthly-contribution">Your monthly contribution</label>
                                 <input type="hidden" name="payment.amount" id="monthly-contribution" value="@contributionValue" class="js-monthly-contribution" data-validation="validContributionValue"/>
-                                <span class="monthly-contribution__amount">£@contributionValue</span><span class="monthly-contribution__edit"><a class="text-link">Edit</a></span>
+                                <span class="monthly-contribution__amount">£@("%.2f".format(contributionValue).replace(".00",""))</span><span class="monthly-contribution__edit"><a class="text-link">Edit</a></span>
                                 @fragments.form.errorMessage("The minimum monthly contribution is £5.")
                             </div>
 

--- a/frontend/app/views/joiner/form/monthlyContribution.scala.html
+++ b/frontend/app/views/joiner/form/monthlyContribution.scala.html
@@ -68,21 +68,14 @@
             <!-- CHECKOUT FORM -->
         <form action="@routes.Contributor.joinMonthlyContribution()" method="POST" id="payment-form" class="js-form" novalidate>
             @CSRF.formField
-
             <section class="form-content">
-
                 <!-- ACCORDION SECTION - NAME -->
-                <section class="form-panel sub-heading form-panel--monthly-contribution">
-
+                <section class="form-panel sub-heading">
                     <div class="form-panel__heading">
-                        <div class="form-panel__edit js-edit-name-address is-hidden">edit</div>
-                        <div class="sign-in-required js-sign-in-note sign-in-required--monthly-contribution">
+                        <div class="sign-in-required js-sign-in-note">
                         @fragments.joiner.signedInAs(request.uri, inline = true)
                         </div>
-                    </div>
-
-                    <div class="form-panel__content js-form-panel-name-address">
-                        <!-- Name -->
+                    </div><div class="form-panel__content js-form-panel-name-address"><!-- Name -->
                         <div class="form-section__name-detail">
                         @fragments.form.nameDetailFields(
                             Some(idUser.privateFields)
@@ -95,9 +88,8 @@
                             @fragments.form.createPassword()
                         }
                     </div>
-
                 </section>
-                <section class="form-panel form-group--little-padding form-panel--monthly-contribution">
+                <section class="form-panel form-group--little-padding">
 
                     <div class="form-panel__heading"></div>
                     <input type="hidden" name="country" id="monthly-contribution-country" value="GB"/>
@@ -106,22 +98,16 @@
                     <div class="form-panel__content">
                         <div class="fieldset__fields  js-form-panel-payment form-panel--no-margin">
 
-                            <div class="js-monthly-contribution">
-                                <div class="form-field js-monthly-contribution-section">
-                                    <label class="label" for="monthly-contribution">Your monthly contribution</label>
-                                    <input type="text"
-                                    name="payment.amount"
-                                    id="monthly-contribution"
-                                    class="input-text js-monthly-contribution"
-                                    data-validation="validContributionValue"
-                                    value="@contributionValue"/>
-                                    @fragments.form.errorMessage("The minimum monthly contribution is £5.")
-                                </div>
+                            <div class="form-field js-monthly-contribution monthly-contribution__section">
+                                <label class="label" for="monthly-contribution">Your monthly contribution</label>
+                                <input type="hidden" name="payment.amount" id="monthly-contribution" value="@contributionValue" data-validation="validContributionValue"/>
+                                <span class="monthly-contribution__amount">£@contributionValue</span>
+                                @fragments.form.errorMessage("The minimum monthly contribution is £5.")
                             </div>
 
                             <!-- Payment Options -->
-                            <fieldset class="fieldset js-payment-methods">
-                                <div class="fieldset__heading fieldset__heading--monthly-contribution">
+                            <fieldset class="fieldset js-payment-methods form-panel__payment">
+                                <div class="fieldset__heading">
                                     <h2 class="fieldset__headline fieldset__headline--payment">Payment methods</h2>
                                     <p class="security-note">@fragments.inlineIcon("lock", List("icon-inline--small", "icon-inline--top")) Secure</p>
                                 </div>

--- a/frontend/app/views/joiner/form/monthlyContribution.scala.html
+++ b/frontend/app/views/joiner/form/monthlyContribution.scala.html
@@ -8,7 +8,7 @@
     pageInfo: PageInfo,
     countryGroup: Option[CountryGroup],
     touchpointBackendResolution: services.TouchpointBackend.Resolution,
-    contributionValue: Double)(implicit token: play.filters.csrf.CSRF.Token, request: actions.AuthRequest[_])
+    contributionValue: String)(implicit token: play.filters.csrf.CSRF.Token, request: actions.AuthRequest[_])
 
 @main("", pageInfo = pageInfo, titleOverride = Some("Become a contributor"), header = SimpleHeader, margins = false, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
     <script>
@@ -100,8 +100,8 @@
 
                             <div class="form-field monthly-contribution__section">
                                 <label class="label" for="monthly-contribution">Your monthly contribution</label>
-                                <input type="hidden" name="payment.amount" id="monthly-contribution" value="@("%.2f".format(contributionValue).replace(".00",""))" class="js-monthly-contribution" data-validation="validContributionValue"/>
-                                <span class="monthly-contribution__amount">£@("%.2f".format(contributionValue).replace(".00",""))</span><span class="monthly-contribution__edit"><a class="text-link">Edit</a></span>
+                                <input type="hidden" name="payment.amount" id="monthly-contribution" value="@contributionValue" class="js-monthly-contribution" data-validation="validContributionValue"/>
+                                <span class="monthly-contribution__amount">£@contributionValue</span><span class="monthly-contribution__edit"><a class="text-link">Edit</a></span>
                                 @fragments.form.errorMessage("The minimum monthly contribution is £5.")
                             </div>
 

--- a/frontend/app/views/support/Pricing.scala
+++ b/frontend/app/views/support/Pricing.scala
@@ -33,6 +33,8 @@ case class Pricing(yearly: Price, monthly: Price) {
 }
 
 object Pricing {
+  def bigDecimalToPrice(price: BigDecimal): String = "%.2f".format(price).replace(".00","")
+
   implicit class WithPricing(plans: PaidMembershipPlans[PaidMemberTier]) {
     lazy val allPricing: List[Pricing] = Currency.all.flatMap(pricing)
 

--- a/frontend/assets/javascripts/src/modules/form/stripe.es6
+++ b/frontend/assets/javascripts/src/modules/form/stripe.es6
@@ -13,7 +13,7 @@ export function init() {
         let period = billingPeriod.noun;
         const monthlyContributionField = $('.js-monthly-contribution');
         if (monthlyContributionField.length > 0){
-            amount = "£" + parseFloat(monthlyContributionField[1].value);
+            amount = "£" + parseFloat(monthlyContributionField[0].value);
         }
         return "Pay " + amount + " per " + period;
     };

--- a/frontend/assets/stylesheets/components/_payment-monthly-contribution.scss
+++ b/frontend/assets/stylesheets/components/_payment-monthly-contribution.scss
@@ -15,10 +15,15 @@
 
     .fieldset__headline.fieldset__headline--payment {
         @include fs-bodyCopy(2);
-        color: $c-neutral1;
+        color: guss-colour(neutral-1);
         cursor: pointer;
-        display: block;
+        display: inline-block;
         font-weight: 400;
+
+    }
+
+    .form-panel__payment > .fieldset__heading {
+        display: inline-block;
     }
 
     .fieldset__fields.form-panel--no-margin,
@@ -26,8 +31,9 @@
         margin-bottom: 0;
     }
 
-    .security-note {
-        margin-top: $gs-baseline;
+    .fieldset__heading > .security-note {
+        margin: 0;
+        padding: 4px 0 0;
     }
 
     .form-panel__content.js-form-panel-name-address,
@@ -52,27 +58,55 @@
         font-weight: 400;
     }
 
+    .monthly-contribution__edit {
+        float: right;
+    }
+
+    .monthly-contribution__edit > .text-link,
+    .text-note > .text-link {
+        @include fs-textSans(1)
+        border-bottom-color: guss-colour(comment-main-2);
+    }
+
     .monthly-contribution__section {
-        padding-top: 5px;
-        padding-bottom: 18px;
+        padding: 2px 0 18px;
         border-top: dotted guss-colour(comment-main-1) 1px;
         border-bottom: dotted guss-colour(comment-main-1) 1px;
+        display: inline-block;
+        width: 100%;
     }
 
     .checkout-header > .checkout-headline {
         font-weight: 900;
+        line-height: 38px;
+    }
+
+    section.checkout-header {
+        padding-bottom: $gs-baseline * 2;
     }
 
     .form-field {
-        margin-top: 24px;
+        margin-top: $gs-baseline * 2;
         margin-bottom: 0;
     }
 
+
+    @include mq($from: tablet) {
+        .form-section__name-detail .form-field:first-of-type {
+            margin-top: 0;
+        }
+    }
+
+    .form-panel__payment > .fieldset__fields > .form-field:nth-of-type(2),
+    .form-panel__payment > .fieldset__fields > .form-field:first-of-type {
+        margin-top: 0;
+    }
+
     .form-panel__payment > .fieldset__fields > .form-field {
-        margin-top: 12px;
+        margin-top: $gs-baseline;
     }
 
     .form-panel__payment > .fieldset__fields {
-        padding-bottom: 12px;
+        padding-bottom: $gs-baseline;
     }
 }

--- a/frontend/assets/stylesheets/components/_payment-monthly-contribution.scss
+++ b/frontend/assets/stylesheets/components/_payment-monthly-contribution.scss
@@ -1,8 +1,7 @@
 
 .skin-monthly-contribution {
     .sign-in-required .text-note {
-        margin-left: 0;
-        padding-top: 8px;
+        margin: 0;
     }
 
     .form-content .form-panel,
@@ -10,12 +9,8 @@
         border-top: none;
     }
 
-    .fieldset .fieldset__fields {
-        margin-bottom: $gs-baseline;
-    }
-
     .fieldset .fieldset__heading {
-        margin-bottom: $gs-baseline;
+        padding-top: 5px;
     }
 
     .fieldset__headline.fieldset__headline--payment {
@@ -26,7 +21,8 @@
         font-weight: 400;
     }
 
-    .fieldset__fields.form-panel--no-margin {
+    .fieldset__fields.form-panel--no-margin,
+    .fieldset > .fieldset__fields {
         margin-bottom: 0;
     }
 
@@ -39,7 +35,44 @@
         margin-bottom: 0;
     }
 
-    .form-panel  .form-panel__heading {
+    .form-panel > .form-panel__heading {
         padding-bottom: 0;
+    }
+
+    .sub-heading > .form-panel__heading {
+        padding-top: 7px;
+    }
+
+    section .form-panel {
+        background-color : guss-colour(multimedia-main-2);
+    }
+
+    .monthly-contribution__amount {
+        @include fs-header(5);
+        font-weight: 400;
+    }
+
+    .monthly-contribution__section {
+        padding-top: 5px;
+        padding-bottom: 18px;
+        border-top: dotted guss-colour(comment-main-1) 1px;
+        border-bottom: dotted guss-colour(comment-main-1) 1px;
+    }
+
+    .checkout-header > .checkout-headline {
+        font-weight: 900;
+    }
+
+    .form-field {
+        margin-top: 24px;
+        margin-bottom: 0;
+    }
+
+    .form-panel__payment > .fieldset__fields > .form-field {
+        margin-top: 12px;
+    }
+
+    .form-panel__payment > .fieldset__fields {
+        padding-bottom: 12px;
     }
 }

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -38,7 +38,7 @@ GET            /choose-tier                           controllers.Joiner.tierCho
 GET            /membership-content                    controllers.MemberOnlyContent.membershipContent(referringContent: Option[String] ?= None)
 
 # Monthly Contribution
-GET            /monthly-contribution                  controllers.Contributor.enterMonthlyContributionsDetails(countryGroup: CountryGroup ?= CountryGroup.UK, contributionValue : Option[Double] ?= None)
+GET            /monthly-contribution                  controllers.Contributor.enterMonthlyContributionsDetails(countryGroup: CountryGroup ?= CountryGroup.UK, contributionValue : Option[BigDecimal] ?= None)
 POST           /monthly-contribution                  controllers.Contributor.joinMonthlyContribution
 GET            /monthly-contribution/thankyou         controllers.Contributor.thankyouContributor
 

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -38,7 +38,7 @@ GET            /choose-tier                           controllers.Joiner.tierCho
 GET            /membership-content                    controllers.MemberOnlyContent.membershipContent(referringContent: Option[String] ?= None)
 
 # Monthly Contribution
-GET            /monthly-contribution                  controllers.Contributor.enterMonthlyContributionsDetails(countryGroup: CountryGroup ?= CountryGroup.UK, contributionValue : Option[Int] ?= None)
+GET            /monthly-contribution                  controllers.Contributor.enterMonthlyContributionsDetails(countryGroup: CountryGroup ?= CountryGroup.UK, contributionValue : Option[Double] ?= None)
 POST           /monthly-contribution                  controllers.Contributor.joinMonthlyContribution
 GET            /monthly-contribution/thankyou         controllers.Contributor.thankyouContributor
 

--- a/frontend/test/views/support/PricingTest.scala
+++ b/frontend/test/views/support/PricingTest.scala
@@ -1,0 +1,36 @@
+package views.support
+
+import org.joda.time.DateTime
+import org.joda.time.Interval
+import org.specs2.mutable.Specification
+
+class PricingTest extends Specification {
+
+
+  "bigDecimalToPrice" should {
+    "show 1 as 1 and not 1.00" in {
+      val bigDecimal = BigDecimal("1")
+      Pricing.bigDecimalToPrice(bigDecimal) mustEqual  "1"
+    }
+
+    "show 1.5 as 1.50" in {
+      val bigDecimal = BigDecimal("1.5")
+      Pricing.bigDecimalToPrice(bigDecimal) mustEqual  "1.50"
+    }
+
+    "show 0.123 as 0.12" in {
+      val bigDecimal = BigDecimal("0.123")
+      Pricing.bigDecimalToPrice(bigDecimal) mustEqual  "0.12"
+    }
+
+    "show 0.127 as 0.13" in {
+      val bigDecimal = BigDecimal("0.127")
+      Pricing.bigDecimalToPrice(bigDecimal) mustEqual  "0.13"
+    }
+
+    "show 0.125 as 0.13" in {
+      val bigDecimal = BigDecimal("0.125")
+      Pricing.bigDecimalToPrice(bigDecimal) mustEqual  "0.13"
+    }
+  }
+}


### PR DESCRIPTION
## Why are you doing this?

We would like to have a coherent flow from the design point of view for the 'monthly contribution' product. As a result, our user will feel less confused about the flow.
## Trello card: [Here](https://trello.com/c/zzUjEiMP/410-apply-the-new-design-to-monthly-contribution-checkout)

## Changes
* Applied the new design for the monthly contribution form.

## Tested in
| Browser | Supporter Stripe checkout | Supporter Paypal checkout | Stripe Monthly Contribution |  Paypal Monthly Contribution|
|---------|-----------------|-----------------|----------------------|----------------------|
| IE      |      🐟             |     🐟                  |      🐟                 |       🐟                   |
| Chrome  |       🐕                |      🐕                      |                   🐕       |                🐕        |  


## Screenshots

### Desired design
![monthlycss](https://cloud.githubusercontent.com/assets/825398/24252965/e46675f2-0fd6-11e7-9154-465ae3e01746.png)

### Before

![monthbeforea](https://cloud.githubusercontent.com/assets/825398/24253009/020a948a-0fd7-11e7-9082-ea46d0a88889.png)

### After

![monthlymobile](https://cloud.githubusercontent.com/assets/825398/24253142/622d4fce-0fd7-11e7-88a6-a1943edf3499.png)

![monthlynewcsswide](https://cloud.githubusercontent.com/assets/825398/24253149/6926c634-0fd7-11e7-91da-f51e991f8b55.png)
