### PR TITLE
Copy change and PayPal fix for monthly contributions

### DIFF
--- a/frontend/app/views/fragments/form/terms.scala.html
+++ b/frontend/app/views/fragments/form/terms.scala.html
@@ -4,7 +4,7 @@
 
 @(countryGroup: Option[CountryGroup] = None, monthlyContribution: Boolean = false)
 
-<p class="ts-and-cs">@if(monthlyContribution){By proceeding,}else{By joining Guardian Members,} you are agreeing to our
+<p class="ts-and-cs">@if(monthlyContribution){By proceeding,} else {By joining Guardian Members,} you are agreeing to our
     <a href="@Links.membershipTerms(countryGroup)" class="text-link" target="_blank">Terms and Conditions</a> and
     <a href="@Links.guardianPrivacyPolicy" class="text-link" target="_blank">Privacy Policy</a>.
 </p>

--- a/frontend/app/views/fragments/form/terms.scala.html
+++ b/frontend/app/views/fragments/form/terms.scala.html
@@ -2,9 +2,9 @@
 @import com.gu.i18n.CountryGroup
 @import configuration.CopyConfig.usLegalTerms
 
-@(countryGroup: Option[CountryGroup] = None)
+@(countryGroup: Option[CountryGroup] = None, monthlyContribution: Boolean = false)
 
-<p class="ts-and-cs">By joining Guardian Members, you are agreeing to our
+<p class="ts-and-cs">@if(monthlyContribution){By proceeding,}else{By joining Guardian Members,} you are agreeing to our
     <a href="@Links.membershipTerms(countryGroup)" class="text-link" target="_blank">Terms and Conditions</a> and
     <a href="@Links.guardianPrivacyPolicy" class="text-link" target="_blank">Privacy Policy</a>.
 </p>

--- a/frontend/app/views/joiner/form/monthlyContribution.scala.html
+++ b/frontend/app/views/joiner/form/monthlyContribution.scala.html
@@ -100,7 +100,7 @@
 
                             <div class="form-field monthly-contribution__section">
                                 <label class="label" for="monthly-contribution">Your monthly contribution</label>
-                                <input type="hidden" name="payment.amount" id="monthly-contribution" value="@contributionValue" class="js-monthly-contribution" data-validation="validContributionValue"/>
+                                <input type="hidden" name="payment.amount" id="monthly-contribution" value="@contributionValue" data-validation="validContributionValue"/>
                                 <span class="monthly-contribution__amount">£@contributionValue</span><span class="monthly-contribution__edit"><a class="text-link">Edit</a></span>
                                 @fragments.form.errorMessage("The minimum monthly contribution is £5.")
                             </div>
@@ -130,7 +130,7 @@
                         </div>
                     </div>
                 </section>
-                @fragments.form.terms(countryGroup)
+                @fragments.form.terms(countryGroup, monthlyContribution = true)
             </section>
         </form>
     </main>

--- a/frontend/assets/javascripts/src/modules/form/paypal.es6
+++ b/frontend/assets/javascripts/src/modules/form/paypal.es6
@@ -25,7 +25,7 @@ function handleSetupResponse (response) {
 
 function getAmount(checkoutForm) {
     if (checkoutForm.isMonthlyContributorCheckout) {
-        return parseInt(document.getElementById('monthly-contribution').value);
+        return parseFloat(document.getElementById('monthly-contribution').value);
     }
     return checkoutForm.billingPeriods[checkoutForm.billingPeriod].amount[checkoutForm.currency];
 }

--- a/frontend/assets/javascripts/src/modules/form/stripe.es6
+++ b/frontend/assets/javascripts/src/modules/form/stripe.es6
@@ -11,9 +11,9 @@ export function init() {
         let billingPeriod = guardian.membership.checkoutForm.billingPeriods[guardian.membership.checkoutForm.billingPeriod];
         let amount = billingPeriod.generateDisplayAmount();
         let period = billingPeriod.noun;
-        const monthlyContributionField = $('.js-monthly-contribution');
-        if (monthlyContributionField.length > 0){
-            amount = "£" + parseFloat(monthlyContributionField[0].value);
+        const monthlyContributionField = document.getElementById('monthly-contribution');
+        if (monthlyContributionField) {
+            amount = "£" + parseFloat(monthlyContributionField.value);
         }
         return "Pay " + amount + " per " + period;
     };


### PR DESCRIPTION
## Why are you doing this?
In the monthly checkout flow, we don't want to show "By joining Guardian Members, ...", instead, we want to show "By proceeding, ..". In addition, a fix in the javascript code in the PayPal flow is introduced, now we are able to charge pence in Paypal.

## Trello card: [Here](https://trello.com/c/u9LTwlZ1/428-update-the-copy-for-monthly-contribution-checkout-flow)

## Changes
* Updated the T&C copy for monthly contribution
* Parse float the amount for PayPal checkout

## Tested in
| Browser | Supporter Stripe checkout | Supporter Paypal checkout | Stripe Monthly Contribution |  Paypal Monthly Contribution|
|---------|---------------------------|---------------------------|-----------------------------|-----------------------------|
| IE      | ✅                           |   ✅                         |                         ✅     |                          ✅    | 


## Screenshots

### Before
We can see that we introduced 20.50 but PayPal shows 20.00. In addition, the copy states: "By Joining Guardian Members,..."

<img width="759" alt="picture 225" src="https://cloud.githubusercontent.com/assets/825398/24301980/ec3ddb9e-10a8-11e7-8440-55393ac69c03.png">

### After

<img width="628" alt="picture 226" src="https://cloud.githubusercontent.com/assets/825398/24302653/4599cb56-10ab-11e7-849f-50b5eefcb8f3.png">

We still show Guardian Members in other flows.

![pi123](https://cloud.githubusercontent.com/assets/825398/24302808/ced8e0aa-10ab-11e7-8570-4529e152fa5c.png)




