### PR TITLE
Fix the roundel overlap

### DIFF
--- a/frontend/assets/stylesheets/components/_contributions.scss
+++ b/frontend/assets/stylesheets/components/_contributions.scss
@@ -140,6 +140,7 @@ $max-content-width: 750px;
 
 .contributions__inner {
     background: $medium-yellow;
+    clear: both;
 
     @include mq(tablet) {
         padding-top: 18px;

--- a/frontend/assets/stylesheets/components/_guardian-header.scss
+++ b/frontend/assets/stylesheets/components/_guardian-header.scss
@@ -38,10 +38,10 @@
 }
 
 .guardian-header__roundel-height {
-    height: 36px;
+    height: 42px;
     width: 42px;
     @include mq($from: mobile-wider) {
-        height: 46px;
+        height: 52px;
         width: 52px;
     }
 }


### PR DESCRIPTION
## Why are you doing this?
In response to feedback from design that the roundel in the navigation should overlap the top of the content

## Trello card: Nope

## Screenshots
Old version (note that the roundel is clipped by the bottom of the header):
![screen shot 2017-03-28 at 10 13 43](https://cloud.githubusercontent.com/assets/181371/24397942/a66ec944-139f-11e7-869f-fc7d7ed90d63.png)
New version (the roundel overlaps the content):
![screen shot 2017-03-28 at 18 27 02](https://cloud.githubusercontent.com/assets/181371/24418554/389c5d38-13e4-11e7-87b6-9043057eac5c.png)

