### PR TITLE
Render a supporter page for /US/supporter as well as /us/supporter etc

### DIFF
--- a/frontend/app/controllers/Binders.scala
+++ b/frontend/app/controllers/Binders.scala
@@ -37,11 +37,11 @@ object Binders {
   )
 
   implicit object bindableCountryGroupPathParser extends PathParsing[CountryGroup](
-    id => CountryGroup.byId(id).get, _.id, (key: String, _: Exception) => s"Cannot parse path parameter $key as a CountryGroup"
+    id => (CountryGroup.byId(id) orElse CountryGroup.byCountryCode(id)).get, _.id, (key: String, _: Exception) => s"Cannot parse path parameter $key as a CountryGroup"
   )
 
   implicit object bindableCountryGroupQueryParser extends QueryParsing[CountryGroup](
-    id => CountryGroup.byId(id).get, _.id, (key: String, _: Exception) => s"Cannot parse parameter $key as a CountryGroup"
+    id => (CountryGroup.byId(id) orElse CountryGroup.byCountryCode(id)).get, _.id, (key: String, _: Exception) => s"Cannot parse parameter $key as a CountryGroup"
   )
 
   implicit object bindablePrpId extends QueryParsing[ProductRatePlanId](


### PR DESCRIPTION
Render a supporter page for /US/supporter as well as /us/supporter as 
## Why are you doing this?
Many big email comms keep going out with that capitalised URL. Right now it shows a horrible 400 error.
https://sentry.io/the-guardian/membership/issues/123747866/
<img width="328" alt="picture 63" src="https://cloud.githubusercontent.com/assets/1515970/24459284/0ce3a0c0-1493-11e7-8029-0950f9079165.png">

## Changes
* Render a supporter page for /US/supporter as well as /us/supporter etc

## Screenshots
![picture 62](https://cloud.githubusercontent.com/assets/1515970/24459218/e77f01a8-1492-11e7-9db8-1583b38a6415.png)

cc @rtyley @jacobwinch 