### PR TITLE
Bundles Landing Page - Pass Through INTCMP (And Other Tweaks)

### DIFF
--- a/frontend/app/views/bundle/bundlesLanding.scala.html
+++ b/frontend/app/views/bundle/bundlesLanding.scala.html
@@ -78,7 +78,7 @@
 						<div>
 							<p class="bundles__copy bundles__copy--bottom js-digital-details">Support the Guardian and enjoy a subscription to our digital Daily Edition and the premium tier of our app.</p>
 							<div class="bundles__more-details js-digital-more"><button>@fragments.inlineIcon("cross-upright")</button> More details</div>
-							<a class="bundles__cta" href="https://subscribe.theguardian.com/uk/digital?INTCMP=GU_SIMPLE_UK_DIGITAL">Become a digital subscriber @fragments.inlineIcon("arrow-right-straight")</a>
+							<a class="bundles__cta js-digi-link" href="https://subscribe.theguardian.com/uk/digital">Become a digital subscriber @fragments.inlineIcon("arrow-right-straight")</a>
 						</div>
 					</div>
 				</div>
@@ -115,7 +115,7 @@
 						<div>
 							<p class="bundles__copy bundles__copy--bottom js-print-details">Support the Guardian and enjoy a subscription to the Guardian and the Observer newspapers.</p>
 							<div class="bundles__more-details js-print-more"><button>@fragments.inlineIcon("cross-upright")</button> More details</div>
-							<a class="bundles__cta js-print-link" href="https://subscribe.theguardian.com/collection/paper-digital?INTCMP=GU_SIMPLE_UK_PAPER_DIGITAL">Become a paper subscriber @fragments.inlineIcon("arrow-right-straight")</a>
+							<a class="bundles__cta js-print-link" href="https://subscribe.theguardian.com/collection/paper-digital">Become a paper subscriber @fragments.inlineIcon("arrow-right-straight")</a>
 						</div>
 					</div>
 				</div>

--- a/frontend/app/views/bundle/bundlesLanding.scala.html
+++ b/frontend/app/views/bundle/bundlesLanding.scala.html
@@ -49,7 +49,7 @@
 							<button class="contribution-fields__amount js-contribution-one contribution-fields__field--selected">£5</button>
 							<button class="contribution-fields__amount js-contribution-two">£10</button>
 							<button class="contribution-fields__amount js-contribution-three">£20</button>
-							<input type="text" class="contribution-fields__other-amount js-contribution-other" placeholder="Other amount">
+							<input type="text" class="contribution-fields__other-amount js-contribution-other" placeholder="Other amount (£)">
 						</div>
 						<div class="contribution-error js-contribution-error"></div>
 						<div>

--- a/frontend/app/views/bundle/bundlesLanding.scala.html
+++ b/frontend/app/views/bundle/bundlesLanding.scala.html
@@ -12,7 +12,14 @@
 	eventsImage: ResponsiveImageGroup
 )
 
-@main("Support The Guardian", pageInfo=pageInfo, header=GuardianHeader, footer=SimpleFooter, margins=false) {
+@main(
+	"Support The Guardian",
+	pageInfo=pageInfo,
+	header=GuardianHeader,
+	footer=SimpleFooter,
+	margins=false,
+	titleOverride=Some("Support the Guardian")
+) {
 
 	<section class="introduction">
 		<div class="introduction__content">

--- a/frontend/assets/javascripts/src/modules/bundlesLanding.es6
+++ b/frontend/assets/javascripts/src/modules/bundlesLanding.es6
@@ -1,3 +1,8 @@
+// ----- Imports ----- //
+
+import URLSearchParams from 'URLSearchParams';
+
+
 // ----- Setup ----- //
 
 const SELECTED_CONTRIB = 'contribution-fields__field--selected';
@@ -5,15 +10,20 @@ const SELECTED_PRINT = 'print-fields__field--selected';
 const SHOW_DETAILS = 'show-details';
 const MONTHLY_URL = '/monthly-contribution';
 const ONEOFF_URL = 'https://contribute.theguardian.com/uk';
-const PRINT_DIGI_URL = 'https://subscribe.theguardian.com/collection/paper-digital?INTCMP=GU_SIMPLE_UK_PAPER_DIGITAL';
-const PRINT_URL = 'https://subscribe.theguardian.com/collection/paper?INTCMP=GU_SIMPLE_UK_PAPER';
+const DIGI_URL = 'https://subscribe.theguardian.com/uk/digital';
+const PRINT_DIGI_URL = 'https://subscribe.theguardian.com/collection/paper-digital';
+const PRINT_URL = 'https://subscribe.theguardian.com/collection/paper';
 const CONTRIB_ERROR = 'contribution-error--shown';
+const DEFAULT_INTCMP = 'gdnwb_copts_bundles_landing_default';
 
-let STATE = {
+const STATE = {
 	contribAmount: '5',
 	contribPeriod: 'MONTHLY',
 	printBundle: 'PRINT+DIGITAL',
-	amountButton: 'ONE'
+	amountButton: 'ONE',
+	intcmp: null,
+	printUrl: PRINT_URL,
+	printDigiUrl: PRINT_DIGI_URL
 };
 
 const PRICES = {
@@ -39,6 +49,47 @@ const ERRORS = {
 
 // ----- Functions ----- //
 
+function contribLink (elems) {
+
+	let params = new URLSearchParams();
+	params.append('INTCMP', STATE.intcmp);
+
+	if (STATE.contribPeriod === 'MONTHLY') {
+		params.append('contributionValue', STATE.contribAmount);
+		elems.contribLink.href = `${MONTHLY_URL}?${params.toString()}`;
+	} else {
+		params.append('amount', STATE.contribAmount);
+		elems.contribLink.href = `${ONEOFF_URL}?${params.toString()}`;
+	}
+
+}
+
+function subsLinks (elems) {
+
+	let params = new URLSearchParams();
+	params.append('INTCMP', STATE.intcmp);
+
+	const digiUrl = `${DIGI_URL}?${params.toString()}`;
+	STATE.printDigiUrl = `${PRINT_DIGI_URL}?${params.toString()}`;
+	STATE.printUrl = `${PRINT_URL}?${params.toString()}`;
+
+	elems.digiLink.href = digiUrl;
+	elems.printLink.href = STATE.printDigiUrl;
+
+}
+
+function updateLinks (elems) {
+
+	let currentParams = new URLSearchParams(window.location.search.slice(1));
+	let campaignCode = currentParams.get('INTCMP');
+
+	STATE.intcmp = campaignCode ? campaignCode : DEFAULT_INTCMP;
+
+	contribLink(elems);
+	subsLinks(elems);
+
+}
+
 function contribUpdate (elems) {
 
 	let amount = PRICES[STATE.contribPeriod][STATE.amountButton];
@@ -48,21 +99,17 @@ function contribUpdate (elems) {
 	elems.contribTwo.textContent = `£${PRICES[STATE.contribPeriod].TWO}`;
 	elems.contribThree.textContent = `£${PRICES[STATE.contribPeriod].THREE}`;
 
-	if (STATE.contribPeriod === 'MONTHLY') {
-		elems.contribLink.href = `${MONTHLY_URL}?contributionValue=${STATE.contribAmount}`;
-	} else {
-		elems.contribLink.href = `${ONEOFF_URL}?amount=${STATE.contribAmount}`;
-	}
+	contribLink(elems);
 
 }
 
 function printUpdate (elems, bundle) {
 
 	if (bundle === 'PRINT') {
-		elems.printLink.href = PRINT_URL;
+		elems.printLink.href = STATE.printUrl;
 		elems.digitalBenefits.classList.add('is-hidden');
 	} else {
-		elems.printLink.href = PRINT_DIGI_URL;
+		elems.printLink.href = STATE.printDigiUrl;
 		elems.digitalBenefits.classList.remove('is-hidden');
 	}
 
@@ -241,6 +288,7 @@ function getElems () {
 		print: document.getElementsByClassName('js-print-paper')[0],
 		printDigital: document.getElementsByClassName('js-print-paper-digital')[0],
 		contribLink: document.getElementsByClassName('js-contrib-link')[0],
+		digiLink: document.getElementsByClassName('js-digi-link')[0],
 		printLink: document.getElementsByClassName('js-print-link')[0],
 		digitalBenefits: document.getElementsByClassName('js-digital-benefits')[0],
 		digitalMore: document.getElementsByClassName('js-digital-more')[0],
@@ -260,6 +308,7 @@ export function init () {
 
 		let elems = getElems();
 
+		updateLinks(elems);
 		contributionClicks(elems);
 		validateOtherAmount(elems);
 		amountClicks(elems);

--- a/frontend/assets/javascripts/src/modules/bundlesLanding.es6
+++ b/frontend/assets/javascripts/src/modules/bundlesLanding.es6
@@ -143,6 +143,8 @@ function validateOtherAmount (elems) {
 			contribError(elems, 'badInput');
 		} else if (amount < 5 && STATE.contribPeriod === 'MONTHLY') {
 			contribError(elems, 'tooLittle');
+		} else if (amount < 1 && STATE.contribPeriod === 'ONE_OFF') {
+			contribError(elems, 'tooLittle');
 		} else if (amount > 2000) {
 			contribError(elems, 'tooMuch');
 		} else {

--- a/frontend/assets/stylesheets/components/_bundle-landing.scss
+++ b/frontend/assets/stylesheets/components/_bundle-landing.scss
@@ -339,9 +339,9 @@ $why-support-colour: #7cb523;
 	}
 }
 
-.contribution-fields__amount::placeholder {
-	font-weight: normal;
-	color: guss-colour(neutral-3);
+.contribution-fields__field--selected::placeholder {
+	color: #fff;
+	opacity: 0.4;
 }
 
 .contribution-fields__type, .print-fields__type {


### PR DESCRIPTION
## Why are you doing this?

We want to keep track of how users are moving through the landing page flow, which we plan to do with INTCMP code. This passes INTCMP codes through from wherever the user arrives from (e.g. the epic), to the places they end up at (e.g. contributions, subs, etc.). If there is no INTCMP code, it sets a default: `gdnwb_copts_bundles_landing_default` (@jranks123, @desbo, @alexduf does this default work for you?).

It also includes some minor UI tweaks and fixes.

## Changes

- Tweak js to pass through INTCMP codes, or set a default in the situation this param is missing.
- Added minimum amount for contributions (fixes a bug where spaces were interpreted as `0` in other amount, because JavaScript is stupid).
- Changes the title of the page to 'Support the Guardian'.
- Minor tweak to other amount placeholder colour and added a `£` symbol.