### PR TITLE
Remove duplication by payment-methods in `createContributor()`

### DIFF
--- a/frontend/app/services/api/MemberService.scala
+++ b/frontend/app/services/api/MemberService.scala
@@ -8,6 +8,7 @@ import com.gu.memsub.subsv2._
 import com.gu.memsub.{BillingSchedule, Subscription => S}
 import com.gu.salesforce.{ContactId, PaidTier, Tier}
 import com.gu.stripe.Stripe.Customer
+import com.gu.zuora.soap.models.Commands.PaymentMethod
 import com.gu.zuora.soap.models.Results.{CreateResult, SubscribeResult}
 import controllers.IdentityRequest
 import forms.MemberForm._
@@ -92,10 +93,9 @@ trait MemberService {
   def createContribution(contactId: ContactId,
                          joinData: ContributorForm,
                          nameData: NameForm,
-                         stripeCustomer: Option[Customer],
                          campaignCode: Option[CampaignCode],
                          email: String,
-                         payPalEmail: Option[String]): Future[SubscribeResult]
+                         paymentMethod: Option[PaymentMethod]): Future[SubscribeResult]
 }
 
 object MemberService {


### PR DESCRIPTION
## Why are you doing this?

This was prompted by the duplication in `createContributor()` increasing in size slightly with https://github.com/guardian/membership-frontend/pull/1567#discussion_r108980121

By abstracting the payment method a little earlier, we can remove a lot of the duplicated creation steps (they're really important steps, so it's good not to duplicate them!), and reduce the number of arguments passed to methods.

This is a pure refactor, and should not affect functionality!