### PR TITLE
Change the link destinations and the nav size

### DIFF
--- a/frontend/app/views/fragments/global/guardianHeader.scala.html
+++ b/frontend/app/views/fragments/global/guardianHeader.scala.html
@@ -3,15 +3,17 @@
 @import com.gu.i18n.CountryGroup
 @(pageInfo: PageInfo, countryGroup: Option[CountryGroup])
 
+@url = {https://www.theguardian.com}
+
 <header class="guardian-header hidden-print js-header" role="banner">
     <div class="guardian-header__inner l-constrained header-padding">
         <div class="guardian-header__logo">
-            <a href="/" class="guardian-header__logo-link guardian-header__title-height">
-                @fragments.common.inlineSvgImage(Logos.guardianTitlePiece, List("guardian-header__title-height"))
+            <a href="@url" class="guardian-header__logo-link guardian-header__title-height">
+            @fragments.common.inlineSvgImage(Logos.guardianTitlePiece, List("guardian-header__title-height"))
             </a>
         </div>
         <div class="guardian-header__logo guardian-header__logo-roundel">
-            <a href="/" class="guardian-header__logo-link guardian-header__roundel-height">
+            <a href="@url" class="guardian-header__logo-link guardian-header__roundel-height">
             @fragments.common.inlineSvgImage(Logos.guardianRoundel, List("guardian-header__roundel-height"))
             </a>
         </div>

--- a/frontend/app/views/joiner/thankyouMonthly.scala.html
+++ b/frontend/app/views/joiner/thankyouMonthly.scala.html
@@ -20,7 +20,6 @@
     "Thank you!"
 }
 
-
 @getStarted(title: String)(content: Html) = {
     <section class="page-section page-section--bordered">
         <div class="page-section__lead-in">

--- a/frontend/assets/stylesheets/components/_guardian-header.scss
+++ b/frontend/assets/stylesheets/components/_guardian-header.scss
@@ -94,9 +94,6 @@
     @include mq($from: mobileLandscape) {
         @include font-size(24, 42);
     }
-    @include mq($from: tablet) {
-        @include font-size(28, 48);
-    }
 }
 
 .guardian-header__navigation-list {


### PR DESCRIPTION
## Why are you doing this?
Alex B via Ben has asked for some minor changes to the text size of the navigation. 

## Trello card: [Here](https://trello.com/c/4DDZFxF6/433-minor-changes-to-navigation)

## Changes
* Logos in the nav bar now link to the Guardian main site
* Reduce the size of the text in the nav bar for tablet and above

<!--
If you are making heavy client-side changes, consider manual test the following
critical flow before merging
## Tested in
| Browser | Supporter Stripe checkout | Supporter Paypal checkout | Stripe Monthly Contribution |  Paypal Monthly Contribution| Upgrade from Friend to Supporter  |
|---------|---------------------------|---------------------------|-----------------------------|-----------------------------|-----------------------------------|
| IE      |                           |                           |                             |                             |                                   |
| Firefox |                           |                           |                             |                             |                                   |
| Safari  |                           |                           |                             |                             |                                   |
| Chrome  |                           |                           |                             |                             |                                   |

-->
