### PR TITLE
Remove Edit Button From Monthly Contribution Checkout

### DIFF
--- a/frontend/app/views/joiner/form/monthlyContribution.scala.html
+++ b/frontend/app/views/joiner/form/monthlyContribution.scala.html
@@ -102,7 +102,7 @@
                             <div class="form-field monthly-contribution__section">
                                 <label class="label" for="monthly-contribution">Your monthly contribution</label>
                                 <input type="hidden" name="payment.amount" id="monthly-contribution" value="@contributionValue" data-validation="validContributionValue"/>
-                                <span class="monthly-contribution__amount">£@contributionValue</span><span class="monthly-contribution__edit"><a class="text-link">Edit</a></span>
+                                <span class="monthly-contribution__amount">£@contributionValue</span>
                                 @fragments.form.errorMessage("The minimum monthly contribution is £5.")
                             </div>
 

--- a/frontend/assets/stylesheets/components/_payment-monthly-contribution.scss
+++ b/frontend/assets/stylesheets/components/_payment-monthly-contribution.scss
@@ -58,11 +58,6 @@
         font-weight: 400;
     }
 
-    .monthly-contribution__edit {
-        float: right;
-    }
-
-    .monthly-contribution__edit > .text-link,
     .text-note > .text-link {
         @include fs-textSans(1)
         border-bottom-color: guss-colour(comment-main-2);


### PR DESCRIPTION
## Why are you doing this?

We've decided we don't want the edit button on the monthly contribution checkout. It was planned to send people back to the landing page, and we've decided that from a UX perspective that's a bit wonky.

[**Trello Card**](https://trello.com/c/PF0UyQDj/427-remove-the-edit-button-from-monthly-contribution-checkout-screen)

## Changes

- Removed it from the HTML.
- Removed the corresponding CSS.

## Screenshots

To follow.