### PR TITLE
Allow the app to access the thank you email SQS queue

### DIFF
--- a/cloud-formation/membership-app.cf.json
+++ b/cloud-formation/membership-app.cf.json
@@ -49,11 +49,6 @@
             "Description": "ELB SSL Certificate ARN",
             "Type": "String"
         },
-        "EmailSqsQueueArn": {
-            "Description": "The ARN of the email SQS queue",
-            "Type": "String",
-            "Default": "arn:aws:sqs:eu-west-1:865473395570:contributions-thanks"
-        },
         "VulnerabilityScanningSecurityGroup": {
             "Description": "Security group that grants access to the account's Vulnerability Scanner",
             "Type": "AWS::EC2::SecurityGroup::Id"
@@ -204,11 +199,7 @@
                                     "sqs:GetQueueUrl",
                                     "sqs:SendMessage"
                                 ],
-                                "Resource": [
-                                    {
-                                        "Ref": "EmailSqsQueueArn"
-                                    }
-                                ]
+                                "Resource": "arn:aws:sqs:eu-west-1:865473395570:contributions-thanks"
                             }
                         ]
                     }

--- a/cloud-formation/membership-app.cf.json
+++ b/cloud-formation/membership-app.cf.json
@@ -49,6 +49,11 @@
             "Description": "ELB SSL Certificate ARN",
             "Type": "String"
         },
+        "EmailSqsQueueArn": {
+            "Description": "The ARN of the email SQS queue",
+            "Type": "String",
+            "Default": "arn:aws:sqs:eu-west-1:865473395570:contributions-thanks"
+        },
         "VulnerabilityScanningSecurityGroup": {
             "Description": "Security group that grants access to the account's Vulnerability Scanner",
             "Type": "AWS::EC2::SecurityGroup::Id"
@@ -189,6 +194,26 @@
                     }
                 },
                 {
+                    "PolicyName": "SqsMessages",
+                    "PolicyDocument": {
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Effect": "Allow",
+                                "Action": [
+                                    "sqs:GetQueueUrl",
+                                    "sqs:SendMessage"
+                                ],
+                                "Resource": [
+                                    {
+                                        "Ref": "EmailSqsQueueArn"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                    {
                     "PolicyName": "DynamoPromotions",
                     "PolicyDocument": {
                         "Statement": [


### PR DESCRIPTION
## Why are you doing this?
In order to send 'Thank you' emails the app needs to be able to access an SQS queue. 
Currently it doesn't have the necessary permissions, this PR fixes that.