### PR TITLE
updated membership common

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "7.2.3"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.9" // v0.9 is the latest version published for Play 2.4...
-  val membershipCommon = "com.gu" %% "membership-common" % "0.382"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.387"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playFilters = PlayImport.filters


### PR DESCRIPTION
## Why are you doing this?
updating membership common version to include special [armed forces states](https://github.com/guardian/membership-common/pull/457)

## Trello card: [Here](https://trello.com/c/nryweB6d/60-us-military-state-codes-are-not-included-in-our-drop-down-list-this-prevents-their-employees-from-supporting-the-guardian)

## Changes
* Us Armed forces states are now available in the state drop down list

## Screenshots
![delivadd](https://cloud.githubusercontent.com/assets/15324270/24552661/47bd20a8-161f-11e7-88c2-4a4722ea3f91.png)

@paulbrown1982 @jacobwinch 