### PR TITLE
Update Acceptance Tests To Include US

### DIFF
--- a/frontend/test/acceptance/JoinSupporterSpec.scala
+++ b/frontend/test/acceptance/JoinSupporterSpec.scala
@@ -29,9 +29,9 @@ class JoinSupporterSpec extends FeatureSpec with Browser
         "\nPlease run identity-frontend server before running tests.")
   }
 
-  feature("Become a Supporter in UK") {
+  feature("Become a Supporter in UK and US") {
 
-    scenario("User joins as Supporter by clicking 'Become a Supporter' button on Membership homepage, and pays using Stripe", Acceptance) {
+    scenario("User joins as Supporter using Stripe in US", Acceptance) {
       checkDependenciesAreAvailable
 
       val testUser = new TestUser
@@ -67,7 +67,7 @@ class JoinSupporterSpec extends FeatureSpec with Browser
       assert(enterDetails.currencyHasChangedTo("US$"))
 
       When("Users fill in delivery address details,")
-      enterDetails.fillInDeliveryAddress()
+      enterDetails.fillInDeliveryAddressUS()
 
       And("click Continue")
       enterDetails.clickContinue()
@@ -106,7 +106,7 @@ class JoinSupporterSpec extends FeatureSpec with Browser
       assert(ThankYou.userIsSignedInAsSupporter)
     }
 
-    scenario("User joins as Supporter using PayPal", Acceptance) {
+    scenario("User joins as Supporter using PayPal in UK", Acceptance) {
 
       checkDependenciesAreAvailable
 
@@ -144,7 +144,7 @@ class JoinSupporterSpec extends FeatureSpec with Browser
       assert(enterDetails.currencyHasChangedTo("US$"))
 
       When("Users fill in delivery address details,")
-      enterDetails.fillInDeliveryAddress()
+      enterDetails.fillInDeliveryAddressUK()
 
       And("click Continue")
       enterDetails.clickContinue()

--- a/frontend/test/acceptance/pages/EnterDetails.scala
+++ b/frontend/test/acceptance/pages/EnterDetails.scala
@@ -88,9 +88,7 @@ case class EnterDetails(val testUser: TestUser) extends Page with Browser {
       setSingleSelectionValue(country, "US")
       setValue(addressLine1, "222 Broadway")
       setValue(town, "New York")
-
-      val state = id("state-deliveryAddress")
-      setSingleSelectionValue(state, "New York")
+      setSingleSelectionValue(id("state-deliveryAddress"), "New York")
       setValue(postCode, "10038")
     }
 

--- a/frontend/test/acceptance/pages/EnterDetails.scala
+++ b/frontend/test/acceptance/pages/EnterDetails.scala
@@ -11,7 +11,9 @@ case class EnterDetails(val testUser: TestUser) extends Page with Browser {
 
   def userIsSignedIn: Boolean = elementHasText(userDisplayName, testUser.username)
 
-  def fillInDeliveryAddress() { DeliveryAddress.fillIn() }
+  def fillInDeliveryAddressUK() = { DeliveryAddress.fillInUK() }
+
+  def fillInDeliveryAddressUS() = { DeliveryAddress.fillInUS() }
 
   def clickContinue() = clickOn(className("js-continue-name-address"))
 
@@ -75,11 +77,21 @@ case class EnterDetails(val testUser: TestUser) extends Page with Browser {
     val town = id("town-deliveryAddress")
     val postCode = id("postCode-deliveryAddress")
 
-    def fillIn() = {
+    def fillInUK() = {
       setSingleSelectionValue(country, "GB")
       setValue(addressLine1, "Kings Place")
       setValue(town, "London")
       setValue(postCode, "N1 9GU")
+    }
+
+    def fillInUS() = {
+      setSingleSelectionValue(country, "US")
+      setValue(addressLine1, "222 Broadway")
+      setValue(town, "New York")
+
+      val state = id("state-deliveryAddress")
+      setSingleSelectionValue(state, "New York")
+      setValue(postCode, "10038")
     }
 
     def selectCountryCode(countryCode:  String) { setSingleSelectionValue(country, countryCode) }


### PR DESCRIPTION
## Why are you doing this?

We want to make sure we don't break the US flow by accident. Now that the acceptance tests do two runs, one for Stripe and another for PayPal, we can switch one to the US flow and keep one on the UK version.

[**Trello card**](https://trello.com/c/MwH3sX1n/364-we-should-update-our-acceptance-tests-to-capture-us-checkout-flow)

**Note**: The PayPal acceptance test is flaky locally due to the PayPal overlay doing stuff. If you want to run these locally, they pass fine using @mario-galic's sauce labs tunnel 🚂.

## Changes

- Added new method for filling out US address details.
- Switched Stripe flow over to checking the US checkout.