### PR TITLE
Bundles Landing Tweaks

### DIFF
--- a/frontend/app/views/bundle/bundlesLanding.scala.html
+++ b/frontend/app/views/bundle/bundlesLanding.scala.html
@@ -83,8 +83,7 @@
 							</li>
 						</ul>
 						<div>
-							<p class="bundles__copy bundles__copy--bottom js-digital-details">Support the Guardian and enjoy a subscription to our digital Daily Edition and the premium tier of our app.</p>
-							<div class="bundles__more-details js-digital-more"><button>@fragments.inlineIcon("cross-upright")</button> More details</div>
+							<p class="bundles__copy bundles__copy--bottom">Support the Guardian and enjoy a subscription to our digital Daily Edition and the premium tier of our app.</p>
 							<a class="bundles__cta js-digi-link" href="https://subscribe.theguardian.com/uk/digital">Become a digital subscriber @fragments.inlineIcon("arrow-right-straight")</a>
 						</div>
 					</div>
@@ -120,8 +119,7 @@
 							</ul>
 						</div>
 						<div>
-							<p class="bundles__copy bundles__copy--bottom js-print-details">Support the Guardian and enjoy a subscription to the Guardian and the Observer newspapers.</p>
-							<div class="bundles__more-details js-print-more"><button>@fragments.inlineIcon("cross-upright")</button> More details</div>
+							<p class="bundles__copy bundles__copy--bottom">Support the Guardian and enjoy a subscription to the Guardian and the Observer newspapers.</p>
 							<a class="bundles__cta js-print-link" href="https://subscribe.theguardian.com/collection/paper-digital">Become a paper subscriber @fragments.inlineIcon("arrow-right-straight")</a>
 						</div>
 					</div>

--- a/frontend/assets/javascripts/src/modules/bundlesLanding.es6
+++ b/frontend/assets/javascripts/src/modules/bundlesLanding.es6
@@ -257,26 +257,6 @@ function printClicks (elems) {
 
 }
 
-function detailsClicks (elems) {
-
-	elems.digitalMore.addEventListener('click', () => {
-		if (elems.digitalDetails.classList.contains(SHOW_DETAILS)) {
-			elems.digitalDetails.classList.remove(SHOW_DETAILS);
-		} else {
-			elems.digitalDetails.classList.add(SHOW_DETAILS);
-		}
-	});
-
-	elems.printMore.addEventListener('click', () => {
-		if (elems.printDetails.classList.contains(SHOW_DETAILS)) {
-			elems.printDetails.classList.remove(SHOW_DETAILS);
-		} else {
-			elems.printDetails.classList.add(SHOW_DETAILS);
-		}
-	});
-
-}
-
 function getElems () {
 
 	return {
@@ -292,11 +272,7 @@ function getElems () {
 		contribLink: document.getElementsByClassName('js-contrib-link')[0],
 		digiLink: document.getElementsByClassName('js-digi-link')[0],
 		printLink: document.getElementsByClassName('js-print-link')[0],
-		digitalBenefits: document.getElementsByClassName('js-digital-benefits')[0],
-		digitalMore: document.getElementsByClassName('js-digital-more')[0],
-		digitalDetails: document.getElementsByClassName('js-digital-details')[0],
-		printMore: document.getElementsByClassName('js-print-more')[0],
-		printDetails: document.getElementsByClassName('js-print-details')[0]
+		digitalBenefits: document.getElementsByClassName('js-digital-benefits')[0]
 	};
 
 }

--- a/frontend/assets/stylesheets/components/_bundle-landing.scss
+++ b/frontend/assets/stylesheets/components/_bundle-landing.scss
@@ -206,8 +206,11 @@ $why-support-colour: #7cb523;
 }
 
 .bundles__copy--bottom {
-	@include mq($until: desktop) {
+	@include mq($from: tablet, $until: desktop) {
 		display: none;
+	}
+
+	@include mq($until: desktop) {
 		margin-top: $gs-baseline;
 	}
 
@@ -236,10 +239,6 @@ $why-support-colour: #7cb523;
 	button {
 		border-color: guss-colour(neutral-1);
 	}
-}
-
-.show-details {
-	display: block;
 }
 
 .bundles__more-details button {

--- a/frontend/assets/stylesheets/components/_bundle-landing.scss
+++ b/frontend/assets/stylesheets/components/_bundle-landing.scss
@@ -98,6 +98,7 @@ $why-support-colour: #7cb523;
 	@include mq($from: desktop) {
 		display: flex;
 		flex-direction: column;
+		height: gs-height(10) + $gs-baseline;
 		// Fix for IE10.
 		max-width: gs-span(4);
 	}

--- a/frontend/assets/stylesheets/components/_bundle-landing.scss
+++ b/frontend/assets/stylesheets/components/_bundle-landing.scss
@@ -370,8 +370,9 @@ $why-support-colour: #7cb523;
 }
 
 .contribution-error {
+	color: #000;
 	display: none;
-	font-size: 12px;
+	font-size: 13px;
 	line-height: 15px;
 	font-family: $f-data;
 }


### PR DESCRIPTION
## Why are you doing this?

It has been decided that there should be UX and copy tweaks to the bundles landing page.

[**Trello Card**](https://trello.com/c/0AwV6Lqm/431-make-changes-to-new-bundles-landing-page)

## Changes

- On desktop, when switching print bundles, the height of all the bundles would jump because the print bundle has one less bullet point. They now have a fixed height to stop this.
- Mobile previously had a 'more details' button to show extra copy. That copy is now visible by default.
- The contribution error message was a little hard to read. The size has been bumped and the colour tweaked to fix this.

## Screenshots

**More Details - Before**:

![more-details-before](https://cloud.githubusercontent.com/assets/5131341/24613441/3ad06f72-1880-11e7-9085-fef403498df4.jpg)

**More Details - After**:

![more-details-after](https://cloud.githubusercontent.com/assets/5131341/24613443/3c3c30c6-1880-11e7-93a4-592f28f6f3b5.jpg)
