### PR TITLE
Bundles Landing Price Tweaks

### DIFF
--- a/frontend/app/views/bundle/bundlesLanding.scala.html
+++ b/frontend/app/views/bundle/bundlesLanding.scala.html
@@ -63,7 +63,7 @@
 			<div class="bundles__bundle bundles__bundle--digital">
 				<div class="bundles__bundle-content">
 					<div class="bundles__top">
-						<h1 class="bundles__heading">£12/month</h1>
+						<h1 class="bundles__heading">£11.99/month</h1>
 						<h2 class="bundles__subheading"><span class="bundles__wrap-line">Become a </span>digital subscriber</h2>
 						<p class="bundles__copy bundles__copy--top">Support the Guardian and enjoy a subscription to our digital Daily Edition and the premium tier of our app.</p>
 					</div>
@@ -93,7 +93,7 @@
 			<div class="bundles__bundle bundles__bundle--print">
 				<div class="bundles__bundle-content">
 					<div class="bundles__top">
-						<h1 class="bundles__heading">From £20/month</h1>
+						<h1 class="bundles__heading">From £10.79/month</h1>
 						<h2 class="bundles__subheading"><span class="bundles__wrap-line">Become a </span>paper subscriber</h2>
 						<p class="bundles__copy bundles__copy--top">Support the Guardian and enjoy a subscription to the Guardian and the Observer newspapers.</p>
 					</div>

--- a/frontend/assets/stylesheets/components/_bundle-landing.scss
+++ b/frontend/assets/stylesheets/components/_bundle-landing.scss
@@ -370,10 +370,11 @@ $why-support-colour: #7cb523;
 }
 
 .contribution-error {
-	color: #000;
+	color: guss-colour(live-support-2);
 	display: none;
 	font-size: 13px;
 	line-height: 15px;
+	font-weight: bold;
 	font-family: $f-data;
 }
 


### PR DESCRIPTION
## Why are you doing this?

The prices for some of the bundles are wrong. The error message isn't visible enough.

## Changes

- Update the bundles prices.
- Make the error message more visible.

## Screenshots

![updated-prices](https://cloud.githubusercontent.com/assets/5131341/24653587/492a8de2-192e-11e7-971a-f85375aafcf4.png)
