### PR TITLE
Removed Missing Function Call

### DIFF
--- a/frontend/assets/javascripts/src/modules/bundlesLanding.es6
+++ b/frontend/assets/javascripts/src/modules/bundlesLanding.es6
@@ -292,7 +292,6 @@ export function init () {
 		amountClicks(elems);
 		printClicks(elems);
 		otherAmountEvents(elems);
-		detailsClicks(elems);
 
 	}
 


### PR DESCRIPTION
## Why are you doing this?

This removes a hangover call to a function that was removed in #1576.

## Trello card: [Here](https://trello.com)

## Changes

- Remove broken function call.
