### PR TITLE
Use play's default execution context

### DIFF
--- a/frontend/app/actions/CommonActions.scala
+++ b/frontend/app/actions/CommonActions.scala
@@ -14,7 +14,7 @@ import services.{TouchpointBackend, AuthenticationService}
 import utils.GuMemCookie
 import utils.TestUsers.isTestUser
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import scala.concurrent.Future
 
 trait CommonActions {

--- a/frontend/app/controllers/Info.scala
+++ b/frontend/app/controllers/Info.scala
@@ -14,7 +14,7 @@ import services._
 import tracking.RedirectWithCampaignCodes._
 import utils.RequestCountry._
 import views.support.{Asset, PageInfo}
-import scala.concurrent.ExecutionContext.Implicits.global
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
 import scala.concurrent.Future
 

--- a/frontend/app/controllers/OAuth.scala
+++ b/frontend/app/controllers/OAuth.scala
@@ -8,7 +8,7 @@ import play.api.Play.current
 import play.api.libs.json.Json
 import play.api.mvc.{Session, Action, Controller}
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import scala.concurrent.Future
 
 

--- a/frontend/app/controllers/Testing.scala
+++ b/frontend/app/controllers/Testing.scala
@@ -6,7 +6,7 @@ import com.typesafe.scalalogging.LazyLogging
 import play.api.mvc.{Controller, Cookie}
 import utils.TestUsers.testUsers
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
 object Testing extends Controller with LazyLogging {
 

--- a/frontend/app/monitoring/ErrorHandler.scala
+++ b/frontend/app/monitoring/ErrorHandler.scala
@@ -15,7 +15,7 @@ import play.api.mvc._
 import play.api.routing.Router
 import services.AuthenticationService
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import scala.concurrent._
 
 class ErrorHandler @Inject() (

--- a/frontend/app/services/EmailService.scala
+++ b/frontend/app/services/EmailService.scala
@@ -17,7 +17,7 @@ import model.ContributorRow
 import play.api.libs.json.Json
 import utils.AwsAsyncHandler
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
 import scalaz.\/

--- a/frontend/app/services/EventbriteService.scala
+++ b/frontend/app/services/EventbriteService.scala
@@ -19,7 +19,7 @@ import play.api.cache.Cache
 import play.api.libs.json.Reads
 import play.api.libs.ws._
 import utils.StringUtils._
-import scala.concurrent.ExecutionContext.Implicits.global
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import scala.concurrent.Future
 import scala.concurrent.duration._
 

--- a/frontend/app/services/GridService.scala
+++ b/frontend/app/services/GridService.scala
@@ -16,7 +16,7 @@ import monitoring.GridApiMetrics
 import okhttp3.Request
 import play.api.libs.json.Json
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import scala.concurrent.Future
 
 object GridService extends WebServiceHelper[GridObject, Grid.Error] with LazyLogging {

--- a/frontend/app/services/GuardianContentService.scala
+++ b/frontend/app/services/GuardianContentService.scala
@@ -10,7 +10,7 @@ import monitoring.ContentApiMetrics
 import org.joda.time.DateTime
 import play.api.Logger
 import play.api.libs.iteratee.{Iteratee, Enumerator}
-import scala.concurrent.ExecutionContext.Implicits.global
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import scala.concurrent.Future
 import scala.util.{Success, Try, Failure}
 import scala.concurrent.duration._

--- a/frontend/app/services/IdentityService.scala
+++ b/frontend/app/services/IdentityService.scala
@@ -13,7 +13,7 @@ import play.api.libs.json._
 import play.api.libs.ws.WS
 import views.support.IdentityUser
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}


### PR DESCRIPTION
## Why are you doing this?
It's considered best practice to use Play's default execution context unless you have some reason to create a specific thread pool: 
https://www.playframework.com/documentation/2.5.x/ThreadPools

<!--
Remember, PRs are documentation for future contributors

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Trello card: [Here](https://trello.com/c/7CTCozNx/58-use-play-s-default-execution-context)

## Changes
* Switching to use Play's default execution context rather than Scala's global execution context. 

## Screenshots