### PR TITLE
Send Bundles Landing Campaign Code Through To Patrons and Events

### DIFF
--- a/frontend/app/views/bundle/bundlesLanding.scala.html
+++ b/frontend/app/views/bundle/bundlesLanding.scala.html
@@ -173,7 +173,7 @@
 				</picture>
 				<h2>Patrons</h2>
 				<p>The Patrons tier is for those who care deeply about the Guardian's journalism and the impact it has on the world</p>
-				<a class="other-ways__cta other-ways__cta--patron" href="/patrons"><button>@fragments.inlineIcon("arrow-right-straight")</button><span>Become a Patron</span></a>
+				<a class="other-ways__cta other-ways__cta--patron js-patrons" href="/patrons"><button>@fragments.inlineIcon("arrow-right-straight")</button><span>Become a Patron</span></a>
 			</div>
 			<div class="other-ways__way other-ways__way--burnt-yellow">
 				<picture>
@@ -182,7 +182,7 @@
 				</picture>
 				<h2>Guardian Live events</h2>
 				<p>Events, discussions, debates, interviews, festivals, dinners and private views exclusively for Guardian members</p>
-				<a class="other-ways__cta" href="/events"><button>@fragments.inlineIcon("arrow-right-straight")</button><span>Find out about events</span></a>
+				<a class="other-ways__cta js-events" href="/events"><button>@fragments.inlineIcon("arrow-right-straight")</button><span>Find out about events</span></a>
 			</div>
 		</div>
 	</section>

--- a/frontend/assets/javascripts/src/modules/bundlesLanding.es6
+++ b/frontend/assets/javascripts/src/modules/bundlesLanding.es6
@@ -78,6 +78,16 @@ function subsLinks (elems) {
 
 }
 
+function otherLinks (elems) {
+
+	let params = new URLSearchParams();
+	params.append('INTCMP', STATE.intcmp);
+
+	elems.patrons.href = `${elems.patrons.href}?${params.toString()}`;
+	elems.events.href = `${elems.events.href}?${params.toString()}`;
+
+}
+
 function updateLinks (elems) {
 
 	let currentParams = new URLSearchParams(window.location.search.slice(1));
@@ -87,6 +97,7 @@ function updateLinks (elems) {
 
 	contribLink(elems);
 	subsLinks(elems);
+	otherLinks(elems);
 
 }
 
@@ -272,7 +283,9 @@ function getElems () {
 		contribLink: document.getElementsByClassName('js-contrib-link')[0],
 		digiLink: document.getElementsByClassName('js-digi-link')[0],
 		printLink: document.getElementsByClassName('js-print-link')[0],
-		digitalBenefits: document.getElementsByClassName('js-digital-benefits')[0]
+		digitalBenefits: document.getElementsByClassName('js-digital-benefits')[0],
+		patrons: document.getElementsByClassName('js-patrons')[0],
+		events: document.getElementsByClassName('js-events')[0]
 	};
 
 }

--- a/frontend/assets/javascripts/src/modules/bundlesLanding.es6
+++ b/frontend/assets/javascripts/src/modules/bundlesLanding.es6
@@ -49,6 +49,8 @@ const ERRORS = {
 
 // ----- Functions ----- //
 
+// Sets the link to contributions to include INTCMP,
+// and based upon billing period and amount.
 function contribLink (elems) {
 
 	let params = new URLSearchParams();
@@ -64,6 +66,8 @@ function contribLink (elems) {
 
 }
 
+// Sets the links to subscriptions to include INTCMP,
+// and based upon bundle selected.
 function subsLinks (elems) {
 
 	let params = new URLSearchParams();
@@ -78,6 +82,7 @@ function subsLinks (elems) {
 
 }
 
+// Sets the patrons and events links to include INTCMP.
 function otherLinks (elems) {
 
 	let params = new URLSearchParams();
@@ -88,6 +93,7 @@ function otherLinks (elems) {
 
 }
 
+// Updates all the links on the page based on INTCMP.
 function updateLinks (elems) {
 
 	let currentParams = new URLSearchParams(window.location.search.slice(1));
@@ -101,6 +107,8 @@ function updateLinks (elems) {
 
 }
 
+// Updates the contributions amount in the state object, and changes the
+// possible amount based on billing period.
 function contribUpdate (elems) {
 
 	let amount = PRICES[STATE.contribPeriod][STATE.amountButton];
@@ -114,6 +122,8 @@ function contribUpdate (elems) {
 
 }
 
+// Updates the print link and digital benefits bullet point based on bundle
+// selected.
 function printUpdate (elems, bundle) {
 
 	if (bundle === 'PRINT') {
@@ -126,6 +136,7 @@ function printUpdate (elems, bundle) {
 
 }
 
+// Displays an error for the contributions (other amount) input.
 function contribError (elems, errorType) {
 
 	if (errorType) {
@@ -137,6 +148,7 @@ function contribError (elems, errorType) {
 
 }
 
+// Checks that the other amount field is valid.
 function validateOtherAmount (elems) {
 
 	elems.contribLink.addEventListener('click', (event) => {
@@ -166,6 +178,7 @@ function validateOtherAmount (elems) {
 
 }
 
+// Handles clicks on the contributions bundle element on the page.
 function contributionClicks (elems) {
 
 	elems.contribMonth.addEventListener('click', () => {
@@ -186,6 +199,7 @@ function contributionClicks (elems) {
 
 }
 
+// Changes the visual appearance of the selected contribution amount.
 function selectAmount (elems, selectedElem) {
 
 	let amountElems = [elems.contribOne, elems.contribTwo, elems.contribThree,
@@ -199,6 +213,7 @@ function selectAmount (elems, selectedElem) {
 
 }
 
+// Handles clicks on the predefined contribution amount elements.
 function amountClicks (elems) {
 
 	elems.contribOne.addEventListener('click', () => {
@@ -230,6 +245,7 @@ function amountClicks (elems) {
 
 }
 
+// Handles clicks on the contribution other amount element.
 function otherAmountEvents (elems) {
 
 	elems.contribOther.addEventListener('click', () => {
@@ -250,6 +266,7 @@ function otherAmountEvents (elems) {
 
 }
 
+// Handles clicks on the print bundle buttons.
 function printClicks (elems) {
 
 	elems.print.addEventListener('click', () => {
@@ -268,6 +285,7 @@ function printClicks (elems) {
 
 }
 
+// Retrieves an object of references to the DOM elements in the page.
 function getElems () {
 
 	return {


### PR DESCRIPTION
## Why are you doing this?

Some traffic from the bundles landing page may go through to patrons and events. We don't want to lose this traffic from our reports.

[**Trello Card**](https://trello.com/c/RUXeN5ck/457-add-landing-page-campaign-codes-to-patrons-and-events)

## Changes

- Added function to pass through campaign code to patrons and events through links.

## Screenshots

**Patrons Link - Default Campaign Code**:

![landing-patrons](https://cloud.githubusercontent.com/assets/5131341/24708229/2bd85a40-1a0e-11e7-97ab-27715edc0ca1.jpg)

**Events Link - Passed Through Campaign Code**:

![landing-events](https://cloud.githubusercontent.com/assets/5131341/24708259/3d76c7be-1a0e-11e7-96f0-e7d10152d903.jpg)
