### PR TITLE
Remove duplication by payment-methods from MemberService.createMember()

### DIFF
--- a/frontend/app/forms/MemberForm.scala
+++ b/frontend/app/forms/MemberForm.scala
@@ -8,6 +8,7 @@ import com.gu.memsub.BillingPeriod._
 import com.gu.memsub.{Address, BillingPeriod, FullName}
 import com.gu.salesforce.PaidTier
 import com.gu.salesforce.Tier._
+import forms.MemberForm.PaidForm
 import model._
 import play.api.data.Forms._
 import play.api.data.format.Formatter
@@ -56,13 +57,17 @@ object MemberForm {
     val planChoice: PlanChoice
   }
 
-  trait PaidMemberForm {
+  trait PaidForm {
+    val payment: CommonPaymentForm
+  }
+
+  trait PaidMemberForm extends PaidForm {
     val featureChoice: Set[FeatureChoice]
     val zuoraAccountAddress : Address
     val payment: PaymentForm
   }
 
-  trait ContributorForm extends CommonForm {
+  trait ContributorForm extends CommonForm with PaidForm {
     val planChoice: ContributionPlanChoice
     val payment: MonthlyPaymentForm
   }

--- a/frontend/app/monitoring/MemberMetrics.scala
+++ b/frontend/app/monitoring/MemberMetrics.scala
@@ -28,19 +28,10 @@ class MemberMetrics(val backendEnv: String) extends TouchpointBackendMetrics {
     put(s"failed-sign-up-${tier.name}")
   }
 
-  def putCreationOfPaidSubscription(paymentMethod: Option[PaymentMethod]) = {
+  def putCreationOfPaidSubscription(paymentMethod: PaymentMethod) = {
+    val paymentDimension = new Dimension().withName("PaymentMethod").withValue(paymentMethod.getClass.getSimpleName)
 
-    for {
-      method <- paymentMethod
-    } {
-
-      val paymentDimension = new Dimension().withName("PaymentMethod")
-        .withValue(method.getClass.getSimpleName)
-
-      put(s"create-paid-subscription", 1, paymentDimension)
-
-    }
-
+    put(s"create-paid-subscription", 1, paymentDimension)
   }
 
   private def put(metricName: String) {

--- a/frontend/app/services/api/MemberService.scala
+++ b/frontend/app/services/api/MemberService.scala
@@ -80,10 +80,9 @@ trait MemberService {
                              joinData: PaidMemberForm,
                              nameData: NameForm,
                              tier: PaidTier,
-                             stripeCustomer: Option[Customer],
                              campaignCode: Option[CampaignCode],
                              email: String,
-                             payPalEmail: Option[String],
+                             paymentMethod: PaymentMethod,
                              ipCountry: Option[Country]): Future[SubscribeResult]
 
   def createFreeSubscription(contactId: ContactId,
@@ -98,7 +97,7 @@ trait MemberService {
                          nameData: NameForm,
                          campaignCode: Option[CampaignCode],
                          email: String,
-                         paymentMethod: Option[PaymentMethod]): Future[SubscribeResult]
+                         paymentMethod: PaymentMethod): Future[SubscribeResult]
 }
 
 object MemberService {

--- a/frontend/app/services/paymentmethods/AvailablePaymentMethods.scala
+++ b/frontend/app/services/paymentmethods/AvailablePaymentMethods.scala
@@ -1,0 +1,23 @@
+package services.paymentmethods
+
+import com.gu.identity.play.IdMinimalUser
+import com.gu.zuora
+import forms.MemberForm.CommonPaymentForm
+
+import scala.concurrent.Future
+
+
+case class InitialiserAndToken(initialiser: PaymentMethodInitialiser[_ <: zuora.soap.models.Commands.PaymentMethod], token: String) {
+  def initialiseUsing(user: IdMinimalUser): Future[zuora.soap.models.Commands.PaymentMethod] = {
+    initialiser.initialiseWith(token, user)
+  }
+}
+
+class AvailablePaymentMethods(initialisers: Seq[PaymentMethodInitialiser[_ <: zuora.soap.models.Commands.PaymentMethod]]) {
+
+  def deriveInitialiserAndTokenFrom(form: CommonPaymentForm): InitialiserAndToken = (for {
+    initialiser <- initialisers
+    token <- initialiser.extractTokenFrom(form)
+  } yield InitialiserAndToken(initialiser, token)).head
+
+}

--- a/frontend/app/services/paymentmethods/PaymentMethodInitialiser.scala
+++ b/frontend/app/services/paymentmethods/PaymentMethodInitialiser.scala
@@ -1,0 +1,52 @@
+package services.paymentmethods
+
+import com.gu.i18n.CountryGroup
+import com.gu.identity.play.IdMinimalUser
+import com.gu.stripe.StripeService
+import com.gu.zuora
+import com.gu.zuora.soap.models.Commands.{CreditCardReferenceTransaction, PayPalReferenceTransaction}
+import com.typesafe.scalalogging.LazyLogging
+import forms.MemberForm.CommonPaymentForm
+import services.PayPalService
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.util.Failure
+
+/** An initialiser just takes a token from the Payment form and sends it on to the 3rd-party
+  * payment-processor (PayPal, Stripe, GoCardless) to exchange for a summary of the customer's
+  * payment method. This payment method summary can then be sent on to Zuora for charging.
+  */
+trait PaymentMethodInitialiser[PMCommand <: zuora.soap.models.Commands.PaymentMethod] {
+
+  // at some point, the token may be more complicated, but right now it's always a string
+  def extractTokenFrom(form: CommonPaymentForm): Option[String]
+
+  def initialiseWith(token: String, user: IdMinimalUser): Future[PMCommand]
+}
+
+class StripeInitialiser(stripeService: StripeService) extends
+  PaymentMethodInitialiser[CreditCardReferenceTransaction] with LazyLogging {
+
+  def extractTokenFrom(form: CommonPaymentForm): Option[String] = form.stripeToken
+
+  def initialiseWith(stripeToken: String, user: IdMinimalUser): Future[CreditCardReferenceTransaction] = for {
+    stripeCustomer <- stripeService.Customer.create(user.id, stripeToken).andThen {
+      case Failure(e) => logger.warn(s"Could not create Stripe customer for user ${user.id}", e)
+    }
+  } yield {
+    val card = stripeCustomer.card
+    CreditCardReferenceTransaction(card.id, stripeCustomer.id, card.last4, CountryGroup.countryByCode(card.country), card.exp_month, card.exp_year, card.`type`)
+  }
+}
+
+class PayPalInitialiser(payPalService: PayPalService) extends PaymentMethodInitialiser[PayPalReferenceTransaction] {
+
+  def extractTokenFrom(form: CommonPaymentForm): Option[String] = form.payPalBaid
+
+  def initialiseWith(baid: String, user: IdMinimalUser): Future[PayPalReferenceTransaction] = Future {
+    val payPalEmail = payPalService.retrieveEmail(baid) // currently blocking, not async
+    PayPalReferenceTransaction(baid, payPalEmail)
+  }
+
+}


### PR DESCRIPTION
## Why are you doing this?

This refactor is similar to https://github.com/guardian/membership-frontend/pull/1569, but (apart from removing duplication!) the reason for doing it is the [Merge Registration & Checkout](https://trello.com/c/TpuX5Fdb/298-a-b-testing-for-new-checkout-flow-test-merging-registration-into-supporter-checkout) work ... I need to put different code-paths in place for the Identity-related calls in `createMember()` (ie _`getIdentityUserDetails()` and `updateIdentity()`_) and because they were duplicated in 3 places within `createMember()` it was desirable to remove some of that duplication.

The `PaymentMethodInitialiser` abstraction would be helpful with code on the _free-to-paid-upgrade_ path as well, but I'm gonna [leave that](https://github.com/guardian/membership-common/pull/439/files#r110198600) to a separate PR.

## Trello card: [Here](https://trello.com/c/TpuX5Fdb/298-a-b-testing-for-new-checkout-flow-test-merging-registration-into-supporter-checkout)

## Changes

This is a pure refactor, and should not affect functionality.