### PR TITLE
Added Promo Codes To Subscriptions Links On Bundles Landing Page

### DIFF
--- a/frontend/app/views/bundle/bundlesLanding.scala.html
+++ b/frontend/app/views/bundle/bundlesLanding.scala.html
@@ -84,7 +84,7 @@
 						</ul>
 						<div>
 							<p class="bundles__copy bundles__copy--bottom">Support the Guardian and enjoy a subscription to our digital Daily Edition and the premium tier of our app.</p>
-							<a class="bundles__cta js-digi-link" href="https://subscribe.theguardian.com/uk/digital">Become a digital subscriber @fragments.inlineIcon("arrow-right-straight")</a>
+							<a class="bundles__cta js-digi-link" href="https://subscribe.theguardian.com/p/DXX83X">Become a digital subscriber @fragments.inlineIcon("arrow-right-straight")</a>
 						</div>
 					</div>
 				</div>
@@ -120,7 +120,7 @@
 						</div>
 						<div>
 							<p class="bundles__copy bundles__copy--bottom">Support the Guardian and enjoy a subscription to the Guardian and the Observer newspapers.</p>
-							<a class="bundles__cta js-print-link" href="https://subscribe.theguardian.com/collection/paper-digital">Become a paper subscriber @fragments.inlineIcon("arrow-right-straight")</a>
+							<a class="bundles__cta js-print-link" href="https://subscribe.theguardian.com/p/GXX83X">Become a paper subscriber @fragments.inlineIcon("arrow-right-straight")</a>
 						</div>
 					</div>
 				</div>

--- a/frontend/assets/javascripts/src/modules/bundlesLanding.es6
+++ b/frontend/assets/javascripts/src/modules/bundlesLanding.es6
@@ -10,9 +10,9 @@ const SELECTED_PRINT = 'print-fields__field--selected';
 const SHOW_DETAILS = 'show-details';
 const MONTHLY_URL = '/monthly-contribution';
 const ONEOFF_URL = 'https://contribute.theguardian.com/uk';
-const DIGI_URL = 'https://subscribe.theguardian.com/uk/digital';
-const PRINT_DIGI_URL = 'https://subscribe.theguardian.com/collection/paper-digital';
-const PRINT_URL = 'https://subscribe.theguardian.com/collection/paper';
+const DIGI_URL = 'https://subscribe.theguardian.com/p/DXX83X';
+const PRINT_DIGI_URL = 'https://subscribe.theguardian.com/p/GXX83X';
+const PRINT_URL = 'https://subscribe.theguardian.com/p/GXX83P';
 const CONTRIB_ERROR = 'contribution-error--shown';
 const DEFAULT_INTCMP = 'gdnwb_copts_bundles_landing_default';
 


### PR DESCRIPTION
## Why are you doing this?

To better track traffic through the subs site, and to pick up the correct discounts.

[**Trello Card**](https://trello.com/c/lYF1Wifg/467-add-promo-codes-to-subscriptions-links-on-bundles-landing-page)

## Changes

- Update the links to subs to use the new promo code URLs.
