### PR TITLE
Add attempt/success metrics for monthly contributions

### DIFF
--- a/cloud-formation/membership-app.cf.yaml
+++ b/cloud-formation/membership-app.cf.yaml
@@ -272,6 +272,27 @@ Resources:
       - Fn::GetAtt:
         - FrontendElasticLoadBalancer
         - DNSName
+
+  monthlyContributorAttempts:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Sub FrontendLogs-${Stage}
+      FilterPattern: "attempting to become a monthly contributor"
+      MetricTransformations:
+      - MetricNamespace: !Sub ${Stage}/contributions
+        MetricName: new-monthly-contributor-attempt
+        MetricValue: 1
+
+  monthlyContributorSuccess:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Sub FrontendLogs-${Stage}
+      FilterPattern: "successfully became monthly contributor"
+      MetricTransformations:
+      - MetricNamespace: !Sub ${Stage}/contributions
+        MetricName: new-monthly-contributor-success
+        MetricValue: 1
+
 Outputs:
   URL:
     Description: URL of the Frontend website


### PR DESCRIPTION
## Why are you doing this?

So that we can monitor the number of contributor attempts/successes to detect faults in the system.

## Trello card: [Here](https://trello.com/c/QBDa9YDs/405-add-monitoring-for-monthly-contributions)

## Changes
* Add metric filter for new monthly contributor attempt
* Add metric filter for successful new monthly contributor
