### PR TITLE
Allow users who don't have an Identity account to complete checkout

### DIFF
--- a/frontend/app/controllers/Contributor.scala
+++ b/frontend/app/controllers/Contributor.scala
@@ -17,10 +17,10 @@ import play.api.i18n.Messages.Implicits._
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json.Json
 import play.api.mvc.{Controller, Result}
+import services.checkout.identitystrategy.Strategy.identityStrategyFor
 import services.TouchpointBackend
 import tracking.ActivityTracking
 import utils.CampaignCode
-import utils.RequestCountry._
 import utils.TestUsers.PreSigninTestCookie
 import views.support.{PageInfo, Pricing, ThankYouMonthlySummary}
 
@@ -83,27 +83,27 @@ object Contributor extends Controller with ActivityTracking with PaymentGatewayE
   private def makeContributor(onSuccess: => Result)(formData: ContributorForm)(implicit request: AuthRequest[_]) = {
     logger.info(s"User ${request.user.id} attempting to become a monthly contributor...")
     implicit val bp: BackendProvider = request
-    val idRequest = IdentityRequest(request)
     val campaignCode = CampaignCode.fromRequest
-    val ipCountry = request.getFastlyCountry
 
-    Timing.record(salesforceService.metrics, "createContributor") {
-      memberService.createContributor(request.user, formData, idRequest, campaignCode).map {
-        case (sfContactId, zuoraSubName) =>
-          logger.info(s"User ${request.user.id} successfully became monthly contributor $zuoraSubName.")
-          onSuccess
-      }.recover {
-        // errors due to user's card are logged at WARN level as they are not logic errors
-        case error: Stripe.Error =>
-          logger.warn(s"Stripe API call returned error: \n\t$error \n\tuser=${request.user.id}")
-          Forbidden(Json.toJson(error))
+    identityStrategyFor(request, formData).ensureIdUser { user =>
+      Timing.record(salesforceService.metrics, "createContributor") {
+        memberService.createContributor(user, formData, campaignCode).map {
+          case (sfContactId, zuoraSubName) =>
+            logger.info(s"User ${user.id} successfully became monthly contributor $zuoraSubName.")
+            onSuccess
+        }.recover {
+          // errors due to user's card are logged at WARN level as they are not logic errors
+          case error: Stripe.Error =>
+            logger.warn(s"Stripe API call returned error: \n\t$error \n\tuser=${user.id}")
+            Forbidden(Json.toJson(error))
 
-        case error: PaymentGatewayError =>
-          handlePaymentGatewayError(error, request.user.id, "monthly contributor", idRequest.trackingParameters)
+          case error: PaymentGatewayError =>
+            handlePaymentGatewayError(error, user.id, "monthly contributor")
 
-        case error =>
-          logger.error(s"User ${request.user.id} could not become monthly contributor member: ${idRequest.trackingParameters}", error)
-          Forbidden
+          case error =>
+            logger.error(s"User ${user.id} could not become monthly contributor member", error)
+            Forbidden
+        }
       }
     }
   }

--- a/frontend/app/controllers/IdentityRequest.scala
+++ b/frontend/app/controllers/IdentityRequest.scala
@@ -3,10 +3,14 @@ package controllers
 import configuration.Config
 import play.api.mvc.{Request, RequestHeader}
 
-case class IdentityRequest(headers: List[(String, String)], trackingParameters: List[(String, String)])
+case class IdentityRequest(
+  ip: String,
+  headers: List[(String, String)],
+  trackingParameters: List[(String, String)]
+)
 
 object IdentityRequest extends RemoteAddress {
-  def apply(request: Request[_]): IdentityRequest = {
+  def apply(request: RequestHeader): IdentityRequest = {
     val ipAddress = clientIp(request)
 
     val headers = List("X-GU-ID-Client-Access-Token" -> s"Bearer ${Config.idApiClientToken}") ++
@@ -18,7 +22,7 @@ object IdentityRequest extends RemoteAddress {
       request.headers.get("User-Agent").map("trackingUserAgent" -> _) ++
       ipAddress.map("trackingIpAddress" -> _)
 
-    IdentityRequest(headers, trackingParameters)
+    IdentityRequest(ipAddress.mkString, headers, trackingParameters)
 
   }
 }

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -215,16 +215,6 @@ object Joiner extends Controller with ActivityTracking with PaymentGatewayErrorH
         s"There has been an error in updating your email. You may already have an Identity account with $googleEmail. Please try signing in with that email."),
       _ => Redirect(routes.Joiner.enterStaffDetails()).flashing("success" ->
         s"Your email address has been changed to $googleEmail"))
-//      yield {
-//        responseCode match {
-//          case 200 => Redirect(routes.Joiner.enterStaffDetails())
-//            .flashing("success" ->
-//              s"Your email address has been changed to $googleEmail")
-//          case _ => Redirect(routes.Joiner.staff())
-//            .flashing("error" ->
-//              s"There has been an error in updating your email. You may already have an Identity account with $googleEmail. Please try signing in with that email.")
-//        }
-//      }
   }
 
   def unsupportedBrowser = CachedAction(Ok(views.html.joiner.unsupportedBrowser()))

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -8,8 +8,7 @@ import com.gu.contentapi.client.model.v1.{MembershipTier => ContentAccess}
 import com.gu.i18n.CountryGroup
 import com.gu.i18n.CountryGroup.UK
 import com.gu.i18n.Currency.GBP
-import com.gu.memsub.BillingPeriod
-import com.gu.memsub.util.Timing
+import com.gu.identity.play.{AuthenticationService => _, _}
 import com.gu.salesforce._
 import com.gu.stripe.Stripe
 import com.gu.stripe.Stripe.Serializer._
@@ -17,7 +16,7 @@ import com.gu.zuora.soap.models.errors._
 import com.netaporter.uri.dsl._
 import com.typesafe.scalalogging.LazyLogging
 import configuration.{Config, CopyConfig}
-import forms.MemberForm._
+import forms.MemberForm.{paidMemberJoinForm, _}
 import model._
 import play.api.Play.current
 import play.api.i18n.Messages.Implicits._
@@ -25,12 +24,12 @@ import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json.Json
 import play.api.mvc._
 import services.AuthenticationService.authenticatedIdUserProvider
-
+import services.checkout.identitystrategy.Strategy.identityStrategyFor
 import services.{GuardianContentService, _}
 import tracking.ActivityTracking
 import utils.Feature.MergedRegistration
 import utils.RequestCountry._
-import utils.TestUsers.PreSigninTestCookie
+import utils.TestUsers.{NameEnteredInForm, PreSigninTestCookie}
 import utils.{CampaignCode, TierChangeCookies}
 import views.support
 import views.support.MembershipCompat._
@@ -200,7 +199,7 @@ object Joiner extends Controller with ActivityTracking with PaymentGatewayErrorH
       makeMember(Tier.partner, Redirect(routes.Joiner.thankyouStaff())))
   }
 
-  def joinPaid(tier: PaidTier) = AuthenticatedNonMemberAction.async { implicit request =>
+  def joinPaid(tier: PaidTier) = OptionallyAuthenticatedNonMemberAction(tier).async { implicit request =>
     paidMemberJoinForm.bindFromRequest.fold({ formWithErrors =>
       Future.successful(BadRequest(formWithErrors.errorsAsJson))
     },
@@ -210,53 +209,66 @@ object Joiner extends Controller with ActivityTracking with PaymentGatewayErrorH
   def updateEmailStaff() = AuthenticatedStaffNonMemberAction.async { implicit request =>
     val googleEmail = request.googleUser.email
     for {
-      responseCode <- IdentityService(IdentityApi).updateEmail(request.identityUser, googleEmail, IdentityRequest(request))
-    }
-      yield {
-        responseCode match {
-          case 200 => Redirect(routes.Joiner.enterStaffDetails())
-            .flashing("success" ->
-              s"Your email address has been changed to $googleEmail")
-          case _ => Redirect(routes.Joiner.staff())
-            .flashing("error" ->
-              s"There has been an error in updating your email. You may already have an Identity account with $googleEmail. Please try signing in with that email.")
-        }
-      }
+      emailUpdateResult <- identityService.updateEmail(request.identityUser, googleEmail)(IdentityRequest(request)).value
+    } yield emailUpdateResult.fold(
+      _ => Redirect(routes.Joiner.staff()).flashing("error" ->
+        s"There has been an error in updating your email. You may already have an Identity account with $googleEmail. Please try signing in with that email."),
+      _ => Redirect(routes.Joiner.enterStaffDetails()).flashing("success" ->
+        s"Your email address has been changed to $googleEmail"))
+//      yield {
+//        responseCode match {
+//          case 200 => Redirect(routes.Joiner.enterStaffDetails())
+//            .flashing("success" ->
+//              s"Your email address has been changed to $googleEmail")
+//          case _ => Redirect(routes.Joiner.staff())
+//            .flashing("error" ->
+//              s"There has been an error in updating your email. You may already have an Identity account with $googleEmail. Please try signing in with that email.")
+//        }
+//      }
   }
 
   def unsupportedBrowser = CachedAction(Ok(views.html.joiner.unsupportedBrowser()))
 
-  private def makeMember(tier: Tier, onSuccess: => Result)(formData: JoinForm)(implicit request: AuthRequest[_]) = {
-    logger.info(s"User ${request.user.id} attempting to become ${tier.name}...")
+  private def makeMember(tier: Tier, onSuccess: => Result)(formData: JoinForm)(implicit request: Request[_]) = {
+    val userOpt = authenticatedIdUserProvider(request)
+    val userDescription = s"User id=${userOpt.map(_.id).mkString}"
+    logger.info(s"$userDescription attempting to become ${tier.name}...")
     val eventId = PreMembershipJoiningEventFromSessionExtractor.eventIdFrom(request.session)
-    implicit val bp: BackendProvider = request
-    val idRequest = IdentityRequest(request)
+    implicit val resolution: TouchpointBackend.Resolution =
+      TouchpointBackend.forRequest(NameEnteredInForm, Some(formData))
+
+    implicit val tpBackend = resolution.backend
+
+    implicit val backendProvider: BackendProvider = new BackendProvider {
+      override def touchpointBackend = tpBackend
+    }
+
     val campaignCode = CampaignCode.fromRequest
     val ipCountry = request.getFastlyCountry
 
-    Timing.record(salesforceService.metrics, "createMember") {
-      memberService.createMember(request.user, formData, idRequest, eventId, campaignCode, tier, ipCountry).map {
+    identityStrategyFor(request, formData).ensureIdUser { user =>
+      memberService.createMember(user, formData, eventId, campaignCode, tier, ipCountry).map {
         case (sfContactId, zuoraSubName) =>
-          logger.info(s"User ${request.user.id} successfully became ${tier.name} $zuoraSubName.")
+          logger.info(s"$userDescription successfully became ${tier.name} $zuoraSubName.")
           salesforceService.metrics.putSignUp(tier)
-          trackRegistration(formData, tier, sfContactId, request.user, campaignCode)
-          trackRegistrationViaEvent(sfContactId, request.user, eventId, campaignCode, tier)
+          trackRegistration(formData, tier, sfContactId, user.minimal, campaignCode)
+          trackRegistrationViaEvent(sfContactId, user.minimal, eventId, campaignCode, tier)
           onSuccess
       }.recover {
         // errors due to user's card are logged at WARN level as they are not logic errors
         case error: Stripe.Error =>
-          logger.warn(s"Stripe API call returned error: \n\t$error \n\tuser=${request.user.id}")
-          setBehaviourNote(tier.name, error.code)(request)
+          logger.warn(s"Stripe API call returned error: \n\t$error \n\tuser=$userOpt")
+          setBehaviourNote(tier.name, error.code, userOpt)
           Forbidden(Json.toJson(error))
 
         case error: PaymentGatewayError =>
-          setBehaviourNote(tier.name, error.code)(request)
-          handlePaymentGatewayError(error, request.user.id, tier.name, idRequest.trackingParameters, formData.deliveryAddress.countryName)
+          setBehaviourNote(tier.name, error.code, userOpt)
+          handlePaymentGatewayError(error, user.id, tier.name, formData.deliveryAddress.countryName)
 
         case error =>
           salesforceService.metrics.putFailSignUp(tier)
-          logger.error(s"User ${request.user.id} could not become ${tier.name} member: ${idRequest.trackingParameters}", error)
-          setBehaviourNote(tier.name, "card_error")(request)
+          logger.error(s"$userDescription could not become ${tier.name} member", error)
+          setBehaviourNote(tier.name, "card_error", userOpt)
           Forbidden
       }
     }
@@ -288,9 +300,9 @@ object Joiner extends Controller with ActivityTracking with PaymentGatewayErrorH
 
   def thankyouStaff = thankyou(Tier.partner)
 
-  private def setBehaviourNote(tier: String, errorCode: String)(implicit request: AuthRequest[_]) = {
+  private def setBehaviourNote(tier: String, errorCode: String, userOpt: Option[AuthenticatedIdUser]) = for (user <- userOpt) {
     if (tier.toLowerCase == "supporter") {
-      MembersDataAPI.Service.upsertBehaviour(request.user, note = Some(errorCode))
+      MembersDataAPI.Service.upsertBehaviour(user, note = Some(errorCode))
     }
   }
 

--- a/frontend/app/controllers/PaymentGatewayErrorHandler.scala
+++ b/frontend/app/controllers/PaymentGatewayErrorHandler.scala
@@ -7,10 +7,10 @@ import play.api.libs.json.Json
 
 trait PaymentGatewayErrorHandler extends LazyLogging {
 
-  def handlePaymentGatewayError(e: PaymentGatewayError, userId: String, tier: String, tracking: List[(String, String)], country: String = "") = {
+  def handlePaymentGatewayError(e: PaymentGatewayError, userId: String, tier: String, country: String = "") = {
 
     def handleError(code: String) = {
-      logger.warn(s"User $userId could not become $tier member due to payment gateway failed transaction: \n\terror=$e \n\tuser=$userId \n\ttracking=$tracking \n\tcountry=$country")
+      logger.warn(s"User $userId could not become $tier member due to payment gateway failed transaction: \n\terror=$e \n\tuser=$userId \n\tcountry=$country")
       Forbidden(Json.obj("type" -> "PaymentGatewayError", "code" -> code))
     }
 

--- a/frontend/app/controllers/TierController.scala
+++ b/frontend/app/controllers/TierController.scala
@@ -207,8 +207,8 @@ object TierController extends Controller with ActivityTracking
 
       paidMember.contact.email.map { email =>
         for {
-          status <- IdentityService(IdentityApi).reauthUser(email, form.password, identityRequest)
-          result <- if (status == 200) doUpgrade() else reauthFailedMessage
+          reauthResult <- IdentityService(IdentityApi).reauthUser(email, form.password).value
+          result <- reauthResult.fold(_ => reauthFailedMessage, _ => doUpgrade())
         } yield result
       }.getOrElse(noEmailMessage)
     }

--- a/frontend/app/forms/MemberForm.scala
+++ b/frontend/app/forms/MemberForm.scala
@@ -8,7 +8,6 @@ import com.gu.memsub.BillingPeriod._
 import com.gu.memsub.{Address, BillingPeriod, FullName}
 import com.gu.salesforce.PaidTier
 import com.gu.salesforce.Tier._
-import forms.MemberForm.PaidForm
 import model._
 import play.api.data.Forms._
 import play.api.data.format.Formatter
@@ -44,14 +43,21 @@ object MemberForm {
 
   case class MarketingChoicesForm(gnm: Option[Boolean], thirdParty: Option[Boolean])
 
+  trait HasDeliveryAddress {
+    val deliveryAddress: Address
+  }
+
+  trait HasBillingAddress {
+    val billingAddress: Option[Address]
+  }
+
   trait CommonForm {
     val name: NameForm
     val password: Option[String]
     val marketingChoices: MarketingChoicesForm
   }
 
-  trait JoinForm extends CommonForm {
-    val deliveryAddress: Address
+  trait JoinForm extends CommonForm with HasDeliveryAddress {
     val marketingChoices: MarketingChoicesForm
     val password: Option[String]
     val planChoice: PlanChoice
@@ -61,7 +67,7 @@ object MemberForm {
     val payment: CommonPaymentForm
   }
 
-  trait PaidMemberForm extends PaidForm {
+  trait PaidMemberForm extends PaidForm with HasBillingAddress {
     val featureChoice: Set[FeatureChoice]
     val zuoraAccountAddress : Address
     val payment: PaymentForm

--- a/frontend/app/services/IdentityService.scala
+++ b/frontend/app/services/IdentityService.scala
@@ -1,26 +1,81 @@
 package services
 
-import com.gu.identity.play.{IdMinimalUser, IdUser}
-import com.gu.memsub.util.Timing
+import cats.data.EitherT
+import cats.instances.all._
+import cats.syntax.either._
+import com.gu.identity.play._
+import com.gu.identity.play.idapi.{CreateIdUser, UpdateIdUser, UserRegistrationResult}
 import com.gu.memsub.Address
+import com.gu.memsub.util.Timing
 import configuration.Config
 import controllers.IdentityRequest
+import dispatch.Defaults.timer
+import dispatch._
 import forms.MemberForm._
 import monitoring.IdentityApiMetrics
 import play.api.Logger
 import play.api.Play.current
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import play.api.libs.json.Json.toJson
 import play.api.libs.json._
-import play.api.libs.ws.WS
+import play.api.libs.ws.{WS, WSResponse}
+import services.IdentityService.DisregardResponseContent
 import views.support.IdentityUser
 
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.util.{Failure, Success}
-import dispatch._, Defaults.timer
 
 case class IdentityServiceError(s: String) extends Throwable {
   override def getMessage: String = s
+}
+
+object IdentityService {
+  val DisregardResponseContent: (WSResponse => Either[String, Unit]) = resp => Right(Unit)
+
+  def privateFieldsFor(form: CommonForm): PrivateFields = {
+    val deliveryOpt = form match {
+      case d: HasDeliveryAddress => Some(d.deliveryAddress)
+      case _ => None
+    }
+
+    privateFieldsFor(
+      firstName = Some(form.name.first),
+      lastName = Some(form.name.last),
+      delivery = deliveryOpt,
+      billing = form match {
+        case b: HasBillingAddress => b.billingAddress.orElse(deliveryOpt)
+        case _ => None
+      }
+    )
+  }
+
+  def privateFieldsFor(
+    firstName: Option[String] = None,
+    lastName: Option[String] = None,
+    delivery: Option[Address] = None,
+    billing: Option[Address] = None): PrivateFields = {
+
+    def country(address: Option[Address]) = address.map(a => a.country.fold(a.countryName)(_.name))
+
+    PrivateFields(
+      firstName,
+      lastName,
+
+      delivery.map(_.lineOne),
+      delivery.map(_.lineTwo),
+      delivery.map(_.town),
+      delivery.map(_.countyOrState),
+      delivery.map(_.postCode),
+      country(delivery),
+
+      billing.map(_.lineOne),
+      billing.map(_.lineTwo),
+      billing.map(_.town),
+      billing.map(_.countyOrState),
+      billing.map(_.postCode),
+      country(billing)
+    )
+  }
 }
 
 case class IdentityService(identityApi: IdentityApi) {
@@ -44,80 +99,40 @@ case class IdentityService(identityApi: IdentityApi) {
   def doesUserPasswordExist(identityRequest: IdentityRequest): Future[Boolean] =
     identityApi.getUserPasswordExists(identityRequest.headers, identityRequest.trackingParameters)
 
-  def updateUserFieldsBasedOnJoining(user: IdMinimalUser, formData: CommonForm, identityRequest: IdentityRequest) {
-
-    val billingDetails = formData match {
-      case billingForm : PaidMemberJoinForm =>
-        val billingAddressForm = billingForm.billingAddress.getOrElse(billingForm.deliveryAddress)
-        billingAddress(billingAddressForm)
-      case _ => Json.obj()
-    }
-
-    val deliverAddress = formData match {
-      case jf : JoinForm => deliveryAddress(jf.deliveryAddress)
-      case _ => Json.obj()
-    }
-
-    val fields = Json.obj(
-      "secondName" -> formData.name.last,
-      "firstName" -> formData.name.first
-    ) ++ deliverAddress ++ billingDetails
-
-    val json = Json.obj("privateFields" -> fields)
-    postFields(json, user.id, identityRequest)
+  def updateUserPassword(password: String)(implicit idReq: IdentityRequest) {
+    identityApi.post("/user/password", Some(Json.obj("newPassword" -> password)), idReq.headers, idReq.trackingParameters, "update-user-password")(DisregardResponseContent)
   }
-
-  def updateUserPassword(password: String, identityRequest: IdentityRequest, userId: String) {
-    val json = Json.obj("newPassword" -> password)
-    identityApi.post("/user/password", Some(json), identityRequest.headers, identityRequest.trackingParameters, "update-user-password")
-  }
-
-  def updateUserMarketingPreferences(req: IdentityRequest, user: IdMinimalUser, allowMarketing: Boolean) =
-    postFields(Json.obj("statusFields.receiveGnmMarketing" -> allowMarketing), user.id, req)
 
   def updateUserFieldsBasedOnUpgrade(userId: String, addressDetails: AddressDetails)(implicit r: IdentityRequest) {
-    val billingAddressForm = addressDetails.billingAddress.getOrElse(addressDetails.deliveryAddress)
-    val fields = deliveryAddress(addressDetails.deliveryAddress) ++ billingAddress(billingAddressForm)
-    val json = Json.obj("privateFields" -> fields)
-    postFields(json, userId, r)
+    updateUser(UpdateIdUser(privateFields = Some(IdentityService.privateFieldsFor(
+          delivery = Some(addressDetails.deliveryAddress),
+          billing = Some(addressDetails.billingAddress.getOrElse(addressDetails.deliveryAddress))))), userId)(r)
   }
 
-  def updateEmail(user: IdMinimalUser, email: String, identityRequest: IdentityRequest) = {
-    val json = Json.obj("primaryEmailAddress" -> email)
-    postFields(json, user.id, identityRequest)
+  def updateEmail(user: IdMinimalUser, email: String)(implicit idReq: IdentityRequest): EitherT[Future, String, Unit] =
+    updateUser(UpdateIdUser(primaryEmailAddress = Some(email)), user.id)
+
+  def reauthUser(email: String, password: String)(implicit idReq: IdentityRequest): EitherT[Future, String, Unit] = {
+    val params = ("email" -> email) :: ("password" -> password) :: idReq.trackingParameters
+    identityApi.post("auth", None, idReq.headers, params, "reauth")(DisregardResponseContent)
   }
 
-  def reauthUser(email: String, password: String, identityRequest: IdentityRequest) = {
-    val params = ("email" -> email) :: ("password" -> password) :: identityRequest.trackingParameters
-    identityApi.post("auth", None, identityRequest.headers, params, "reauth")
-
+  def createUser(userCreationCommand: CreateIdUser)(implicit idReq: IdentityRequest): EitherT[Future, String, UserRegistrationResult] = identityApi.post("user",
+    Some(toJson(userCreationCommand)),
+    idReq.headers,
+    idReq.trackingParameters ++ Seq("authenticate" -> "true", "format" -> "cookies"),
+    "create-user") {
+    _.json.validate[UserRegistrationResult].asEither.leftMap(_.mkString(","))
   }
 
-  private def postFields(json: JsObject, userId: String, identityRequest: IdentityRequest) = {
+  def updateUser(userUpdateCommand: UpdateIdUser, userId: String)(implicit idReq: IdentityRequest): EitherT[Future, String, Unit] = {
     Logger.info(s"Posting updated information to Identity for user :$userId")
-    identityApi.post(s"user/$userId", Some(json), identityRequest.headers, identityRequest.trackingParameters, "update-user")
-  }
 
-  private def deliveryAddress(addressForm: Address): JsObject = {
-    Json.obj(
-      "address1" -> addressForm.lineOne,
-      "address2" -> addressForm.lineTwo,
-      "address3" -> addressForm.town,
-      "address4" -> addressForm.countyOrState,
-      "postcode" -> addressForm.postCode,
-      "country" -> addressForm.country.fold(addressForm.countryName)(_.name)
-    )
-  }
-
-  private def billingAddress(billingAddress: Address): JsObject = {
-    Json.obj(
-      "billingAddress1" -> billingAddress.lineOne,
-      "billingAddress2" -> billingAddress.lineTwo,
-      "billingAddress3" -> billingAddress.town,
-      "billingAddress4" -> billingAddress.countyOrState,
-      "billingPostcode" -> billingAddress.postCode,
-      "billingCountry" -> billingAddress.country.fold(billingAddress.countryName)(_.name)
-    )
+    identityApi.post(s"user/$userId",
+      Some(toJson(userUpdateCommand)),
+      idReq.headers,
+      idReq.trackingParameters,
+      "update-user")(DisregardResponseContent)
   }
 }
 
@@ -155,21 +170,19 @@ trait IdentityApi {
     }
   }
 
-  def post(endpoint: String, data: Option[JsObject], headers: List[(String, String)], parameters: List[(String, String)], metricName: String): Future[Int] = {
-    Timing.record(IdentityApiMetrics, metricName) {
+  def post[A](
+    endpoint: String, data: Option[JsValue],
+    headers: List[(String, String)],
+    parameters: List[(String, String)],
+    metricName: String)(func: WSResponse => Either[String, A]): EitherT[Future, String, A] = {
       val requestHolder = WS.url(s"${Config.idApiUrl}/$endpoint").withHeaders(headers: _*).withQueryString(parameters: _*).withRequestTimeout(5000)
-      val response = requestHolder.post(data.getOrElse(JsNull))
-      response.foreach(r => recordAndLogResponse(r.status, s"POST $metricName", endpoint ))
-      response.map(_.status)
-        .andThen {
-          case Success(status) =>
-            if ((status / 100) != 2) // non 2xx code
-              Logger.error(s"Identity API error: POST ${Config.idApiUrl}/$endpoint STATUS $status")
 
-          case Failure(e) =>
-            Logger.error(s"Identity API error: POST ${Config.idApiUrl}/$endpoint", e)
-        }
-    }
+      for {
+        r <- EitherT.right(Timing.record(IdentityApiMetrics, metricName)(requestHolder.post(data.getOrElse(JsNull))))
+        _ = recordAndLogResponse(r.status, s"POST $metricName", endpoint )
+        response <- EitherT.fromEither[Future](Either.cond((r.status / 100) == 2, right = r, left = s"Identity API error: POST ${Config.idApiUrl}/$endpoint STATUS ${r.status}"))
+        result <- EitherT.fromEither[Future](func(response))
+      } yield result
   }
 
   private def recordAndLogResponse(status: Int, responseMethod: String, endpoint: String) {

--- a/frontend/app/services/api/MemberService.scala
+++ b/frontend/app/services/api/MemberService.scala
@@ -1,13 +1,12 @@
 package services.api
 
 import com.gu.i18n.Country
-import com.gu.identity.play.IdMinimalUser
+import com.gu.identity.play.IdUser
 import com.gu.memsub.Subscriber._
-import com.gu.memsub.promo.{PromoError, Upgrades, ValidPromotion}
+import com.gu.memsub.promo.PromoError
 import com.gu.memsub.subsv2._
 import com.gu.memsub.{BillingSchedule, Subscription => S}
 import com.gu.salesforce.{ContactId, PaidTier, Tier}
-import com.gu.stripe.Stripe.Customer
 import com.gu.zuora.soap.models.Commands.PaymentMethod
 import com.gu.zuora.soap.models.Results.{CreateResult, SubscribeResult}
 import controllers.IdentityRequest
@@ -28,17 +27,15 @@ trait MemberService {
 
   def country(contact: GenericSFContact)(implicit i: IdentityRequest): Future[Country]
 
-  def createMember(user: IdMinimalUser,
+  def createMember(user: IdUser,
                    formData: JoinForm,
-                   identityRequest: IdentityRequest,
                    fromEventId: Option[String],
                    campaignCode: Option[CampaignCode],
                    tier: Tier,
                    ipCountry: Option[Country]): Future[(ContactId, ZuoraSubName)]
 
-  def createContributor(user: IdMinimalUser,
+  def createContributor(user: IdUser,
                    formData: ContributorForm,
-                   identityRequest: IdentityRequest,
                    campaignCode: Option[CampaignCode]): Future[(ContactId, ZuoraSubName)]
 
   def previewUpgradeSubscription(subscriber: PaidMember, newPlan: PlanChoice)

--- a/frontend/app/services/checkout/identitystrategy/ExistingSignedInUser.scala
+++ b/frontend/app/services/checkout/identitystrategy/ExistingSignedInUser.scala
@@ -1,0 +1,39 @@
+package services.checkout.identitystrategy
+
+import com.gu.identity.play.idapi.UpdateIdUser
+import com.gu.identity.play.{IdMinimalUser, IdUser}
+import com.typesafe.scalalogging.LazyLogging
+import controllers.IdentityRequest
+import forms.MemberForm.CommonForm
+import play.api.mvc.{RequestHeader, Result}
+import services.AuthenticationService.authenticatedIdUserProvider
+import services.IdentityService
+import services.checkout.identitystrategy.Strategy.identityService
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+object ExistingSignedInUser {
+  def strategyFrom(request: RequestHeader, form: CommonForm)(implicit idRequest: IdentityRequest) = for {
+    idUser <- authenticatedIdUserProvider(request)
+  } yield ExistingSignedInUser(idUser, form)
+}
+
+case class ExistingSignedInUser(userId: IdMinimalUser, formData: CommonForm)(implicit idReq: IdentityRequest) extends Strategy with LazyLogging {
+
+  def ensureIdUser(checkoutFunc: (IdUser) => Future[Result]) = {
+    val fieldsFromForm = Some(IdentityService.privateFieldsFor(formData))
+
+    for (password <- formData.password) {
+      identityService.updateUserPassword(password) // Update user password (social signin)
+    }
+
+    val updateUserF = identityService.updateUser(UpdateIdUser(privateFields = fieldsFromForm), userId.id).value
+
+    for {
+      fullIdUser <- identityService.getFullUserDetails(userId)
+      _ <- updateUserF
+      result <- checkoutFunc(fullIdUser.copy(privateFields = fieldsFromForm))
+    } yield result
+  }
+}

--- a/frontend/app/services/checkout/identitystrategy/NewUser.scala
+++ b/frontend/app/services/checkout/identitystrategy/NewUser.scala
@@ -1,0 +1,38 @@
+package services.checkout.identitystrategy
+
+import cats.data.EitherT
+import cats.implicits._
+import com.gu.identity.play.CookieBuilder.cookiesFromDescription
+import com.gu.identity.play.idapi.CreateIdUser
+import com.gu.identity.play.{IdUser, PublicFields}
+import configuration.Config
+import controllers.IdentityRequest
+import forms.MemberForm.{CommonForm, PaidMemberJoinForm}
+import play.api.mvc.{Result, Results}
+import services.IdentityService
+import services.checkout.identitystrategy.Strategy.identityService
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+object NewUser {
+  def strategyFrom(form: CommonForm)(implicit idReq: IdentityRequest) = for {
+    paidMemberJoinForm <- Option(form).collect { case p: PaidMemberJoinForm => p }
+    password <- paidMemberJoinForm.password
+  } yield NewUser(CreateIdUser(
+    paidMemberJoinForm.email,
+    password,
+    PublicFields(displayName = Some(s"${form.name.first} ${form.name.last}")),
+    Some(IdentityService.privateFieldsFor(form))
+  ))
+}
+
+case class NewUser(creationCommand: CreateIdUser)(implicit idReq: IdentityRequest) extends Strategy {
+
+  def ensureIdUser(checkoutFunc: (IdUser) => Future[Result]) = (for {
+    userRegAndAuthResponse <- identityService.createUser(creationCommand)
+    result <- EitherT.right[Future, String, Result](checkoutFunc(userRegAndAuthResponse.user))
+  } yield result.withCookies(cookiesFromDescription(userRegAndAuthResponse.cookies.get, Some(Config.guardianShortDomain)): _*)
+    ).valueOr { error => Results.InternalServerError(error) }
+
+}

--- a/frontend/app/services/checkout/identitystrategy/Strategy.scala
+++ b/frontend/app/services/checkout/identitystrategy/Strategy.scala
@@ -1,0 +1,27 @@
+package services.checkout.identitystrategy
+
+import com.gu.identity.play.IdUser
+import controllers.IdentityRequest
+import forms.MemberForm.CommonForm
+import play.api.mvc.{RequestHeader, Result}
+import services.{IdentityApi, IdentityService}
+
+import scala.concurrent.Future
+
+object Strategy {
+  val identityService = IdentityService(IdentityApi)
+
+  def identityStrategyFor(request: RequestHeader, form: CommonForm): Strategy = {
+    implicit val idRequest = IdentityRequest(request)
+
+    val strategies = ExistingSignedInUser.strategyFrom(request, form) ++ NewUser.strategyFrom(form)
+
+    assert(strategies.size == 1, s"Should have exactly 1 CheckoutIdentityStrategy, instead have ${strategies.size}")
+
+    strategies.head
+  }
+}
+
+trait Strategy {
+  def ensureIdUser(checkoutFunc: (IdUser) => Future[Result]): Future[Result]
+}

--- a/frontend/test/services/IdentityServiceTest.scala
+++ b/frontend/test/services/IdentityServiceTest.scala
@@ -2,32 +2,35 @@ package services
 
 import com.gu.i18n.Country
 import com.gu.identity.play.IdMinimalUser
+import com.gu.identity.play.idapi.UpdateIdUser
 import com.gu.memsub.Address
+import com.gu.memsub.BillingPeriod.Year
 import com.gu.salesforce.Tier.partner
 import controllers.IdentityRequest
 import forms.MemberForm._
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import play.api.libs.json.{JsObject, Json}
+import services.IdentityService.DisregardResponseContent
 import utils.Resource
-import com.gu.memsub.BillingPeriod.Year
 
 class IdentityServiceTest extends Specification with Mockito {
 
+  val ip = "8.8.8.8"
   val user = new IdMinimalUser("4444", Some("Joe Bloggs"))
   val headers = List("headers" -> "a header")
   val trackingParameters = List("some tracking parameters" -> "a tracking param")
-  val identityRequest = new IdentityRequest(headers, trackingParameters)
+  implicit val identityRequest = new IdentityRequest(ip, headers, trackingParameters)
 
   "IdentityService" should {
     "post json for updating an users email" in {
       val identityAPI = mock[IdentityApi]
       val identityService = IdentityService(identityAPI)
 
-      identityService.updateEmail(user, "joe.bloggs@awesome-email.com", identityRequest)
+      identityService.updateEmail(user, "joe.bloggs@awesome-email.com")(identityRequest)
 
       val expectedJson = Json.parse("{\"primaryEmailAddress\": \"joe.bloggs@awesome-email.com\"}").as[JsObject]
-      there was one(identityAPI).post("user/4444", Some(expectedJson) , headers, trackingParameters, "update-user")
+      there was one(identityAPI).post("user/4444", Some(expectedJson) , headers, trackingParameters, "update-user")(DisregardResponseContent)
     }
 
     "post json for updating users details on joining friend" in {
@@ -42,10 +45,10 @@ class IdentityServiceTest extends Specification with Mockito {
         None
       )
 
-      identityService.updateUserFieldsBasedOnJoining(user, friendForm, identityRequest)
+      identityService.updateUser(UpdateIdUser(privateFields = Some(IdentityService.privateFieldsFor(friendForm))), user.id)
 
       val expectedJson = Resource.getJson(s"model/identity/update-friend.json").as[JsObject]
-      there was one(identityAPI).post("user/4444", Some(expectedJson), headers, trackingParameters, "update-user")
+      there was one(identityAPI).post("user/4444", Some(expectedJson), headers, trackingParameters, "update-user")(DisregardResponseContent)
     }
 
     "post json for updating users details on joining paid tier" in {
@@ -67,10 +70,10 @@ class IdentityServiceTest extends Specification with Mockito {
         Set.empty
       )
 
-      identityService.updateUserFieldsBasedOnJoining(user, paidForm, identityRequest)
+      identityService.updateUser(UpdateIdUser(privateFields = Some(IdentityService.privateFieldsFor(paidForm))), user.id)
 
       val expectedJson = Resource.getJson(s"model/identity/update-paid.json").as[JsObject]
-      there was one(identityAPI).post("user/4444", Some(expectedJson), headers, trackingParameters, "update-user")
+      there was one(identityAPI).post("user/4444", Some(expectedJson), headers, trackingParameters, "update-user")(DisregardResponseContent)
     }
   }
 
@@ -86,6 +89,6 @@ class IdentityServiceTest extends Specification with Mockito {
     identityService.updateUserFieldsBasedOnUpgrade(user.id, addressDetails)(identityRequest)
 
     val expectedJson = Resource.getJson(s"model/identity/update-upgrade.json").as[JsObject]
-    there was one(identityAPI).post("user/4444", Some(expectedJson), headers, trackingParameters, "update-user")
+    there was one(identityAPI).post("user/4444", Some(expectedJson), headers, trackingParameters, "update-user")(DisregardResponseContent)
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,12 +27,14 @@ object Dependencies {
   val dispatch = "net.databinder.dispatch" %% "dispatch-core" % "0.11.3"
   val pegdown = "org.pegdown" % "pegdown" % "1.6.0"
   val enumPlay = "com.beachape" %% "enumeratum-play" % "1.3.7"
+  val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "0.22"
+  val catsCore = "org.typelevel" %% "cats-core" % "0.9.0"
 
   //projects
 
   val frontendDependencies =  Seq(memsubCommonPlayAuth, scalaUri, membershipCommon, enumPlay,
     contentAPI, playWS, playFilters, playCache, sentryRavenLogback, awsSimpleEmail, sqs, snowPlow, bCrypt, scalaz, pegdown,
-    PlayImport.specs2 % "test", specs2Extra, dispatch)
+    PlayImport.specs2 % "test", specs2Extra, dispatch, identityPlayAuth, catsCore)
 
   val acceptanceTestDependencies = Seq(memsubCommonPlayAuth, scalaTest, selenium, seleniumHtmlUnitDriver, seleniumManager)
 


### PR DESCRIPTION
## Why are you doing this?

This work follows on from https://github.com/guardian/membership-frontend/pull/1539, which allowed unauthenticated users to view the checkout page - this change actually makes checkout work! When the user hits the buy button (eg Credit Card or PayPal), an Identity account is created for the user as a first step, before the rest of the Salesforce/Zuora processing occurs.

The feature is hidden behind the `MergedRegistration` feature switch:

https://membership.theguardian.com/feature/MergedRegistration/On

Once that cookie is dropped, you can go to the checkout page without already being signed in:

https://membership.theguardian.com/join/supporter/enter-details

## Trello card: [Here](https://trello.com/c/TpuX5Fdb/298-a-b-testing-for-new-checkout-flow-test-merging-registration-into-supporter-checkout)

## Changes
The classes under the new `services.checkout.identitystrategy` Scala package handle the Identity-related tasks around checkout:

* `NewUser` : Creates a new Identity account
* `ExistingSignedInUser` : Gets & *updates* the user's existing Id account

This also simplifies the implementation code for `MemberService.createMember()`.

This change uses the new Create-And-Authenticate-User Identity API call added with https://github.com/guardian/identity/pull/621, as well as the handy authentication-cookie classes added with https://github.com/guardian/identity/pull/622. There was also supporting code in https://github.com/guardian/identity-play-auth/commit/0babd70f02f5b8c089af8ef734f01daf8c6e288b

I've also introduced Cats for the the Identity API client, I realise we still have Scalaz all over the place... I apologise for having increased the number of FP libraries to 2.

There's still another PR to check if the email address is already in use: https://github.com/guardian/membership-frontend/pull/1575

cc @dominickendrick 