### PR TITLE
Fix acceptance tests in Dev for paypal payments

### DIFF
--- a/frontend/test/acceptance/pages/EnterDetails.scala
+++ b/frontend/test/acceptance/pages/EnterDetails.scala
@@ -1,7 +1,8 @@
 package acceptance.pages
 
-import acceptance.util.{TestUser, Browser, Config}
+import acceptance.util.{Browser, Config, TestUser}
 import Config.baseUrl
+import org.openqa.selenium.support.ui.ExpectedConditions
 import org.scalatest.selenium.Page
 
 case class EnterDetails(val testUser: TestUser) extends Page with Browser {
@@ -63,6 +64,7 @@ case class EnterDetails(val testUser: TestUser) extends Page with Browser {
   def payPalSummaryHasCorrectAmount() = elementHasText(PayPalCheckout.paymentAmount, "£49.00")
 
   def acceptPayPalPayment() = {
+    pageDoesNotHaveElement(id("spinner"))
     PayPalCheckout.acceptPayment
     switchToParentWindow
   }

--- a/frontend/test/acceptance/util/Browser.scala
+++ b/frontend/test/acceptance/util/Browser.scala
@@ -20,6 +20,9 @@ trait Browser extends WebBrowser {
   def pageHasElement(q: Query): Boolean =
     waitUntil(ExpectedConditions.visibilityOfElementLocated(q.by))
 
+  def pageDoesNotHaveElement(q: Query): Boolean =
+    waitUntil(ExpectedConditions.not(ExpectedConditions.presenceOfAllElementsLocatedBy(q.by)))
+
   def pageHasUrl(urlFraction: String): Boolean =
     waitUntil(ExpectedConditions.urlContains(urlFraction))
 


### PR DESCRIPTION
This fixes a consistent failure of PayPal payments in the acceptance tests in Dev (note that they still worked in post-deploy testing on Prod!). The failure indicated that the 'spinner' was still in the way of the PayPal 'accept payment' button ...possibly a bit of a race condition there.

Fix is to wait until the spinner is not visible.

The failure which was occurring:

```
[info]   Scenario: User joins as Supporter using PayPal in UK *** FAILED *** (27 seconds, 38 milliseconds)
[info]   org.openqa.selenium.WebDriverException: unknown error: Element <input track-submit="" type="submit" value="Agree and Pay" id="confirmButtonTop" class="btn full confirmButton continueButton" validate-submit="onPay()"> is not clickable at point (225, 225). Other element would receive the click: <p class="spinnerImage"></p>
[info]   (Session info: chrome=57.0.2987.133)
[info]   (Driver info: chromedriver=2.29.461571 (8a88bbe0775e2a23afda0ceaf2ef7ee74e822cc5),platform=Linux 4.8.0-39-generic x86_64) (WARNING: The server did not provide any stacktrace information)
[info] Command duration or timeout: 48 milliseconds
[info] Build info: version: '3.0.1', revision: '1969d75', time: '2016-10-18 09:49:13 -0700'
[info] System info: host: 'gnm41073', ip: '127.0.1.1', os.name: 'Linux', os.arch: 'amd64', os.version: '4.8.0-39-generic', java.version: '1.8.0_121'
[info] Driver info: org.openqa.selenium.chrome.ChromeDriver
[info] Capabilities [{applicationCacheEnabled=false, rotatable=false, mobileEmulationEnabled=false, networkConnectionEnabled=false, chrome={chromedriverVersion=2.29.461571 (8a88bbe0775e2a23afda0ceaf2ef7ee74e822cc5), userDataDir=/tmp/.org.chromium.Chromium.qg5HgZ}, takesHeapSnapshot=true, pageLoadStrategy=normal, databaseEnabled=false, handlesAlerts=true, hasTouchScreen=false, version=57.0.2987.133, platform=LINUX, browserConnectionEnabled=false, nativeEvents=true, acceptSslCerts=true, locationContextEnabled=true, webStorageEnabled=true, browserName=chrome, takesScreenshot=true, javascriptEnabled=true, cssSelectorsEnabled=true, unexpectedAlertBehaviour=}]
[info] Session ID: 403a60c1f535fcacbaad2dee37dabf6d
[info]   at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
[info]   at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
[info]   at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
[info]   at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
[info]   at org.openqa.selenium.remote.ErrorHandler.createThrowable(ErrorHandler.java:216)
[info]   at org.openqa.selenium.remote.ErrorHandler.throwIfResponseFailed(ErrorHandler.java:168)
[info]   at org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:635)
[info]   at org.openqa.selenium.remote.RemoteWebElement.execute(RemoteWebElement.java:274)
[info]   at org.openqa.selenium.remote.RemoteWebElement.click(RemoteWebElement.java:84)
[info]   at org.scalatest.selenium.WebBrowser$click$.on(WebBrowser.scala:3788)
[info]   ...
[info]     Given users click 'Become a Supporter' button on Membership homepage
[info]     When They land on 'Identity Frontend' page,
[info]     And fill in personal details,
[info]     And submit the form to create their Identity account,
[info]     Then they should land on 'Enter Details' page,
[info]     And they should have Identity cookies,
[info]     And should be logged in with their Identity account.
[info]     When Users select USA delivery country,
[info]     Then the currency should change.
[info]     When Users fill in delivery address details,
[info]     And click Continue
[info]     And click PayPal button,
[info]     Then the PayPal Express Checkout mini-browser should display
[info]     When Users fill in their PayPal credentials
[info]     And click 'Log In'
[info]     Then payment summary appears
[info]     And it displays the correct amount
[info]     When User agrees to payment
```
