### PR TITLE
upgrade membership common version to 0.390 

### DIFF
--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -12,9 +12,6 @@ import com.gu.identity.play.{AuthenticationService => _, _}
 import com.gu.salesforce._
 import com.gu.stripe.Stripe
 import com.gu.stripe.Stripe.Serializer._
-import com.gu.zuora.ZuoraRestService
-import com.gu.zuora.ZuoraRestService.AccountSummary
-import com.gu.zuora.soap.models.Queries.Account
 import com.gu.zuora.soap.models.errors._
 import com.netaporter.uri.dsl._
 import com.typesafe.scalalogging.LazyLogging
@@ -42,7 +39,6 @@ import views.support.{CheckoutForm, CountryWithCurrency, IdentityUser, PageInfo}
 
 import scala.concurrent.Future
 import scala.util.Failure
-import scalaz.{-\/, \/, \/-}
 
 object Joiner extends Controller with ActivityTracking with PaymentGatewayErrorHandler
   with LazyLogging

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -273,11 +273,8 @@ object Joiner extends Controller with ActivityTracking with PaymentGatewayErrorH
     implicit val resolution: TouchpointBackend.Resolution = TouchpointBackend.forRequest(PreSigninTestCookie, request.cookies)
     implicit val idReq = IdentityRequest(request)
 
-    val emailFromZuora = zuoraRestService.getAccount(request.subscriber.subscription.accountId) map { email =>
-      email match {
-        case \/-((accountSummary: AccountSummary)) => accountSummary.billToContact.email
-        case -\/(_) => None
-      }
+    val emailFromZuora = zuoraRestService.getAccount(request.subscriber.subscription.accountId) map { account =>
+      account.toOption.flatMap(_.billToContact.email)
     }
 
     for {

--- a/frontend/app/controllers/TierController.scala
+++ b/frontend/app/controllers/TierController.scala
@@ -15,6 +15,7 @@ import com.gu.stripe.Stripe.Serializer._
 import com.gu.zuora.ZuoraRestService.AccountSummary
 import com.gu.zuora.soap.models.errors._
 import com.typesafe.scalalogging.LazyLogging
+import controllers.Joiner.zuoraRestService
 import forms.MemberForm._
 import model._
 import org.joda.time.LocalDate
@@ -207,11 +208,8 @@ object TierController extends Controller with ActivityTracking
         }
       }
 
-      val emailFromZuora = zuoraRestService.getAccount(request.subscriber.subscription.accountId) map { email =>
-        email match {
-          case \/-((accountSummary: AccountSummary)) => accountSummary.billToContact.email
-          case -\/(_) => None
-        }
+      val emailFromZuora = zuoraRestService.getAccount(request.subscriber.subscription.accountId) map { account =>
+        account.toOption.flatMap(_.billToContact.email)
       }
 
       emailFromZuora.flatMap { maybeEmail =>

--- a/frontend/app/controllers/TierController.scala
+++ b/frontend/app/controllers/TierController.scala
@@ -12,10 +12,8 @@ import com.gu.memsub.subsv2.{Catalog, PaidMembershipPlans}
 import com.gu.salesforce._
 import com.gu.stripe.Stripe
 import com.gu.stripe.Stripe.Serializer._
-import com.gu.zuora.ZuoraRestService.AccountSummary
 import com.gu.zuora.soap.models.errors._
 import com.typesafe.scalalogging.LazyLogging
-import controllers.Joiner.zuoraRestService
 import forms.MemberForm._
 import model._
 import org.joda.time.LocalDate
@@ -36,7 +34,7 @@ import scala.language.implicitConversions
 import scalaz.std.scalaFuture._
 import scalaz.syntax.monad._
 import scalaz.syntax.std.option._
-import scalaz.{-\/, EitherT, \/, \/-}
+import scalaz.{EitherT, \/}
 
 object TierController extends Controller with ActivityTracking
   with LazyLogging

--- a/frontend/app/controllers/package.scala
+++ b/frontend/app/controllers/package.scala
@@ -5,6 +5,7 @@ import com.gu.memsub.services.api.PaymentService
 import com.gu.memsub.subsv2.Catalog
 import com.gu.memsub.subsv2.services._
 import com.gu.stripe.StripeService
+import com.gu.zuora.ZuoraRestService
 import com.gu.zuora.api.ZuoraService
 import com.typesafe.scalalogging.LazyLogging
 import play.api.data.Form
@@ -48,6 +49,11 @@ package object controllers extends CommonActions with LazyLogging{
   trait ZuoraServiceProvider {
     def zuoraService(implicit request: BackendProvider): ZuoraService =
       request.touchpointBackend.zuoraService
+  }
+
+  trait ZuoraRestServiceProvider {
+    def zuoraRestService(implicit request: BackendProvider): ZuoraRestService[Future] =
+      request.touchpointBackend.zuoraRestService
   }
 
   trait SalesforceServiceProvider {

--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -8,7 +8,7 @@ import com.gu.i18n.Currency.GBP
 import com.gu.i18n.{Country, CountryGroup, Currency}
 import com.gu.identity.play.{IdMinimalUser, IdUser}
 import com.gu.memsub.Subscriber.{FreeMember, PaidMember}
-import com.gu.memsub.Subscription.{AccountId, Feature, ProductRatePlanId, RatePlanId}
+import com.gu.memsub.Subscription.{Feature, ProductRatePlanId, RatePlanId}
 import com.gu.memsub.promo.PromotionApplicator._
 import com.gu.memsub.promo._
 import com.gu.memsub.services.PromoService
@@ -25,7 +25,6 @@ import com.gu.stripe.Stripe.Customer
 import com.gu.stripe.StripeService
 import com.gu.subscriptions.Discounter
 import com.gu.zuora.ZuoraRestService
-import com.gu.zuora.ZuoraRestService.AccountSummary
 import com.gu.zuora.api.ZuoraService
 import com.gu.zuora.soap.models.Commands._
 import com.gu.zuora.soap.models.Results.{CreateResult, SubscribeResult, UpdateResult}
@@ -33,8 +32,6 @@ import com.gu.zuora.soap.models.errors.PaymentGatewayError
 import com.gu.zuora.soap.models.{Queries => SoapQueries}
 import com.typesafe.scalalogging.LazyLogging
 import controllers.IdentityRequest
-import controllers.Joiner.zuoraRestService
-import controllers.TierController.zuoraRestService
 import forms.MemberForm.{ContributorForm, _}
 import model.Eventbrite.{EBCode, EBOrder, EBTicketClass}
 import model.RichEvent.RichEvent

--- a/frontend/app/views/joiner/thankyou.scala.html
+++ b/frontend/app/views/joiner/thankyou.scala.html
@@ -16,7 +16,8 @@
   paymentMethod: Option[PaymentMethod],
   returnDestinationOpt: Option[model.Destination],
   upgrade: Boolean,
-  touchpointBackendResolution: services.TouchpointBackend.Resolution
+  touchpointBackendResolution: services.TouchpointBackend.Resolution,
+  emailFromZuora: Option[String]
 )
 
 @title = @{
@@ -83,7 +84,7 @@
         @fragments.page.pageHeader(
             pageHeader,
             Some(s"You're the newest ${member.subscription.plan.tier.name} of the Guardian and we're thrilled to have you on board. " +
-                member.contact.email.map(email => s"We've sent confirmation of your membership to $email").getOrElse("Our system failed to store your email address, please contact customer services.")),
+                emailFromZuora.map(email => s"We've sent confirmation of your membership to $email").getOrElse("Our system failed to store your email address, please contact customer services.")),
             classes = Seq("sessioncamhidetext")
         )
 

--- a/frontend/test/services/DestinationServiceTest.scala
+++ b/frontend/test/services/DestinationServiceTest.scala
@@ -30,7 +30,7 @@ class DestinationServiceTest extends Specification {
 
     def createRequestWithSession(newSessions: (String, String)*) = {
 
-      val testMember = Contact("id", None, None, Some("fn"), "ln", Some("email"), new DateTime(), "contactId", "accountId", None, None, None, None, None)
+      val testMember = Contact("id", None, None, Some("fn"), "ln", new DateTime(), "contactId", "accountId", None, None, None, None, None)
       val partnerCharge: PaidCharge[Partner.type, Month.type] = PaidCharge[Partner.type, Month.type](Partner, Month, PricingSummary(Map(GBP -> Price(0.1f, GBP))), ProductRatePlanChargeId("prpcId"))
       val testSub: Subscription[SubscriptionPlan.Member] = new Subscription[SubscriptionPlan.Partner](
         id = com.gu.memsub.Subscription.Id(""),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "7.2.3"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.9" // v0.9 is the latest version published for Play 2.4...
-  val membershipCommon = "com.gu" %% "membership-common" % "0.388"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.390"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playFilters = PlayImport.filters


### PR DESCRIPTION
Upgrade to version 0.390 of membership-common. PR [453](https://github.com/guardian/membership-common/pull/453) in membership common means that now is the time to fetch email from Zuora rather than salesforce. 

## Why are you doing this?
<!--
Remember, PRs are documentation for future contributors

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->
Keep up to date with membership common. 

## Trello card: I need to do this before continuing with the card [Here](https://trello.com/c/aPZWc7PY/102-ensure-membership-common-doesn-t-have-its-own-execution-context)

## Changes
* Use a newer version of membership common
* This means that we need to get email from Zuora rather than from Salesforce.


<!--
If you are making heavy client-side changes, consider manual test the following
critical flow before merging
## Tested in
| Browser | Supporter Stripe checkout | Supporter Paypal checkout | Stripe Monthly Contribution |  Paypal Monthly Contribution| Upgrade from Friend to Supporter  |
|---------|---------------------------|---------------------------|-----------------------------|-----------------------------|-----------------------------------|
| IE      |                           |                           |                             |                             |                                   |
| Firefox |                           |                           |                             |                             |                                   |
| Safari  |                           |                           |                             |                             |                                   |
| Chrome  |                           |                           |                             |                             |                                   |

-->

## Screenshots
