### PR TITLE
Ensure we set the full name country in Salesforce

### DIFF
--- a/frontend/app/services/SalesforceService.scala
+++ b/frontend/app/services/SalesforceService.scala
@@ -1,11 +1,12 @@
 package services
 
-import com.gu.i18n.Country._
 import com.gu.identity.play.{IdMinimalUser, IdUser}
 import com.gu.salesforce.ContactDeserializer.Keys
 import com.gu.salesforce._
 import com.gu.stripe.Stripe.Customer
-import forms.MemberForm.{MonthlyContributorForm, CommonForm, JoinForm}
+import dispatch.Defaults.timer
+import dispatch._
+import forms.MemberForm.{CommonForm, JoinForm, MonthlyContributorForm}
 import model.GenericSFContact
 import monitoring.MemberMetrics
 import play.api.Play.current
@@ -16,8 +17,6 @@ import services.FrontendMemberRepository._
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import dispatch._
-import Defaults.timer
 
 object FrontendMemberRepository {
   type UserId = String
@@ -63,7 +62,7 @@ class SalesforceService(salesforceConfig: SalesforceConfig) extends api.Salesfor
         Keys.MAILING_CITY -> jf.deliveryAddress.town,
         Keys.MAILING_STATE -> jf.deliveryAddress.countyOrState,
         Keys.MAILING_POSTCODE -> jf.deliveryAddress.postCode,
-        Keys.MAILING_COUNTRY -> jf.deliveryAddress.country.getOrElse(UK).alpha2,
+        Keys.MAILING_COUNTRY -> jf.deliveryAddress.country.map(_.name).getOrElse(jf.deliveryAddress.countryName),
         Keys.ALLOW_MEMBERSHIP_MAIL -> true
       )) ++ Map(
         Keys.ALLOW_THIRD_PARTY_EMAIL -> formData.marketingChoices.thirdParty,

--- a/frontend/app/services/SalesforceService.scala
+++ b/frontend/app/services/SalesforceService.scala
@@ -62,7 +62,7 @@ class SalesforceService(salesforceConfig: SalesforceConfig) extends api.Salesfor
         Keys.MAILING_CITY -> jf.deliveryAddress.town,
         Keys.MAILING_STATE -> jf.deliveryAddress.countyOrState,
         Keys.MAILING_POSTCODE -> jf.deliveryAddress.postCode,
-        Keys.MAILING_COUNTRY -> jf.deliveryAddress.country.map(_.name).getOrElse(jf.deliveryAddress.countryName),
+        Keys.MAILING_COUNTRY -> jf.deliveryAddress.country.fold(jf.deliveryAddress.countryName)(_.name),
         Keys.ALLOW_MEMBERSHIP_MAIL -> true
       )) ++ Map(
         Keys.ALLOW_THIRD_PARTY_EMAIL -> formData.marketingChoices.thirdParty,


### PR DESCRIPTION
## Why are you doing this?
Currently Membership sets the country code in Salesforce to a 2-letter ISO code. This is different to subscriptions-frontend and Identity, so this change mitigates the risk of breaking international paper deliveries if a subscriber goes on to become a member.

## Trello card: [Here](https://trello.com/c/3L1cGAEo/110-address-data-consistency)

## Changes
- Use the full name for countries in Salesforce to make Membership consistent with subs.

## Screenshots
![picture 78](https://cloud.githubusercontent.com/assets/1515970/25181950/083849f8-250b-11e7-9d35-17f6a9d3e387.png)

Also see: https://github.com/guardian/subscriptions-frontend/pull/915

cc @jacobwinch @rtyley @Ap0c @rupertbates @ajosephides 