### PR TITLE
Update Sentry Raven library to v8.0.2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   //versions
   val awsClientVersion = "1.11.95"
   //libraries
-  val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "7.2.3"
+  val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "8.0.2"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.9" // v0.9 is the latest version published for Play 2.4...
   val membershipCommon = "com.gu" %% "membership-common" % "0.390"


### PR DESCRIPTION
## Why are you doing this?

To get rid of these warnings we've been seeing:

!["This event was reported with an old version of the java SDK."](https://cloud.githubusercontent.com/assets/52038/25175795/f335356e-24f3-11e7-9b24-fca5f79cbe45.png)

E.g. on https://sentry.io/the-guardian/membership/issues/254948502/

Note we may also want to update `raven-js` - we're using `3.0.4` and the latest is `3.14.2`: https://github.com/getsentry/raven-js/releases
