### PR TITLE
Update membership-common to 0.395

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "8.0.2"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.9" // v0.9 is the latest version published for Play 2.4...
-  val membershipCommon = "com.gu" %% "membership-common" % "0.390"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.395"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playFilters = PlayImport.filters


### PR DESCRIPTION
## Why are you doing this?
We've made a [couple](https://github.com/guardian/membership-common/pull/460) [changes](https://github.com/guardian/membership-common/pull/462) in membership-common recently. 

It's good to be up to date, but this also means we use version of membership common that doesn't keep its own execution context, instead using the one passed from membership-frontend.

<!--
Remember, PRs are documentation for future contributors

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Trello card: [Here](https://trello.com/c/aPZWc7PY/102-ensure-membership-common-doesn-t-have-its-own-execution-context)

## Changes
* Use latest membership-common 0.395
<!--
If you are making heavy client-side changes, consider manual test the following
critical flow before merging
## Tested in
| Browser | Supporter Stripe checkout | Supporter Paypal checkout | Stripe Monthly Contribution |  Paypal Monthly Contribution| Upgrade from Friend to Supporter  |
|---------|---------------------------|---------------------------|-----------------------------|-----------------------------|-----------------------------------|
| IE      |                           |                           |                             |                             |                                   |
| Firefox |                           |                           |                             |                             |                                   |
| Safari  |                           |                           |                             |                             |                                   |
| Chrome  |                           |                           |                             |                             |                                   |

-->

## Screenshots
