### PR TITLE
Email-in-use redux

### DIFF
--- a/frontend/app/controllers/User.scala
+++ b/frontend/app/controllers/User.scala
@@ -6,9 +6,11 @@ import org.joda.time.Instant
 import org.joda.time.format.ISODateTimeFormat
 import play.api.libs.json._
 import play.api.mvc.Controller
-import services.MembersDataAPI
+import services.{IdentityApi, IdentityService, MembersDataAPI}
 import utils.GuMemCookie
 import views.support.MembershipCompat._
+import scala.concurrent.ExecutionContext.Implicits.global
+
 
 trait User extends Controller {
   val standardFormat = ISODateTimeFormat.dateTime.withZoneUTC
@@ -18,6 +20,12 @@ trait User extends Controller {
     val json = basicDetails(request.subscriber)
     MembersDataAPI.Service.checkMatchesResolvedMemberIn(request)
     Ok(json).withCookies(GuMemCookie.getAdditionCookie(json))
+  }
+
+  def checkExistingEmail(email: String) = CachedAction.async { implicit request =>
+    for {
+      doesUserExist <- IdentityService(IdentityApi).doesUserExist(email)(IdentityRequest(request))
+    } yield Ok(Json.obj("emailInUse" -> doesUserExist))
   }
 
   def basicDetails(subscriber: Subscriber.Member) = Json.obj(

--- a/frontend/app/services/IdentityService.scala
+++ b/frontend/app/services/IdentityService.scala
@@ -111,8 +111,8 @@ case class IdentityService(identityApi: IdentityApi) {
   def getUser(user: IdMinimalUser)(implicit idReq: IdentityRequest): EitherT[Future, String, IdUser] = identityApi.get(s"user/${user.id}",
     idReq.headers,
     idReq.trackingParameters,
-    "get-user") {
-      _.json.validate[IdUser].asEither.leftMap(_.mkString(","))
+    "get-user") { resp =>
+      (resp.json \ "user").validate[IdUser].asEither.leftMap(_.mkString(","))
     }
 
   def doesUserPasswordExist(identityRequest: IdentityRequest): Future[Boolean] =

--- a/frontend/app/views/fragments/joiner/signedIn.scala.html
+++ b/frontend/app/views/fragments/joiner/signedIn.scala.html
@@ -1,0 +1,6 @@
+@(returnUri: String)
+
+@import configuration.Config.idWebAppSigninUrl
+
+<p class="text-note">Already have a Guardian account? <a class="s-prose" href="@idWebAppSigninUrl(returnUri)" class="text-link">Sign in</a>
+</p>

--- a/frontend/app/views/joiner/form/payment.scala.html
+++ b/frontend/app/views/joiner/form/payment.scala.html
@@ -17,6 +17,8 @@
     touchpointBackendResolution: services.TouchpointBackend.Resolution
 )(implicit token: play.filters.csrf.CSRF.Token, request: RequestHeader)
 
+@import configuration.Config.idWebAppSigninUrl
+
 @main(
     plans.tier.cta,
     pageInfo = pageInfo,
@@ -31,6 +33,8 @@
             <!-- FORM TITLE -->
         <section class="checkout-header">
             <h1 class="checkout-headline">@fragments.form.formCta(plans.tier)</h1>
+            <p class="security-note">@fragments.inlineIcon("lock", List("icon-inline--small", "icon-inline--top"))
+                Secure</p>
         </section>
 
             <!-- CHECKOUT FORM -->
@@ -55,8 +59,11 @@
                     <div class="form-panel__heading">
                         <h2 class="form-panel__headline">Name and address</h2>
                         <div class="form-panel__edit js-edit-name-address is-hidden">edit</div>
+                        <div class="sign-in-hidden">
+                            @fragments.joiner.signedIn(request.uri)
+                        </div>
                         <div class="sign-in-required js-sign-in-note @if(plans.tier == Partner()) {is-hidden}">
-                        @fragments.joiner.signedInAs(request.uri, inline = true)
+                            @fragments.joiner.signedInAs(request.uri, inline = true)
                         </div>
                     </div>
 
@@ -79,6 +86,7 @@
                                 required
                                 aria-required="true"/>
                                 @fragments.form.errorMessage("Please enter your email")
+                                <p id="form-field__error-message-email-checker" class="form-field__error-message is-hidden">You already have a Guardian account. Please <a href="@idWebAppSigninUrl(request.uri)">sign in</a> or use another email address.</p>
                             </div>
                         </div>
 
@@ -130,8 +138,6 @@
 
                             <div class="fieldset__heading">
                                 <h2 class="fieldset__headline fieldset__headline--payment">Payment methods</h2>
-                                <p class="security-note">@fragments.inlineIcon("lock", List("icon-inline--small", "icon-inline--top"))
-                                    Secure</p>
                             </div>
 
                             <div class="fieldset__fields">

--- a/frontend/assets/javascripts/src/modules/form.js
+++ b/frontend/assets/javascripts/src/modules/form.js
@@ -67,10 +67,11 @@ define([
     'src/modules/form/billingPeriodChoice',
     'src/modules/form/paypal',
     'src/modules/form/stripe',
-    'src/modules/form/accordion'
+    'src/modules/form/accordion',
+    'src/modules/form/validation/existEmail'
 ], function (validation, form, payment, address, options, submitButton,
-    password, ongoingCardPayments, billingPeriodChoice, paypal,
-    stripe, accordion) {
+             password, ongoingCardPayments, billingPeriodChoice, paypal,
+             stripe, accordion, existEmail) {
     'use strict';
 
     var init = function () {
@@ -85,19 +86,15 @@ define([
             billingPeriodChoice.init();
 
             if (form.hasPayment) {
-
                 curl('js!stripe').then(function () {
                     payment.init();
                 });
-
             }
 
             if (form.hasPaypal) {
-
                 curl('js!paypal').then(function () {
                     paypal.init();
                 });
-
             }
 
             if (form.hasStripeCheckout) {
@@ -106,16 +103,15 @@ define([
                     .then(function () {
                         stripe.init();
                     });
-
-
-
             }
 
             if (form.hasAccordion){
                 accordion.init();
             }
 
-
+            if (form.hasEmailInput){
+                existEmail.init();
+            }
         }
     };
 

--- a/frontend/assets/javascripts/src/modules/form/helper/formUtil.js
+++ b/frontend/assets/javascripts/src/modules/form/helper/formUtil.js
@@ -60,6 +60,10 @@ define([
         return !!document.querySelector('.js-continue-name-address');
     }
 
+    function hasEmailInput () {
+        return !!document.getElementById('email') && (document.getElementById('email') instanceof HTMLInputElement);
+    }
+
     /**
      * formUtil singleton provides:
      *    elem: DomElement - the form element
@@ -81,6 +85,7 @@ define([
                 hasPayment: hasPayment(),
                 hasPaypal: hasPaypal(),
                 hasStripeCheckout: hasStripeCheckout(),
+                hasEmailInput: hasEmailInput(),
                 errs: [],
                 flush: function () {
                     this.elem = getFormElem();

--- a/frontend/assets/javascripts/src/modules/form/validation/existEmail.es6
+++ b/frontend/assets/javascripts/src/modules/form/validation/existEmail.es6
@@ -1,0 +1,31 @@
+import ajax from 'ajax';
+import debounce from 'lodash/debounce';
+
+export function init() {
+    const emailField = document.getElementById('email');
+    const isUseErrorMessage = document.getElementById('form-field__error-message-email-checker');
+    const checkerURL = '/user/check-existing-email';
+
+    const validateEmail = debounce(() => {
+        let prospectiveEmail = emailField.value;
+
+        if(!prospectiveEmail.includes('@')) {
+            return;
+        }
+
+        ajax({
+            url: checkerURL + '?email=' + encodeURIComponent(emailField.value),
+            method: 'get',
+            success: ({emailInUse}) => {
+                if(emailInUse){
+                    isUseErrorMessage.classList.remove('is-hidden');
+                }else {
+                    isUseErrorMessage.classList.add('is-hidden');
+                }
+            },
+        });
+
+    }, 250);
+
+    emailField.addEventListener('keyup', validateEmail);
+}

--- a/frontend/assets/stylesheets/components/_payment-paypal.scss
+++ b/frontend/assets/stylesheets/components/_payment-paypal.scss
@@ -122,7 +122,7 @@
     .fieldset__heading--no-border {
         @include mq(tablet) {
             padding-top: 0;
-            border: none;            
+            border: none;
         }
     }
 
@@ -221,6 +221,7 @@
         background-color: #fff;
         top: 2px;
         margin-left: -12px;
+        border: 1px solid guss-colour(neutral-4);
     }
 
     .pseudo-radio__header {

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -124,6 +124,7 @@ GET            /patterns                              controllers.PatternLibrary
 
 # User
 GET            /user/me                               controllers.User.me
+GET            /user/check-existing-email             controllers.User.checkExistingEmail(email: String)
 
 # Vanity URLS
 GET            /subscriber-offer                      controllers.Redirects.homepageRedirect


### PR DESCRIPTION
This is a replay of https://github.com/guardian/membership-frontend/pull/1575, with the addition of a tweak fixing the `IdentityService`, which I managed to break when I forgot that [the response from the Identity API](https://idapi.code.dev-theguardian.com/user/30000193) wraps the user json with a response fields (ie `status` and `user`):

```
{
   "status":"ok",
   "user":{
      "id":"30000193",
      "dates":{
         "accountCreatedDate":"2017-04-21T09:51:05Z"
      },
      "publicFields":{
         "displayName":"EmailRedux EmailRedux"
      }
   }
}
```

...if I had run the acceptance tests locally I would have spotted this straight away (_bad_ Roberto).


