### PR TITLE
Avoiding the hasEmailInput returns true in other screen.

### DIFF
--- a/frontend/assets/javascripts/src/modules/form/helper/formUtil.js
+++ b/frontend/assets/javascripts/src/modules/form/helper/formUtil.js
@@ -61,7 +61,7 @@ define([
     }
 
     function hasEmailInput () {
-        return !!document.getElementById('email') && (document.getElementById('email') instanceof HTMLInputElement);
+        return !!document.getElementById('form-field__error-message-email-checker') && (document.getElementById('form-field__error-message-email-checker') instanceof HTMLParagraphElement);
     }
 
     /**


### PR DESCRIPTION
## Why are you doing this?
We have seen some sentry logs ([here](https://sentry.io/the-guardian/membership-client-side/issues/258894041/)) returning undefined regarding the EmailChecker's code. This took place because `formUtil ` was using the id field as a way of checking if it has to call the init function of this module. Unfortunately, that id was being also used in the feedback form. Therefore, in this PR I am changing that condition, to check whether the paragraph `element form-field__error-message-email-checker` exists or not.


