### PR TITLE
Shut off non-HTTPS access to mem.thegulocal.com

### DIFF
--- a/nginx/membership.conf
+++ b/nginx/membership.conf
@@ -1,13 +1,4 @@
 server {
-    server_name mem.thegulocal.com;
-
-    location / {
-        proxy_pass http://localhost:9100/;
-        proxy_set_header Host $http_host;
-    }
-}
-
-server {
     listen 443;
     server_name mem.thegulocal.com;
 


### PR DESCRIPTION
## Why are you doing this?
We should run the site under https. Therefore, we are updating the membership.conf file which contains the nginx configuration for DEV.
