### PR TITLE
Digital bundle price test 1 (AB)

### DIFF
--- a/frontend/app/abtests/BundleVariant.scala
+++ b/frontend/app/abtests/BundleVariant.scala
@@ -12,7 +12,10 @@ object BundleVariant {
     BundleVariant(CONTROL, Map((Supporter, 6.5), (DigitalPack, 12), (Saturday, 18), (GuardianWeekly, 18), (Weekend, 25), (SatGW, 25), (SixDay, 45), (SevenDay, 50))),
     BundleVariant(VARIANT, Map((Supporter, 6.5), (DigitalPack, 12), (Saturday, 18), (GuardianWeekly, 18), (Weekend, 25), (SatGW, 25), (SixDay, 45), (SevenDay, 50)), hasAdFree = false),
     BundleVariant(PDCPRE, Map((Supporter, 6.5), (DigitalPack, 12), (Saturday, 18), (GuardianWeekly, 18), (Weekend, 25), (SatGW, 25), (SixDay, 45), (SevenDay, 50)), hasPaidComments = true, hasContributions = false),
-    BundleVariant(PDCPOST, Map((Supporter, 6.5), (DigitalPack, 12), (Saturday, 18), (GuardianWeekly, 18), (Weekend, 25), (SatGW, 25), (SixDay, 45), (SevenDay, 50)), hasPaidComments = true, hasContributions = false)
+    BundleVariant(PDCPOST, Map((Supporter, 6.5), (DigitalPack, 12), (Saturday, 18), (GuardianWeekly, 18), (Weekend, 25), (SatGW, 25), (SixDay, 45), (SevenDay, 50)), hasPaidComments = true, hasContributions = false),
+    BundleVariant(DIGIPRICE1A, Map((Supporter, 6.5), (DigitalPack, 11.99), (Saturday, 18), (GuardianWeekly, 18), (Weekend, 25), (SatGW, 25), (SixDay, 45), (SevenDay, 50)), hasAdFree = true, hasPaidComments = false, hasContributions = true, hasDigital = true, hasPrintAndDigital = false),
+    BundleVariant(DIGIPRICE1B, Map((Supporter, 6.5), (DigitalPack, 14.99), (Saturday, 18), (GuardianWeekly, 18), (Weekend, 25), (SatGW, 25), (SixDay, 45), (SevenDay, 50)), hasAdFree = true, hasPaidComments = false, hasContributions = true, hasDigital = true, hasPrintAndDigital = false),
+    BundleVariant(DIGIPRICE1C, Map((Supporter, 6.5), (DigitalPack, 9.99), (Saturday, 18), (GuardianWeekly, 18), (Weekend, 25), (SatGW, 25), (SixDay, 45), (SevenDay, 50)), hasAdFree = true, hasPaidComments = false, hasContributions = true, hasDigital = true, hasPrintAndDigital = false)
   )
 
   def lookup(name: String): Option[BundleVariant] = {
@@ -24,7 +27,9 @@ case class BundleVariant(distribution: Distribution,
                          prices: Map[BundleTier, Double],
                          hasAdFree: Boolean = true,
                          hasPaidComments: Boolean = false,
-                         hasContributions: Boolean = true) {
+                         hasContributions: Boolean = true,
+                         hasDigital: Boolean = true,
+                         hasPrintAndDigital: Boolean = true) {
   val testId =  distribution.name
 
   def prettyMonthlyPrice(tier: BundleTier) = f"£${prices(tier)}%.2f/month"
@@ -58,6 +63,9 @@ object Distribution {
   val VARIANT = Distribution("MEMBERSHIP_A_ADX_THRASHER_UK_VARIANT")
   val PDCPRE = Distribution("MEMBERSHIP_A_PDCOM_PRE")
   val PDCPOST = Distribution("MEMBERSHIP_A_PDCOM_POST")
+  val DIGIPRICE1A = Distribution("BUNDLE_PRICE_TEST_1_UK_A")
+  val DIGIPRICE1B = Distribution("BUNDLE_PRICE_TEST_1_UK_B")
+  val DIGIPRICE1C = Distribution("BUNDLE_PRICE_TEST_1_UK_C")
 }
 
 case class Distribution(name: String)

--- a/frontend/app/controllers/Bundle.scala
+++ b/frontend/app/controllers/Bundle.scala
@@ -47,7 +47,8 @@ trait Bundle extends Controller {
         byline = None,
         credit = None
       )),
-      availableImages=ResponsiveImageGenerator("a1b0524bdd81bf9f5e92d199c0977c04b59731ec/0_0_480_400", Seq(480), "png")
+      //https://media.gutools.co.uk/images/62a6d58f49c10d5864d024c16ba05554a32cee5a?crop=0_0_480_275
+      availableImages=ResponsiveImageGenerator("62a6d58f49c10d5864d024c16ba05554a32cee5a/0_0_480_275", Seq(480), "png")
     )
 
     val heroOrientated = OrientatedImages(portrait = heroImage, landscape = heroImage)
@@ -59,7 +60,8 @@ trait Bundle extends Controller {
         byline = None,
         credit = None
       )),
-      availableImages=ResponsiveImageGenerator("6bf759b538128aed0f90cebe8b2465875e85c7ce/0_0_460_650", Seq(460), "png")
+      //https://media.gutools.co.uk/images/2a88bdcbe6ff74ca49f203d70b4b8f1fab885d71?crop=0_0_460_627
+      availableImages=ResponsiveImageGenerator("2a88bdcbe6ff74ca49f203d70b4b8f1fab885d71/0_0_460_627", Seq(460), "png")
     )
 
     val bottomImageOrientated = OrientatedImages(portrait = bottomImage, landscape = bottomImage)

--- a/frontend/app/controllers/Bundle.scala
+++ b/frontend/app/controllers/Bundle.scala
@@ -59,7 +59,7 @@ trait Bundle extends Controller {
         byline = None,
         credit = None
       )),
-      availableImages=ResponsiveImageGenerator("2a88bdcbe6ff74ca49f203d70b4b8f1fab885d71/0_0_460_627", Seq(460), "png")
+      availableImages=ResponsiveImageGenerator("2a88bdcbe6ff74ca49f203d70b4b8f1fab885d71/0_76_460_550", Seq(460), "png")
     )
 
     val bottomImageOrientated = OrientatedImages(portrait = bottomImage, landscape = bottomImage)

--- a/frontend/app/controllers/Bundle.scala
+++ b/frontend/app/controllers/Bundle.scala
@@ -47,7 +47,6 @@ trait Bundle extends Controller {
         byline = None,
         credit = None
       )),
-      //https://media.gutools.co.uk/images/62a6d58f49c10d5864d024c16ba05554a32cee5a?crop=0_0_480_275
       availableImages=ResponsiveImageGenerator("62a6d58f49c10d5864d024c16ba05554a32cee5a/0_0_480_275", Seq(480), "png")
     )
 
@@ -60,14 +59,13 @@ trait Bundle extends Controller {
         byline = None,
         credit = None
       )),
-      //https://media.gutools.co.uk/images/2a88bdcbe6ff74ca49f203d70b4b8f1fab885d71?crop=0_0_460_627
       availableImages=ResponsiveImageGenerator("2a88bdcbe6ff74ca49f203d70b4b8f1fab885d71/0_0_460_627", Seq(460), "png")
     )
 
     val bottomImageOrientated = OrientatedImages(portrait = bottomImage, landscape = bottomImage)
 
     bundleVariant match {
-      case BundleVariant(_, _, _, _, _, _, _) => Ok(views.html.bundle.bundleSetA(
+      case _:BundleVariant => Ok(views.html.bundle.bundleSetA(
         heroOrientated,
         TouchpointBackend.Normal.catalog.supporter,
         PageInfo(

--- a/frontend/app/controllers/Bundle.scala
+++ b/frontend/app/controllers/Bundle.scala
@@ -89,7 +89,7 @@ trait Bundle extends Controller {
         byline = None,
         credit = None
       )),
-      availableImages=ResponsiveImageGenerator("a1b0524bdd81bf9f5e92d199c0977c04b59731ec/0_0_480_400", Seq(480), "png")
+      availableImages=ResponsiveImageGenerator("62a6d58f49c10d5864d024c16ba05554a32cee5a/0_0_480_275", Seq(480), "png")
     )
     val heroOrientated = OrientatedImages(portrait = heroImage, landscape = heroImage)
 

--- a/frontend/app/controllers/Bundle.scala
+++ b/frontend/app/controllers/Bundle.scala
@@ -65,7 +65,7 @@ trait Bundle extends Controller {
     val bottomImageOrientated = OrientatedImages(portrait = bottomImage, landscape = bottomImage)
 
     bundleVariant match {
-      case BundleVariant(_, _, _, _, _) => Ok(views.html.bundle.bundleSetA(
+      case BundleVariant(_, _, _, _, _, _, _) => Ok(views.html.bundle.bundleSetA(
         heroOrientated,
         TouchpointBackend.Normal.catalog.supporter,
         PageInfo(

--- a/frontend/app/views/bundle/bundleSetA.scala.html
+++ b/frontend/app/views/bundle/bundleSetA.scala.html
@@ -21,7 +21,7 @@
         heroImage,
         Html("Support<br/>the Guardian"),
         Html("We\'re introducing <strong>new ways</strong> to support the&nbsp;Guardian\'s quality journalism and independent voice"),
-        Html("Our most important relationship is with our readers. Please help to fund our journalism by becoming a Supporter, and together we can keep the world informed. You can do this by signing up to one of our Digital or Paper packages shown below.")
+        Html("Our most important relationship is with our readers. Please help to fund our journalism by becoming a Supporter, and together we can keep the world informed. You can do this by starting a digital subscription or by making a contribution as shown below.")
     )
 
     @* ===== Offerings ===== *@

--- a/frontend/app/views/bundle/thankYou.scala.html
+++ b/frontend/app/views/bundle/thankYou.scala.html
@@ -23,6 +23,6 @@
         Html("")
     )
     <div class="l-constrained">
-        @fragments.bundle.bundleThankYouExplainer(bundleVariant)
+        @fragments.bundle.bundleThankYouExplainer(bundleVariant, selectedOption)
     </div>
 }

--- a/frontend/app/views/bundle/thankYou.scala.html
+++ b/frontend/app/views/bundle/thankYou.scala.html
@@ -4,6 +4,8 @@
 @import views.support.PageInfo
 @import tracking.AppnexusPixel
 @import com.gu.salesforce.Tier.Supporter
+@import model.Header.BundlesHeader
+@import model.Footer.BundlesFooter
 
 @import abtests.BundleVariant
 @(  pageInfo: PageInfo,
@@ -12,15 +14,15 @@
     heroImage: model.OrientatedImages,
     returnUrl: Option[String] = None)(implicit token: play.filters.csrf.CSRF.Token)
 
-@main("Supporters", pageInfo=pageInfo) {
+@main("Supporters", pageInfo=pageInfo, header=BundlesHeader, footer=BundlesFooter) {
     @* ===== First part ===== *@
     @fragments.bundle.bundleHeader(
         heroImage,
         Html("Thank you for<br/>your interest"),
-        Html("We are currently evaluating the demand for the feature you selected"),
-        Html("We have a number of tests underway that help us determine which products our readers are interested in. Your participation has helped us with this evaluation, and from now on you won't be directed here again.<br><br>Thank you.</p>")
+        Html("<br><br><br>"),
+        Html("")
     )
     <div class="l-constrained">
-        @fragments.bundle.bundleButton("Continue to comment", returnUrl.getOrElse("https://www.theguardian.com"))
+        @fragments.bundle.bundleThankYouExplainer(bundleVariant)
     </div>
 }

--- a/frontend/app/views/fragments/bundle/bundleOfferingsA.scala.html
+++ b/frontend/app/views/fragments/bundle/bundleOfferingsA.scala.html
@@ -201,6 +201,7 @@
                 <div class="bundle-offering-a__give__content">
                     <h1>Support through giving</h1>
                     <div class="bundle-offering-a__give__content__body">
+                        <h2>Contribute to the Guardian</h2>
                         <p class="bundle-offering-a__give__content__body__description">
                             Fund our journalism on your own terms – either a regular or one-off payment. Every penny goes to supporting our fearless, in-depth reporting and keeping our website and apps open to all.</p>
                         <div class="bundle-offering-a__give__button">

--- a/frontend/app/views/fragments/bundle/bundleOfferingsA.scala.html
+++ b/frontend/app/views/fragments/bundle/bundleOfferingsA.scala.html
@@ -22,8 +22,8 @@
                                         @icon
                                     }
                                     </div><div class="bundle-offering-a__subscribe__offer__list__item__content">
-                                    <h1>Ad-free</h1>
-                                    <p>Enjoy our website and apps without adverts</p>
+                                    <h1>Banner-free</h1>
+                                    <p>Enjoy our website and apps without intrusive banner or inline adverts</p>
                                 </div>
                                 </li>
                             }
@@ -47,7 +47,7 @@
                                 }
                                 </div><div class="bundle-offering-a__subscribe__offer__list__item__content">
                                 <h1>Exclusive content</h1>
-                                <p>Behind-the-scenes updates from Guardian journalists, a regular newsletter and our new member podcast</p>
+                                <p>Behind-the-scenes updates from Guardian journalists, a regular newsletter and our new weekly member podcast</p>
                             </div>
                             </li>
 

--- a/frontend/app/views/fragments/bundle/bundleOfferingsA.scala.html
+++ b/frontend/app/views/fragments/bundle/bundleOfferingsA.scala.html
@@ -59,7 +59,7 @@
                                 </div>
                                 <div class="bundle-offering-a__subscribe__offer__list__item__content">
                                 <h1>Exclusive content</h1>
-                                <p>Behind-the-scenes updates from Guardian journalists, a regular newsletter and our new weekly supporter podcast</p>
+                                <p>Behind-the-scenes updates from Guardian journalists, a regular newsletter and our new weekly podcast</p>
                                 </div>
                             </li>
                         </ul>
@@ -204,7 +204,7 @@
                         <p class="bundle-offering-a__give__content__body__description">
                             Fund our journalism on your own terms – either a regular or one-off payment. Every penny goes to supporting our fearless, in-depth reporting and keeping our website and apps open to all.</p>
                         <div class="bundle-offering-a__give__button">
-                        @fragments.bundle.bundleButton("Make a contribution", s"https://support.theguardian.com/uk?INTCMP=${bundleVariant.testId}", className = Option("js-commit-button"))
+                        @fragments.bundle.bundleButton("Make a contribution", routes.Bundle.thankYou(bundleVariant, "contribution").url, className = Option("js-commit-button"))
                         </div>
                     </div>
                 </div>

--- a/frontend/app/views/fragments/bundle/bundleOfferingsA.scala.html
+++ b/frontend/app/views/fragments/bundle/bundleOfferingsA.scala.html
@@ -42,24 +42,25 @@
                             }
                             <li class="bundle-offering-a__subscribe__offer__list__item">
                                 <div class="bundle-offering-a__subscribe__offer__list__item__icon">
-                                @for(icon <- Asset.inlineSvg("bundle-guardian_g")) {
-                                    @icon
-                                }
-                                </div><div class="bundle-offering-a__subscribe__offer__list__item__content">
-                                <h1>Exclusive content</h1>
-                                <p>Behind-the-scenes updates from Guardian journalists, a regular newsletter and our new weekly supporter podcast</p>
-                            </div>
-                            </li>
-
-                            <li class="bundle-offering-a__subscribe__offer__list__item">
-                                <div class="bundle-offering-a__subscribe__offer__list__item__icon">
                                 @for(icon <- Asset.inlineSvg("bundle-tabletedition")) {
                                     @icon
                                 }
-                                </div><div class="bundle-offering-a__subscribe__offer__list__item__content">
-                                <h1>Tablet edition</h1>
-                                <p>Your daily newspaper optimised for tablet</p>
-                            </div>
+                                </div>
+                                <div class="bundle-offering-a__subscribe__offer__list__item__content">
+                                    <h1>Tablet edition</h1>
+                                    <p>Your daily newspaper optimised for tablet</p>
+                                </div>
+                            </li>
+                            <li class="bundle-offering-a__subscribe__offer__list__item">
+                                <div class="bundle-offering-a__subscribe__offer__list__item__icon">
+                                @for(icon <- Asset.inlineSvg("bundle-guardian_g")) {
+                                    @icon
+                                }
+                                </div>
+                                <div class="bundle-offering-a__subscribe__offer__list__item__content">
+                                <h1>Exclusive content</h1>
+                                <p>Behind-the-scenes updates from Guardian journalists, a regular newsletter and our new weekly supporter podcast</p>
+                                </div>
                             </li>
                         </ul>
                         @fragments.bundle.bundleButton("Find out more", routes.Bundle.thankYou(bundleVariant, "digital-pack").url, className = Option("js-commit-button"), returnUrl = Some(java.net.URLEncoder.encode(returnUrl.getOrElse("https://www.theguardian.com"), "utf-8")))

--- a/frontend/app/views/fragments/bundle/bundleOfferingsA.scala.html
+++ b/frontend/app/views/fragments/bundle/bundleOfferingsA.scala.html
@@ -203,7 +203,7 @@
                         <p class="bundle-offering-a__give__content__body__description">
                             Fund our journalism on your own terms – either a regular or one-off payment. Every penny goes to supporting our fearless, in-depth reporting and keeping our website and apps open to all.</p>
                         <div class="bundle-offering-a__give__button">
-                        @fragments.bundle.bundleButton("Make a contribution", s"https://support.theguardian.com/uk?INTCMP=${bundleVariant.testId}")
+                        @fragments.bundle.bundleButton("Make a contribution", s"https://support.theguardian.com/uk?INTCMP=${bundleVariant.testId}", className = Option("js-commit-button"))
                         </div>
                     </div>
                 </div>

--- a/frontend/app/views/fragments/bundle/bundleOfferingsA.scala.html
+++ b/frontend/app/views/fragments/bundle/bundleOfferingsA.scala.html
@@ -22,8 +22,8 @@
                                         @icon
                                     }
                                     </div><div class="bundle-offering-a__subscribe__offer__list__item__content">
-                                    <h1>Banner-free</h1>
-                                    <p>Enjoy our website and apps without intrusive banner or inline adverts</p>
+                                    <h1>Banner ad-free</h1>
+                                    <p>Enjoy our website and apps without banner or inline adverts</p>
                                 </div>
                                 </li>
                             }
@@ -47,7 +47,7 @@
                                 }
                                 </div><div class="bundle-offering-a__subscribe__offer__list__item__content">
                                 <h1>Exclusive content</h1>
-                                <p>Behind-the-scenes updates from Guardian journalists, a regular newsletter and our new weekly member podcast</p>
+                                <p>Behind-the-scenes updates from Guardian journalists, a regular newsletter and our new weekly supporter podcast</p>
                             </div>
                             </li>
 
@@ -202,11 +202,8 @@
                     <div class="bundle-offering-a__give__content__body">
                         <p class="bundle-offering-a__give__content__body__description">
                             Fund our journalism on your own terms – either a regular or one-off payment. Every penny goes to supporting our fearless, in-depth reporting and keeping our website and apps open to all.</p>
-                        <div class="bundle-offering-a__give__monthly-button">
-                        @fragments.bundle.bundleButton("Make a monthly contribution", routes.Bundle.thankYou(bundleVariant, "monthly-contribution").url)
-                        </div>
-                        <div class="bundle-offering-a__give__one-off-button">
-                        @fragments.bundle.bundleButton("Make a one-off contribution", s"https://contribute.theguardian.com?INTCMP=${bundleVariant.testId}")
+                        <div class="bundle-offering-a__give__button">
+                        @fragments.bundle.bundleButton("Make a contribution", s"https://support.theguardian.com/uk?INTCMP=${bundleVariant.testId}")
                         </div>
                     </div>
                 </div>

--- a/frontend/app/views/fragments/bundle/bundleOfferingsA.scala.html
+++ b/frontend/app/views/fragments/bundle/bundleOfferingsA.scala.html
@@ -5,6 +5,196 @@
 @(bundleVariant: BundleVariant, returnUrl: Option[String])
 <section class="bundle-section">
     <div class="bundle-offering-a l-constrained">
+        <div class="bundle-offering-a__subscribe">
+            <h1>Support through subscribing</h1>
+            @if(bundleVariant.hasDigital) {
+                <div class="bundle-offering-a__subscribe__offer">
+                    <div class="bundle-offering-a__subscribe__offer__content">
+                        <h2>Digital subscription</h2>
+                        <span class="bundle-offering-a__subscribe__offer__price-description">@bundleVariant.prettyMonthlyPrice(DigitalPack)</span>
+
+                        <ul class="bundle-offering-a__subscribe__offer__list">
+
+                            @if(bundleVariant.hasAdFree) {
+                                <li class="bundle-offering-a__subscribe__offer__list__item">
+                                    <div class="bundle-offering-a__subscribe__offer__list__item__icon">
+                                    @for(icon <- Asset.inlineSvg("bundle-adfree")) {
+                                        @icon
+                                    }
+                                    </div><div class="bundle-offering-a__subscribe__offer__list__item__content">
+                                    <h1>Ad-free</h1>
+                                    <p>Enjoy our website and apps without adverts</p>
+                                </div>
+                                </li>
+                            }
+                            @if(bundleVariant.hasPaidComments) {
+                                <li class="bundle-offering-a__subscribe__offer__list__item">
+                                    <div class="bundle-offering-a__subscribe__offer__list__item__icon">
+                                    @for(icon <- Asset.inlineSvg("bundle-commenting")) {
+                                        @icon
+                                    }
+                                    </div>
+                                    <div class="bundle-offering-a__subscribe__offer__list__item__content">
+                                        <h1>Commenting</h1>
+                                        <p>Discussion threads on articles are reserved for paying supporters only</p>
+                                    </div>
+                                </li>
+                            }
+                            <li class="bundle-offering-a__subscribe__offer__list__item">
+                                <div class="bundle-offering-a__subscribe__offer__list__item__icon">
+                                @for(icon <- Asset.inlineSvg("bundle-guardian_g")) {
+                                    @icon
+                                }
+                                </div><div class="bundle-offering-a__subscribe__offer__list__item__content">
+                                <h1>Exclusive content</h1>
+                                <p>Behind-the-scenes updates from Guardian journalists, a regular newsletter and our new member podcast</p>
+                            </div>
+                            </li>
+
+                            <li class="bundle-offering-a__subscribe__offer__list__item">
+                                <div class="bundle-offering-a__subscribe__offer__list__item__icon">
+                                @for(icon <- Asset.inlineSvg("bundle-tabletedition")) {
+                                    @icon
+                                }
+                                </div><div class="bundle-offering-a__subscribe__offer__list__item__content">
+                                <h1>Tablet edition</h1>
+                                <p>Your daily newspaper optimised for tablet</p>
+                            </div>
+                            </li>
+                        </ul>
+                        @fragments.bundle.bundleButton("Find out more", routes.Bundle.thankYou(bundleVariant, "digital-pack").url, className = Option("js-commit-button"), returnUrl = Some(java.net.URLEncoder.encode(returnUrl.getOrElse("https://www.theguardian.com"), "utf-8")))
+                    </div>
+                </div>
+            }
+            @if(bundleVariant.hasPrintAndDigital) {
+                <div class="bundle-offering-a__subscribe__offer">
+                    <div class="bundle-offering-a__subscribe__offer__content">
+                        <h2>Print&amp;Digital subscription</h2>
+                        <span class="bundle-offering-a__subscribe__offer__price-description">
+                            from @bundleVariant.prettyMonthlyPrice(Saturday)</span>
+                        <ul class="bundle-offering-a__subscribe__offer__list">
+
+                            @if(bundleVariant.hasAdFree) {
+                                <li class="bundle-offering-a__subscribe__offer__list__item">
+                                    <div class="bundle-offering-a__subscribe__offer__list__item__icon">
+                                    @for(icon <- Asset.inlineSvg("bundle-adfree")) {
+                                        @icon
+                                    }
+                                    </div><div class="bundle-offering-a__subscribe__offer__list__item__content">
+                                    <h1>Ad-free</h1>
+                                    <p>Enjoy our website and apps without adverts</p>
+                                </div>
+                                </li>
+                            }
+                            @if(bundleVariant.hasPaidComments) {
+                                <li class="bundle-offering-a__subscribe__offer__list__item">
+                                    <div class="bundle-offering-a__subscribe__offer__list__item__icon">
+                                    @for(icon <- Asset.inlineSvg("bundle-commenting")) {
+                                        @icon
+                                    }
+                                    </div>
+                                    <div class="bundle-offering-a__subscribe__offer__list__item__content">
+                                        <h1>Commenting</h1>
+                                        <p>Discussion threads on articles are reserved for paying supporters only</p>
+                                    </div>
+                                </li>
+                            }
+
+                            <li class="bundle-offering-a__subscribe__offer__list__item">
+                                <div class="bundle-offering-a__subscribe__offer__list__item__icon">
+                                @for(icon <- Asset.inlineSvg("bundle-guardian_g")) {
+                                    @icon
+                                }
+                                </div><div class="bundle-offering-a__subscribe__offer__list__item__content">
+                                <h1>Exclusive content</h1>
+                                <p>Behind-the-scenes updates from Guardian journalists, a regular newsletter and our new member podcast</p>
+                            </div>
+                            </li>
+                            <li class="bundle-offering-a__subscribe__offer__list__item">
+                                <div class="bundle-offering-a__subscribe__offer__list__item__icon">
+                                @for(icon <- Asset.inlineSvg("bundle-tabletedition")) {
+                                    @icon
+                                }
+                                </div><div class="bundle-offering-a__subscribe__offer__list__item__content">
+                                <h1>Tablet edition</h1>
+                                <p>Your daily newspaper optimised for tablet</p>
+                            </div>
+                            </li>
+                            <li class="bundle-offering-a__subscribe__offer__list__item">
+                                <div class="bundle-offering-a__subscribe__offer__list__item__icon">
+                                @for(icon <- Asset.inlineSvg("bundle-newspaper")) {
+                                    @icon
+                                }
+                                </div><div class="bundle-offering-a__subscribe__offer__list__item__content">
+                                <h1>Print</h1>
+                                <p>Pick the package you want: Saturday, Sunday, Weekly, Weekend or Everyday.  Save up to 36% on the Guardian and Observer newspapers</p>
+                            </div>
+                            </li>
+                        </ul>
+                        @fragments.bundle.bundleButton("See options", "#", Option("js-see-more-button"), chevron = true)
+                        <div class="bundle-offering-a__subscribe__offer__print-options">
+                            <ul>
+                                <li class="bundle-offering-a__subscribe__offer__print-options__option subscribe_option--selected">
+                                    <div class="bundle-offering-a__print-option__description">
+                                        <h1>Saturday</h1>
+                                        <p></p>
+                                    </div><div class="bundle-offering-a__print-option__price">
+                                @bundleVariant.prettyMonthlyPrice(Saturday)
+                                </div>
+                                    <div class="bundle-offering-a__print-option__id">saturday</div>
+                                </li>
+                                <li class="bundle-offering-a__subscribe__offer__print-options__option">
+                                    <div class="bundle-offering-a__print-option__description">
+                                        <h1>The Guardian Weekly</h1>
+                                        <p></p>
+                                    </div><div class="bundle-offering-a__print-option__price">
+                                @bundleVariant.prettyMonthlyPrice(GuardianWeekly)
+                                </div>
+                                    <div class="bundle-offering-a__print-option__id">guardian-weekly</div>
+                                </li>
+                                <li class="bundle-offering-a__subscribe__offer__print-options__option">
+                                    <div class="bundle-offering-a__print-option__description">
+                                        <h1>Weekend</h1>
+                                        <p>Saturday &amp; Sunday</p>
+                                    </div><div class="bundle-offering-a__print-option__price">
+                                @bundleVariant.prettyMonthlyPrice(Weekend)
+                                </div>
+                                    <div class="bundle-offering-a__print-option__id">weekend</div>
+                                </li>
+                                <li class="bundle-offering-a__subscribe__offer__print-options__option">
+                                    <div class="bundle-offering-a__print-option__description">
+                                        <h1>Saturday &amp; The&nbsp;Guardian Weekly</h1>
+                                        <p></p>
+                                    </div><div class="bundle-offering-a__print-option__price">
+                                @bundleVariant.prettyMonthlyPrice(SatGW)
+                                </div>
+                                    <div class="bundle-offering-a__print-option__id">satgwe</div>
+                                </li>
+                                <li class="bundle-offering-a__subscribe__offer__print-options__option">
+                                    <div class="bundle-offering-a__print-option__description">
+                                        <h1>Sixday</h1>
+                                        <p>Monday - Saturday</p>
+                                    </div><div class="bundle-offering-a__print-option__price">
+                                @bundleVariant.prettyMonthlyPrice(SixDay)
+                                </div>
+                                    <div class="bundle-offering-a__print-option__id">six-day</div>
+                                </li>
+                                <li class="bundle-offering-a__subscribe__offer__print-options__option">
+                                    <div class="bundle-offering-a__print-option__description">
+                                        <h1>Everyday</h1>
+                                        <p>Monday - Sunday</p>
+                                    </div><div class="bundle-offering-a__print-option__price">
+                                @bundleVariant.prettyMonthlyPrice(SevenDay)
+                                </div>
+                                    <div class="bundle-offering-a__print-option__id">seven-day</div>
+                                </li>
+                            </ul>
+                            @fragments.bundle.bundleButton(bundleVariant.prettyMonthlyPrice(Saturday), routes.Bundle.thankYou(bundleVariant, "saturday").url, Option("js-print-button"), returnUrl = Some(java.net.URLEncoder.encode(returnUrl.getOrElse("https://www.theguardian.com"), "utf-8")))
+                        </div>
+                    </div>
+                </div>
+            }
+        </div>
         @if(bundleVariant.hasContributions) {
             <div class="bundle-offering-a__give">
                 <div class="bundle-offering-a__give__content">
@@ -22,190 +212,6 @@
                 </div>
             </div>
         }
-        <div class="bundle-offering-a__subscribe">
-            <h1>Support through subscribing</h1>
-            <div class="bundle-offering-a__subscribe__offer">
-                <div class="bundle-offering-a__subscribe__offer__content">
-                    <h2>Digital subscription</h2>
-                    <span class="bundle-offering-a__subscribe__offer__price-description">@bundleVariant.prettyMonthlyPrice(DigitalPack)</span>
-
-                    <ul class="bundle-offering-a__subscribe__offer__list">
-
-                        @if(bundleVariant.hasAdFree) {
-                            <li class="bundle-offering-a__subscribe__offer__list__item">
-                                <div class="bundle-offering-a__subscribe__offer__list__item__icon">
-                                @for(icon <- Asset.inlineSvg("bundle-adfree")) {
-                                    @icon
-                                }
-                                </div><div class="bundle-offering-a__subscribe__offer__list__item__content">
-                                <h1>Ad-free</h1>
-                                <p>Enjoy our website and apps without adverts</p>
-                            </div>
-                            </li>
-                        }
-                        @if(bundleVariant.hasPaidComments) {
-                            <li class="bundle-offering-a__subscribe__offer__list__item">
-                                <div class="bundle-offering-a__subscribe__offer__list__item__icon">
-                                @for(icon <- Asset.inlineSvg("bundle-commenting")) {
-                                    @icon
-                                }
-                                </div>
-                                <div class="bundle-offering-a__subscribe__offer__list__item__content">
-                                    <h1>Commenting</h1>
-                                    <p>Discussion threads on articles are reserved for paying supporters only</p>
-                                </div>
-                            </li>
-                        }
-                        <li class="bundle-offering-a__subscribe__offer__list__item">
-                            <div class="bundle-offering-a__subscribe__offer__list__item__icon">
-                                @for(icon <- Asset.inlineSvg("bundle-guardian_g")) {
-                                    @icon
-                                }
-                            </div><div class="bundle-offering-a__subscribe__offer__list__item__content">
-                                <h1>Exclusive content</h1>
-                                <p>Behind-the-scenes updates from Guardian journalists, a regular newsletter and our new member podcast</p>
-                            </div>
-                        </li>
-
-                        <li class="bundle-offering-a__subscribe__offer__list__item">
-                            <div class="bundle-offering-a__subscribe__offer__list__item__icon">
-                                @for(icon <- Asset.inlineSvg("bundle-tabletedition")) {
-                                    @icon
-                                }
-                            </div><div class="bundle-offering-a__subscribe__offer__list__item__content">
-                                <h1>Tablet edition</h1>
-                                <p>Your daily newspaper optimised for tablet</p>
-                            </div>
-                        </li>
-                    </ul>
-                    @fragments.bundle.bundleButton("Find out more", routes.Bundle.thankYou(bundleVariant, "digital-pack").url, className = Option("js-commit-button"), returnUrl = Some(java.net.URLEncoder.encode(returnUrl.getOrElse("https://www.theguardian.com"), "utf-8")))
-                </div>
-            </div><div class="bundle-offering-a__subscribe__offer">
-                <div class="bundle-offering-a__subscribe__offer__content">
-                    <h2>Print&amp;Digital subscription</h2>
-                    <span class="bundle-offering-a__subscribe__offer__price-description">from @bundleVariant.prettyMonthlyPrice(Saturday)</span>
-                    <ul class="bundle-offering-a__subscribe__offer__list">
-
-                    @if(bundleVariant.hasAdFree) {
-                        <li class="bundle-offering-a__subscribe__offer__list__item">
-                            <div class="bundle-offering-a__subscribe__offer__list__item__icon">
-                            @for(icon <- Asset.inlineSvg("bundle-adfree")) {
-                                @icon
-                            }
-                            </div><div class="bundle-offering-a__subscribe__offer__list__item__content">
-                            <h1>Ad-free</h1>
-                            <p>Enjoy our website and apps without adverts</p>
-                           </div>
-                        </li>
-                    }
-                    @if(bundleVariant.hasPaidComments) {
-                        <li class="bundle-offering-a__subscribe__offer__list__item">
-                            <div class="bundle-offering-a__subscribe__offer__list__item__icon">
-                            @for(icon <- Asset.inlineSvg("bundle-commenting")) {
-                                @icon
-                            }
-                            </div>
-                            <div class="bundle-offering-a__subscribe__offer__list__item__content">
-                                <h1>Commenting</h1>
-                                <p>Discussion threads on articles are reserved for paying supporters only</p>
-                            </div>
-                        </li>
-                    }
-
-                        <li class="bundle-offering-a__subscribe__offer__list__item">
-                            <div class="bundle-offering-a__subscribe__offer__list__item__icon">
-                                @for(icon <- Asset.inlineSvg("bundle-guardian_g")) {
-                                    @icon
-                                }
-                            </div><div class="bundle-offering-a__subscribe__offer__list__item__content">
-                                <h1>Exclusive content</h1>
-                                <p>Behind-the-scenes updates from Guardian journalists, a regular newsletter and our new member podcast</p>
-                            </div>
-                        </li>
-                        <li class="bundle-offering-a__subscribe__offer__list__item">
-                            <div class="bundle-offering-a__subscribe__offer__list__item__icon">
-                            @for(icon <- Asset.inlineSvg("bundle-tabletedition")) {
-                                @icon
-                            }
-                            </div><div class="bundle-offering-a__subscribe__offer__list__item__content">
-                                <h1>Tablet edition</h1>
-                                <p>Your daily newspaper optimised for tablet</p>
-                            </div>
-                        </li>
-                        <li class="bundle-offering-a__subscribe__offer__list__item">
-                            <div class="bundle-offering-a__subscribe__offer__list__item__icon">
-                            @for(icon <- Asset.inlineSvg("bundle-newspaper")) {
-                                @icon
-                            }
-                            </div><div class="bundle-offering-a__subscribe__offer__list__item__content">
-                                <h1>Print</h1>
-                                <p>Pick the package you want: Saturday, Sunday, Weekly, Weekend or Everyday.  Save up to 36% on the Guardian and Observer newspapers</p>
-                            </div>
-                        </li>
-                    </ul>
-                    @fragments.bundle.bundleButton("See options","#", Option("js-see-more-button"), chevron = true)
-                    <div class="bundle-offering-a__subscribe__offer__print-options">
-                        <ul>
-                            <li class="bundle-offering-a__subscribe__offer__print-options__option subscribe_option--selected">
-                                <div class="bundle-offering-a__print-option__description">
-                                    <h1>Saturday</h1>
-                                    <p></p>
-                                </div><div class="bundle-offering-a__print-option__price">
-                                        @bundleVariant.prettyMonthlyPrice(Saturday)
-                                </div>
-                                <div class="bundle-offering-a__print-option__id">saturday</div>
-                            </li>
-                            <li class="bundle-offering-a__subscribe__offer__print-options__option">
-                                <div class="bundle-offering-a__print-option__description">
-                                    <h1>The Guardian Weekly</h1>
-                                    <p></p>
-                                </div><div class="bundle-offering-a__print-option__price">
-                                    @bundleVariant.prettyMonthlyPrice(GuardianWeekly)
-                                </div>
-                                <div class="bundle-offering-a__print-option__id">guardian-weekly</div>
-                            </li>
-                            <li class="bundle-offering-a__subscribe__offer__print-options__option">
-                                <div class="bundle-offering-a__print-option__description">
-                                    <h1>Weekend</h1>
-                                    <p>Saturday &amp; Sunday</p>
-                                </div><div class="bundle-offering-a__print-option__price">
-                                    @bundleVariant.prettyMonthlyPrice(Weekend)
-                                </div>
-                                <div class="bundle-offering-a__print-option__id">weekend</div>
-                            </li>
-                            <li class="bundle-offering-a__subscribe__offer__print-options__option">
-                                <div class="bundle-offering-a__print-option__description">
-                                    <h1>Saturday &amp; The&nbsp;Guardian Weekly</h1>
-                                    <p></p>
-                                </div><div class="bundle-offering-a__print-option__price">
-                                    @bundleVariant.prettyMonthlyPrice(SatGW)
-                                </div>
-                                <div class="bundle-offering-a__print-option__id">satgwe</div>
-                            </li>
-                            <li class="bundle-offering-a__subscribe__offer__print-options__option">
-                                <div class="bundle-offering-a__print-option__description">
-                                    <h1>Sixday</h1>
-                                    <p>Monday - Saturday</p>
-                                </div><div class="bundle-offering-a__print-option__price">
-                                    @bundleVariant.prettyMonthlyPrice(SixDay)
-                                </div>
-                                <div class="bundle-offering-a__print-option__id">six-day</div>
-                            </li>
-                            <li class="bundle-offering-a__subscribe__offer__print-options__option">
-                                <div class="bundle-offering-a__print-option__description">
-                                    <h1>Everyday</h1>
-                                    <p>Monday - Sunday</p>
-                                </div><div class="bundle-offering-a__print-option__price">
-                                    @bundleVariant.prettyMonthlyPrice(SevenDay)
-                                </div>
-                                <div class="bundle-offering-a__print-option__id">seven-day</div>
-                            </li>
-                        </ul>
-                        @fragments.bundle.bundleButton(bundleVariant.prettyMonthlyPrice(Saturday), routes.Bundle.thankYou(bundleVariant, "saturday").url, Option("js-print-button"), returnUrl = Some(java.net.URLEncoder.encode(returnUrl.getOrElse("https://www.theguardian.com"), "utf-8")))
-                    </div>
-                </div>
-            </div>
-        </div>
     </div>
 </section>
 

--- a/frontend/app/views/fragments/bundle/bundleThankYouExplainer.scala.html
+++ b/frontend/app/views/fragments/bundle/bundleThankYouExplainer.scala.html
@@ -1,0 +1,68 @@
+@import views.support.Asset
+@import abtests.BundleVariant
+
+@(bundleVariant: BundleVariant, className: Option[String] = None, chevron: Boolean = false, secondary: Boolean = false, returnUrl: Option[String] = None)
+
+<div class="bundle-thankyou__explainer-content">
+    <p>Don't worry, nothing has broken.</p>
+    <p>We have a number of tests underway that help us determine which products our readers may be interested in, and you were selected to participate in one of these tests.</p>
+    <p>The digital subscription product you selected is not yet available, but there are still some things you can do:</p>
+    <ul>
+        <li>
+            Leave a message in the feedback form below, and we will get in touch with you if sufficient demand exists for this feature.
+        </li>
+        <li>
+            Find out more about the subscription products that are currently available by clicking the Become a supporter button.
+        </li>
+        <li>
+            Make a one-off, or a recurring financial contribution. For that you can also just click the Become a supporter button.
+        </li>
+        <li>
+            Continue reading the guardian by clicking the Continue button.
+        </li>
+    </ul>
+    <p>
+        Thank you for your participation. We hope to be able to provide the features you are interested in soon.
+    </p>
+
+    <div class="bundle-thankyou__email-form  bundle-thankyou-js">
+        <script type="text/javascript" src="https://example-memberhsip.formstack.com/forms/js.php/membership?bundle_variant=@bundleVariant.testId"></script><noscript><a href="https://example-memberhsip.formstack.com/forms/membership?bundle-variant=@bundleVariant.testId" title="Online Form">Online Form - Membership</a></noscript><div style="text-align:right; font-size:x-small;"><a href="http://www.formstack.com?utm_source=jsembed&utm_medium=product&utm_campaign=product+branding&fa=h,2576843" title="HTML Form Builder">HTML Form Builder</a></div>
+    </div>
+
+    <div class="bundle-button__content__support">
+        <a class="bundle-button" href="https://support.theguardian.com/uk">
+            <p>Become a supporter</p>
+            <div class="bundle-button__content__arrow">
+            @if(chevron){
+                @for(icon <- Asset.inlineSvg("bundle-chevron")) {
+                    @icon
+                }
+            }else{
+                @for(icon <- Asset.inlineSvg("bundle-arrow")) {
+                    @icon
+                }
+            }
+            </div>
+        </a>
+    </div>
+
+    <div class="bundle-button__content__continue">
+        <a class="bundle-button" href="https://www.theguardian.com">
+            <p>Continue</p>
+            <div class="bundle-button__content__arrow">
+            @if(chevron){
+                @for(icon <- Asset.inlineSvg("bundle-chevron")) {
+                    @icon
+                }
+            }else{
+                @for(icon <- Asset.inlineSvg("bundle-arrow")) {
+                    @icon
+                }
+            }
+            </div>
+        </a>
+    </div>
+
+</div>
+
+

--- a/frontend/app/views/fragments/bundle/bundleThankYouExplainer.scala.html
+++ b/frontend/app/views/fragments/bundle/bundleThankYouExplainer.scala.html
@@ -5,64 +5,22 @@
 
 <div class="bundle-thankyou__explainer-content">
     <p>Don't worry, nothing has broken.</p>
-    <p>We have a number of tests underway that help us determine which products our readers may be interested in, and you were selected to participate in one of these tests.</p>
-    <p>The digital subscription product you selected is not yet available, but there are still some things you can do:</p>
+    <p>We have a number of tests underway that help us determine which products our readers may enjoy, and you were selected to participate in one of these tests.</p>
+    <p>The digital subscription product you selected is not yet available but your interest in it has been recorded. From here you can:</p>
     <ul>
         <li>
-            Leave a message in the feedback form below, and we will get in touch with you if sufficient demand exists for this feature.
+            <a href="https://support.theguardian.com/uk?INTCMP=@bundleVariant.testId">Find out more about the subscription products that are currently available</a>
         </li>
         <li>
-            Find out more about the subscription products that are currently available by clicking the Become a supporter button.
+            <a href="https://support.theguardian.com/uk?INTCMP=@bundleVariant.testId">Make a one-off, or a recurring financial contribution</a>
         </li>
         <li>
-            Make a one-off, or a recurring financial contribution. For that you can also just click the Become a supporter button.
-        </li>
-        <li>
-            Continue reading the guardian by clicking the Continue button.
+            <a href="https://www.theguardian.com?INTCMP=@bundleVariant.testId">Continue reading the guardian</a>
         </li>
     </ul>
     <p>
         Thank you for your participation. We hope to be able to provide the features you are interested in soon.
     </p>
-
-    <div class="bundle-thankyou__email-form  bundle-thankyou-js">
-        <script type="text/javascript" src="https://example-memberhsip.formstack.com/forms/js.php/membership?bundle_variant=@bundleVariant.testId"></script><noscript><a href="https://example-memberhsip.formstack.com/forms/membership?bundle-variant=@bundleVariant.testId" title="Online Form">Online Form - Membership</a></noscript><div style="text-align:right; font-size:x-small;"><a href="http://www.formstack.com?utm_source=jsembed&utm_medium=product&utm_campaign=product+branding&fa=h,2576843" title="HTML Form Builder">HTML Form Builder</a></div>
-    </div>
-
-    <div class="bundle-button__content__support">
-        <a class="bundle-button" href="https://support.theguardian.com/uk">
-            <p>Become a supporter</p>
-            <div class="bundle-button__content__arrow">
-            @if(chevron){
-                @for(icon <- Asset.inlineSvg("bundle-chevron")) {
-                    @icon
-                }
-            }else{
-                @for(icon <- Asset.inlineSvg("bundle-arrow")) {
-                    @icon
-                }
-            }
-            </div>
-        </a>
-    </div>
-
-    <div class="bundle-button__content__continue">
-        <a class="bundle-button" href="https://www.theguardian.com">
-            <p>Continue</p>
-            <div class="bundle-button__content__arrow">
-            @if(chevron){
-                @for(icon <- Asset.inlineSvg("bundle-chevron")) {
-                    @icon
-                }
-            }else{
-                @for(icon <- Asset.inlineSvg("bundle-arrow")) {
-                    @icon
-                }
-            }
-            </div>
-        </a>
-    </div>
-
 </div>
 
 

--- a/frontend/app/views/fragments/bundle/bundleThankYouExplainer.scala.html
+++ b/frontend/app/views/fragments/bundle/bundleThankYouExplainer.scala.html
@@ -1,26 +1,24 @@
 @import views.support.Asset
 @import abtests.BundleVariant
 
-@(bundleVariant: BundleVariant, className: Option[String] = None, chevron: Boolean = false, secondary: Boolean = false, returnUrl: Option[String] = None)
+@(bundleVariant: BundleVariant, selectedOption: String, className: Option[String] = None, chevron: Boolean = false, secondary: Boolean = false, returnUrl: Option[String] = None)
 
 <div class="bundle-thankyou__explainer-content">
-    <p>Don't worry, nothing has broken.</p>
-    <p>We have a number of tests underway that help us determine which products our readers may enjoy, and you were selected to participate in one of these tests.</p>
-    <p>The digital subscription product you selected is not yet available but your interest in it has been recorded. From here you can:</p>
+    <p>We are currently evaluating different ways in which we allow readers to support the Guardian.</p>
+    <p>As a visitor to the Guardian homepage, you were selected to take part in one of these tests.</p>
+    <p>If you have any feedback on the product you were shown today, do let us know below.</p>
+    <div class="bundle-thankyou__email-form  bundle-thankyou-js">
+        <script type="text/javascript" src="https://guardiannewsampampmedia.formstack.com/forms/js.php/membership_team__feedback_form?bundle_variant=@bundleVariant.testId&selected_option=@selectedOption"></script><noscript><a href="https://guardiannewsampampmedia.formstack.com/forms/membership_team__feedback_form?bundle_variant=@bundleVariant.testId&selected_option=@selectedOption" title="Online Form">Online Form - Membership team - feedback form</a></noscript><div style="display:none; text-align:right; font-size:x-small;"><a href="http://www.formstack.com?utm_source=jsembed&utm_medium=product&utm_campaign=product+branding&fa=h,2583327" title="Web Form Generator">Web Form Generator</a></div>
+    </div>
+    <p>You can also support the Guardian right now by:</p>
     <ul>
         <li>
-            <a href="https://support.theguardian.com/uk?INTCMP=@bundleVariant.testId">Find out more about the subscription products that are currently available</a>
+            <a href="https://support.theguardian.com/uk?INTCMP=@bundleVariant.testId">Subscribing to our current digital pack</a>
         </li>
         <li>
-            <a href="https://support.theguardian.com/uk?INTCMP=@bundleVariant.testId">Make a one-off, or a recurring financial contribution</a>
-        </li>
-        <li>
-            <a href="https://www.theguardian.com?INTCMP=@bundleVariant.testId">Continue reading the guardian</a>
+            <a href="https://support.theguardian.com/uk?INTCMP=@bundleVariant.testId">Making a one-off or regular contribution</a>
         </li>
     </ul>
-    <p>
-        Thank you for your participation. We hope to be able to provide the features you are interested in soon.
-    </p>
 </div>
 
 

--- a/frontend/app/views/fragments/bundle/bundleThankYouExplainer.scala.html
+++ b/frontend/app/views/fragments/bundle/bundleThankYouExplainer.scala.html
@@ -4,21 +4,23 @@
 @(bundleVariant: BundleVariant, selectedOption: String, className: Option[String] = None, chevron: Boolean = false, secondary: Boolean = false, returnUrl: Option[String] = None)
 
 <div class="bundle-thankyou__explainer-content">
-    <p>We are currently evaluating different ways in which we allow readers to support the Guardian.</p>
-    <p>As a visitor to the Guardian homepage, you were selected to take part in one of these tests.</p>
-    <p>If you have any feedback on the product you were shown today, do let us know below.</p>
+    <p>We are currently evaluating different ways in which we allow readers to support the Guardian.
+        As a visitor to the Guardian homepage, you were selected to take part in one of these tests.
+        If you have any feedback on the product you were shown today, do let us know below.
+    </p>
     <div class="bundle-thankyou__email-form  bundle-thankyou-js">
         <script type="text/javascript" src="https://guardiannewsampampmedia.formstack.com/forms/js.php/membership_team__feedback_form?bundle_variant=@bundleVariant.testId&selected_option=@selectedOption"></script><noscript><a href="https://guardiannewsampampmedia.formstack.com/forms/membership_team__feedback_form?bundle_variant=@bundleVariant.testId&selected_option=@selectedOption" title="Online Form">Online Form - Membership team - feedback form</a></noscript><div style="display:none; text-align:right; font-size:x-small;"><a href="http://www.formstack.com?utm_source=jsembed&utm_medium=product&utm_campaign=product+branding&fa=h,2583327" title="Web Form Generator">Web Form Generator</a></div>
     </div>
     <p>You can also support the Guardian right now by:</p>
     <ul>
         <li>
-            <a href="https://support.theguardian.com/uk?INTCMP=@bundleVariant.testId">Subscribing to our current digital pack</a>
+            <p><a href="/uk?INTCMP=@bundleVariant.testId">Subscribing to our current digital pack</a></p>
         </li>
         <li>
-            <a href="https://support.theguardian.com/uk?INTCMP=@bundleVariant.testId">Making a one-off or regular contribution</a>
+            <p><a href="/uk?INTCMP=@bundleVariant.testId">Making a one-off or regular contribution</a></p>
         </li>
     </ul>
+    <p>Or you can <a href="https://www.theguardian.com">return to the front page to continue reading</a></p>
 </div>
 
 

--- a/frontend/assets/javascripts/src/modules/landingBundles.es6
+++ b/frontend/assets/javascripts/src/modules/landingBundles.es6
@@ -18,7 +18,7 @@ const SEE_MORE_CTA = document.querySelector(SEE_MORE_CTA_SELECTOR);
 const PRINT_OPTIONS = document.querySelectorAll(PRINT_OPTIONS_SELECTOR);
 const PRINT_CTA = document.querySelector(PRINT_CTA_SELECTOR);
 const COMMIT_CTA = document.querySelector(COMMIT_BUTTON_SELECTOR);
-const COMMIT_COOKIE_NAME = 'GU_PDCOMCTA';
+const COMMIT_COOKIE_NAME = 'GU_DBPT1';
 
 const cookieDomain = () => {
     return document.location.host.substr(document.location.host.indexOf('.') ? document.location.host.indexOf('.') + 1 : 0);
@@ -55,7 +55,7 @@ function bindButtonBehaviour() {
     });
 
     COMMIT_CTA.addEventListener('click', function(evt){
-        setCookie(COMMIT_COOKIE_NAME, 1, 60);
+        setCookie(COMMIT_COOKIE_NAME, 1, 30);
     });
 }
 

--- a/frontend/assets/javascripts/src/modules/landingBundles.es6
+++ b/frontend/assets/javascripts/src/modules/landingBundles.es6
@@ -17,7 +17,7 @@ const PRINT_B = document.querySelectorAll(PRINT_B_SELECTOR);
 const SEE_MORE_CTA = document.querySelector(SEE_MORE_CTA_SELECTOR);
 const PRINT_OPTIONS = document.querySelectorAll(PRINT_OPTIONS_SELECTOR);
 const PRINT_CTA = document.querySelector(PRINT_CTA_SELECTOR);
-const COMMIT_CTA = document.querySelector(COMMIT_BUTTON_SELECTOR);
+const COMMIT_CTAS = document.querySelectorAll(COMMIT_BUTTON_SELECTOR);
 const COMMIT_COOKIE_NAME = 'GU_DBPT1';
 
 const cookieDomain = () => {
@@ -29,12 +29,21 @@ const setCookie = (name, value, days = 7, path = '/', domain = cookieDomain()) =
 };
 
 export function init() {
+    bindCommitButtonEvents();
 
     if(PRINT_A.length == 0 && PRINT_B.length == 0){
         return;
     }
 
     bindPrintEvents();
+}
+
+function bindCommitButtonEvents() {
+    COMMIT_CTAS.forEach(function(el) {
+        el.addEventListener('click', function(evt){
+            setCookie(COMMIT_COOKIE_NAME, 1, 30);
+        });
+    });
 }
 
 function bindPrintEvents(){
@@ -54,9 +63,6 @@ function bindButtonBehaviour() {
         setCookie(COMMIT_COOKIE_NAME, 1, 60);
     });
 
-    COMMIT_CTA.addEventListener('click', function(evt){
-        setCookie(COMMIT_COOKIE_NAME, 1, 30);
-    });
 }
 
 function bindOptionsBehaviour() {

--- a/frontend/assets/stylesheets/components/_bundle-header.scss
+++ b/frontend/assets/stylesheets/components/_bundle-header.scss
@@ -110,6 +110,7 @@
 
 .bundle-header__main__img {
     @include bundle-column-narrow();
+    float: right;
     img {
         position: absolute;
         @include mq($from: tablet, $until: desktop) {

--- a/frontend/assets/stylesheets/components/_bundle-header.scss
+++ b/frontend/assets/stylesheets/components/_bundle-header.scss
@@ -61,10 +61,10 @@
 
 .bundle-header__main__content {
     @include bundle-column-wide();
-    @include mq($from: tablet) {
+    @include mq($from: tablet, $until: desktop) {
         padding-left: $gs-gutter;
     }
-    @include mq($from: desktop) {
+    @include mq($from: desktop, $until: mem-full) {
         padding-left: $gs-gutter * 2;
     }
     @include mq($from: mem-full) {
@@ -74,9 +74,11 @@
         @include text-title();
         @include mq($from: tablet, $until: desktop) {
             font-size: 46px;
+            line-height: 46px;
         }
         @include mq($from: desktop, $until: mem-full) {
             font-size: 50px;
+            line-height: 50px;
         }
         @include mq($from: mem-full) {
             padding-top: $gs-baseline * 2;
@@ -87,10 +89,12 @@
         @include text-tag-line();
         @include mq($from: tablet, $until: desktop) {
             font-size: 20px;
+            line-height: 24px;
             width: gs-span(5.25);
         }
         @include mq($from: desktop, $until: mem-full) {
             font-size: 22px;
+            line-height: 26px;
             width: 400px;
             padding-bottom: 25px;
         }
@@ -107,20 +111,19 @@
     img {
         position: absolute;
         @include mq($from: tablet, $until: desktop) {
-            width: 288px;
-            height: 240px;
-            top: 87px;
-            margin-left: 430px;
+            width: 340px;
+            top: 85px;
+            margin-left: 140px;
         }
         @include mq($from: desktop, $until: mem-full) {
-            width: 288px;
-            height: 240px;
-            top: 117px;
-            margin-left: 180px;
+            width: 401px;
+            height: 230px;
+            top: 109px;
+            margin-left: 65px;
         }
         @include mq($from: mem-full) {
             width: 480px;
-            height: 400px;
+            height: 275px;
             top: 117px;
         }
     }
@@ -128,6 +131,9 @@
 
 .bundle-header__secondary__content {
     @include bundle-column-wide();
+    @include mq($from: tablet, $until: desktop) {
+        padding-left: 20px;
+    }
     @include mq($from: desktop, $until: mem-full) {
         padding-left: 100px;
         width: 900px;

--- a/frontend/assets/stylesheets/components/_bundle-header.scss
+++ b/frontend/assets/stylesheets/components/_bundle-header.scss
@@ -11,20 +11,12 @@
 
     .global-header__logo__image {
         margin-top: 2px;
-        @include mq($from: tablet) {
-            margin-right: 10px;
+        margin-right: 60px;
+        width: 320px;
+        height: 60px;
+        @include mq($from: tablet, $until: desktop) {
             width: 280px;
             height: 50px;
-        }
-        @include mq($from: desktop) {
-            margin-right: 330px;
-            width: 320px;
-            height: 60px;
-        }
-        @include mq($from: mem-full) {
-            margin-right: 20px;
-            width: 320px;
-            height: 60px;
         }
     }
 
@@ -99,7 +91,8 @@
         }
         @include mq($from: desktop, $until: mem-full) {
             font-size: 22px;
-            width: gs-span(3.75);
+            width: 400px;
+            padding-bottom: 25px;
         }
         @include mq($from: mem-full) {
             padding-bottom: $gs-baseline * 3;

--- a/frontend/assets/stylesheets/components/_bundle-header.scss
+++ b/frontend/assets/stylesheets/components/_bundle-header.scss
@@ -123,7 +123,7 @@
             width: 288px;
             height: 240px;
             top: 117px;
-            margin-left: 336px;
+            margin-left: 180px;
         }
         @include mq($from: mem-full) {
             width: 480px;
@@ -135,8 +135,9 @@
 
 .bundle-header__secondary__content {
     @include bundle-column-wide();
-    @include mq($until: mem-full) {
-        padding-left: $gs-gutter;
+    @include mq($from: desktop, $until: mem-full) {
+        padding-left: 100px;
+        width: 900px;
     }
     @include mq($from: mem-full) {
         padding-left: $gs-gutter * 5;

--- a/frontend/assets/stylesheets/components/_bundle-offerings-a.scss
+++ b/frontend/assets/stylesheets/components/_bundle-offerings-a.scss
@@ -1,30 +1,28 @@
 /* Give */
 .bundle-offering-a__give {
+    @include bundle-column-wide();
     margin: auto;
-    display: inherit;
+    display: inline-block;
     float: left;
+    width: 690px;
     @include mq($from: tablet, $until: desktop) {
+        width: 460px;
         margin-left: 110px;
-        max-width: 30rem;
     }
     @include mq($from: desktop, $until: mem-full) {
-        @include bundle-column-wide();
-        width: gs-span(9.25);
         padding-left: 230px;
     }
     @include mq($from: mem-full) {
         @include bundle-column-narrow();
         float: right;
         padding-left: $gs-gutter;
+        margin-right: 60px;
     }
 }
 
 .bundle-offering-a__give__content {
     margin-top: $gs-baseline * 3;
 
-    @include mq($from: mem-full) {
-        max-width: 28rem;
-    }
     >h1 {
         margin-top: $gs-baseline * 3;
         padding-top: 2px;
@@ -32,10 +30,6 @@
         border-top: 1px guss-colour(news-main-2) solid;
     }
 
-    //.bundle-button__content {
-    //    margin-bottom: $gs-baseline;
-    //    margin-left: $gs-gutter/2;
-    //}
 }
 
 .bundle-offering-a__give__content__body {
@@ -74,20 +68,20 @@
 /* Subscribe */
 
 .bundle-offering-a__subscribe {
-    margin: auto;
-    @include mq($from: tablet, $until: mem-full) {
-        display: inherit;
-    }
-    @include mq($from: mem-full) {
-        display: inline-block;
-        margin-left: gs-span(1.5);
-    }
     @include bundle-column-narrow();
-    padding-right: $gs-gutter;
+    padding-right: 0;
+    margin-left: 100px;
+    width: 460px;
+    display: inline-block;
     @include mq($until: mem-full) {
         padding-top: $gs-baseline * 2;
     }
-    //width: gs-span(9);
+    @include mq($from: tablet, $until: desktop) {
+        margin-left: 110px;
+    }
+    @include mq($from: desktop, $until: mem-full) {
+        margin-left: 230px;
+    }
     >h1 {
         @include mq($from: mem-full) {
             margin-top: $gs-baseline * 3;
@@ -107,19 +101,11 @@
 }
 
 .bundle-offering-a__subscribe__offer {
-    width: gs-span(4.25);
+    width: 460px;
     display: inline-block;
     vertical-align: top;
     margin-top: $gs-baseline * 2;
-    @include mq($from: tablet, $until: desktop) {
-        margin-left: 60px;
-    }
-    @include mq($from: desktop, $until: mem-full) {
-        margin-left: 80px;
-    }
-    @include mq($from: mem-full) {
-        margin-left: 60px;
-    }
+    margin-left: 0;
 }
 
 .bundle-offering-a__subscribe__offer__content {
@@ -135,7 +121,7 @@
     }
 
     .bundle-button {
-        margin-left: 80px;
+        margin-left: 150px;
     }
 
     .bundle-button__content {

--- a/frontend/assets/stylesheets/components/_bundle-offerings-a.scss
+++ b/frontend/assets/stylesheets/components/_bundle-offerings-a.scss
@@ -7,6 +7,10 @@
         @include bundle-column-narrow();
         padding-left: $gs-gutter * 5;
     }
+    @include mq($from: mem-full) {
+        float: right;
+        padding-left: $gs-gutter;
+    }
 }
 
 .bundle-offering-a__give__content {
@@ -16,9 +20,11 @@
         max-width: gs-span(3.75);
     }
     @include mq($from: desktop) {
-        max-width: gs-span(4.75);
+        max-width: gs-span(4.0);
     }
-
+    @include mq($from: mem-full) {
+        max-width: 28rem;
+    }
     >h1 {
         margin-top: $gs-baseline * 3;
         padding-top: 2px;
@@ -61,12 +67,16 @@
     @include mq($from: desktop) {
         display: inherit;
     }
-    @include bundle-column-wide();
+    @include mq($from: mem-full) {
+        display: inline-block;
+        margin-left: gs-span(1.5);
+    }
+    @include bundle-column-narrow();
     padding-right: $gs-gutter;
     @include mq($until: mem-full) {
         padding-top: $gs-baseline * 2;
     }
-    width: gs-span(9);
+    //width: gs-span(9);
     >h1 {
         @include mq($from: mem-full) {
             margin-top: $gs-baseline * 3;
@@ -90,6 +100,9 @@
     display: inline-block;
     vertical-align: top;
     margin-top: $gs-baseline * 2;
+    @include mq($from: mem-full) {
+        margin-left: 60px;
+    }
 }
 
 .bundle-offering-a__subscribe__offer__content {

--- a/frontend/assets/stylesheets/components/_bundle-offerings-a.scss
+++ b/frontend/assets/stylesheets/components/_bundle-offerings-a.scss
@@ -28,18 +28,20 @@
         border-top: 1px guss-colour(news-main-2) solid;
     }
 
-    .bundle-button__content {
-        margin-bottom: $gs-baseline;
-        margin-left: $gs-gutter/2;
-    }
+    //.bundle-button__content {
+    //    margin-bottom: $gs-baseline;
+    //    margin-left: $gs-gutter/2;
+    //}
 }
 
 .bundle-offering-a__give__content__body {
     background-color: #d4ebf8;
     margin-top: 10px;
+    padding-bottom: 10px;
     @include mq($from: desktop, $until: mem-full) {
         .bundle-button {
-            margin-left: 100px;
+            margin-bottom: $gs-baseline;
+            margin-left: 120px;
         }
     }
     @include mq($from: mem-full) {
@@ -55,8 +57,11 @@
     }
 }
 
-.bundle-offering-a__give__monthly-button,
-.bundle-offering-a__give__one-off-button{
+.bundle-offering-a__give__content__body__description {
+    padding: 10px;
+}
+
+.bundle-offering-a__give__button {
     .bundle-button__content {
         width: gs-span(3.35);
     }

--- a/frontend/assets/stylesheets/components/_bundle-offerings-a.scss
+++ b/frontend/assets/stylesheets/components/_bundle-offerings-a.scss
@@ -1,3 +1,6 @@
+body {
+    overflow: hidden;   // close the borders!
+}
 /* Give */
 .bundle-offering-a__give {
     @include bundle-column-wide();

--- a/frontend/assets/stylesheets/components/_bundle-offerings-a.scss
+++ b/frontend/assets/stylesheets/components/_bundle-offerings-a.scss
@@ -3,11 +3,13 @@
     margin: auto;
     display: inherit;
     float: left;
-    @include mq($from: desktop) {
-        @include bundle-column-narrow();
-        padding-left: $gs-gutter * 5;
+    @include mq($from: desktop, $until: mem-full) {
+        @include bundle-column-wide();
+        width: gs-span(9.25);
+        padding-left: 230px;
     }
     @include mq($from: mem-full) {
+        @include bundle-column-narrow();
         float: right;
         padding-left: $gs-gutter;
     }
@@ -16,12 +18,6 @@
 .bundle-offering-a__give__content {
     margin-top: $gs-baseline * 3;
 
-    @include mq($from: tablet) {
-        max-width: gs-span(3.75);
-    }
-    @include mq($from: desktop) {
-        max-width: gs-span(4.0);
-    }
     @include mq($from: mem-full) {
         max-width: 28rem;
     }
@@ -40,6 +36,12 @@
 
 .bundle-offering-a__give__content__body {
     background-color: #d4ebf8;
+    margin-top: 10px;
+    @include mq($from: desktop, $until: mem-full) {
+        .bundle-button {
+            margin-left: 100px;
+        }
+    }
     @include mq($from: mem-full) {
         margin-top: $gs-baseline * 2;
 
@@ -90,7 +92,7 @@
         padding-right: 1px;
 
         .bundle-button__content {
-            margin-top: 108px;
+            margin-top: 0;
         }
     }
 }
@@ -100,6 +102,9 @@
     display: inline-block;
     vertical-align: top;
     margin-top: $gs-baseline * 2;
+    @include mq($from: desktop, $until: mem-full) {
+        margin-left: 80px;
+    }
     @include mq($from: mem-full) {
         margin-left: 60px;
     }
@@ -117,9 +122,12 @@
         font-weight: 900;
     }
 
+    .bundle-button {
+        margin-left: 80px;
+    }
+
     .bundle-button__content {
         margin-bottom: $gs-baseline;
-        margin-left: $gs-gutter/2;
     }
 }
 

--- a/frontend/assets/stylesheets/components/_bundle-offerings-a.scss
+++ b/frontend/assets/stylesheets/components/_bundle-offerings-a.scss
@@ -3,6 +3,10 @@
     margin: auto;
     display: inherit;
     float: left;
+    @include mq($from: tablet, $until: desktop) {
+        margin-left: 110px;
+        max-width: 30rem;
+    }
     @include mq($from: desktop, $until: mem-full) {
         @include bundle-column-wide();
         width: gs-span(9.25);
@@ -71,7 +75,7 @@
 
 .bundle-offering-a__subscribe {
     margin: auto;
-    @include mq($from: desktop) {
+    @include mq($from: tablet, $until: mem-full) {
         display: inherit;
     }
     @include mq($from: mem-full) {
@@ -107,6 +111,9 @@
     display: inline-block;
     vertical-align: top;
     margin-top: $gs-baseline * 2;
+    @include mq($from: tablet, $until: desktop) {
+        margin-left: 60px;
+    }
     @include mq($from: desktop, $until: mem-full) {
         margin-left: 80px;
     }

--- a/frontend/assets/stylesheets/components/_bundle-offerings-a.scss
+++ b/frontend/assets/stylesheets/components/_bundle-offerings-a.scss
@@ -44,14 +44,20 @@
     }
     @include mq($from: mem-full) {
         margin-top: $gs-baseline * 2;
-
-        > p {
-            @include fs-headline(2);
-            font-size: 18px;
-            line-height: 22px;
-            margin-bottom: $gs-baseline * 2;
-            padding: 8px $gs-gutter/2 0;
+    }
+    >h2 {
+        @include fs-headline(4);
+        @include mq($until: mem-full) {
+            font-size: 22px;
         }
+        padding: 8px $gs-gutter/2 0;
+        font-weight: 900;
+    }
+    > p {
+        @include fs-textSans(4);
+        color: guss-colour(news-support-7);
+        padding-bottom: 0;
+        line-height: 18px;
     }
 }
 

--- a/frontend/assets/stylesheets/components/_bundle-support-us.scss
+++ b/frontend/assets/stylesheets/components/_bundle-support-us.scss
@@ -32,8 +32,11 @@
 .bundle-support__main__title {
     @include bundle-column-narrow();
     padding-right: $gs-gutter;
-    @include mq($until: mem-full) {
+    @include mq($until: tablet) {
         margin-left: $gs-gutter;
+    }
+    @include mq($from: tablet, $until: mem-full) {
+        margin-left: 230px;
     }
     @include mq($from: mem-full) {
         margin-left: 650px;
@@ -45,10 +48,13 @@
         @include text-offering-title();
         border-top: 1px guss-colour(news-main-2) solid;
         margin-top: $gs-baseline * 4;
+        @include mq($from: desktop, $until: mem-full) {
+            margin-top: 1rem;
+        }
         @include mq($from: mem-full) {
             margin-top: 1.5rem;
         }
-        margin-bottom: $gs-baseline * 2;
+        margin-bottom: $gs-baseline;
     }
 }
 
@@ -73,6 +79,9 @@
 
 .bundle-support__content__body {
     @include bundle-column-narrow();
+    @include mq($from: desktop, $until: mem-full) {
+        width: gs-span(9.25);
+    }
     @include mq($from: mem-full) {
         margin-right: -100px;
         margin-left: -40px;
@@ -81,15 +90,23 @@
 
 .bundle-support__content__img-space,
 .bundle-support__one-off__img-space {
-    @include bundle-column-narrow();
+    @include mq($until: mem-full) {
+        display: none;
+    }
+    @include mq($from: mem-full) {
+        @include bundle-column-narrow();
+    }
 }
 
 .bundle-support__content__body__text {
     @include text-paragraph();
     padding-top: 8px;
     max-width: gs-span(6);
-    @include mq($until: mem-full){
+    @include mq($until: desktop){
         margin-left: $gs-gutter;
+    }
+    @include mq($from: desktop, $until: mem-full) {
+        margin-left: 230px;
     }
     @include mq($from: mem-full) {
         margin-left: 150px;

--- a/frontend/assets/stylesheets/components/_bundle-support-us.scss
+++ b/frontend/assets/stylesheets/components/_bundle-support-us.scss
@@ -3,7 +3,7 @@
     padding-left: 20px;
 
     @include mq($from: mem-full) {
-      margin-left: 80px;
+        margin-left: 80px;
     }
 
     >img {
@@ -11,9 +11,7 @@
             display: none;
         }
         position: absolute;
-        margin-top: 22px;
-        width: 460px;
-        height: 627px;
+        margin-top: 75px;
     }
 
 }
@@ -42,8 +40,7 @@
         margin-left: 230px;
     }
     @include mq($from: mem-full) {
-        margin-left: 650px;
-        max-width: 28rem;
+        margin-left: 20px;
     }
 
     >h1 {
@@ -89,6 +86,7 @@
         width: gs-span(9.25);
     }
     @include mq($from: mem-full) {
+        min-height: 550px;
         margin-right: -100px;
         margin-left: -40px;
     }
@@ -115,7 +113,7 @@
         margin-left: 230px;
     }
     @include mq($from: mem-full) {
-        margin-left: 150px;
+        margin-left: 100px;
     }
     color: guss-colour(neutral-1);
     >p {

--- a/frontend/assets/stylesheets/components/_bundle-support-us.scss
+++ b/frontend/assets/stylesheets/components/_bundle-support-us.scss
@@ -11,9 +11,9 @@
             display: none;
         }
         position: absolute;
-        margin-top: $gs-baseline * 4;
+        margin-top: 22px;
         width: 460px;
-        height: 650px;
+        height: 627px;
     }
 
 }
@@ -35,7 +35,10 @@
     @include mq($until: tablet) {
         margin-left: $gs-gutter;
     }
-    @include mq($from: tablet, $until: mem-full) {
+    @include mq($from: tablet, $until: desktop) {
+        margin-left: 110px;
+    }
+    @include mq($from: desktop, $until: mem-full) {
         margin-left: 230px;
     }
     @include mq($from: mem-full) {
@@ -79,6 +82,9 @@
 
 .bundle-support__content__body {
     @include bundle-column-narrow();
+    @include mq($from: tablet, $until: desktop) {
+        width: 590px;
+    }
     @include mq($from: desktop, $until: mem-full) {
         width: gs-span(9.25);
     }
@@ -103,7 +109,7 @@
     padding-top: 8px;
     max-width: gs-span(6);
     @include mq($until: desktop){
-        margin-left: $gs-gutter;
+        margin-left: 110px;
     }
     @include mq($from: desktop, $until: mem-full) {
         margin-left: 230px;

--- a/frontend/assets/stylesheets/components/_bundle-support-us.scss
+++ b/frontend/assets/stylesheets/components/_bundle-support-us.scss
@@ -2,6 +2,10 @@
     @include bundle-column-narrow();
     padding-left: 20px;
 
+    @include mq($from: mem-full) {
+      margin-left: 80px;
+    }
+
     >img {
         @include mq($until: mem-full) {
             display: none;
@@ -26,10 +30,14 @@
 }
 
 .bundle-support__main__title {
-    @include bundle-column-wide();
+    @include bundle-column-narrow();
     padding-right: $gs-gutter;
     @include mq($until: mem-full) {
         margin-left: $gs-gutter;
+    }
+    @include mq($from: mem-full) {
+        margin-left: 650px;
+        max-width: 28rem;
     }
 
     >h1 {
@@ -37,6 +45,9 @@
         @include text-offering-title();
         border-top: 1px guss-colour(news-main-2) solid;
         margin-top: $gs-baseline * 4;
+        @include mq($from: mem-full) {
+            margin-top: 1.5rem;
+        }
         margin-bottom: $gs-baseline * 2;
     }
 }
@@ -55,10 +66,17 @@
 .bundle-support__content {
     background: guss-colour(comment-support-2);
     margin-bottom: 102px;
+    @include mq($from: mem-full) {
+        margin-right: -100px;
+    }
 }
 
 .bundle-support__content__body {
-    @include bundle-column-wide();
+    @include bundle-column-narrow();
+    @include mq($from: mem-full) {
+        margin-right: -100px;
+        margin-left: -40px;
+    }
 }
 
 .bundle-support__content__img-space,
@@ -69,13 +87,14 @@
 .bundle-support__content__body__text {
     @include text-paragraph();
     padding-top: 8px;
-    @include mq($from: mem-full) {
-        max-width: gs-span(6);
-    }
-    color: guss-colour(neutral-1);
+    max-width: gs-span(6);
     @include mq($until: mem-full){
         margin-left: $gs-gutter;
     }
+    @include mq($from: mem-full) {
+        margin-left: 150px;
+    }
+    color: guss-colour(neutral-1);
     >p {
         margin-bottom: $gs-baseline;
     }

--- a/frontend/assets/stylesheets/components/_bundle-thank-you.scss
+++ b/frontend/assets/stylesheets/components/_bundle-thank-you.scss
@@ -1,3 +1,36 @@
+.bundle-thankyou__explainer-content {
+    padding-right: $gs-gutter;
+    @include mq($from: tablet, $until: desktop) {
+        padding-left: $gs-gutter;
+    }
+    @include mq($from: desktop, $until: mem-full) {
+        padding-left: $gs-gutter * 2;
+    }
+    @include mq($from: mem-full) {
+        padding-left: 100px;
+    }
+
+    > p {
+        @include fs-headline(2);
+        font-size: 18px;
+        line-height: 22px;
+        margin-bottom: $gs-baseline * 2;
+        padding: 8px $gs-gutter/2 0;
+    }
+
+    > ul {
+        list-style: none;
+    }
+
+    > ul li {
+        @include fs-headline(2);
+        font-size: 18px;
+        line-height: 22px;
+        margin-bottom: $gs-baseline * 2;
+        padding: 0 $gs-gutter * 2;
+    }
+}
+
 .bundle-thankyou__email-form {
 
     margin-top: 24px;

--- a/frontend/assets/stylesheets/components/_bundle-thank-you.scss
+++ b/frontend/assets/stylesheets/components/_bundle-thank-you.scss
@@ -1,5 +1,5 @@
 .bundle-thankyou__explainer-content {
-    padding-right: $gs-gutter;
+    padding-right: 60px;
     @include mq($from: tablet, $until: desktop) {
         padding-left: $gs-gutter;
     }
@@ -36,12 +36,16 @@
     margin-top: 24px;
 
     .fsBody {
-        padding-top: 0;
+        padding: 0;
     }
 
     .fsForm {
         margin-top: 0 !important;
         padding-top: 0 !important;
+        .fsRow,
+        .fsSubmit {
+            margin-left: -70px;
+        }
     }
 
     .fsSubmit {


### PR DESCRIPTION
## Why are you doing this?
We're about to test different price points for the digital pack subscription. This PR uses the original /bundles landing page, and adjusts it to work (functionally, at least) down to tablet breakpoints.

We also drop a cookie when someone clicks one of the intent-to-buy buttons, whether it's to follow up on the Digi Pack or to make a contribution.

The dotcom portion of this is (currently) on CODE, but that may need to be redeployed from time to time. 

## Trello card: [Here](https://trello.com/c/mJND7IWz/472-price-testing-new-digital-bundle)

## Changes
Should only affect the old /bundles landing page, so I'm not anticipating problems with any of the production features we're running.

## Screenshots
### Dotcom thrasher
![screen shot 2017-04-28 at 10 40 50](https://cloud.githubusercontent.com/assets/690395/25528688/f23fc7bc-2c16-11e7-85f5-c41bd09a658a.png)

### Bundles landing page - wide
![screen shot 2017-05-03 at 17 01 00 - bundles-1-wide](https://cloud.githubusercontent.com/assets/690395/25670143/a4f77318-3023-11e7-8cce-4b20e6e069f3.png)

### Bundles landing page - desktop
![screen shot 2017-05-03 at 17 00 00 - bundles-1-desktop](https://cloud.githubusercontent.com/assets/690395/25670159/b5482762-3023-11e7-93a9-b6fc95267df4.png)

### Bundles landing page - tablet
![screen shot 2017-05-03 at 16 58 00 - bundles-1-tablet](https://cloud.githubusercontent.com/assets/690395/25670175/c1f15be6-3023-11e7-9091-348a94a25c7d.png)

### Thank you page (tablet version shown)
![screen shot 2017-05-03 at 17 04 00 - bundles-1-thankyou-tablet](https://cloud.githubusercontent.com/assets/690395/25670207/dcc6bd08-3023-11e7-8b0a-24b9ad72d24f.png)
