### PR TITLE
Remove Eventbrite API key for Guardian Local

### DIFF
--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -66,7 +66,6 @@ object Config {
   val eventbriteApiUrl = config.getString("eventbrite.api.url")
   val eventbriteApiToken = config.getString("eventbrite.api.token")
   val eventbriteMasterclassesApiToken = config.getString("eventbrite.masterclasses.api.token")
-  val eventbriteLocalApiToken = config.getString("eventbrite.local.api.token")
   val eventbriteApiIframeUrl = config.getString("eventbrite.api.iframe-url")
   val eventbriteRefreshTime = config.getInt("eventbrite.api.refresh-time-seconds")
   val eventbriteRefreshTimeForPriorityEvents = config.getInt("eventbrite.api.refresh-time-priority-events-seconds")


### PR DESCRIPTION
## Why are you doing this?

Follows on from https://github.com/guardian/membership-frontend/pull/1606 - note that I've now removed the `eventbrite.local.api.token` key from our private credentials files on S3.

This PR is tiny enough that I'm going to Just Merge It - approval from #1606 was enough :)