### PR TITLE
Add receive gnm marketing checkbox

### DIFF
--- a/frontend/app/forms/MemberForm.scala
+++ b/frontend/app/forms/MemberForm.scala
@@ -58,8 +58,6 @@ object MemberForm {
   }
 
   trait JoinForm extends CommonForm with HasDeliveryAddress {
-    val marketingChoices: MarketingChoicesForm
-    val password: Option[String]
     val planChoice: PlanChoice
   }
 

--- a/frontend/app/views/fragments/form/marketingChoices.scala.html
+++ b/frontend/app/views/fragments/form/marketingChoices.scala.html
@@ -1,12 +1,29 @@
-@(marketingChoices: Option[com.gu.identity.play.StatusFields])
+@(marketingChoicesOpt: Option[com.gu.identity.play.StatusFields])
+@marketingChoicesOpt match {
+    case Some(marketingChoices) => {
+        <fieldset class="u-h">
+            <input type="hidden"
+            name="marketingChoices.gnnMarketing"
+            value="@marketingChoices.receiveGnmMarketing" />
 
-<fieldset class="u-h">
+            <input type="hidden"
+            name="marketingChoices.thirdParty"
+            value="@marketingChoices.receive3rdPartyMarketing" />
+        </fieldset>
+    }
+    case None => {
+        <div class="fieldset__fields">
 
-    <input type="hidden"
-           name="marketingChoices.gnnMarketing"
-           value="@marketingChoices.map(_.receiveGnmMarketing)" />
+            <div class="form-field js-billing-input-container">
 
-    <input type="hidden"
-           name="marketingChoices.thirdParty"
-           value="@marketingChoices.map(_.receive3rdPartyMarketing)" />
-</fieldset>
+                <label class="label" for="use-delivery-address">
+                    <input type="checkbox" name="marketingChoices.gnnMarketing" id="receive-gnn-marketing" value="true"/>
+                    Keep me up to date with offers from the Guardian
+                </label>
+            </div>
+
+        </div>
+    }
+}
+
+

--- a/frontend/app/views/joiner/form/payment.scala.html
+++ b/frontend/app/views/joiner/form/payment.scala.html
@@ -94,6 +94,8 @@
                             @fragments.form.createPassword()
                         }
 
+                        @fragments.form.marketingChoices(idUser.map(_.marketingChoices))
+
                         <!-- Address -->
                         @fragments.form.addressDetailFields(
                             countriesWithCurrencies = countriesWithCurrencies,
@@ -112,8 +114,6 @@
                             address = idUser.map(_.billingAddress).getOrElse(BlankAddress),
                             showHeading = false
                         )
-
-                        @fragments.form.marketingChoices(idUser.map(_.marketingChoices))
 
                         <button class="action form-panel__continue js-continue-name-address" type="button">Continue</button>
                         <div class="flash-message flash-message--error is-hidden js-payment-errors qa-form-error">


### PR DESCRIPTION
## Why are you doing this?

Spoke to Evie Wilson & Robert Chilvers on the Data Privacy team regarding the 'Receive Guardian Marketing' checkbox. They are happy for us to go ahead with the current wording as used on
https://profile.theguardian.com/register, ie:

    "Keep me up to date with offers from the Guardian"

Evie said it would be best to put the checkbox near where we're asking for the email, to make it clear what it was in relation to (so near the start of the flow, rather than the end, in our case). The checkbox must also default to 'off' for new users, this is a requirement of GDPR.

They pointed out that General Data Protection Regulation (GDPR) is coming into effect in 2018, at which point we will be required to return an audit trail, with each change being accompanied by:

* DateTime
* Application where change was made (eg Identity or Membership)
* What wording was used when the user accepted the mailing

...however, that is going to be a larger project which we do not need to implement now.



## Trello card: [Here](https://trello.com/c/TpuX5Fdb/298-a-b-testing-for-new-checkout-flow-test-merging-registration-into-supporter-checkout)

## Changes
*  Adding the "Keep me up to date with offers from the Guardian" checkbox

## Screenshots
![image](https://cloud.githubusercontent.com/assets/52038/25629453/7228c2e2-2f61-11e7-99e2-73c5a2d87e3f.png)
