### PR TITLE
Take advantage of the AMIgo `cloud-watch-logs` role to reduce conf

### DIFF
--- a/cloud-formation/membership-app.cf.yaml
+++ b/cloud-formation/membership-app.cf.yaml
@@ -107,7 +107,7 @@ Resources:
               dpkg -i /tmp/frontend_1.0-SNAPSHOT_all.deb
               chown frontend /etc/gu/membership.private.conf
               chmod 0600 /etc/gu/membership.private.conf
-              /opt/cloudwatch-logs/configure-logs application ${Stack} ${Stage} ${App} /var/log/${App}/frontend.log
+              /opt/cloudwatch-logs/configure-logs application ${Stack} ${Stage} ${App} /var/log/frontend/frontend.log
   MembershipAppRole:
     Type: AWS::IAM::Role
     Properties:

--- a/cloud-formation/membership-app.cf.yaml
+++ b/cloud-formation/membership-app.cf.yaml
@@ -107,12 +107,7 @@ Resources:
               dpkg -i /tmp/frontend_1.0-SNAPSHOT_all.deb
               chown frontend /etc/gu/membership.private.conf
               chmod 0600 /etc/gu/membership.private.conf
-              wget https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py
-              sed -i -e s"/__DATE/$(date +%F)/" -e 's/__STAGE/${Stage}/' $CONF_DIR/logger.conf
-              python awslogs-agent-setup.py -nr ${AWS::Region} -c $CONF_DIR/logger.conf
-              systemctl enable awslogs
-              systemctl start awslogs
-            - {}
+              /opt/cloudwatch-logs/configure-logs application ${Stack} ${Stage} ${App} /var/log/${App}/frontend.log
   MembershipAppRole:
     Type: AWS::IAM::Role
     Properties:

--- a/cloud-formation/membership-app.cf.yaml
+++ b/cloud-formation/membership-app.cf.yaml
@@ -20,6 +20,10 @@ Parameters:
     Description: Applied directly as a tag
     Type: String
     Default: PROD
+  App:
+    Description: Applied directly as a tag
+    Type: String
+    Default: frontend
   SiteDomain:
     Description: Site domain Name
     Type: String
@@ -74,7 +78,7 @@ Resources:
           Ref: Stack
         PropagateAtLaunch: 'true'
       - Key: App
-        Value: frontend
+        Value: !Ref App
         PropagateAtLaunch: 'true'
       - Key: Stage
         Value:
@@ -97,17 +101,16 @@ Resources:
       AssociatePublicIpAddress: true
       UserData:
         Fn::Base64:
-          !Sub
-            - |
-              #!/bin/bash -ev
-              CONF_DIR=/etc/frontend
-              aws --region ${AWS::Region} s3 cp s3://membership-dist/${Stack}/${Stage}/frontend/frontend_1.0-SNAPSHOT_all.deb /tmp
-              mkdir /etc/gu
-              aws --region ${AWS::Region} s3 cp s3://membership-private/${Stage}/membership.private.conf /etc/gu
-              dpkg -i /tmp/frontend_1.0-SNAPSHOT_all.deb
-              chown frontend /etc/gu/membership.private.conf
-              chmod 0600 /etc/gu/membership.private.conf
-              /opt/cloudwatch-logs/configure-logs application ${Stack} ${Stage} ${App} /var/log/frontend/frontend.log
+          !Sub |
+            #!/bin/bash -ev
+            CONF_DIR=/etc/frontend
+            aws --region ${AWS::Region} s3 cp s3://membership-dist/${Stack}/${Stage}/frontend/frontend_1.0-SNAPSHOT_all.deb /tmp
+            mkdir /etc/gu
+            aws --region ${AWS::Region} s3 cp s3://membership-private/${Stage}/membership.private.conf /etc/gu
+            dpkg -i /tmp/frontend_1.0-SNAPSHOT_all.deb
+            chown frontend /etc/gu/membership.private.conf
+            chmod 0600 /etc/gu/membership.private.conf
+            /opt/cloudwatch-logs/configure-logs application ${Stack} ${Stage} ${App} /var/log/frontend/frontend.log
   MembershipAppRole:
     Type: AWS::IAM::Role
     Properties:

--- a/frontend/conf/logger.conf
+++ b/frontend/conf/logger.conf
@@ -1,8 +1,0 @@
-[general]
-state_file = /var/awslogs/agent-state
-
-[membership-logstream]
-file = /var/log/frontend/frontend.log
-log_group_name = FrontendLogs-__STAGE
-log_stream_name = __DATE/{instance_id}/frontend.log
-datetime_format = %Y-%m-%d %H:%M-%S


### PR DESCRIPTION
## Why are you doing this?

This change stops us from setting up the awslogs-agent *twice*, and instead takes advantage of the fact that our [AMI image](https://amigo.gutools.co.uk/recipes/xenial-membership) includes the [`cloud-watch-logs`](https://amigo.gutools.co.uk/roles#cloud-watch-logs) role, which [already](https://github.com/guardian/amigo/blob/bf2a16128/roles/cloud-watch-logs/tasks/main.yml) installs the [CloudWatch Logs Agent](http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/QuickStartEC2Instance.html) for us.



Note that this will change the AWS CloudWatch Log Group name from [`FrontendLogs-PROD`](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logStream:group=FrontendLogs-PROD) to `membership-frontend-PROD` (see the [`configure-logs`](https://github.com/guardian/amigo/blob/bf2a1612/roles/cloud-watch-logs/files/configure-logs#L14) script).

![image](https://cloud.githubusercontent.com/assets/52038/25657907/0c687c94-2ff8-11e7-9b03-40b25117fcdc.png)


cc @alexduf, who wrote the `cloud-watch-logs` role in amigo.
