### PR TITLE
Fix passing of Marketing Choices to Identity on Merged Registration

### DIFF
--- a/frontend/app/services/IdentityService.scala
+++ b/frontend/app/services/IdentityService.scala
@@ -54,6 +54,11 @@ object IdentityService {
     )
   }
 
+  def statusFieldsFor(form: CommonForm): StatusFields = StatusFields(
+    receiveGnmMarketing = form.marketingChoices.gnm,
+    receive3rdPartyMarketing = form.marketingChoices.thirdParty
+  )
+
   def privateFieldsFor(
     firstName: Option[String] = None,
     lastName: Option[String] = None,

--- a/frontend/app/services/checkout/identitystrategy/NewUser.scala
+++ b/frontend/app/services/checkout/identitystrategy/NewUser.scala
@@ -23,8 +23,9 @@ object NewUser {
     paidMemberJoinForm.email,
     password,
     PublicFields(displayName = Some(s"${form.name.first} ${form.name.last}")),
-    Some(IdentityService.privateFieldsFor(form))
-  ))
+    Some(IdentityService.privateFieldsFor(form)),
+    Some(IdentityService.statusFieldsFor(form)))
+  )
 }
 
 case class NewUser(creationCommand: CreateIdUser)(implicit idReq: IdentityRequest) extends Strategy {


### PR DESCRIPTION

## Why are you doing this?

I forgot to do this in https://github.com/guardian/membership-frontend/pull/1609 - the value of the 'Receive Marketing' checkbox on the merged Membership Checkout flow wasn't being passed through to Identity - so regardless of whether or not they had consented to Guardian marketing, the user _would not_ get marketing emails.

## Trello card: [Here](https://trello.com/c/TpuX5Fdb/298-a-b-testing-for-new-checkout-flow-test-merging-registration-into-supporter-checkout)

## Screenshots

This is after a test on local dev - the value is correctly set on _"Receive email from Guardian News and Media Ltd."_:

![image](https://cloud.githubusercontent.com/assets/52038/25697564/63167530-30b3-11e7-8a64-850919305954.png)
