### PR TITLE
Fix for the US to UK to US bug.

### DIFF
--- a/frontend/assets/javascripts/src/modules/form/address/subdivision.js
+++ b/frontend/assets/javascripts/src/modules/form/address/subdivision.js
@@ -62,6 +62,9 @@ define(['$'], function ($) {
         } else {
             $townLabel.text(TOWN_STRING);
             $countyContainer.append($countySelectParent.removeClass(HIDE_CONTENT_VISUALLY_CLASSNAME));
+            // In the line below we select the current label that is being display in order to update it.
+            // More information in:
+            $countyLabel= $('label',$countyContainer);
             $postcodeLabel.text(POST_CODE_STRING);
             $countyLabel.text(COUNTY_STRING);
             $countyLabel.addClass(OPTIONAL_CLASSNAME);

--- a/frontend/assets/javascripts/src/modules/form/address/subdivision.js
+++ b/frontend/assets/javascripts/src/modules/form/address/subdivision.js
@@ -63,7 +63,7 @@ define(['$'], function ($) {
             $townLabel.text(TOWN_STRING);
             $countyContainer.append($countySelectParent.removeClass(HIDE_CONTENT_VISUALLY_CLASSNAME));
             // In the line below we select the current label that is being display in order to update it.
-            // More information in:
+            // More information in: https://github.com/guardian/membership-frontend/pull/1612
             $countyLabel= $('label',$countyContainer);
             $postcodeLabel.text(POST_CODE_STRING);
             $countyLabel.text(COUNTY_STRING);


### PR DESCRIPTION
## Why are you doing this?
We found a bug where when you change country UK -> US/Canada -> UK the name of the State/County field was incorrectly populated. This fix select the label that is being shown in the "other" case which includes the case of UK.

## Trello card: [Here](https://trello.com/c/yPqCJTNe/435-us-to-uk-country-change-leaves-state-field-behind)

## Changes
* Added a fix in the `subdivision.js` file 


## Flows tested

| Browser | Supporter Stripe checkout | Supporter Paypal checkout | Upgrade from Friend to Supporter  |
|---------|---------------------------|---------------------------|-----------------------------|
| IE      |          ✅                  |                 👍           |                👍              |   
| Chrome  |         Tested by acceptance test                  |      Tested by acceptance test                     |                              👍              |  


|Flows | Checked |
|---------|---------------------------|
|UK -> US -> UK | ✅  |
|US-> UK -> US  | ✅    |
|UK -> US -> Canada -> UK |  ✅ |
|US -> US -> Canada -> Random non-special country -> UK | ✅  |
