### PR TITLE
use the new billing period reader

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "8.0.2"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.9" // v0.9 is the latest version published for Play 2.4...
-  val membershipCommon = "com.gu" %% "membership-common" % "0.395"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.401"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playFilters = PlayImport.filters


### PR DESCRIPTION
This updates membership common, I have rewritten the billing period reader to be understandable, and added more logging to the process of reading a subscription from zuora.

This is mainly for subs' frontend benefit, but I've got rid of some of the orElseing from the readers and I'm thinking of doing away with it all.  If that, it will please @svillafe as he had to do a lot of repetitive adding to get things to work for contributions!

See
https://github.com/guardian/membership-common/pull/471
https://github.com/guardian/membership-common/pull/470

@guardian/membership-and-subscriptions 