### PR TITLE
Reinstate Australian supporter page

### DIFF
--- a/frontend/app/controllers/Info.scala
+++ b/frontend/app/controllers/Info.scala
@@ -66,6 +66,47 @@ trait Info extends Controller {
     )
   }
 
+  def supporterAustralia = CachedAndOutageProtected { implicit request =>
+    implicit val countryGroup = Australia
+
+    val heroImage = ResponsiveImageGroup(
+      name = Some("intro"),
+      metadata = Some(Grid.Metadata(
+        description = Some("""Same-Sex marriage activists march in the street during a Same-Sex Marriage rally in Sydney, Sunday, Aug. 9, 2015""".stripMargin),
+        byline = None,
+        credit = Some("Carol Cho/AAP")
+      )),
+      availableImages = ResponsiveImageGenerator("73f50662f5834f4194a448e966637fc88c0b36f6/0_0_5760_3840", Seq(2000, 1000))
+    )
+
+    val heroOrientated = OrientatedImages(portrait = heroImage, landscape = heroImage)
+
+    val pageImages = Seq(
+      ResponsiveImageGroup(
+        name = Some("coral"),
+        metadata = Some(Grid.Metadata(
+          description = Some("The impact of coral bleaching at Lizard Island on the Great Barrier Reef: (left) the coral turns white, known as 'bleaching', in March 2016; (right) the dead coral is blanketed by seaweed in May 2016"),
+          byline = None,
+          credit = None
+        )),
+        availableImages = ResponsiveImageGenerator(
+          id = "03d7db325026227b0832bfcd17b2f16f8eb5cfed/0_167_5000_3000",
+          sizes = List(1000, 500)
+        )
+      ))
+
+    Ok(views.html.info.supporterAustralia(
+      heroOrientated,
+      TouchpointBackend.Normal.catalog.supporter,
+      PageInfo(
+        title = CopyConfig.copyTitleSupporters,
+        url = request.path,
+        description = Some(CopyConfig.copyDescriptionSupporters),
+        navigation = Nil
+      ),
+      pageImages))
+  }
+
   def supporterFor(implicit countryGroup: CountryGroup) = CachedAndOutageProtected { implicit request =>
 
     val heroImage = ResponsiveImageGroup(

--- a/frontend/app/views/info/supporterAustralia.scala.html
+++ b/frontend/app/views/info/supporterAustralia.scala.html
@@ -1,0 +1,85 @@
+@import views.support.PageInfo
+@import com.gu.i18n.CountryGroup
+
+@import com.gu.memsub.Current
+@import views.support.Asset
+@import configuration.Videos
+@import com.gu.memsub.Benefit
+@import com.gu.memsub.subsv2.PaidMembershipPlans
+@import views.support.MembershipCompat._
+@import com.gu.salesforce.Tier.Supporter
+@import tracking.AppnexusPixel
+
+@import com.gu.memsub.subsv2.CatalogPlan
+@(heroImage: model.OrientatedImages, supporterPlans: PaidMembershipPlans[Benefit.Supporter.type],
+    pageInfo: PageInfo,
+    pageImages: Seq[com.gu.memsub.images.ResponsiveImageGroup])(implicit token: play.filters.csrf.CSRF.Token, countryGroup: CountryGroup)
+
+@main("Supporters", pageInfo=pageInfo, countryGroup=Some(countryGroup)) {
+
+    @fragments.analytics.appNexusPixel("add", AppnexusPixel.landingPageIds.get(Supporter()))
+
+    @* ===== About Supporters ===== *@
+    @fragments.page.heroBanner(heroImage) {
+        Become a Guardian&nbsp;Supporter
+    } {
+        Supporters keep our journalism fearless and free to tell the stories that matter
+    }()
+    @fragments.page.section(hasBorder = false) {
+        @fragments.tier.packagePromoSupporter(supporterPlans, countryGroup, "Top Button")
+    }
+    @fragments.page.section("Support independent journalism", isNarrow = false, hasBottomPadding = false) {
+        <div class="video-preview video-preview--plain">
+            <div class="video-preview__video">
+            @fragments.media.videoPlayer(Videos.supportersAU)
+            </div>
+            <div class="video-preview__header">
+                @fragments.inlineIcon("video", List("icon-inline--scale"))
+                Watch our journalists explain why the Guardian’s unique approach to journalism is worth defending
+            </div>
+        </div>
+    }
+
+    @fragments.page.section(hasBorder = false, hasBottomPadding = false){
+        <div class="listing__text">
+            <p>The Guardian shines a light on critical, under-reported stories across Australia and the globe.</p>
+            <p>We’ve revealed the reality of <a href="https://www.theguardian.com/australia-news/2016/jun/20/the-worst-ive-seen-trauma-expert-lifts-lid-on-atrocity-of-australias-detention-regime">Australia’s offshore detention regime</a>, and in our committed coverage of climate change, our <a href="http://www.theguardian.com/australia-news/series/reef-on-the-brink">Reef on the brink</a> series exposed the mass coral bleaching on the Great Barrier Reef.</p>
+
+        </div>
+    }
+
+    @* ===== Ensuring our independence ===== *@
+    @for(img <- pageImages.find(_.name.contains("coral"))) {
+        @fragments.page.sectionCardStack(img, topPadding = false) {
+            <div class="listing__text">
+                <p>We've led the way on discussion of <a href="https://www.theguardian.com/commentisfree/2015/jul/30/i-can-tell-you-how-adam-goodes-feels-every-indigenous-person-has-felt-it">discrimination against Indigenous people</a>. In our fearless politics coverage, we've reported scoops that have <a href="https://www.theguardian.com/world/2013/nov/18/australia-tried-to-monitor-indonesian-presidents-phone">dominated national debate</a>. We've also told the story <a href="https://www.theguardian.com/society/2015/sep/28/im-not-a-hypochondriac-i-have-a-disease-all-these-things-that-are-wrong-with-me-are-real-they-are-endometriosis">of the suffering of millions of women living with endometriosis</a>.</p>
+                <p>Our independence allows us to produce award-winning journalism free from outside influence. Your support is invaluable for us to maintain this.</p>
+                <p>
+                    <a class="action" href="@{routes.Joiner.enterPaidDetails(supporterPlans.tier)}?countryGroup=@countryGroup.id"
+                    data-metric-trigger="click"
+                    data-metric-category="Supporter Landing Page @countryGroup.id"
+                    data-metric-action="cta click"
+                    data-metric-label="Middle Button"
+                    >Become a Supporter</a>
+                </p>
+            </div>
+        }
+    }
+    @* ===== Join The Guardian and support The Guardian ===== *@
+    @fragments.page.section("If you read the Guardian, join the Guardian",contentHasTopPadding = false) {
+        @fragments.promos.promoQuote(
+            Asset.at("images/common/lenore-taylor-cutout.png"),
+            "Lenore Taylor, Editor, Guardian Australia"
+        ) {
+            <blockquote class="blockquote">
+                By becoming a Guardian Australia Member you join the community of readers who support our independent, fearless journalism and help us continue to cover the important stories, the ones that make a difference but so often don't get told.
+                <cite class="blockquote__citation">Lenore Taylor, Editor, Guardian Australia</cite>
+            </blockquote>
+        }
+    }
+
+    @* ===== Join Today ===== *@
+    @fragments.page.section("What's included") {
+        @fragments.tier.packagePromoSupporter(supporterPlans, countryGroup, "Bottom Button")
+    }
+}

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -102,6 +102,7 @@ GET            /tier/change/:tier/summary             controllers.TierController
 GET            /patrons                               controllers.Info.patron
 GET            /supporter                             controllers.Info.supporterRedirect(countryGroup: Option[CountryGroup])
 GET            /us/supporter                          controllers.Info.supporterUSA
+GET            /au/supporter                          controllers.Info.supporterAustralia
 GET            /about/supporter                       controllers.Redirects.supporterRedirect
 GET            /:countryGroup/supporter               controllers.Info.supporterFor(countryGroup: CountryGroup)
 GET            /help                                  controllers.Info.help

--- a/frontend/test/controllers/RedirectsTest.scala
+++ b/frontend/test/controllers/RedirectsTest.scala
@@ -9,7 +9,7 @@ class RedirectsTest extends Specification {
     redirectToSupporterPage(CountryGroup.UK) must_=== routes.Info.supporterFor(CountryGroup.UK)
     redirectToSupporterPage(CountryGroup.US) must_=== routes.Info.supporterUSA()
     redirectToSupporterPage(CountryGroup.Europe) must_=== routes.Info.supporterFor(CountryGroup.Europe)
-    redirectToSupporterPage(CountryGroup.Australia) must_=== routes.Info.supporterFor(CountryGroup.Australia)
+    redirectToSupporterPage(CountryGroup.Australia) must_=== routes.Info.supporterAustralia()
     redirectToSupporterPage(CountryGroup.Canada) must_=== routes.Info.supporterFor(CountryGroup.Canada)
     redirectToSupporterPage(CountryGroup.RestOfTheWorld) must_=== routes.Info.supporterFor(CountryGroup.RestOfTheWorld)
   }


### PR DESCRIPTION
In #1616, I apparently shouldn't have removed the custom Australian page! We need to discuss the new copy & design with the Australian office before making this change.

So, it's back:

# Australia Screenshot
![picture 541](https://cloud.githubusercontent.com/assets/5122968/25741953/13ae14bc-3185-11e7-99ce-1e615d76e339.png)
