### PR TITLE
Change eventbrite.api.url & update membership-common to 4.02

### DIFF
--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -16,7 +16,7 @@ event.discountMultiplier=0.8
 
 eventbrite.url="http://www.eventbrite.co.uk"
 
-eventbrite.api.url="https://d1s44y2vc5rmbm.cloudfront.net/v3"
+eventbrite.api.url="https://eventbrite-proxy.guardianapis.com/v3"
 
 eventbrite.api.iframe-url="https://www.eventbrite.com/tickets-external?ref=etckt&v=2"
 eventbrite.api.refresh-time-seconds=59

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "8.0.2"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.9" // v0.9 is the latest version published for Play 2.4...
-  val membershipCommon = "com.gu" %% "membership-common" % "0.401"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.402"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playFilters = PlayImport.filters


### PR DESCRIPTION
## Why are you doing this?
 We are seeing timeout issues with Eventbrite in sentry logs. We are trying to log it better and reduce the incidence of timeouts.


## Trello card: [Here](https://trello.com)
None

## Changes
1) Changed Eventbrite API url to go through fastly shield node - as we've seen issues with response times from cloudfront.
2) New logging in membership-common to track okhttp socket-timeout exceptions

## Tested in
Tested in events and masterclasses and signed up patron flow.

