### PR TITLE
Increase timeout on PayPal requests from 10 to 20 seconds

### DIFF
--- a/frontend/app/services/paymentmethods/PaymentMethodInitialiser.scala
+++ b/frontend/app/services/paymentmethods/PaymentMethodInitialiser.scala
@@ -44,9 +44,8 @@ class PayPalInitialiser(payPalService: PayPalService) extends PaymentMethodIniti
 
   def extractTokenFrom(form: CommonPaymentForm): Option[String] = form.payPalBaid
 
-  def initialiseWith(baid: String, user: IdMinimalUser): Future[PayPalReferenceTransaction] = Future {
-    val payPalEmail = payPalService.retrieveEmail(baid) // currently blocking, not async
-    PayPalReferenceTransaction(baid, payPalEmail)
-  }
+  def initialiseWith(baid: String, user: IdMinimalUser): Future[PayPalReferenceTransaction] = for {
+    payPalEmail <- payPalService.retrieveEmail(baid)
+  } yield PayPalReferenceTransaction(baid, payPalEmail)
 
 }


### PR DESCRIPTION
## Why are you doing this?

We've seen quite a few failures in dev, because the PayPal sandbox is so slow - also in our acceptance tests [using test-users on PROD](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logEventViewer:group=membership-frontend-PROD;stream=membership-frontend-PROD-application-i-02547072286a9a83d;refid=33314970187306741362686890102563553358816392836826202112;reftime=1493894930000).

## Trello card: [Here](https://trello.com)

## Changes
* Timeout increased on PayPal requests from 10 to 20 seconds
* Change requests to PayPal use Futures rather than blocking calls - prompted because the `configurableFutureRunner(20.seconds)` method gives a `Future`-based response.

Acceptance tests pass in dev (and hopefully slightly more reliably!)
