### PR TITLE
Add 'become a supporter' link to main nav

### DIFF
--- a/frontend/app/model/Nav.scala
+++ b/frontend/app/model/Nav.scala
@@ -19,6 +19,7 @@ object Nav {
   }
 
   val primaryNavigation = List(
+    NavItem("become a supporter", "/supporter?INTCMP=gdnwb_copts_memco_internal_supporter_link", "Become a supporter"),
     NavItem("events", routes.WhatsOn.list.url, "Events", subNav = Seq(
       NavItem("archive", routes.WhatsOn.listArchive.url, "Archive")
     )),


### PR DESCRIPTION
## Why are you doing this?
Based on the 84% bounce rate of people arriving on the supporter page, it's possible that people are heading to other parts of the site to understand what becoming a supporter means.

But we don't provide an easy means to get back to the supporter page. Since patrons only comprise 0.32% of our supporter equivalents (even accounting for the fact that a patron is worth 12 times a supporter) and they make it into the nav bar, it seems fair "become a supporter" should be there too

## Changes
* Add "become a supporter" to the top nav
* Put a campaign code on the link so we know if this work had any effect

## Screenshots
![picture 549](https://cloud.githubusercontent.com/assets/5122968/25815800/ec5ebbe0-3419-11e7-86f9-0e8302fd97ec.png)
![picture 550](https://cloud.githubusercontent.com/assets/5122968/25815799/ec598ddc-3419-11e7-8b3c-dc11f719bb3b.png)
