### PR TITLE
Remove promo-related code, including healthcheck test

### DIFF
--- a/frontend/app/controllers/Healthcheck.scala
+++ b/frontend/app/controllers/Healthcheck.scala
@@ -23,7 +23,6 @@ object Healthcheck extends Controller {
     new BoolTest("Events", () => GuardianLiveEventService.events.nonEmpty),
     new BoolTest("CloudWatch", () => CloudWatchHealth.hasPushedMetricSuccessfully),
     new BoolTest("ZuoraPing", () => zuoraSoapClient.lastPingTimeWithin(2.minutes)),
-    new BoolTest("Promotions", () => promos.all.nonEmpty),
     new BoolTest("Salesforce", () => salesforceService.isAuthenticated)
   )
 

--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -9,9 +9,6 @@ import com.gu.i18n.{Country, CountryGroup, Currency}
 import com.gu.identity.play.{IdMinimalUser, IdUser}
 import com.gu.memsub.Subscriber.{FreeMember, PaidMember}
 import com.gu.memsub.Subscription.{Feature, ProductRatePlanId, RatePlanId}
-import com.gu.memsub.promo.PromotionApplicator._
-import com.gu.memsub.promo._
-import com.gu.memsub.services.PromoService
 import com.gu.memsub.services.api.PaymentService
 import com.gu.memsub.subsv2.reads.ChargeListReads._
 import com.gu.memsub.subsv2.reads.SubPlanReads._
@@ -43,7 +40,6 @@ import utils.CampaignCode
 import views.support.MembershipCompat._
 import views.support.ThankyouSummary
 import views.support.ThankyouSummary.NextPayment
-
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
 import scalaz._
@@ -83,7 +79,6 @@ class MemberService(identityService: IdentityService,
                     payPalService: PayPalService,
                     subscriptionService: SubscriptionService[Future],
                     catalogService: CatalogService[Future],
-                    promoService: PromoService,
                     paymentService: PaymentService,
                     discounter: Discounter,
                     discountIds: DiscountRatePlanIds)
@@ -519,7 +514,7 @@ class MemberService(identityService: IdentityService,
     * Construct an Amend command (used for subscription upgrades)
     */
   private def amend(sub: Subscription[SubscriptionPlan.Member], planChoice: PlanChoice, form: Set[FeatureChoice])
-                   (implicit r: IdentityRequest, applicator: PromotionApplicator[Upgrades, Amend]): Future[Amend] = {
+                   (implicit r: IdentityRequest): Future[Amend] = {
 
     val newPlan = catalog.unsafeFindPaid(planChoice.productRatePlanId)
     val tier = newPlan.tier

--- a/frontend/app/services/TouchpointBackend.scala
+++ b/frontend/app/services/TouchpointBackend.scala
@@ -2,7 +2,6 @@ package services
 
 import com.gu.config.MembershipRatePlanIds
 import com.gu.identity.play.IdMinimalUser
-import com.gu.memsub.promo.{DynamoPromoCollection, PromotionCollection}
 import com.gu.memsub.services.{PaymentService, PromoService, api => memsubapi}
 import com.gu.memsub.subsv2
 import com.gu.memsub.subsv2.Catalog
@@ -73,8 +72,6 @@ object TouchpointBackend extends LazyLogging {
 
     val zuoraSoapClient = new ClientWithFeatureSupplier(FeatureChoice.codes, config.zuoraSoap, runner, extendedRunner)
     val discounter = new Discounter(Config.discountRatePlanIds(config.zuoraEnvName))
-    val promoCollection = DynamoPromoCollection.forStage(Config.config, restBackendConfig.envName)
-    val promoService = new PromoService(promoCollection, discounter)
     val zuoraService = new ZuoraServiceImpl(zuoraSoapClient)
     val zuoraRestService = new ZuoraRestService[Future]()
 
@@ -87,7 +84,7 @@ object TouchpointBackend extends LazyLogging {
     val salesforceService = new SalesforceService(config.salesforce)
     val identityService = IdentityService(IdentityApi)
     val memberService = new MemberService(
-      identityService, salesforceService, zuoraService, zuoraRestService, stripeService, payPalService, newSubsService, newCatalogService, promoService, paymentService, discounter,
+      identityService, salesforceService, zuoraService, zuoraRestService, stripeService, payPalService, newSubsService, newCatalogService, paymentService, discounter,
         Config.discountRatePlanIds(config.zuoraEnvName))
 
     TouchpointBackend(
@@ -107,8 +104,6 @@ object TouchpointBackend extends LazyLogging {
       catalogService = newCatalogService,
       zuoraService = zuoraService,
       zuoraRestService = zuoraRestService,
-      promoService = promoService,
-      promos = promoCollection,
       membershipRatePlanIds = memRatePlanIds,
       paymentService = paymentService,
       identityService = identityService,
@@ -167,8 +162,6 @@ case class TouchpointBackend(
   zuoraService: ZuoraService,
   zuoraRestService: ZuoraRestService[Future],
   membershipRatePlanIds: MembershipRatePlanIds,
-  promos: PromotionCollection,
-  promoService: PromoService,
   paymentService: PaymentService,
   identityService: IdentityService,
   simpleRestClient: SimpleClient[Future]

--- a/frontend/app/views/tier/upgrade/paidToPaid.scala.html
+++ b/frontend/app/views/tier/upgrade/paidToPaid.scala.html
@@ -20,7 +20,7 @@
           <form action="@routes.TierController.upgrade(summary.target.tier)" method="POST" class="js-form" id="payment-form">
               @CSRF.formField
 
-              @fragments.page.pageHeader("Great, glad to see you've decided to become a " + summary.target.tier.name)
+              @fragments.page.pageHeader("Great, glad to see you've decided to become a " + summary.target.tier.name, Some("Join as an annual Partner or Patron Member and get 2 months free"))
 
               @for(flashMsg <- flashMessage) {
                   <section class="page-section page-section--no-padding">

--- a/frontend/app/views/tier/upgrade/paidToPaid.scala.html
+++ b/frontend/app/views/tier/upgrade/paidToPaid.scala.html
@@ -20,7 +20,7 @@
           <form action="@routes.TierController.upgrade(summary.target.tier)" method="POST" class="js-form" id="payment-form">
               @CSRF.formField
 
-              @fragments.page.pageHeader("Great, glad to see you've decided to become a " + summary.target.tier.name, Some("Join as an annual Partner or Patron Member and get 2 months free"))
+              @fragments.page.pageHeader("Great, glad to see you've decided to become a " + summary.target.tier.name)
 
               @for(flashMsg <- flashMessage) {
                   <section class="page-section page-section--no-padding">


### PR DESCRIPTION
## Why are you doing this?
We no longer use promotions to incentivise membership products. A couple of PRs have already been merged to remove promo-related code:
https://github.com/guardian/membership-frontend/pull/1535
https://github.com/guardian/membership-frontend/pull/1555

I noticed that we were still checking promotions as part of the healthcheck, so I removed the test and the associated wiring in a couple of services (it's now redundant code, as far as I can tell).

## Trello card: 
N/A

## Changes

1. Remove healthcheck test related to promos
2. Remove promo wiring from services

## Testing Done
* Ran acceptance tests locally
* Tested Supporter > Patron upgrade

## Screenshots
N/A

cc @rupertbates @paulbrown1982 @rtyley 