### PR TITLE
Update Eventbrite, update membership common, increase timeout on newCatalogService

### DIFF
--- a/frontend/app/services/TouchpointBackend.scala
+++ b/frontend/app/services/TouchpointBackend.scala
@@ -79,7 +79,7 @@ object TouchpointBackend extends LazyLogging {
     val zuoraRestService = new ZuoraRestService[Future]()
 
     val pids = Config.productIds(restBackendConfig.envName)
-    val newCatalogService = new subsv2.services.CatalogService[Future](pids, simpleRestClient, Await.result(_, 10.seconds), restBackendConfig.envName)
+    val newCatalogService = new subsv2.services.CatalogService[Future](pids, simpleRestClient, Await.result(_, 20.seconds), restBackendConfig.envName)
     val futureCatalog: Future[CatalogMap] = newCatalogService.catalog.map(_.fold[CatalogMap](error => {println(s"error: ${error.list.mkString}"); Map()}, _.map))
     val newSubsService = new subsv2.services.SubscriptionService[Future](pids, futureCatalog, simpleRestClient, zuoraService.getAccountIds)
 

--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -16,7 +16,7 @@ event.discountMultiplier=0.8
 
 eventbrite.url="http://www.eventbrite.co.uk"
 
-eventbrite.api.url="https://d1s44y2vc5rmbm.cloudfront.net/v3"
+eventbrite.api.url="https://eventbrite-proxy.guardianapis.com/v3"
 
 eventbrite.api.iframe-url="https://www.eventbrite.com/tickets-external?ref=etckt&v=2"
 eventbrite.api.refresh-time-seconds=59

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "8.0.2"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.9" // v0.9 is the latest version published for Play 2.4...
-  val membershipCommon = "com.gu" %% "membership-common" % "0.401"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.402"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playFilters = PlayImport.filters


### PR DESCRIPTION
This is a rerun of https://github.com/guardian/membership-frontend/pull/1618
This deploy failed and upon investigation it was discovered that the load-balancer tests were failing on startup of the AWS instances. This failure was caused by the job that sets up paymentService timing out and nothing to do with any changes in the deploy itself. 
There is an extra change in this pull request to extend the timeout for newCatalogService in Touchpoint Backend. This should reduce the number of deploys in the future that fail due to this set-up job timing out.

Why are you doing this?

We are seeing timeout issues with Eventbrite in sentry logs. We are trying to log it better and reduce the incidence of timeouts.
New CatalogService timed out during deploys yesterday. Increasing timeout should reduce incidences of false alarms due to slow connections killing our boxes.

Changes:

Changed Eventbrite API url to go through fastly shield node - as we've seen issues with response times from cloudfront.
New logging in membership-common to track okhttp socket-timeout exceptions
Changed timeout from 10 seconds to 20 for newCatalogService in TouchpointBackend.

Tested in:

Tested in events and masterclasses and signed up patron flow.