### PR TITLE
updating membership common to 4.02 in its own pr

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "8.0.2"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.9" // v0.9 is the latest version published for Play 2.4...
-  val membershipCommon = "com.gu" %% "membership-common" % "0.401"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.402"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playFilters = PlayImport.filters


### PR DESCRIPTION
This is a partial rerun of #1618 - this change only updates the membership common version.

Why are you doing this?

We are seeing timeout issues with Eventbrite in sentry logs. We are trying to log it better 

Changes:
Update membership common version to 0.402 to pick up new logging which will track okhttp socket-timeout exceptions

Tested in:

Tested in events and masterclasses and signed up patron flow.