### PR TITLE
Allow mobile traffic into bundle price AB test

### DIFF
--- a/frontend/app/abtests/BundleVariant.scala
+++ b/frontend/app/abtests/BundleVariant.scala
@@ -63,9 +63,9 @@ object Distribution {
   val VARIANT = Distribution("MEMBERSHIP_A_ADX_THRASHER_UK_VARIANT")
   val PDCPRE = Distribution("MEMBERSHIP_A_PDCOM_PRE")
   val PDCPOST = Distribution("MEMBERSHIP_A_PDCOM_POST")
-  val DIGIPRICE1A = Distribution("BUNDLE_PRICE_TEST_1_UK_A")
-  val DIGIPRICE1B = Distribution("BUNDLE_PRICE_TEST_1_UK_B")
-  val DIGIPRICE1C = Distribution("BUNDLE_PRICE_TEST_1_UK_C")
+  val DIGIPRICE1A = Distribution("BUNDLE_PRICE_TEST_1M_UK_A")
+  val DIGIPRICE1B = Distribution("BUNDLE_PRICE_TEST_1M_UK_B")
+  val DIGIPRICE1C = Distribution("BUNDLE_PRICE_TEST_1M_UK_C")
 }
 
 case class Distribution(name: String)

--- a/frontend/app/views/bundle/bundleSetA.scala.html
+++ b/frontend/app/views/bundle/bundleSetA.scala.html
@@ -14,7 +14,7 @@
     whySupportImage: model.OrientatedImages,
     bundleVariant: BundleVariant)(implicit token: play.filters.csrf.CSRF.Token)
 
-@main("Supporters", pageInfo=pageInfo, header=BundlesHeader, footer=BundlesFooter) {
+@main("Supporters", pageInfo=pageInfo, header=BundlesHeader, footer=BundlesFooter, marginsOverride=Some("l-side-margins-bundles")) {
 
     @* ===== First part ===== *@
     @fragments.bundle.bundleHeader(

--- a/frontend/app/views/fragments/bundle/bundleHeader.scala.html
+++ b/frontend/app/views/fragments/bundle/bundleHeader.scala.html
@@ -6,7 +6,7 @@
 
 <section class="bundle-section">
     <div class="bundle-header__main">
-        <div class="l-constrained">
+        <div class="l-constrained-bundles">
             <div class="bundle-header__main__content">
                 <h1>@mainTitle</h1>
                 <p>@tagLine</p>
@@ -15,7 +15,7 @@
             </div>
         </div>
     </div>
-    <div class="l-constrained">
+    <div class="l-constrained-bundles">
         <div class="bundle-header__secondary">
             <div class="bundle-header__secondary__content">
                 <p>@paragraph</p>

--- a/frontend/app/views/fragments/bundle/bundleOfferingsA.scala.html
+++ b/frontend/app/views/fragments/bundle/bundleOfferingsA.scala.html
@@ -4,7 +4,7 @@
 
 @(bundleVariant: BundleVariant, returnUrl: Option[String])
 <section class="bundle-section">
-    <div class="bundle-offering-a l-constrained">
+    <div class="bundle-offering-a l-constrained-bundles">
         <div class="bundle-offering-a__subscribe">
             <h1>Support through subscribing</h1>
             @if(bundleVariant.hasDigital) {

--- a/frontend/app/views/fragments/bundle/bundleSupportUs.scala.html
+++ b/frontend/app/views/fragments/bundle/bundleSupportUs.scala.html
@@ -8,14 +8,14 @@
 
 <section class="bundle-section">
 
-    <div class="bundle-support__main  l-constrained">
+    <div class="bundle-support__main  l-constrained-bundles">
         <div class="bundle-support__main__img"><img src="@whySupportImage.landscape.defaultImage"></div><div class="bundle-support__main__title@if(bVariant){--b-variant}">
             @if(bVariant){<hr class="bundle-support__line">}
             <h1>Why do we need Supporters?</h1>
         </div>
     </div>
     <div class="bundle-support__content">
-        <div class="l-constrained">
+        <div class="l-constrained-bundles">
             <div class="bundle-support__content__img-space"></div><div class="bundle-support__content__body">
             <div class="bundle-support__content__body__text">
                 @whySupportText

--- a/frontend/app/views/main.scala.html
+++ b/frontend/app/views/main.scala.html
@@ -13,7 +13,8 @@
     header: Header = DefaultHeader,
     footer: Footer = DefaultFooter,
     touchpointBackendResolutionOpt: Option[services.TouchpointBackend.Resolution] = None,
-    margins: Boolean = true
+    margins: Boolean = true,
+    marginsOverride: Option[String] = None
     )(content: Html)
 @import play.api.libs.json.Json
 @import configuration.{Config, Social}
@@ -122,7 +123,7 @@
         <div class="container-global">
             @fragments.global.header(pageInfo, countryGroup, header)
             @if(margins) {
-                <div class="l-side-margins" id="container">
+                <div class="@if(marginsOverride.isDefined){@marginsOverride.get}else{l-side-margins}" id="container">
                     @content
                 </div>
             } else {

--- a/frontend/assets/javascripts/src/modules/landingBundles.es6
+++ b/frontend/assets/javascripts/src/modules/landingBundles.es6
@@ -18,7 +18,8 @@ const SEE_MORE_CTA = document.querySelector(SEE_MORE_CTA_SELECTOR);
 const PRINT_OPTIONS = document.querySelectorAll(PRINT_OPTIONS_SELECTOR);
 const PRINT_CTA = document.querySelector(PRINT_CTA_SELECTOR);
 const COMMIT_CTAS = document.querySelectorAll(COMMIT_BUTTON_SELECTOR);
-const COMMIT_COOKIE_NAME = 'GU_DBPT1';
+const COMMIT_COOKIE_NAME = 'GU_DBPT1M';
+const COMMIT_COOKIE_DAYS = 30;
 
 const cookieDomain = () => {
     return document.location.host.substr(document.location.host.indexOf('.') ? document.location.host.indexOf('.') + 1 : 0);
@@ -41,7 +42,7 @@ export function init() {
 function bindCommitButtonEvents() {
     COMMIT_CTAS.forEach(function(el) {
         el.addEventListener('click', function(evt){
-            setCookie(COMMIT_COOKIE_NAME, 1, 30);
+            setCookie(COMMIT_COOKIE_NAME, 1, COMMIT_COOKIE_DAYS);
         });
     });
 }
@@ -60,7 +61,7 @@ function bindButtonBehaviour() {
     });
 
     PRINT_CTA.addEventListener('click', function(evt){
-        setCookie(COMMIT_COOKIE_NAME, 1, 60);
+        setCookie(COMMIT_COOKIE_NAME, 1, COMMIT_COOKIE_DAYS);
     });
 
 }

--- a/frontend/assets/stylesheets/_mixins.scss
+++ b/frontend/assets/stylesheets/_mixins.scss
@@ -36,6 +36,20 @@ $gs-max-columns: 16;
 @mixin constrain-layout($offset: $gs-gutter * 2) {
     margin: 0 auto;
 
+    @include mq(tablet) {
+        max-width: map-get($max-widths, max-tablet) + $offset;
+    }
+    @include mq(desktop) {
+        max-width: map-get($max-widths, max-desktop) + $offset;
+    }
+    @include mq(mem-full) {
+        max-width: map-get($max-widths, max-mem-full) + $offset;
+    }
+}
+
+@mixin constrain-bundles-layout($offset: $gs-gutter * 2) {
+    margin: 0 auto;
+
     @include mq(mobile) {
         max-width: map-get($max-widths, max-mobile) + $offset;
     }
@@ -48,15 +62,8 @@ $gs-max-columns: 16;
     @include mq(phablet) {
         max-width: map-get($max-widths, max-phablet) + $offset;
     }
-    @include mq(tablet) {
-        max-width: map-get($max-widths, max-tablet) + $offset;
-    }
-    @include mq(desktop) {
-        max-width: map-get($max-widths, max-desktop) + $offset;
-    }
-    @include mq(mem-full) {
-        max-width: map-get($max-widths, max-mem-full) + $offset;
-    }
+
+    @include constrain-layout($offset);
 }
 
 // Side Margins
@@ -65,6 +72,25 @@ $gs-max-columns: 16;
 // The media queries and widths need to match the ones in constrain-layout()
 
 @mixin side-margins-calc($property) {
+    $offset: ($gs-gutter * 2);
+    @include mq(tablet) {
+        $width: map-get($max-widths, max-tablet);
+        #{$property}: -webkit-calc((100% - #{rem($width + $offset)}) / 2);
+        #{$property}: calc((100% - #{rem($width + $offset)}) / 2);
+    }
+    @include mq(desktop) {
+        $width: map-get($max-widths, max-desktop);
+        #{$property}: -webkit-calc((100% - #{rem($width + $offset)}) / 2);
+        #{$property}: calc((100% - #{rem($width + $offset)}) / 2);
+    }
+    @include mq(mem-full) {
+        $width: map-get($max-widths, max-mem-full);
+        #{$property}: -webkit-calc((100% - #{rem($width + $offset)}) / 2);
+        #{$property}: calc((100% - #{rem($width + $offset)}) / 2);
+    }
+}
+
+@mixin side-margins-bundles-calc($property) {
     $offset: ($gs-gutter * 2);
     @include mq(mobile) {
         $width: map-get($max-widths, max-mobile);

--- a/frontend/assets/stylesheets/_mixins.scss
+++ b/frontend/assets/stylesheets/_mixins.scss
@@ -36,6 +36,12 @@ $gs-max-columns: 16;
 @mixin constrain-layout($offset: $gs-gutter * 2) {
     margin: 0 auto;
 
+    @include mq(mobileLandscape) {
+        max-width: map-get($max-widths, max-mobileLandscape) + $offset;
+    }
+    @include mq(phablet) {
+        max-width: map-get($max-widths, max-phablet) + $offset;
+    }
     @include mq(tablet) {
         max-width: map-get($max-widths, max-tablet) + $offset;
     }
@@ -54,6 +60,21 @@ $gs-max-columns: 16;
 
 @mixin side-margins-calc($property) {
     $offset: ($gs-gutter * 2);
+    @include mq($until: mobileLandscape) {
+        $width: map-get($max-widths, max-mobile);
+        #{$property}: -webkit-calc((100% - #{rem($width + $offset)}) / 2);
+        #{$property}: calc((100% - #{rem($width + $offset)}) / 2);
+    }
+    @include mq(mobileLandscape) {
+        $width: map-get($max-widths, max-mobileLandscape);
+        #{$property}: -webkit-calc((100% - #{rem($width + $offset)}) / 2);
+        #{$property}: calc((100% - #{rem($width + $offset)}) / 2);
+    }
+    @include mq(phablet) {
+        $width: map-get($max-widths, max-phablet);
+        #{$property}: -webkit-calc((100% - #{rem($width + $offset)}) / 2);
+        #{$property}: calc((100% - #{rem($width + $offset)}) / 2);
+    }
     @include mq(tablet) {
         $width: map-get($max-widths, max-tablet);
         #{$property}: -webkit-calc((100% - #{rem($width + $offset)}) / 2);

--- a/frontend/assets/stylesheets/_mixins.scss
+++ b/frontend/assets/stylesheets/_mixins.scss
@@ -36,6 +36,12 @@ $gs-max-columns: 16;
 @mixin constrain-layout($offset: $gs-gutter * 2) {
     margin: 0 auto;
 
+    @include mq(mobile) {
+        max-width: map-get($max-widths, max-mobile) + $offset;
+    }
+    @include mq(mobile-wider) {
+        max-width: map-get($max-widths, max-mobile-wider) + $offset;
+    }
     @include mq(mobileLandscape) {
         max-width: map-get($max-widths, max-mobileLandscape) + $offset;
     }
@@ -60,8 +66,13 @@ $gs-max-columns: 16;
 
 @mixin side-margins-calc($property) {
     $offset: ($gs-gutter * 2);
-    @include mq($until: mobileLandscape) {
+    @include mq(mobile) {
         $width: map-get($max-widths, max-mobile);
+        #{$property}: -webkit-calc((100% - #{rem($width + $offset)}) / 2);
+        #{$property}: calc((100% - #{rem($width + $offset)}) / 2);
+    }
+    @include mq(mobile-wider) {
+        $width: map-get($max-widths, max-mobile-wider);
         #{$property}: -webkit-calc((100% - #{rem($width + $offset)}) / 2);
         #{$property}: calc((100% - #{rem($width + $offset)}) / 2);
     }

--- a/frontend/assets/stylesheets/_vars.scss
+++ b/frontend/assets/stylesheets/_vars.scss
@@ -185,10 +185,13 @@ $mq-breakpoints: (
 );
 
 $max-widths: (
-    max-tablet: gs-span(9),
-    max-desktop: gs-span(12),
-    max-mem-full: gs-span(14),
-    max-wide: gs-span(16)
+    max-mobile: gs-span(4),             // 300px
+    max-mobileLandscape: gs-span(6),    // 460px
+    max-phablet: gs-span(8),            // 620px
+    max-tablet: gs-span(9),             // 700px
+    max-desktop: gs-span(12),           // 940px
+    max-mem-full: gs-span(14),          // 1100px
+    max-wide: gs-span(16)               // 1260px
 );
 
 // Fonts

--- a/frontend/assets/stylesheets/_vars.scss
+++ b/frontend/assets/stylesheets/_vars.scss
@@ -185,7 +185,7 @@ $mq-breakpoints: (
 );
 
 $max-widths: (
-    max-mobile: gs-span(4),             // 220px
+    max-mobile: gs-span(4),             // 300px
     max-mobile-wider: gs-span(5),       // 380px
     max-mobileLandscape: gs-span(6),    // 460px
     max-phablet: gs-span(8),            // 620px

--- a/frontend/assets/stylesheets/_vars.scss
+++ b/frontend/assets/stylesheets/_vars.scss
@@ -185,7 +185,8 @@ $mq-breakpoints: (
 );
 
 $max-widths: (
-    max-mobile: gs-span(4),             // 300px
+    max-mobile: gs-span(4),             // 220px
+    max-mobile-wider: gs-span(5),       // 380px
     max-mobileLandscape: gs-span(6),    // 460px
     max-phablet: gs-span(8),            // 620px
     max-tablet: gs-span(9),             // 700px

--- a/frontend/assets/stylesheets/components/_bundle-header.scss
+++ b/frontend/assets/stylesheets/components/_bundle-header.scss
@@ -2,6 +2,9 @@
 /* Header */
 .global-header-bundles {
 
+    @include mq($until: tablet) {
+       height: 56px;
+    }
     @include mq($from: tablet) {
         height: 76px;
     }
@@ -12,11 +15,19 @@
     .global-header__logo__image {
         margin-top: 2px;
         margin-right: 60px;
-        width: 320px;
-        height: 60px;
+        @include mq($until: tablet) {
+            height: 40px;
+            width: 180px;
+            margin-top: 0;
+            margin-right: 10px;
+        }
         @include mq($from: tablet, $until: desktop) {
             width: 280px;
             height: 50px;
+        }
+        @include mq($from: desktop) {
+            width: 320px;
+            height: 60px;
         }
     }
 
@@ -56,12 +67,18 @@
 /* Green Part of the Header */
 .bundle-header__main {
     background: #87be27;
-    padding-top: $gs-baseline * 2;
+    @include mq($from: phablet, $until: tablet) {
+        padding-top: $gs-baseline;
+    }
+    @include mq($from: tablet) {
+        padding-top: $gs-baseline * 2;
+    }
 }
 
 .bundle-header__main__content {
     @include bundle-column-wide();
-    @include mq($from: tablet, $until: desktop) {
+    @include mq($until: desktop) {
+        width: 100%;
         padding-left: $gs-gutter;
     }
     @include mq($from: desktop, $until: mem-full) {
@@ -72,6 +89,14 @@
     }
     h1 {
         @include text-title();
+        @include mq($until: phablet) {
+            font-size: 32px;
+            line-height: 32px;
+        }
+        @include mq($from: phablet, $until: tablet) {
+            font-size: 38px;
+            line-height: 38px;
+        }
         @include mq($from: tablet, $until: desktop) {
             font-size: 46px;
             line-height: 46px;
@@ -87,6 +112,18 @@
 
     p {
         @include text-tag-line();
+        @include mq($until: phablet) {
+            padding-top: 5px;
+            font-size: 16px;
+            line-height: 18px;
+            margin-right: 15px;
+        }
+        @include mq($from: phablet, $until: tablet) {
+            padding-top: 5px;
+            font-size: 18px;
+            line-height: 20px;
+            width: 300px;
+        }
         @include mq($from: tablet, $until: desktop) {
             font-size: 20px;
             line-height: 24px;
@@ -110,6 +147,11 @@
     float: right;
     img {
         position: absolute;
+        @include mq($from: phablet, $until: tablet) {
+            height: 169px;
+            top: 56px;
+            margin-left: 180px;
+        }
         @include mq($from: tablet, $until: desktop) {
             width: 340px;
             top: 85px;
@@ -131,6 +173,9 @@
 
 .bundle-header__secondary__content {
     @include bundle-column-wide();
+    @include mq($from: phablet, $until: tablet) {
+        padding-left: 20px;
+    }
     @include mq($from: tablet, $until: desktop) {
         padding-left: 20px;
     }

--- a/frontend/assets/stylesheets/components/_bundle-header.scss
+++ b/frontend/assets/stylesheets/components/_bundle-header.scss
@@ -77,7 +77,12 @@
 
 .bundle-header__main__content {
     @include bundle-column-wide();
-    @include mq($from: mobile, $until: mobileLandscape) {
+    @include mq($from: mobile, $until: mobile-wider) {
+        width: 300px;                       // there's no image
+        padding-left: $gs-gutter;           //20px
+        display: block;
+    }
+    @include mq($from: mobile-wider, $until: mobileLandscape) {
         width: 380px;                       // there's no image
         padding-left: $gs-gutter * 1.5;     //30px
         display: block;
@@ -198,6 +203,10 @@
 .bundle-header__secondary__content {
     @include bundle-column-wide();
     @include mq($from: mobile, $until: mobileLandscape) {
+        width: 300px;
+        padding-left: 20px;
+    }
+    @include mq($from: mobile-wider, $until: mobileLandscape) {
         width: 340px;
         padding-left: 30px;
     }

--- a/frontend/assets/stylesheets/components/_bundle-header.scss
+++ b/frontend/assets/stylesheets/components/_bundle-header.scss
@@ -77,7 +77,7 @@
 
 .bundle-header__main__content {
     @include bundle-column-wide();
-    @include mq($from: mobile, $until: mobile-wider) {
+    @include mq($until: mobile-wider) {
         width: 300px;                       // there's no image
         padding-left: $gs-gutter;           //20px
         display: block;
@@ -202,7 +202,7 @@
 
 .bundle-header__secondary__content {
     @include bundle-column-wide();
-    @include mq($from: mobile, $until: mobileLandscape) {
+    @include mq($until: mobile-wider) {
         width: 300px;
         padding-left: 20px;
     }

--- a/frontend/assets/stylesheets/components/_bundle-header.scss
+++ b/frontend/assets/stylesheets/components/_bundle-header.scss
@@ -77,6 +77,11 @@
 
 .bundle-header__main__content {
     @include bundle-column-wide();
+    @include mq($from: mobile, $until: mobileLandscape) {
+        width: 380px;                       // there's no image
+        padding-left: $gs-gutter * 1.5;     //30px
+        display: block;
+    }
     @include mq($from: mobileLandscape, $until: phablet) {
         width: 240px;
         padding-left: $gs-gutter * 1.5;    //30px
@@ -192,10 +197,12 @@
 
 .bundle-header__secondary__content {
     @include bundle-column-wide();
+    @include mq($from: mobile, $until: mobileLandscape) {
+        width: 340px;
+        padding-left: 30px;
+    }
     @include mq($from: mobileLandscape, $until: phablet) {
         width: 430px;
-    }
-    @include mq($until: phablet) {
         padding-left: 20px;
     }
     @include mq($from: phablet, $until: desktop) {
@@ -219,7 +226,9 @@
             font-size: 16px;
             line-height: 18px;
         }
-        padding-top: $gs-baseline;
+        @include mq($from: phablet) {
+            padding-top: $gs-baseline;
+        }
     }
 
     p:first-of-type {

--- a/frontend/assets/stylesheets/components/_bundle-header.scss
+++ b/frontend/assets/stylesheets/components/_bundle-header.scss
@@ -77,8 +77,15 @@
 
 .bundle-header__main__content {
     @include bundle-column-wide();
-    @include mq($until: desktop) {
-        width: 100%;
+    @include mq($from: mobileLandscape, $until: phablet) {
+        width: 240px;
+        padding-left: $gs-gutter * 1.5;    //30px
+        display: block;
+    }
+    @include mq($from: phablet, $until: tablet) {
+        padding-left: $gs-gutter;    //20px
+    }
+    @include mq($from: tablet, $until: desktop) {
         padding-left: $gs-gutter;
     }
     @include mq($from: desktop, $until: mem-full) {
@@ -89,6 +96,9 @@
     }
     h1 {
         @include text-title();
+        @include mq($from: mobileLandscape, $until: phablet) {
+            padding-top: 5px;
+        }
         @include mq($until: phablet) {
             font-size: 32px;
             line-height: 32px;
@@ -114,6 +124,7 @@
         @include text-tag-line();
         @include mq($until: phablet) {
             padding-top: 5px;
+            padding-bottom: 5px;
             font-size: 16px;
             line-height: 18px;
             margin-right: 15px;
@@ -147,6 +158,14 @@
     float: right;
     img {
         position: absolute;
+        @include mq($until: mobileLandscape) {
+            display: none;
+        }
+        @include mq($from: mobileLandscape, $until: phablet) {
+            height: 125px;
+            top: 60px;
+            margin-left: 270px;
+        }
         @include mq($from: phablet, $until: tablet) {
             height: 169px;
             top: 56px;
@@ -173,11 +192,15 @@
 
 .bundle-header__secondary__content {
     @include bundle-column-wide();
-    @include mq($from: phablet, $until: tablet) {
+    @include mq($from: mobileLandscape, $until: phablet) {
+        width: 430px;
+    }
+    @include mq($until: phablet) {
         padding-left: 20px;
     }
-    @include mq($from: tablet, $until: desktop) {
-        padding-left: 20px;
+    @include mq($from: phablet, $until: desktop) {
+        width: 540px;
+        padding-left: 100px;
     }
     @include mq($from: desktop, $until: mem-full) {
         padding-left: 100px;
@@ -192,10 +215,17 @@
         }
         margin-bottom: 0;
         @include text-paragraph();
+        @include mq($until: phablet) {
+            font-size: 16px;
+            line-height: 18px;
+        }
         padding-top: $gs-baseline;
     }
 
     p:first-of-type {
-        padding-top: $gs-baseline * 2;
+        @include mq($from: phablet) {
+            padding-top: $gs-baseline * 2;
+
+        }
     }
 }

--- a/frontend/assets/stylesheets/components/_bundle-offerings-a.scss
+++ b/frontend/assets/stylesheets/components/_bundle-offerings-a.scss
@@ -8,6 +8,10 @@ body {
     display: inline-block;
     float: left;
     width: 690px;
+    @include mq($from: mobileLandscape, $until: phablet) {
+        width: 430px;
+        margin-left: 20px;
+    }
     @include mq($from: phablet, $until: tablet) {
         width: 460px;
         margin-left: 100px;
@@ -34,6 +38,10 @@ body {
         margin-top: $gs-baseline * 3;
         padding-top: 2px;
         @include text-offering-title();
+        @include mq($from: mobileLandscape, $until: phablet) {
+            font-size: 30px;
+            line-height: 30px;
+        }
         border-top: 1px guss-colour(news-main-2) solid;
     }
 
@@ -84,10 +92,18 @@ body {
     @include bundle-column-narrow();
     padding-right: 0;
     margin-left: 100px;
-    width: 460px;
+    @include mq($from: mobileLandscape, $until: phablet) {
+        width: 430px;
+    }
+    @include mq($from: phablet) {
+        width: 460px;
+    }
     display: inline-block;
     @include mq($until: mem-full) {
         padding-top: $gs-baseline * 2;
+    }
+    @include mq($until: phablet) {
+        margin-left: 20px;
     }
     @include mq($from: tablet, $until: desktop) {
         margin-left: 110px;
@@ -101,6 +117,10 @@ body {
         }
         padding-top: 2px;
         @include text-offering-title();
+        @include mq($from: mobileLandscape, $until: phablet) {
+            font-size: 30px;
+            line-height: 30px;
+        }
         border-top: 1px guss-colour(news-main-2) solid;
     }
 
@@ -114,7 +134,12 @@ body {
 }
 
 .bundle-offering-a__subscribe__offer {
-    width: 460px;
+    @include mq($from: mobileLandscape, $until: phablet) {
+        width: 430px;
+    }
+    @include mq($from: phablet) {
+        width: 460px;
+    }
     display: inline-block;
     vertical-align: top;
     margin-top: $gs-baseline * 2;

--- a/frontend/assets/stylesheets/components/_bundle-offerings-a.scss
+++ b/frontend/assets/stylesheets/components/_bundle-offerings-a.scss
@@ -33,11 +33,19 @@ body {
 
 .bundle-offering-a__give__content {
     margin-top: $gs-baseline * 3;
+    @include mq($from: mobile, $until: mobileLandscape) {
+        width: 310px;
+        margin-left: 30px;
+    }
 
     >h1 {
         margin-top: $gs-baseline * 3;
         padding-top: 2px;
         @include text-offering-title();
+        @include mq($from: mobile, $until: mobileLandscape) {
+            font-size: 24px;
+            line-height: 24px;
+        }
         @include mq($from: mobileLandscape, $until: phablet) {
             font-size: 30px;
             line-height: 30px;
@@ -51,8 +59,12 @@ body {
     background-color: #d4ebf8;
     margin-top: 10px;
     padding-bottom: 10px;
-    @include mq($from: desktop, $until: mem-full) {
-        .bundle-button {
+    .bundle-button {
+        @include mq($from: mobile, $until: mobileLandscape) {
+            margin-bottom: $gs-baseline;
+            margin-left: 50px;
+        }
+        @include mq($from: desktop, $until: mem-full) {
             margin-bottom: $gs-baseline;
             margin-left: 120px;
         }
@@ -82,7 +94,12 @@ body {
 
 .bundle-offering-a__give__button {
     .bundle-button__content {
-        width: gs-span(3.35);
+        @include mq($from: mobile, $until: mobileLandscape) {
+            width: 200px;
+        }
+        @include mq($from: mobileLandscape) {
+            width: gs-span(3.35);
+        }
     }
 }
 
@@ -92,7 +109,12 @@ body {
     @include bundle-column-narrow();
     padding-right: 0;
     margin-left: 100px;
+    @include mq($from: mobile, $until: mobileLandscape) {
+        width: 310px;
+        margin-left: 30px;
+    }
     @include mq($from: mobileLandscape, $until: phablet) {
+        margin-left: 20px;
         width: 430px;
     }
     @include mq($from: phablet) {
@@ -101,9 +123,6 @@ body {
     display: inline-block;
     @include mq($until: mem-full) {
         padding-top: $gs-baseline * 2;
-    }
-    @include mq($until: phablet) {
-        margin-left: 20px;
     }
     @include mq($from: tablet, $until: desktop) {
         margin-left: 110px;
@@ -117,6 +136,10 @@ body {
         }
         padding-top: 2px;
         @include text-offering-title();
+        @include mq($from: mobile, $until: mobileLandscape) {
+            font-size: 24px;
+            line-height: 24px;
+        }
         @include mq($from: mobileLandscape, $until: phablet) {
             font-size: 30px;
             line-height: 30px;
@@ -134,6 +157,9 @@ body {
 }
 
 .bundle-offering-a__subscribe__offer {
+    @include mq($from: mobile, $until: mobileLandscape) {
+        width: 310px;
+    }
     @include mq($from: mobileLandscape, $until: phablet) {
         width: 430px;
     }
@@ -159,7 +185,12 @@ body {
     }
 
     .bundle-button {
-        margin-left: 150px;
+        @include mq($from: mobile, $until: mobileLandscape) {
+            margin-left: 80px;
+        }
+        @include mq($from: mobileLandscape) {
+            margin-left: 150px;
+        }
     }
 
     .bundle-button__content {

--- a/frontend/assets/stylesheets/components/_bundle-offerings-a.scss
+++ b/frontend/assets/stylesheets/components/_bundle-offerings-a.scss
@@ -33,7 +33,7 @@ body {
 
 .bundle-offering-a__give__content {
     margin-top: $gs-baseline * 3;
-    @include mq($from: mobile, $until: mobile-wider) {
+    @include mq($until: mobile-wider) {
         width: 280px;
         margin-left: 20px;
     }
@@ -46,7 +46,7 @@ body {
         margin-top: $gs-baseline * 3;
         padding-top: 2px;
         @include text-offering-title();
-        @include mq($from: mobile, $until: mobile-wider) {
+        @include mq($until: mobile-wider) {
             font-size: 20px;
             line-height: 20px;
         }
@@ -69,7 +69,7 @@ body {
     padding-bottom: 10px;
     .bundle-button {
         margin-bottom: $gs-baseline;
-        @include mq($from: mobile, $until: mobile-wider) {
+        @include mq($until: mobile-wider) {
             margin-left: 40px;
         }
         @include mq($from: mobile-wider, $until: mobileLandscape) {
@@ -104,7 +104,7 @@ body {
 
 .bundle-offering-a__give__button {
     .bundle-button__content {
-        @include mq($from: mobile, $until: mobileLandscape) {
+        @include mq($until: mobileLandscape) {
             width: 200px;
         }
         @include mq($from: mobileLandscape) {
@@ -119,7 +119,7 @@ body {
     @include bundle-column-narrow();
     padding-right: 0;
     margin-left: 100px;
-    @include mq($from: mobile, $until: mobile-wider) {
+    @include mq($until: mobile-wider) {
         width: 280px;
         margin-left: 20px;
     }
@@ -150,7 +150,7 @@ body {
         }
         padding-top: 2px;
         @include text-offering-title();
-        @include mq($from: mobile, $until: mobile-wider) {
+        @include mq($until: mobile-wider) {
             font-size: 20px;
             line-height: 20px;
         }
@@ -175,7 +175,7 @@ body {
 }
 
 .bundle-offering-a__subscribe__offer {
-    @include mq($from: mobile, $until: mobile-wider) {
+    @include mq($until: mobile-wider) {
         width: 280px;
     }
     @include mq($from: mobile-wider, $until: mobileLandscape) {
@@ -206,7 +206,7 @@ body {
     }
 
     .bundle-button {
-        @include mq($from: mobile, $until: mobile-wider) {
+        @include mq($until: mobile-wider) {
             margin-left: 60px;
         }
         @include mq($from: mobile-wider, $until: mobileLandscape) {
@@ -257,7 +257,7 @@ body {
 }
 
 .bundle-offering-a__subscribe__offer__list__item__content {
-    @include mq($from: mobile, $until: mobile-wider) {
+    @include mq($until: mobile-wider) {
         width: 210px;
     }
     @include mq($from: mobile-wider, $until: mem-full) {

--- a/frontend/assets/stylesheets/components/_bundle-offerings-a.scss
+++ b/frontend/assets/stylesheets/components/_bundle-offerings-a.scss
@@ -8,6 +8,10 @@ body {
     display: inline-block;
     float: left;
     width: 690px;
+    @include mq($from: phablet, $until: tablet) {
+        width: 460px;
+        margin-left: 100px;
+    }
     @include mq($from: tablet, $until: desktop) {
         width: 460px;
         margin-left: 110px;

--- a/frontend/assets/stylesheets/components/_bundle-offerings-a.scss
+++ b/frontend/assets/stylesheets/components/_bundle-offerings-a.scss
@@ -33,7 +33,11 @@ body {
 
 .bundle-offering-a__give__content {
     margin-top: $gs-baseline * 3;
-    @include mq($from: mobile, $until: mobileLandscape) {
+    @include mq($from: mobile, $until: mobile-wider) {
+        width: 280px;
+        margin-left: 20px;
+    }
+    @include mq($from: mobile-wider, $until: mobileLandscape) {
         width: 310px;
         margin-left: 30px;
     }
@@ -42,7 +46,11 @@ body {
         margin-top: $gs-baseline * 3;
         padding-top: 2px;
         @include text-offering-title();
-        @include mq($from: mobile, $until: mobileLandscape) {
+        @include mq($from: mobile, $until: mobile-wider) {
+            font-size: 20px;
+            line-height: 20px;
+        }
+        @include mq($from: mobile-wider, $until: mobileLandscape) {
             font-size: 24px;
             line-height: 24px;
         }
@@ -60,12 +68,14 @@ body {
     margin-top: 10px;
     padding-bottom: 10px;
     .bundle-button {
-        @include mq($from: mobile, $until: mobileLandscape) {
-            margin-bottom: $gs-baseline;
+        margin-bottom: $gs-baseline;
+        @include mq($from: mobile, $until: mobile-wider) {
+            margin-left: 40px;
+        }
+        @include mq($from: mobile-wider, $until: mobileLandscape) {
             margin-left: 50px;
         }
         @include mq($from: desktop, $until: mem-full) {
-            margin-bottom: $gs-baseline;
             margin-left: 120px;
         }
     }
@@ -109,7 +119,11 @@ body {
     @include bundle-column-narrow();
     padding-right: 0;
     margin-left: 100px;
-    @include mq($from: mobile, $until: mobileLandscape) {
+    @include mq($from: mobile, $until: mobile-wider) {
+        width: 280px;
+        margin-left: 20px;
+    }
+    @include mq($from: mobile-wider, $until: mobileLandscape) {
         width: 310px;
         margin-left: 30px;
     }
@@ -136,7 +150,11 @@ body {
         }
         padding-top: 2px;
         @include text-offering-title();
-        @include mq($from: mobile, $until: mobileLandscape) {
+        @include mq($from: mobile, $until: mobile-wider) {
+            font-size: 20px;
+            line-height: 20px;
+        }
+        @include mq($from: mobile-wider, $until: mobileLandscape) {
             font-size: 24px;
             line-height: 24px;
         }
@@ -157,7 +175,10 @@ body {
 }
 
 .bundle-offering-a__subscribe__offer {
-    @include mq($from: mobile, $until: mobileLandscape) {
+    @include mq($from: mobile, $until: mobile-wider) {
+        width: 280px;
+    }
+    @include mq($from: mobile-wider, $until: mobileLandscape) {
         width: 310px;
     }
     @include mq($from: mobileLandscape, $until: phablet) {
@@ -185,7 +206,10 @@ body {
     }
 
     .bundle-button {
-        @include mq($from: mobile, $until: mobileLandscape) {
+        @include mq($from: mobile, $until: mobile-wider) {
+            margin-left: 60px;
+        }
+        @include mq($from: mobile-wider, $until: mobileLandscape) {
             margin-left: 80px;
         }
         @include mq($from: mobileLandscape) {
@@ -233,7 +257,10 @@ body {
 }
 
 .bundle-offering-a__subscribe__offer__list__item__content {
-    @include mq($until: mem-full) {
+    @include mq($from: mobile, $until: mobile-wider) {
+        width: 210px;
+    }
+    @include mq($from: mobile-wider, $until: mem-full) {
         width: 224px;
     }
     @include mq($from: mem-full) {

--- a/frontend/assets/stylesheets/components/_bundle-support-us.scss
+++ b/frontend/assets/stylesheets/components/_bundle-support-us.scss
@@ -1,19 +1,17 @@
 .bundle-support__main__img {
-    @include bundle-column-narrow();
-    padding-left: 20px;
-
+    @include mq($until: mem-full) {
+        display: none;
+    }
     @include mq($from: mem-full) {
+        @include bundle-column-narrow();
+        padding-left: 20px;
         margin-left: 80px;
-    }
 
-    >img {
-        @include mq($until: mem-full) {
-            display: none;
+        >img {
+            position: absolute;
+            margin-top: 75px;
         }
-        position: absolute;
-        margin-top: 75px;
     }
-
 }
 
 .bundle-support__line {
@@ -30,8 +28,9 @@
 .bundle-support__main__title {
     @include bundle-column-narrow();
     padding-right: $gs-gutter;
-    @include mq($until: tablet) {
-        margin-left: $gs-gutter;
+    @include mq($from: phablet, $until: tablet) {
+        width: 480px;
+        margin-left: 100px;
     }
     @include mq($from: tablet, $until: desktop) {
         margin-left: 110px;
@@ -71,7 +70,12 @@
 
 .bundle-support__content {
     background: guss-colour(comment-support-2);
-    margin-bottom: 102px;
+    @include mq($from: phablet, $until: tablet) {
+        margin-bottom: 0;
+    }
+    @include mq($from: tablet) {
+        margin-bottom: 102px;
+    }
     @include mq($from: mem-full) {
         margin-right: -100px;
     }
@@ -79,6 +83,9 @@
 
 .bundle-support__content__body {
     @include bundle-column-narrow();
+    @include mq($from: phablet, $until: tablet) {
+        width: 540px;
+    }
     @include mq($from: tablet, $until: desktop) {
         width: 590px;
     }
@@ -103,9 +110,15 @@
 }
 
 .bundle-support__content__body__text {
-    @include text-paragraph();
+    @include mq($until: tablet) {
+        @include fs-textSans(4);
+        line-height: 18px;
+    }
+    @include mq($from: tablet) {
+        @include text-paragraph();
+        max-width: gs-span(6);
+    }
     padding-top: 8px;
-    max-width: gs-span(6);
     @include mq($until: desktop){
         margin-left: 110px;
     }

--- a/frontend/assets/stylesheets/components/_bundle-support-us.scss
+++ b/frontend/assets/stylesheets/components/_bundle-support-us.scss
@@ -28,7 +28,7 @@
 .bundle-support__main__title {
     @include bundle-column-narrow();
     padding-right: $gs-gutter;
-    @include mq($from: mobile, $until: mobile-wider) {
+    @include mq($until: mobile-wider) {
         width: 300px;
         margin-left: 20px;
     }
@@ -57,7 +57,7 @@
     >h1 {
         padding-top: 2px;
         @include text-offering-title();
-        @include mq($from: mobile, $until: mobile-wider) {
+        @include mq($until: mobile-wider) {
             font-size: 20px;
             line-height: 20px;
         }
@@ -143,7 +143,7 @@
         max-width: gs-span(6);
     }
     padding-top: 8px;
-    @include mq($from: mobile, $until: mobile-wider) {
+    @include mq($until: mobile-wider) {
         max-width: 280px;
         margin-left: 20px;
     }

--- a/frontend/assets/stylesheets/components/_bundle-support-us.scss
+++ b/frontend/assets/stylesheets/components/_bundle-support-us.scss
@@ -28,6 +28,10 @@
 .bundle-support__main__title {
     @include bundle-column-narrow();
     padding-right: $gs-gutter;
+    @include mq($from: mobileLandscape, $until: phablet) {
+        width: 430px;
+        margin-left: 20px;
+    }
     @include mq($from: phablet, $until: tablet) {
         width: 480px;
         margin-left: 100px;
@@ -45,6 +49,10 @@
     >h1 {
         padding-top: 2px;
         @include text-offering-title();
+        @include mq($from: mobileLandscape, $until: phablet) {
+            font-size: 30px;
+            line-height: 30px;
+        }
         border-top: 1px guss-colour(news-main-2) solid;
         margin-top: $gs-baseline * 4;
         @include mq($from: desktop, $until: mem-full) {
@@ -119,7 +127,11 @@
         max-width: gs-span(6);
     }
     padding-top: 8px;
-    @include mq($until: desktop){
+    @include mq($from: mobileLandscape, $until: phablet) {
+        max-width: 430px;
+        margin-left: 20px;
+    }
+    @include mq($from: phablet, $until: desktop){
         margin-left: 110px;
     }
     @include mq($from: desktop, $until: mem-full) {

--- a/frontend/assets/stylesheets/components/_bundle-support-us.scss
+++ b/frontend/assets/stylesheets/components/_bundle-support-us.scss
@@ -28,6 +28,10 @@
 .bundle-support__main__title {
     @include bundle-column-narrow();
     padding-right: $gs-gutter;
+    @include mq($from: mobile, $until: mobileLandscape) {
+        width: 330px;
+        margin-left: 30px;
+    }
     @include mq($from: mobileLandscape, $until: phablet) {
         width: 430px;
         margin-left: 20px;
@@ -49,6 +53,10 @@
     >h1 {
         padding-top: 2px;
         @include text-offering-title();
+        @include mq($from: mobile, $until: mobileLandscape) {
+            font-size: 24px;
+            line-height: 24px;
+        }
         @include mq($from: mobileLandscape, $until: phablet) {
             font-size: 30px;
             line-height: 30px;
@@ -127,6 +135,10 @@
         max-width: gs-span(6);
     }
     padding-top: 8px;
+    @include mq($from: mobile, $until: mobileLandscape) {
+        max-width: 310px;
+        margin-left: 30px;
+    }
     @include mq($from: mobileLandscape, $until: phablet) {
         max-width: 430px;
         margin-left: 20px;

--- a/frontend/assets/stylesheets/components/_bundle-support-us.scss
+++ b/frontend/assets/stylesheets/components/_bundle-support-us.scss
@@ -28,7 +28,11 @@
 .bundle-support__main__title {
     @include bundle-column-narrow();
     padding-right: $gs-gutter;
-    @include mq($from: mobile, $until: mobileLandscape) {
+    @include mq($from: mobile, $until: mobile-wider) {
+        width: 300px;
+        margin-left: 20px;
+    }
+    @include mq($from: mobile-wider, $until: mobileLandscape) {
         width: 330px;
         margin-left: 30px;
     }
@@ -53,7 +57,11 @@
     >h1 {
         padding-top: 2px;
         @include text-offering-title();
-        @include mq($from: mobile, $until: mobileLandscape) {
+        @include mq($from: mobile, $until: mobile-wider) {
+            font-size: 20px;
+            line-height: 20px;
+        }
+        @include mq($from: mobile-wider, $until: mobileLandscape) {
             font-size: 24px;
             line-height: 24px;
         }
@@ -135,7 +143,11 @@
         max-width: gs-span(6);
     }
     padding-top: 8px;
-    @include mq($from: mobile, $until: mobileLandscape) {
+    @include mq($from: mobile, $until: mobile-wider) {
+        max-width: 280px;
+        margin-left: 20px;
+    }
+    @include mq($from: mobile-wider, $until: mobileLandscape) {
         max-width: 310px;
         margin-left: 30px;
     }

--- a/frontend/assets/stylesheets/components/_bundle-thank-you.scss
+++ b/frontend/assets/stylesheets/components/_bundle-thank-you.scss
@@ -1,6 +1,6 @@
 .bundle-thankyou__explainer-content {
     padding-right: 60px;
-    @include mq($from: mobile, $until: desktop) {
+    @include mq($until: desktop) {
         padding-left: $gs-gutter;
     }
     @include mq($from: desktop, $until: mem-full) {
@@ -62,7 +62,7 @@
     }
 
     input[type=email] {
-        @include mq($from: mobile, $until: mobileLandscape) {
+        @include mq($until: mobileLandscape) {
             width: 310px !important;
         }
         @include mq($from: mobileLandscape) {
@@ -88,7 +88,7 @@
 
     textarea {
         border-radius: 18px !important;
-        @include mq($from: mobile, $until: mobileLandscape) {
+        @include mq($until: mobileLandscape) {
             width: 310px !important;
         }
         @include mq($from: mobileLandscape) {

--- a/frontend/assets/stylesheets/components/_bundle-thank-you.scss
+++ b/frontend/assets/stylesheets/components/_bundle-thank-you.scss
@@ -1,6 +1,6 @@
 .bundle-thankyou__explainer-content {
     padding-right: 60px;
-    @include mq($from: phablet, $until: desktop) {
+    @include mq($from: mobile, $until: desktop) {
         padding-left: $gs-gutter;
     }
     @include mq($from: desktop, $until: mem-full) {
@@ -62,7 +62,12 @@
     }
 
     input[type=email] {
-        width: 460px !important;
+        @include mq($from: mobile, $until: mobileLandscape) {
+            width: 310px !important;
+        }
+        @include mq($from: mobileLandscape) {
+            width: 460px !important;
+        }
         height: $gs-baseline * 3;
         margin-left: $gs-gutter * 3;
         border-radius: 18px !important;
@@ -83,7 +88,12 @@
 
     textarea {
         border-radius: 18px !important;
-        width: 460px !important;
+        @include mq($from: mobile, $until: mobileLandscape) {
+            width: 310px !important;
+        }
+        @include mq($from: mobileLandscape) {
+            width: 460px !important;
+        }
         margin-left: $gs-gutter * 3;
     }
 }

--- a/frontend/assets/stylesheets/components/_bundle-thank-you.scss
+++ b/frontend/assets/stylesheets/components/_bundle-thank-you.scss
@@ -1,6 +1,6 @@
 .bundle-thankyou__explainer-content {
     padding-right: 60px;
-    @include mq($from: tablet, $until: desktop) {
+    @include mq($from: phablet, $until: desktop) {
         padding-left: $gs-gutter;
     }
     @include mq($from: desktop, $until: mem-full) {

--- a/frontend/assets/stylesheets/utilities/_util-layout.scss
+++ b/frontend/assets/stylesheets/utilities/_util-layout.scss
@@ -11,6 +11,9 @@
     @include constrain-layout();
 }
 
+.l-constrained-bundles {
+    @include constrain-bundles-layout();
+}
 // TODO: Replace l- with u- prefix
 .l-side-margins {
     &:before,
@@ -23,6 +26,26 @@
         height: 100%;
         width: 0;
         @include side-margins-calc('width');
+    }
+    &:before {
+        left: 0;
+    }
+    &:after {
+        right: 0;
+    }
+}
+
+.l-side-margins-bundles {
+    &:before,
+    &:after {
+        background: $c-background-transparent;
+        content: '';
+        position: absolute;
+        z-index: 1;
+        top: 0;
+        height: 100%;
+        width: 0;
+        @include side-margins-bundles-calc('width');
     }
     &:before {
         left: 0;


### PR DESCRIPTION
## Why are you doing this?
We need more readers in the test, so opening it up to smaller devices.

## Trello card: [Here](https://trello.com/c/r0iFK61W/541-add-mobile-traffic-to-bundle-pricing-test)

## Screenshots
There are lots of screenshots on the Trello card. Here are a couple of examples;

_Bundle page_

**320px**
![screen shot 2017-05-10 at 12 41 00 mobile 320 landing](https://cloud.githubusercontent.com/assets/690395/25903784/50ea63f8-3595-11e7-88db-7bb0206c5a93.png)

**480px**
![screen shot 2017-05-10 at 11 14 00 mobile 480 landing](https://cloud.githubusercontent.com/assets/690395/25903824/6b19ee4c-3595-11e7-9f3f-6be84a852870.png)

**660px**
![screen shot 2017-05-10 at 11 16 00 phablet 660 landing](https://cloud.githubusercontent.com/assets/690395/25903855/80c9a49e-3595-11e7-9124-cc9f3542ca4c.png)

_Thank you page_
**320px**
![screen shot 2017-05-10 at 12 41 00 mobile 320 thankyou](https://cloud.githubusercontent.com/assets/690395/25903926/ac36675c-3595-11e7-9908-992f984bf0b8.png)

**480px**
![screen shot 2017-05-10 at 11 14 00 mobile 480 thankyou](https://cloud.githubusercontent.com/assets/690395/25903971/bec6f468-3595-11e7-82cc-0f81e3991b80.png)

**660px**
![screen shot 2017-05-10 at 11 16 00 phablet 660 thankyou](https://cloud.githubusercontent.com/assets/690395/25903993/cc092da8-3595-11e7-8444-5d38e62e4ee8.png)

_Main membership home page (note that we're not constraining it at sub-tablet breakpoints)_
**480px**
![screen shot 2017-05-10 at 18 44 40](https://cloud.githubusercontent.com/assets/690395/25912936/f0be8588-35b0-11e7-87fc-60009e90a96a.png)


cc @Ap0c