### PR TITLE
Show correct minimum amount for one off contributions

### DIFF
--- a/frontend/assets/javascripts/src/modules/bundlesLanding.es6
+++ b/frontend/assets/javascripts/src/modules/bundlesLanding.es6
@@ -40,10 +40,11 @@ const PRICES = {
 };
 
 const ERRORS = {
-	tooLittle: 'Please enter at least £5',
-	tooMuch: 'We are presently only able to accept contributions of £2000 or less',
-	badInput: 'Please enter a numeric amount',
-	noEntry: 'Please enter an amount'
+    tooLittleOneOff: 'Please enter at least £1',
+    tooLittle: 'Please enter at least £5',
+    tooMuch: 'We are presently only able to accept contributions of £2000 or less',
+    badInput: 'Please enter a numeric amount',
+    noEntry: 'Please enter an amount'
 };
 
 
@@ -167,7 +168,7 @@ function validateOtherAmount (elems) {
 		} else if (amount < 5 && STATE.contribPeriod === 'MONTHLY') {
 			contribError(elems, 'tooLittle');
 		} else if (amount < 1 && STATE.contribPeriod === 'ONE_OFF') {
-			contribError(elems, 'tooLittle');
+			contribError(elems, 'tooLittleOneOff');
 		} else if (amount > 2000) {
 			contribError(elems, 'tooMuch');
 		} else {


### PR DESCRIPTION
## Why are you doing this?

The validation checks for a minimum of £1, but the error message shows £5.

## Trello card: [here](https://trello.com/c/qelDOdpG/507-bug-one-off-contributions-showing-wrong-minimum-amount-on-bundles-landing-page)

<!--
If you are making heavy client-side changes, consider manual test the following
critical flow before merging
## Tested in
| Browser | Supporter Stripe checkout | Supporter Paypal checkout | Stripe Monthly Contribution |  Paypal Monthly Contribution| Upgrade from Friend to Supporter  |
|---------|---------------------------|---------------------------|-----------------------------|-----------------------------|-----------------------------------|
| IE      |                           |                           |                             |                             |                                   |
| Firefox |                           |                           |                             |                             |                                   |
| Safari  |                           |                           |                             |                             |                                   |
| Chrome  |                           |                           |                             |                             |                                   |

-->

## Screenshots
