### PR TITLE
Use global execution context in TouchpointBackend

### DIFF
--- a/frontend/app/services/TouchpointBackend.scala
+++ b/frontend/app/services/TouchpointBackend.scala
@@ -26,7 +26,7 @@ import configuration.Config.Implicits.akkaSystem
 import model.FeatureChoice
 import monitoring.TouchpointBackendMetrics
 import org.joda.time.LocalDate
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import scala.concurrent.ExecutionContext.Implicits.global
 import tracking._
 import utils.TestUsers.{TestUserCredentialType, isTestUser}
 import play.api.mvc.RequestHeader


### PR DESCRIPTION
## Why are you doing this?
We've had a lot of issues on app start-up since approx 21/04/2017. This is restricting our ability to deploy quickly - often deploys are taking 10+ minutes due to boxes cycling on start-up, and other deploys fail completely (see the riff-raff history for this project).

I've done a bit of digging, and suspect that the change in execution context might be linked to the problem. Locally this simple import change shows a big improvement, so I'd like to try it out in production before investigating this track too much more.

## Trello card: 
N/A

## Changes
* Use global execution context instead of Play's default execution context

cc @paulbrown1982 @michaelwmcnamara @johnduffell @rtyley @rupertbates @davidfurey 