### PR TITLE
Add AB Testing framework and Merged Registration AB test

### DIFF
--- a/frontend/app/abtests/ABTest.scala
+++ b/frontend/app/abtests/ABTest.scala
@@ -5,11 +5,6 @@ import java.time.Duration.ofDays
 import abtests.AudienceId.idFor
 import play.api.mvc.{Cookie, Request, RequestHeader}
 
-
-case class Allocation(test: ABTest, variant: String) {
-  lazy val cookie = Cookie(test.cookieName, variant, httpOnly = false)
-}
-
 trait BaseVariant {
   val slug: String
 }

--- a/frontend/app/abtests/ABTest.scala
+++ b/frontend/app/abtests/ABTest.scala
@@ -1,0 +1,66 @@
+package abtests
+
+import java.time.Duration.ofDays
+
+import abtests.AudienceId.idFor
+import play.api.mvc.{Cookie, Request, RequestHeader}
+
+
+case class Allocation(test: ABTest, variant: String) {
+  lazy val cookie = Cookie(test.cookieName, variant, httpOnly = false)
+}
+
+trait BaseVariant {
+  val slug: String
+}
+
+abstract class ABTest(val slug: String, val audience: AudienceRange, canRun: RequestHeader => Boolean = _ => true) {
+  val CookiePrefix = "gu.membership"
+
+  val abSlug = s"ab.$slug"
+
+  val cookieName = s"$CookiePrefix.$abSlug"
+
+  type Variant <: BaseVariant
+
+  val variants: Seq[Variant]
+
+  lazy val variantsBySlug: Map[String, Variant] = variants.map(v => v.slug -> v).toMap
+
+  def cookieFor(variant: BaseVariant) =
+    Cookie(cookieName, variant.slug, maxAge = Some(ABTest.CookieAge), httpOnly = false)
+
+  def describeParticipation(implicit request: RequestHeader): String =
+    s"ab.$cookieName=${allocate(request).map(_.slug).getOrElse("None")}"
+
+  def allocate(request: RequestHeader): Option[Variant] = for {
+    v <- variantForcedBy(request) orElse variantFromABCookie(request) orElse defaultVariantFor(idFor(request)) if canRun(request)
+  } yield v
+
+  def variantForcedBy(req: RequestHeader): Option[Variant] = req.getQueryString(abSlug).map(abName => variantsBySlug(abName.stripPrefix("ab.")))
+
+  def variantFromABCookie(req: RequestHeader): Option[Variant] = req.cookies.get(cookieName).map(cookie => variantsBySlug(cookie.value))
+
+  def defaultVariantFor(id: AudienceId): Option[Variant] =
+    if (audience.includes(id)) Some(variants(id.num % variants.size)) else None
+}
+
+object ABTest {
+
+  val CookieAge = ofDays(365).getSeconds.toInt
+
+  lazy val allTests: Set[ABTest] = Set(
+    MergedRegistration
+  )
+
+  def allocations(request: Request[_]): Map[ABTest, BaseVariant] = (for {
+    test <- allTests
+    variant <- test.allocate(request)
+  } yield test -> variant).toMap
+
+  def cookiesWhichShouldBeDropped(request: Request[_]): Seq[Cookie] = for {
+    (test, variant) <- allocations(request).toSeq
+    cookie: Cookie = test.cookieFor(variant) if !request.cookies.get(cookie.name).map(_.value).contains(cookie.value)
+  } yield cookie
+
+}

--- a/frontend/app/abtests/ABTest.scala
+++ b/frontend/app/abtests/ABTest.scala
@@ -32,7 +32,7 @@ abstract class ABTest(val slug: String, val audience: AudienceRange, canRun: Req
     v <- variantForcedBy(request) orElse variantFromABCookie(request) orElse defaultVariantFor(idFor(request)) if canRun(request)
   } yield v
 
-  def variantForcedBy(req: RequestHeader): Option[Variant] = req.getQueryString(abSlug).map(abName => variantsBySlug(abName.stripPrefix("ab.")))
+  def variantForcedBy(req: RequestHeader): Option[Variant] = req.getQueryString(abSlug).map(variantSlug => variantsBySlug(variantSlug))
 
   def variantFromABCookie(req: RequestHeader): Option[Variant] = req.cookies.get(cookieName).map(cookie => variantsBySlug(cookie.value))
 

--- a/frontend/app/abtests/MergedRegistration.scala
+++ b/frontend/app/abtests/MergedRegistration.scala
@@ -1,0 +1,13 @@
+package abtests
+
+import abtests.AudienceRange.FullAudience
+
+case object MergedRegistration extends ABTest("merged-registration",FullAudience) {
+
+  case class Variant(slug: String, canWaiveAuth: Boolean) extends BaseVariant
+
+  val variants = Seq(
+    Variant("control", canWaiveAuth = false),
+    Variant("merged",  canWaiveAuth = true)
+  )
+}

--- a/frontend/app/abtests/audience.scala
+++ b/frontend/app/abtests/audience.scala
@@ -1,0 +1,74 @@
+package abtests
+
+import java.time.Duration.ofDays
+
+import abtests.AudienceId._
+import abtests.AudienceRange.percentageToId
+import com.google.common.hash.Hashing.goodFastHash
+import play.api.mvc.{Cookie, RequestHeader}
+
+import scala.util.Random
+
+object AudienceId {
+  val MaxId: Int = 10000
+
+  val CookieName = "GU_MEM_mvt_id"
+
+  val CookieAge = ofDays(3650).getSeconds.toInt
+
+  private val startupTime = System.currentTimeMillis()
+
+  private val AudienceHash = goodFastHash(64) // Note this isn't stable between VM runs & that's fine for this purpose
+
+  /**
+   * @return an Audience id for this request.
+    *         The Audience id for a given request will always be the same for a given JVM instance, and should distribute
+    *         well over all JVM instances.
+   */
+  def generateIdFor(req: RequestHeader): AudienceId = {
+    val seed = AudienceHash.newHasher()
+      .putLong(req.id) // Integer incremented by 0 for each request, unique only in this JVM instance
+      .putLong(startupTime) // Explicitly placed here to ensure different JVMs have different hash distributions
+      .hash().asLong()
+    AudienceId(new Random(seed).nextInt(MaxId)) // uniformly distributed, even tho' 2^32 is not divisible by MaxId. See https://docs.oracle.com/javase/8/docs/api/java/util/Random.html#nextInt-int-
+  }
+
+  def idFromMVTCookie(req: RequestHeader): Option[AudienceId] = for {
+    cookie <- req.cookies.get(CookieName)
+  } yield AudienceId(cookie.value.toInt)
+
+  def idFor(req: RequestHeader): AudienceId = idFromMVTCookie(req) getOrElse AudienceId.generateIdFor(req)
+
+  def cookieWhichShouldBeDropped(req: RequestHeader): Option[Cookie] = idFromMVTCookie(req) match {
+    case Some(existingCookieValue) => None
+    case None => Some(AudienceId.generateIdFor(req).cookie)
+  }
+}
+
+case class AudienceId(num: Int) {
+  require(0 <= num)
+  require(num < MaxId)
+
+  lazy val cookie = Cookie(CookieName, num.toString, maxAge = Some(CookieAge), httpOnly = false, secure = true)
+}
+
+
+case class AudienceRange(start: Double, end: Double) {
+  val startId: Int = percentageToId(start)
+  val endId: Int = percentageToId(end)
+
+  def includes(audienceId: AudienceId): Boolean = startId <= audienceId.num && audienceId.num < endId
+}
+
+object AudienceRange {
+
+  def percentageToId(p: Double): Int = (AudienceId.MaxId * p / 100).toInt
+
+  implicit class PercentageNum[A](start: A)(implicit num: Numeric[A]) {
+    def upTo(end: A) = AudienceRange(num.toDouble(start), num.toDouble(end))
+  }
+
+  val NoAudience = 0 upTo 0
+
+  val FullAudience = 0 upTo 100
+}

--- a/frontend/app/utils/Features.scala
+++ b/frontend/app/utils/Features.scala
@@ -14,6 +14,9 @@ sealed trait Feature extends EnumEntry {
   def stateFor(request: RequestHeader): OnOrOff = {
     request.cookies.get(cookieName).flatMap(cookie => OnOrOff.withNameOption(cookie.value)).getOrElse(OnOrOff.Off)
   }
+
+  def describeState(implicit request: RequestHeader): String =
+    s"$cookieName=${stateFor(request)}"
 }
 
 object Feature extends PlayEnum[Feature] {

--- a/frontend/app/views/fragments/javaScriptFirstSteps.scala.html
+++ b/frontend/app/views/fragments/javaScriptFirstSteps.scala.html
@@ -38,6 +38,7 @@
             buildNumber: '@app.BuildInfo.buildNumber',
             svgSprite: "@Asset.at("images/svg-sprite.svg")"
         },
+        abTests: @Html(Json.toJson(pageInfo.abTests).toString),
         googleAnalytics: {
             trackingId: '@Config.googleAnalyticsTrackingId',
             cookieDomain: @if(Config.stage == "PROD") { 'auto' } else { 'none' }

--- a/frontend/app/views/support/PageInfo.scala
+++ b/frontend/app/views/support/PageInfo.scala
@@ -1,5 +1,6 @@
 package views.support
 
+import abtests.{ABTest, BaseVariant}
 import com.gu.i18n.{Country, CountryGroup, Currency}
 import com.gu.memsub.BillingPeriod
 import configuration.{Config, CopyConfig}
@@ -17,7 +18,8 @@ case class PageInfo(title: String = CopyConfig.copyTitleDefault,
                     payPalEnvironment: Option[String] = None,
                     initialCheckoutForm: CheckoutForm =
                       CheckoutForm(CountryGroup.UK.defaultCountry, CountryGroup.UK.currency, BillingPeriod.Year),
-                    navigation: Seq[NavItem] = Nav.primaryNavigation
+                    navigation: Seq[NavItem] = Nav.primaryNavigation,
+                    abTests: Map[ABTest, BaseVariant] = Map.empty
                    )
 
 object PageInfo {
@@ -35,4 +37,9 @@ object PageInfo {
   }
 
   implicit val checkoutFormWrites = Json.writes[CheckoutForm]
+
+  implicit val abTestWrites = new Writes[Map[ABTest, BaseVariant]] {
+    override def writes(tests: Map[ABTest, BaseVariant]): JsValue = JsObject(tests.map{case (t,v) => (t.slug, JsString(v.slug)) })
+  }
+
 }

--- a/frontend/assets/javascripts/src/modules/analytics/ga.es6
+++ b/frontend/assets/javascripts/src/modules/analytics/ga.es6
@@ -102,12 +102,16 @@ export function init() {
     wrappedGa('set', dimensions.signedOut, signedOut.toString());
     wrappedGa('set', dimensions.platform, 'membership');
 
+    if (guardian.abTests) {
+        wrappedGa('set', dimensions.experience, Object.keys(guardian.abTests).map(function(k){return k+"="+guardian.abTests[k]}).join(","));
+    }
     if (isLoggedIn) {
         wrappedGa('set', dimensions.identityId, u.id);
     }
     if (guardian.ophan) {
         wrappedGa('set', dimensions.ophanPageViewId, guardian.ophan.pageViewId);
     }
+
     if("productData" in guardian) {
 
         wrappedGa('set',dimensions.membershipNumber,guardian.productData.regNumber);


### PR DESCRIPTION
## Why are you doing this?

Adds Merged Registration as an A/B test, along with a general purpose a/b testing framework for Membership, influenced by https://github.com/guardian/contributions-frontend/blob/fc51a3d7/app/abtests/Test.scala, with a few tweaks to how variants are expressed.

### Cookies

1. The 'audience id' or 'MVT' cookie, called `GU_MEM_mvt_id`, which identifies where the user is in the audience range (from 0 to 10000).
2. The AB-test specific cookies, eg `gu.membership.ab.merged-registration`, which specify which variant a user is in for a given test.

Example cookies:
```
Set-Cookie: GU_MEM_mvt_id=3672; Max-Age=315360000; Expires=Mon, 10 May 2027 10:15:18 GMT; Path=/; Secure
Set-Cookie: gu.membership.ab.merged-registration=control; Max-Age=31536000; Expires=Sat, 12 May 2018 10:15:18 GMT; Path=/
```

These cookies are dropped by the `AddAbTestingCookiesToResponse` Action, which is part of `NoCacheAction` and so dropped on any uncached page view.

### Allocating a variant to a user

The variant allocated to user is chosen using the first of these 3 methods that applies:

1. Forcing a variant with a query parameter, eg: https://mem.thegulocal.com/join/supporter/enter-details?ab.merged-registration=merged
2. Reading the AB-test-specific cookie, eg `gu.membership.ab.merged-registration`
3. Deriving a variant from the MVT id

### Client-Side

A `guardian.abTests` variable is created in `javaScriptFirstSteps` (though you do have to populate `PageInfo` to make this happen, so it's not on every page yet):

```
    var guardian = {
        ...
        abTests: {"merged-registration":"merged"},
        ...
    };
```

### Analytics

Google Analytics gets the `experience` property (custom dimension `dimension16`) set:

![image](https://cloud.githubusercontent.com/assets/52038/25994838/7a717978-3707-11e7-8dc6-1a4df859d40f.png)


## Trello card: [Here](https://trello.com/c/TpuX5Fdb/298-a-b-testing-for-new-checkout-flow-test-merging-registration-into-supporter-checkout)
