### PR TITLE
Update Copy, Layout and Header - Bundles Landing Page

### DIFF
--- a/frontend/app/views/bundle/bundlesLanding.scala.html
+++ b/frontend/app/views/bundle/bundlesLanding.scala.html
@@ -31,7 +31,6 @@
 
 	<section class="bundles">
 		<div class="bundles__content">
-			<div class="bundles__divider"></div>
 			<div class="bundles__bundle bundles__bundle--contribution">
 				<div class="bundles__bundle-content">
 					<div class="bundles__top">

--- a/frontend/app/views/bundle/bundlesLanding.scala.html
+++ b/frontend/app/views/bundle/bundlesLanding.scala.html
@@ -23,12 +23,9 @@
 
 	<section class="introduction">
 		<div class="introduction__content">
-			<h1 class="introduction__heading-one">support the guardian</h1>
-			<p>Our quality journalism takes time and money to produce. But ad revenues are falling, so we need your help to</p>
-			<h1 class="introduction__heading-two">secure our future</h1>
-			<p><span class="introduction__wrap-line">Subscribe or make a regular or one-off contribution </span>today and together we can</p>
-			<h1 class="introduction__heading-three">hold power to account</h1>
-			<p><span class="introduction__wrap-line">As an independent voice, our most important </span>relationship is with our readers</p>
+			<h1 class="introduction__heading">support the guardian</h1>
+			<p>Be part of our future by helping to secure it.</p>
+			<p>Hold power to account by funding quality, independent journalism.</p>
 		</div>
 	</section>
 
@@ -40,7 +37,6 @@
 					<div class="bundles__top">
 						<h1 class="bundles__heading">From £5/month</h1>
 						<h2 class="bundles__subheading"><span class="bundles__wrap-line">Make a </span>contribution</h2>
-						<p class="bundles__copy bundles__copy--top">Support the Guardian. Every penny of your contribution goes to support our fearless, quality journalism.</p>
 					</div>
 					<div class="bundles__bottom">
 						<div class="contribution-fields">
@@ -52,10 +48,7 @@
 							<input type="text" class="contribution-fields__other-amount js-contribution-other" placeholder="Other amount (£)">
 						</div>
 						<div class="contribution-error js-contribution-error"></div>
-						<div>
-							<p class="bundles__copy bundles__copy--bottom">Support the Guardian. Every penny of your contribution goes to support our fearless, quality journalism.</p>
-							<a class="bundles__cta js-contrib-link" href="/monthly-contribution?contributionValue=5">Contribute with credit/debit card @fragments.inlineIcon("arrow-right-straight")</a>
-						</div>
+						<a class="bundles__cta js-contrib-link" href="/monthly-contribution?contributionValue=5">Contribute with credit/debit card @fragments.inlineIcon("arrow-right-straight")</a>
 					</div>
 				</div>
 			</div>
@@ -65,7 +58,6 @@
 					<div class="bundles__top">
 						<h1 class="bundles__heading">£11.99/month</h1>
 						<h2 class="bundles__subheading"><span class="bundles__wrap-line">Become a </span>digital subscriber</h2>
-						<p class="bundles__copy bundles__copy--top">Support the Guardian and enjoy a subscription to our digital Daily Edition and the premium tier of our app.</p>
 					</div>
 					<div class="bundles__bottom">
 						<ul class="bundles__features">
@@ -78,14 +70,10 @@
 								<p>Daily newspaper optimised for tablet; available on Apple, Android and Kindle Fire</p>
 							</li>
 							<li>
-								<h3>Free trial</h3>
-								<p>For 14 days, enjoy on up to 10 devices</p>
+								<h3>Enjoy on up to 10 devices</h3>
 							</li>
 						</ul>
-						<div>
-							<p class="bundles__copy bundles__copy--bottom">Support the Guardian and enjoy a subscription to our digital Daily Edition and the premium tier of our app.</p>
-							<a class="bundles__cta js-digi-link" href="https://subscribe.theguardian.com/p/DXX83X">Become a digital subscriber @fragments.inlineIcon("arrow-right-straight")</a>
-						</div>
+						<a class="bundles__cta js-digi-link" href="https://subscribe.theguardian.com/p/DXX83X">Become a digital subscriber @fragments.inlineIcon("arrow-right-straight")</a>
 					</div>
 				</div>
 			</div>
@@ -95,7 +83,6 @@
 					<div class="bundles__top">
 						<h1 class="bundles__heading">From £10.79/month</h1>
 						<h2 class="bundles__subheading"><span class="bundles__wrap-line">Become a </span>paper subscriber</h2>
-						<p class="bundles__copy bundles__copy--top">Support the Guardian and enjoy a subscription to the Guardian and the Observer newspapers.</p>
 					</div>
 					<div class="bundles__bottom">
 						<div class="bundles__print-selection">
@@ -109,19 +96,14 @@
 									<p>Choose the package you want: Everyday+, Sixday+, Weekend+ and Sunday+</p>
 								</li>
 								<li class="js-digital-benefits">
-									<h3>Digital</h3>
-									<p>All the benefits of the digital subscription</p>
+									<h3>All the benefits of a Digital subscription</h3>
 								</li>
 								<li>
-									<h3>Save money</h3>
-									<p>Up to 36% off the retail price</p>
+									<h3>Save money off the retail price</h3>
 								</li>
 							</ul>
 						</div>
-						<div>
-							<p class="bundles__copy bundles__copy--bottom">Support the Guardian and enjoy a subscription to the Guardian and the Observer newspapers.</p>
-							<a class="bundles__cta js-print-link" href="https://subscribe.theguardian.com/p/GXX83X">Become a paper subscriber @fragments.inlineIcon("arrow-right-straight")</a>
-						</div>
+						<a class="bundles__cta js-print-link" href="https://subscribe.theguardian.com/p/GXX83X">Become a paper subscriber @fragments.inlineIcon("arrow-right-straight")</a>
 					</div>
 				</div>
 			</div>

--- a/frontend/app/views/bundle/bundlesLanding.scala.html
+++ b/frontend/app/views/bundle/bundlesLanding.scala.html
@@ -95,7 +95,7 @@
 									<p>Choose the package you want: Everyday+, Sixday+, Weekend+ and Sunday+</p>
 								</li>
 								<li class="js-digital-benefits">
-									<h3>All the benefits of a Digital subscription</h3>
+									<h3>All the benefits of a digital subscription</h3>
 								</li>
 								<li>
 									<h3>Save money off the retail price</h3>

--- a/frontend/app/views/fragments/global/guardianHeader.scala.html
+++ b/frontend/app/views/fragments/global/guardianHeader.scala.html
@@ -12,12 +12,6 @@
             @fragments.common.inlineSvgImage(Logos.guardianTitlePiece, List("guardian-header__title-height"))
             </a>
         </div>
-        <div class="guardian-header__logo guardian-header__logo-roundel">
-            <a href="@url" class="guardian-header__logo-link guardian-header__roundel-height">
-            @fragments.common.inlineSvgImage(Logos.guardianRoundel, List("guardian-header__roundel-height"))
-            </a>
-        </div>
-        @fragments.bundle.guardianNavigation()
     </div>
 </header>
 

--- a/frontend/assets/stylesheets/components/_bundle-landing.scss
+++ b/frontend/assets/stylesheets/components/_bundle-landing.scss
@@ -50,6 +50,11 @@ $why-support-colour: #7cb523;
 	justify-content: center;
 	margin: 0 auto;
 
+	@include mq($until: mobileLandscape) {
+		background-color: guss-colour(comment-support-2);
+		padding: 0 10px $gs-baseline;
+	}
+
 	@include mq($from: desktop) {
 		display: flex;
 		max-width: gs-span(12) + ($gs-gutter * 2);
@@ -98,7 +103,7 @@ $why-support-colour: #7cb523;
 	@include mq($from: desktop) {
 		display: flex;
 		flex-direction: column;
-		height: gs-height(9) + $gs-baseline;
+		height: gs-height(9) + ($gs-baseline * 2);
 		// Fix for IE10.
 		max-width: gs-span(4);
 	}
@@ -201,7 +206,7 @@ $why-support-colour: #7cb523;
 	background-color: guss-colour(neutral-1);
 	color: #fff;
 	padding: ($gs-baseline / 2) $gs-gutter;
-	margin-top: $gs-baseline;
+	margin-top: $gs-baseline * 3;
 	text-align: left;
 	width: 100%;
 	height: $gs-baseline * 3;
@@ -246,16 +251,15 @@ $why-support-colour: #7cb523;
 .bundles__divider {
 	flex-grow: 1;
 	flex-basis: 100%;
+	background-color: #fff;
 
-	@include mq($until: desktop) {
-		height: $gs-baseline / 2;
-		background-image: url('https://media.guim.co.uk/8f75d2e43000b0e9c3523ca20e5bbfcec9ffe703/0_0_1860_23/500.jpg');
-		background-repeat: repeat-x;
+	@include mq($until: mobileLandscape) {
+		height: $gs-baseline;
+		background-color: guss-colour(comment-support-2);
 	}
 
-	@include mq($from: tablet, $until: desktop) {
+	@include mq($from: mobileLandscape, $until: desktop) {
 		height: $gs-baseline;
-		background-image: url('https://media.guim.co.uk/8f75d2e43000b0e9c3523ca20e5bbfcec9ffe703/0_0_1860_23/1000.jpg');		
 	}
 
 	@include mq($from: desktop) {
@@ -443,11 +447,11 @@ $why-support-colour: #7cb523;
 }
 
 .introduction p {
-	margin: 0 10px 4px 90px;
+	margin: 0 10px 8px 90px;
 	font-family: $f-serif-headline;
 	font-weight: normal;
-	font-size: 17px;
-	line-height: 19px;
+	font-size: 23px;
+	line-height: 23px;
 	color: guss-colour(neutral-1);
 
 	@include mq($from: mobileLandscape) {
@@ -456,26 +460,20 @@ $why-support-colour: #7cb523;
 	}
 
 	@include mq($from: tablet) {
-		margin-left: 260px;
-		margin-bottom: 5px;
-		font-size: 18px;
-		line-height: 22px;
+		margin-left: 210px;
+		font-size: 28px;
+		line-height: 27px;
 	}
 
 	@include mq($from: desktop) {
-		margin-left: 340px;
-		margin-bottom: $gs-baseline;
-		font-size: 24px;
-		line-height: 28px;
+		margin-left: 180px;
 	}
 
 	@include mq($from: mem-full) {
-		margin-left: 420px;
 		margin-right: 100px;
 	}
 
 	@include mq($from: wide) {
-		margin-left: 330px;
 		margin-right: 350px;
 	}
 }
@@ -485,6 +483,10 @@ $why-support-colour: #7cb523;
 
 	@include mq($from: mobileLandscape) {
 		margin-left: 25px;
+	}
+
+	@include mq($from: mem-full) {
+		margin-left: 70px;
 	}
 }
 

--- a/frontend/assets/stylesheets/components/_bundle-landing.scss
+++ b/frontend/assets/stylesheets/components/_bundle-landing.scss
@@ -98,7 +98,7 @@ $why-support-colour: #7cb523;
 	@include mq($from: desktop) {
 		display: flex;
 		flex-direction: column;
-		height: gs-height(10) + $gs-baseline;
+		height: gs-height(9) + $gs-baseline;
 		// Fix for IE10.
 		max-width: gs-span(4);
 	}
@@ -189,65 +189,10 @@ $why-support-colour: #7cb523;
 	}
 }
 
-.bundles__copy {
-	margin: 0;
-	@include fs-headline(2);
-	color: #000;
-}
-
-.bundles__copy--top {
-	@include mq($until: tablet) {
-		display: none;
-	}
-
-	@include mq($from: desktop) {
-		display: none;
-	}
-}
-
-.bundles__copy--bottom {
-	@include mq($from: tablet, $until: desktop) {
-		display: none;
-	}
-
-	@include mq($until: desktop) {
-		margin-top: $gs-baseline;
-	}
-
-	@include mq($from: desktop) {
-		padding-top: $gs-baseline * 3;
-	}
-}
-
-.bundles__cta, .contribution-fields, .print-fields, .bundles__more-details {
+.bundles__cta, .contribution-fields, .print-fields {
 	@include fs-textSans(3);
 	font-weight: bold;
 	color: guss-colour(neutral-1);
-}
-
-.bundles__more-details {
-	color: #000;
-
-	@include mq($from: tablet) {
-		display: none;
-	}
-}
-
-.bundles__more-details:hover {
-	cursor: pointer;
-
-	button {
-		border-color: guss-colour(neutral-1);
-	}
-}
-
-.bundles__more-details button {
-	border-radius: 36px;
-	border: 1px solid rgba(guss-colour(neutral-1), 0.3);
-	background-color: transparent;
-	height: $gs-baseline * 3;
-	width: $gs-baseline * 3;
-	margin: 9px 0 -4px;
 }
 
 .bundles__cta {
@@ -287,6 +232,7 @@ $why-support-colour: #7cb523;
 
 .bundles__features li {
 	margin-left: $gs-gutter - 1;
+	margin-bottom: $gs-baseline;
     list-style-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 13 13"><style>.st0{fill:#fff;fill-opacity:0.25;}</style><circle class="st0" cx="6" cy="6" r="6"/></svg>');
 }
 
@@ -534,29 +480,12 @@ $why-support-colour: #7cb523;
 	}
 }
 
-.introduction__heading-one {
+.introduction__heading {
 	margin-left: 15px;
 
 	@include mq($from: mobileLandscape) {
 		margin-left: 25px;
 	}
-}
-
-.introduction__heading-two {
-	margin-left: 40px;
-
-	@include mq($from: mobileLandscape) {
-		margin-left: 50px;
-	}
-}
-
-.introduction__heading-three {
-	margin-left: 10px;
-
-	@include mq($from: mobileLandscape) {
-		margin-left: 20px;
-	}
-
 }
 
 .introduction__heading-one, .introduction__heading-two, .introduction__heading-three {

--- a/frontend/assets/stylesheets/components/_bundle-landing.scss
+++ b/frontend/assets/stylesheets/components/_bundle-landing.scss
@@ -427,13 +427,19 @@ $why-support-colour: #7cb523;
 	}
 }
 
-.introduction h1 {
+.introduction__heading {
 	color: guss-colour(news-support-2);
 	font-family: 'Guardian Titlepiece Web', sans-serif;
 	font-weight: 400;
 	font-size: 27px;
 	line-height: 30px;
 	word-spacing: -0.08em;
+	margin-left: 15px;
+	margin-bottom: $gs-baseline;
+
+	@include mq($from: mobileLandscape) {
+		margin-left: 25px;
+	}
 
 	@include mq($from: tablet) {
 		font-size: 40px;
@@ -443,6 +449,10 @@ $why-support-colour: #7cb523;
 	@include mq($from: desktop) {
 		font-size: 48px;
 		line-height: 44px;
+	}
+
+	@include mq($from: mem-full) {
+		margin-left: 70px;
 	}
 }
 

--- a/frontend/assets/stylesheets/components/_guardian-header.scss
+++ b/frontend/assets/stylesheets/components/_guardian-header.scss
@@ -3,16 +3,6 @@
    ========================================================================== */
 
 .guardian-header {
-    height: 74px;
-    @include mq($from: mobile-wider) {
-        height: 90px;
-    }
-    @include mq($from: mobileLandscape) {
-        height: 109px;
-    }
-    @include mq($from: tablet) {
-        height: 123px;
-    }
     display: block;
     background-color: $blue;
     position: relative;
@@ -21,10 +11,11 @@
 
 .guardian-header__inner {
     @include clearfix();
-    padding: 6px 10px 0 10px;
+    padding: 6px 10px 12px 10px;
 
-    @include mq($from: mobileLandscape) {
-        padding: 12px 20px 0 20px;
+    @include mq($from: tablet) {
+        padding-left: 0;
+        padding-right: 0;
     }
 }
 
@@ -35,15 +26,6 @@
 
 .guardian-header__logo-link {
     display: block;
-}
-
-.guardian-header__roundel-height {
-    height: 42px;
-    width: 42px;
-    @include mq($from: mobile-wider) {
-        height: 52px;
-        width: 52px;
-    }
 }
 
 .guardian-header__title-height {
@@ -59,60 +41,6 @@
     }
 }
 
-.guardian-header__logo-roundel {
-    /* additional margins for the roundel, the title svg margins are handled by padding */
-    margin-right: 19px;
-    @include mq($from: mobile-wider) {
-        margin-right: 27px;
-        margin-top: -3px; //accounts for the fact that the title changes size but the roundel doesn't
-    }
-    @include mq($from: mobileLandscape) {
-        margin-right: 35px;
-        margin-top: 3px;
-    }
-    @include mq($from: tablet) {
-        margin-right: 59px;
-        margin-top: -3px;
-    }
-    @include mq($from: desktop) {
-        margin-right: 59px;
-    }
-}
-
-/* Navigation
-   ========================================================================== */
-
-.guardian-header__navigation {
-    display: block;
-    float: left;
-    position: absolute;
-    bottom: 0;
-    @include font-size(16, 36);
-    @include mq($from: mobile-wider) {
-        @include font-size(19, 36);
-    }
-    @include mq($from: mobileLandscape) {
-        @include font-size(24, 42);
-    }
-}
-
-.guardian-header__navigation-list {
-    list-style-type: none;
-    li {
-        display: inline;
-    }
-    li + li:before {
-        content: "/";
-        color: color(news-main-2);
-        margin-right: 1px;
-        margin-left: -3px;
-    }
-    a {
-        color: white;
-        font-family: "Guardian Text Sans Web", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
-        text-decoration: none;
-    }
-}
 
 /* Header - In App
    ========================================================================== */

--- a/frontend/assets/stylesheets/components/_guardian-header.scss
+++ b/frontend/assets/stylesheets/components/_guardian-header.scss
@@ -7,6 +7,12 @@
     background-color: $blue;
     position: relative;
     z-index: 3;
+
+    .guardian-header__inner {
+        @include mq($from: wide) {
+            max-width: 1300px;
+        }
+    }
 }
 
 .guardian-header__inner {
@@ -16,7 +22,7 @@
     @include mq($from: tablet) {
         padding-left: 0;
         padding-right: 0;
-    }
+    }    
 }
 
 .guardian-header__logo {


### PR DESCRIPTION
## Why are you doing this?

So there are a few things going on in this PR, because we decided to pull in some of the UX copy/layout changes from a couple of cards. The changes are to the bundles landing page and the 'Guardian Header', which appears on this page and on the monthly contribution checkout and thank you pages.

[Trello card](https://trello.com/c/334eYOYP/512-opportunity-tree-change-header) and [the other one](https://trello.com/c/O9Jqfyrs/517-opportunity-tree-experiment-1-designs-and-spacing).

cc: @superfrank

## Changes

- Trimmed down the introduction, and tweaked the copy and padding.
- Removed the explainer copy from the bundles.
- Tweaked the feature copy and padding on the bundles.
- Removed the divider image that appears between the bundles on sub-desktop breakpoints, and replaced with white space.
- Changed the bundles background colour on mobile to match the introduction background.
- Removed the roundel and nav from the 'Guardian Header'.

## Screenshots

**Desktop:**

![desktop-bundles](https://cloud.githubusercontent.com/assets/5131341/25994328/68409f92-3705-11e7-9209-83ac31cfe917.png)

**Tablet:**

![tablet-bundles](https://cloud.githubusercontent.com/assets/5131341/25994341/70883af2-3705-11e7-831c-bec9c66003af.png)

**Mobile:**

![mobile-bundles](https://cloud.githubusercontent.com/assets/5131341/25994388/991bf364-3705-11e7-8c79-4dea02d3aa01.png)

**Checkout Page (Monthly Contributions):**

![checkout](https://cloud.githubusercontent.com/assets/5131341/25996240/465d081c-370e-11e7-8d1f-b4ba44323784.png)
