### PR TITLE
pull in latest membership common just to keep it clean

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "8.0.2"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.9" // v0.9 is the latest version published for Play 2.4...
-  val membershipCommon = "com.gu" %% "membership-common" % "0.401"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.406"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playFilters = PlayImport.filters

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "8.0.2"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.9" // v0.9 is the latest version published for Play 2.4...
-  val membershipCommon = "com.gu" %% "membership-common" % "0.406"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.408"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playFilters = PlayImport.filters


### PR DESCRIPTION
I've done a few tweaks to subs readers and thought it would be nice to pull everything in to membership frontend just to save anyone else having to take responsibility for my stuff.

https://github.com/guardian/membership-common/pull/473
https://github.com/guardian/membership-common/pull/474
https://github.com/guardian/membership-common/pull/475
https://github.com/guardian/membership-common/pull/476
https://github.com/guardian/membership-common/pull/477
https://github.com/guardian/membership-common/pull/478
https://github.com/guardian/membership-common/pull/479

@guardian/membership-and-subscriptions 

====

old description included this which is addressed below

@michaelwmcnamara @jacobwinch this includes one of your changes, 
Add logging to capture socket timeout exceptions #472
just make sure you're happy with that one too

https://github.com/guardian/membership-common/pull/472

====