### PR TITLE
upgrading to membership common 0.402 - some logging improvements

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "8.0.2"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.9" // v0.9 is the latest version published for Play 2.4...
-  val membershipCommon = "com.gu" %% "membership-common" % "0.401"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.402"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playFilters = PlayImport.filters


### PR DESCRIPTION
## Why are you doing this?
There is a PR to upgrade to membership common V0.407
Before that goes out I want to upgrade to V0.402 - this was experiencing startup issues last time I attempted it (see https://github.com/guardian/membership-frontend/pull/1625), but testing has shown that a recent change: https://github.com/guardian/membership-frontend/pull/1630 has fixed this in test.
That said I want to push it out in isolation to be sure it isnt still causing problems, before it gets wrapped up in later versions.

## Changes
Upgrades membershipCommon library to 0.402
