### PR TITLE
Switched to Using Array.prototype.forEach.call instead of NodeList.forEach In Bundles 404 Page

### DIFF
--- a/frontend/assets/javascripts/src/modules/landingBundles.es6
+++ b/frontend/assets/javascripts/src/modules/landingBundles.es6
@@ -40,7 +40,7 @@ export function init() {
 }
 
 function bindCommitButtonEvents() {
-    COMMIT_CTAS.forEach(function(el) {
+    [].forEach.call(COMMIT_CTAS, function(el) {
         el.addEventListener('click', function(evt){
             setCookie(COMMIT_COOKIE_NAME, 1, COMMIT_COOKIE_DAYS);
         });


### PR DESCRIPTION
## Why are you doing this?

#1605 introduced a [usage](https://github.com/guardian/membership-frontend/pull/1605/files#diff-fb2260c75d55c07e84cdf15072712903R42) of `NodeList.forEach`, which is unfortunately only supported in [modern browsers](https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach#Browser_Compatibility). This resulted in this vague error in Safari 8:

![foreach-safari](https://cloud.githubusercontent.com/assets/5131341/26005093/ea92c1b2-372f-11e7-825a-d6e67034b9a7.png)

and this surprisingly more helpful error in IE10:

![foreach-ie](https://cloud.githubusercontent.com/assets/5131341/26005110/f3a7e3ea-372f-11e7-9683-5c3256b55aa6.png)

This PR switches to using `[].forEach.call`.

Fortunately, because the `landingBundles.es6` script loads fairly far down in the initialisation order, the checkout flows don't seem to have been affected, so the impact is fairly minimal. I only noticed because the bundles landing page javascript stopped working (`bundlesLanding.es6`), because it happens to load further down. This may explain why we didn't notice this for a while.

[**Trello Card**](https://trello.com/c/P6DneiPJ/563-mysterious-foreach-error-in-ie-on-membership)

## Changes

- Switch use of `NodeList.forEach` to `Array.prototype.forEach.call`.