### PR TITLE
add cloudwatch metrics to track membership signup attempts and third-party payment failures

### DIFF
--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -243,6 +243,7 @@ object Joiner extends Controller with ActivityTracking with PaymentGatewayErrorH
 
     val identityStrategy = identityStrategyFor(request, formData)
     identityStrategy.ensureIdUser { user =>
+      salesforceService.metrics.putAttemptedSignUp(tier)
       memberService.createMember(user, formData, eventId, campaignCode, tier, ipCountry).map {
         case (sfContactId, zuoraSubName) =>
           logger.info(s"make-member-success ${tier.name} ${abtests.MergedRegistration.describeParticipation} ${Feature.MergedRegistration.describeState} ${identityStrategy.getClass.getSimpleName} user=${user.id} testUser=${isTestUser(user.minimal)} sub=$zuoraSubName")
@@ -253,11 +254,13 @@ object Joiner extends Controller with ActivityTracking with PaymentGatewayErrorH
       }.recover {
         // errors due to user's card are logged at WARN level as they are not logic errors
         case error: Stripe.Error =>
+          salesforceService.metrics.putFailSignUpStripe(tier)
           logger.warn(s"Stripe API call returned error: \n\t$error \n\tuser=$userOpt")
           setBehaviourNote(tier.name, error.code, userOpt)
           Forbidden(Json.toJson(error))
 
         case error: PaymentGatewayError =>
+          salesforceService.metrics.putFailSignUpPayPal(tier)
           setBehaviourNote(tier.name, error.code, userOpt)
           handlePaymentGatewayError(error, user.id, tier.name, formData.deliveryAddress.countryName)
 

--- a/frontend/app/monitoring/MemberMetrics.scala
+++ b/frontend/app/monitoring/MemberMetrics.scala
@@ -8,6 +8,10 @@ class MemberMetrics(val backendEnv: String) extends TouchpointBackendMetrics {
 
   val service = "Member"
 
+  def putAttemptedSignUp(tier: Tier): Unit ={
+    put(s"attempted-sign-ups-${tier.name}")
+  }
+
   def putSignUp(tier: Tier) {
     put(s"sign-ups-${tier.name}")
   }
@@ -26,6 +30,14 @@ class MemberMetrics(val backendEnv: String) extends TouchpointBackendMetrics {
 
   def putFailSignUp(tier: Tier) {
     put(s"failed-sign-up-${tier.name}")
+  }
+
+  def putFailSignUpStripe(tier: Tier) {
+    put(s"failed-sign-up-stripe${tier.name}")
+  }
+
+  def putFailSignUpPayPal(tier: Tier) {
+    put(s"failed-sign-up-paypal${tier.name}")
   }
 
   def putCreationOfPaidSubscription(paymentMethod: PaymentMethod) = {


### PR DESCRIPTION
## Why are you doing this?
The aim of this change is to add monitoring to the payments process so that we can track the ratio of payment attempts to success/failures and potentially alert if the ratio exceeds a given threshold

## Changes
Add cloudwatch metric for attempted signup to any paid membership tier
Add cloudwatch metric for payment failure returned from stripe during signup for a paid membership tier
Add cloudwatch metric for payment failure returned from paypal during signup for a paid membership tier

## Testing
Simulated payments in dev and confirmed that payment attempt was being tracked in cloudwatch
Ran all tests including integration tests - confirmed tests passed.

## Screenshots
![image](https://cloud.githubusercontent.com/assets/7239344/26008828/50021cf6-373e-11e7-9801-fadb0dfe895a.png)
