### PR TITLE
Update eventbrite address to use fastly

### DIFF
--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -16,7 +16,7 @@ event.discountMultiplier=0.8
 
 eventbrite.url="http://www.eventbrite.co.uk"
 
-eventbrite.api.url="https://d1s44y2vc5rmbm.cloudfront.net/v3"
+eventbrite.api.url="https://eventbrite-proxy.guardianapis.com/v3"
 
 eventbrite.api.iframe-url="https://www.eventbrite.com/tickets-external?ref=etckt&v=2"
 eventbrite.api.refresh-time-seconds=59


### PR DESCRIPTION
## Why are you doing this?
There are a very large number of socket timeout errors reported in Sentry, due to regular request for events from Eventbrite.
This change is to harness the power of Fastly shield nodes to significantly reduce the number of these timeouts being reported, thus reducing load on Eventbrite and removing noise from our Sentry reporting.

## Changes
Change address for Eventbrite API to run through Fastly.

## Tested in
Passes the full automated test suite successfully