### PR TITLE
minor spelling correction to metric names

### DIFF
--- a/frontend/app/monitoring/MemberMetrics.scala
+++ b/frontend/app/monitoring/MemberMetrics.scala
@@ -33,11 +33,11 @@ class MemberMetrics(val backendEnv: String) extends TouchpointBackendMetrics {
   }
 
   def putFailSignUpStripe(tier: Tier) {
-    put(s"failed-sign-up-stripe${tier.name}")
+    put(s"failed-sign-up-stripe-${tier.name}")
   }
 
   def putFailSignUpPayPal(tier: Tier) {
-    put(s"failed-sign-up-paypal${tier.name}")
+    put(s"failed-sign-up-paypal-${tier.name}")
   }
 
   def putCreationOfPaidSubscription(paymentMethod: PaymentMethod) = {


### PR DESCRIPTION
## Why are you doing this?
dropped hyphens on cloudwatch metric names. This will make them consistent

## Changes
added hyphen to cloudwatch metrics for failed signup for stripe and paypal specific metrics
