### PR TITLE
Refresh events archive on an hourly basis

### DIFF
--- a/frontend/app/services/EventbriteService.scala
+++ b/frontend/app/services/EventbriteService.scala
@@ -65,7 +65,7 @@ trait EventbriteService extends WebServiceHelper[EBObject, EBError] {
   // goal here is to keep the downstream cache warm (AWS CloudFront - ttl 61s).
   lazy val eventsTask = eventsTaskFor("live", 1.second, Config.eventbriteRefreshTime.seconds)
 
-  lazy val archivedEventsTask = eventsTaskFor("ended", 29.seconds, Config.eventbriteRefreshTime.seconds)
+  lazy val archivedEventsTask = eventsTaskFor("ended", 29.seconds, 3600.seconds)
 
   lazy val draftEventsTask =  eventsTaskFor("draft", 59.seconds, Config.eventbriteRefreshTime.seconds)
 

--- a/frontend/app/services/EventbriteService.scala
+++ b/frontend/app/services/EventbriteService.scala
@@ -1,7 +1,5 @@
 package services
 
-import java.net.SocketTimeoutException
-
 import com.github.nscala_time.time.OrderingImplicits._
 import com.gu.memsub.util.{ScheduledTask, WebServiceHelper}
 import com.gu.monitoring.StatusMetrics

--- a/frontend/app/services/EventbriteService.scala
+++ b/frontend/app/services/EventbriteService.scala
@@ -1,5 +1,7 @@
 package services
 
+import java.net.SocketTimeoutException
+
 import com.github.nscala_time.time.OrderingImplicits._
 import com.gu.memsub.util.{ScheduledTask, WebServiceHelper}
 import com.gu.monitoring.StatusMetrics
@@ -71,10 +73,9 @@ trait EventbriteService extends WebServiceHelper[EBObject, EBError] {
 
   def start() {
     Logger.info(s"Starting EventbriteService background tasks for ${this.getClass.getSimpleName}")
-    val timeout = (Config.eventbriteRefreshTime - 3).seconds
-    eventsTask.start(timeout)
-    draftEventsTask.start(timeout)
-    archivedEventsTask.start(timeout)
+    eventsTask.start()
+    draftEventsTask.start()
+    archivedEventsTask.start(90.seconds)
   }
 
   def events: Seq[RichEvent] = eventsTask.get().filterNot(e => HiddenEvents.contains(e.id))


### PR DESCRIPTION
## Why are you doing this?
We're seeing 1000s of timeouts from Eventbrite every day. There is some Fastly tuning in progress which should improve matters, but (in my opinion) a major part of the problem is simply that we're making 1000s of unnecessary requests.

If I understand it correctly, the archivedEvents tasks are used to populate /events/archive. Presumably this only actually changes a few times per day, when the previous day's events are marked as ended (perhaps this only actually happens once per day?).

The archiveEvents tasks retrieve all of the events with a status of 'ended' by looping through pages from Eventbrite. This is currently 34 GET requests for Guardian Live Events and 10 GET requests for Masterclasses (so 44 requests combined). We run these tasks every minute (https://github.com/guardian/membership-frontend/blob/master/frontend/conf/application.conf#L22); that's 63K requests per day per instance.

I've made a config change in Fastly which means that we allow a higher max-age for urls which lookup ended events (and I've also configured stale-while-revalidate for these requests). As the chance of this task timing out is now significantly lower, I think we can safely schedule this task on an hourly basis.

## Trello card:
N/A

## Changes
* Run archived events tasks once per hour, instead of once per minute. This means we will make 1056 requests per instance, per day (which is probably still more than we need to, but a lot better than 63K).

## Testing
Confirmed that the archive still loads.

## Screenshots
N/A