### PR TITLE
Accurately track conversions that are redirected through Identity

### DIFF
--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -55,6 +55,8 @@ object Joiner extends Controller with ActivityTracking with PaymentGatewayErrorH
 
   val subscriberOfferDelayPeriod = 6.months
 
+  val ForcedRedirectToIdentity = "forcedRedirectToIdentity"
+
   val EmailMatchingGuardianAuthenticatedStaffNonMemberAction = AuthenticatedStaffNonMemberAction andThen matchingGuardianEmail()
 
   val identityService = IdentityService(IdentityApi)
@@ -108,7 +110,7 @@ object Joiner extends Controller with ActivityTracking with PaymentGatewayErrorH
       val canWaiveAuth = abtests.MergedRegistration.allocate(req).exists(_.canWaiveAuth) || Feature.MergedRegistration.turnedOnFor(req)
       val canAccess = userSignedIn || canWaiveAuth
       logger.info(s"optional-auth ${req.path} canWaiveAuth=$canWaiveAuth userSignedIn=$userSignedIn canAccess=$canAccess testUser=${isTestUser(PreSigninTestCookie, req.cookies)(req).isDefined}")
-      if (canAccess) None else Some(onUnauthenticated(req))
+      if (canAccess) None else Some(onUnauthenticated(req).addingToSession(ForcedRedirectToIdentity -> "true")(req))
     }
   }
 
@@ -246,7 +248,7 @@ object Joiner extends Controller with ActivityTracking with PaymentGatewayErrorH
       salesforceService.metrics.putAttemptedSignUp(tier)
       memberService.createMember(user, formData, eventId, campaignCode, tier, ipCountry).map {
         case (sfContactId, zuoraSubName) =>
-          logger.info(s"make-member-success ${tier.name} ${abtests.MergedRegistration.describeParticipation} ${Feature.MergedRegistration.describeState} ${identityStrategy.getClass.getSimpleName} user=${user.id} testUser=${isTestUser(user.minimal)} sub=$zuoraSubName")
+          logger.info(s"make-member-success ${tier.name} ${abtests.MergedRegistration.describeParticipation} ${Feature.MergedRegistration.describeState} ${identityStrategy.getClass.getSimpleName} user=${user.id} testUser=${isTestUser(user.minimal)} $ForcedRedirectToIdentity=${request.session.get(ForcedRedirectToIdentity).mkString} sub=$zuoraSubName")
           salesforceService.metrics.putSignUp(tier)
           trackRegistration(formData, tier, sfContactId, user.minimal, campaignCode)
           trackRegistrationViaEvent(sfContactId, user.minimal, eventId, campaignCode, tier)


### PR DESCRIPTION
## Why are you doing this?

I should have addressed this with https://github.com/guardian/membership-frontend/pull/1631 :crying_cat_face:  The stats [here](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#dashboards:name=Membership-frontend) for [`NewMemberForcedToRegisterInIdentity`](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#metricFilter:group=membership-frontend-PROD) are incorrect (using just `"make-member-success" "testUser=false" ExistingSignedInUser "ab.gu.membership.ab.merged-registration=control"` incorrectly includes users who were _already_ signed in before the process started) - we need to know explicitly whether we forced the user to go to Identity or not.

## Trello card: [Here](https://trello.com/c/TpuX5Fdb/298-a-b-testing-for-new-checkout-flow-test-merging-registration-into-supporter-checkout)
