### PR TITLE
Increase allowed password size to 72 to match profile.theguardian.com

### DIFF
--- a/frontend/app/views/fragments/form/createPassword.scala.html
+++ b/frontend/app/views/fragments/form/createPassword.scala.html
@@ -2,7 +2,7 @@
 
         <div class="form-field form-field--no-margin">
             <label class="label label--inline" for="user-password">Password</label>
-            <span class="form-note">(between 6 and 20 characters)</span>
+            <span class="form-note">(between 6 and 72 characters)</span>
             <div class="form-note form-note--right mobile-only js-on">
                 <a href="#toggle-password"
                    class="text-link js-toggle-password"
@@ -19,7 +19,7 @@
                    autocorrect="off"
                    spellcheck="false"
                    minlength="6"
-                   maxlength="20"
+                   maxlength="72"
                    required/>
             @fragments.form.errorMessage("Please enter a password")
         </div>


### PR DESCRIPTION
## Why are you doing this?
The approved password size on https://profile.theguardian.com/register was increased with https://github.com/guardian/identity-frontend/pull/134 back in April 2016, and it's definitely better to permit [longer passwords](https://www.schneier.com/blog/archives/2014/03/choosing_secure_1.html).

I've been able to run through the whole register+checkout, logout and re-signin flow in DEV/CODE, and functionality all works.

We use a label rather than placeholder text to alert users to the approved range of password lengths, see:

* https://github.com/alphagov/accessible-autocomplete/issues/41
* https://govuk-elements.herokuapp.com/form-elements/#form-hint-text
* http://adamsilver.io/articles/placeholders-are-problematic/

## Screenshots

https://mem.thegulocal.com/join/supporter/enter-details?countryGroup=uk

![image](https://cloud.githubusercontent.com/assets/52038/26150067/b6ab45ae-3af4-11e7-933d-065585bd1911.png)
