### PR TITLE
tell zuora subscribe command to use None title

### DIFF
--- a/frontend/app/forms/MemberForm.scala
+++ b/frontend/app/forms/MemberForm.scala
@@ -15,7 +15,9 @@ import play.api.data.{FieldMapping, Form, FormError, Mapping}
 import play.api.libs.json.{JsValue, Json}
 
 object MemberForm {
-  case class NameForm(first: String, last: String) extends FullName
+  case class NameForm(first: String, last: String) extends FullName {
+    override def title: Option[Title] = None
+  }
 
   case class SupportForm(
     name: String,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "8.0.2"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.9" // v0.9 is the latest version published for Play 2.4...
-  val membershipCommon = "com.gu" %% "membership-common" % "0.408"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.411-SNAPSHOT"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playFilters = PlayImport.filters

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "8.0.2"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.9" // v0.9 is the latest version published for Play 2.4...
-  val membershipCommon = "com.gu" %% "membership-common" % "0.411-SNAPSHOT"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.412"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playFilters = PlayImport.filters


### PR DESCRIPTION
for subscriptions, to fulfil from zuora, we need to save the user's title.  To do this I need to amend the zuora subscribe command writer to optionally write the title.  However in membership, we don't ask for a title at all.

To allow this difference I could create a new type which has the title too for subs only, and subclass appropriately, but I thought for now since it's only one field I can just None it out in membership.  If it became a second field I'd start to use another approach.

See https://github.com/guardian/membership-common/pull/483 for the change in membership common.

@guardian/membership-and-subscriptions opinions welcome