### PR TITLE
Make metric namespacing consistent

### DIFF
--- a/frontend/app/services/SalesforceService.scala
+++ b/frontend/app/services/SalesforceService.scala
@@ -28,7 +28,7 @@ class SalesforceService(salesforceConfig: SalesforceConfig) extends api.Salesfor
 
   val metricsVal = new MemberMetrics(salesforceConfig.envName)
 
-  private val repository = new SimpleContactRepository(salesforceConfig, system.scheduler, "Frontend")
+  private val repository = new SimpleContactRepository(salesforceConfig, system.scheduler, "membership")
 
   override def getMember(userId: UserId): Future[Option[GenericSFContact]] =
     repository.get(userId)


### PR DESCRIPTION
## Why are you doing this?
CloudWatch metrics for this project are going to the namespace: "membership". Except for metrics related to Salesforce, which go to "Frontend"... I'm a pedant and this annoys me.

cc @michaelwmcnamara 

## Trello card: 
N/A

## Changes
* Fix namespace for Salesforce CloudWatch metrics