### PR TITLE
some updates to cloudwatch metrics

### DIFF
--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -292,8 +292,7 @@ object Joiner extends Controller with ActivityTracking with PaymentGatewayErrorH
         case t: Tier if !upgrade => salesforceService.metrics.putThankYou(tier)
         case _ =>
       }
-      Ok({salesforceService.metrics.putThankYou(tier)
-        views.html.joiner.thankyou(
+      Ok({views.html.joiner.thankyou(
         request.subscriber,
         paymentSummary,
         paymentMethod,

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -287,7 +287,9 @@ object Joiner extends Controller with ActivityTracking with PaymentGatewayErrorH
       email <- emailFromZuora
     } yield {
       tier match {
-        case t: Tier.Supporter if !upgrade => MembersDataAPI.Service.removeBehaviour(request.user)
+        case t: Tier.Supporter if !upgrade => {salesforceService.metrics.putThankYou(tier)
+          MembersDataAPI.Service.removeBehaviour(request.user)}
+        case t: Tier if !upgrade => salesforceService.metrics.putThankYou(tier)
         case _ =>
       }
       Ok({salesforceService.metrics.putThankYou(tier)

--- a/frontend/app/monitoring/MemberMetrics.scala
+++ b/frontend/app/monitoring/MemberMetrics.scala
@@ -16,6 +16,10 @@ class MemberMetrics(val backendEnv: String) extends TouchpointBackendMetrics {
     put(s"sign-ups-${tier.name}")
   }
 
+  def putThankYou(tier: Tier): Unit = {
+    put(s"sign-up-thank-you-${tier.name}")
+  }
+
   def putUpgrade(tier: Tier) {
     put(s"upgrade-${tier.name}")
   }
@@ -32,12 +36,12 @@ class MemberMetrics(val backendEnv: String) extends TouchpointBackendMetrics {
     put(s"failed-sign-up-${tier.name}")
   }
 
-  def putFailSignUpStripe(tier: Tier) {
-    put(s"failed-sign-up-stripe-${tier.name}")
+  def putFailSignUpGatewayError(tier: Tier) {
+    put(s"failed-sign-up-paypal-${tier.name}")
   }
 
-  def putFailSignUpPayPal(tier: Tier) {
-    put(s"failed-sign-up-paypal-${tier.name}")
+  def putFailSignUpStripe(tier: Tier) {
+    put(s"failed-sign-up-stripe-${tier.name}")
   }
 
   def putCreationOfPaidSubscription(paymentMethod: PaymentMethod) = {

--- a/frontend/app/monitoring/MemberMetrics.scala
+++ b/frontend/app/monitoring/MemberMetrics.scala
@@ -37,7 +37,7 @@ class MemberMetrics(val backendEnv: String) extends TouchpointBackendMetrics {
   }
 
   def putFailSignUpGatewayError(tier: Tier) {
-    put(s"failed-sign-up-paypal-${tier.name}")
+    put(s"failed-sign-up-gateway-error-${tier.name}")
   }
 
   def putFailSignUpStripe(tier: Tier) {


### PR DESCRIPTION
## Why are you doing this?
Moving attempted signup metric closer to start of make-member function so that we are tracking as much of this process as possible
Adding extra cloudwatch metrics
A) because we want to be able to track the cause of signup failures
B) in the case of the tracking added to the "thank-you" function, there are a lot of operations in this function and current tracking would not detect if signup failed at this stage


## Changes
Moved attempted signup metric closer to start of make-member function;
added tracking for signup failures due to Gateway errors; 
added tracking to show when user has reached the end of the "thank-you" funtion;
