### PR TITLE
Add canRun condition to supporter landing page test

### DIFF
--- a/frontend/app/abtests/ABTest.scala
+++ b/frontend/app/abtests/ABTest.scala
@@ -25,8 +25,12 @@ abstract class ABTest(val slug: String, val audience: AudienceRange, canRun: Req
   def cookieFor(variant: BaseVariant) =
     Cookie(cookieName, variant.slug, maxAge = Some(ABTest.CookieAge), httpOnly = false)
 
-  def describeParticipation(implicit request: RequestHeader): String =
-    s"ab.$cookieName=${allocate(request).map(_.slug).getOrElse("None")}"
+  def participationString(getAllocation: RequestHeader => Option[Variant])(implicit request: RequestHeader) =
+    s"ab.$cookieName=${getAllocation(request).map(_.slug).getOrElse("None")}"
+
+  def describeParticipation(implicit request: RequestHeader): String = participationString(allocate)
+
+  def describeParticipationFromCookie(implicit request: RequestHeader): String = participationString(variantFromABCookie)
 
   def allocate(request: RequestHeader): Option[Variant] = for {
     v <- variantForcedBy(request) orElse variantFromABCookie(request) orElse defaultVariantFor(idFor(request)) if canRun(request)

--- a/frontend/app/abtests/SupporterLandingPage.scala
+++ b/frontend/app/abtests/SupporterLandingPage.scala
@@ -2,7 +2,7 @@ package abtests
 
 import abtests.AudienceRange.FullAudience
 
-case object SupporterLandingPage extends ABTest("supporter-landing-page", FullAudience) {
+case object SupporterLandingPage extends ABTest("supporter-landing-page-v2", FullAudience, _.path.startsWith("/au/supporter")) {
 
   case class Variant(slug: String, showNewDesign: Boolean) extends BaseVariant
 

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -248,7 +248,7 @@ object Joiner extends Controller with ActivityTracking with PaymentGatewayErrorH
       salesforceService.metrics.putAttemptedSignUp(tier)
       memberService.createMember(user, formData, eventId, campaignCode, tier, ipCountry).map {
         case (sfContactId, zuoraSubName) =>
-          logger.info(s"make-member-success ${tier.name} ${ABTest.allTests.map(_.describeParticipation).mkString(" ")} ${Feature.MergedRegistration.describeState} ${identityStrategy.getClass.getSimpleName} user=${user.id} testUser=${isTestUser(user.minimal)} $ForcedRedirectToIdentity=${request.session.get(ForcedRedirectToIdentity).mkString} sub=$zuoraSubName")
+          logger.info(s"make-member-success ${tier.name} ${ABTest.allTests.map(_.describeParticipationFromCookie).mkString(" ")} ${Feature.MergedRegistration.describeState} ${identityStrategy.getClass.getSimpleName} user=${user.id} testUser=${isTestUser(user.minimal)} $ForcedRedirectToIdentity=${request.session.get(ForcedRedirectToIdentity).mkString} sub=$zuoraSubName")
           salesforceService.metrics.putSignUp(tier)
           trackRegistration(formData, tier, sfContactId, user.minimal, campaignCode)
           trackRegistrationViaEvent(sfContactId, user.minimal, eventId, campaignCode, tier)


### PR DESCRIPTION
When I log a successful signup with A/B test participation data, I want to know that this person actually saw the thing relevant to the A/B test.

It seemed the best way to do this was to use the `canRun` function so the cookie only gets dropped if the user visits (say) the Australian supporter landing page.

But this messes with the behaviour of `describeParticipation` which we use for logging - when logging on the signup page it will assume they aren't in the test because `canRun` isn't true on that page.

So I added `describeParticipationFromCookie` which takes the cookie as the source of truth for test participation. This function would not be suitable for use on a request where a test cookie may or may not be dropped, but is it suitable for requests which we know are not relevant for A/B tests - and the post-join request certainly seems like one of these.

What do you think @rtyley?