### PR TITLE
AB test removing password requirement for social-signin users

### DIFF
--- a/frontend/app/abtests/ABTest.scala
+++ b/frontend/app/abtests/ABTest.scala
@@ -22,6 +22,8 @@ abstract class ABTest(val slug: String, val audience: AudienceRange, canRun: Req
 
   lazy val variantsBySlug: Map[String, Variant] = variants.map(v => v.slug -> v).toMap
 
+  lazy val control = variantsBySlug("control")
+
   def cookieFor(variant: BaseVariant) =
     Cookie(cookieName, variant.slug, maxAge = Some(ABTest.CookieAge), httpOnly = false)
 
@@ -31,6 +33,9 @@ abstract class ABTest(val slug: String, val audience: AudienceRange, canRun: Req
   def describeParticipation(implicit request: RequestHeader): String = participationString(allocate)
 
   def describeParticipationFromCookie(implicit request: RequestHeader): String = participationString(variantFromABCookie)
+
+  def testVariantOrElseControl(implicit request: RequestHeader): Variant =
+    allocate(request).getOrElse(control)
 
   def allocate(request: RequestHeader): Option[Variant] = for {
     v <- variantForcedBy(request) orElse variantFromABCookie(request) orElse defaultVariantFor(idFor(request)) if canRun(request)
@@ -50,7 +55,8 @@ object ABTest {
 
   lazy val allTests: Set[ABTest] = Set(
     SupporterLandingPageAustralia,
-    SupporterLandingPageUSA
+    SupporterLandingPageUSA,
+    RemovePasswordRequirement
   )
 
   def allocations(request: Request[_]): Map[ABTest, BaseVariant] = (for {

--- a/frontend/app/abtests/RemovePasswordRequirement.scala
+++ b/frontend/app/abtests/RemovePasswordRequirement.scala
@@ -1,0 +1,17 @@
+package abtests
+
+import abtests.AudienceRange.FullAudience
+import views.support.IdentityUser
+
+case object RemovePasswordRequirement extends ABTest("remove-password-requirement", FullAudience) {
+
+  case class Variant(slug: String, requireGuardianPasswordForSocialSignInUsers: Boolean) extends BaseVariant {
+    def requirePasswordFor(identityUser: Option[IdentityUser]) =
+      identityUser.map(u => requireGuardianPasswordForSocialSignInUsers && !u.passwordExists).getOrElse(true)
+  }
+
+  val variants = Seq(
+    Variant("control", requireGuardianPasswordForSocialSignInUsers = true),
+    Variant("password-not-required",  requireGuardianPasswordForSocialSignInUsers = false)
+  )
+}

--- a/frontend/app/abtests/RemovePasswordRequirement.scala
+++ b/frontend/app/abtests/RemovePasswordRequirement.scala
@@ -1,13 +1,18 @@
 package abtests
 
 import abtests.AudienceRange.FullAudience
+import com.gu.i18n.CountryGroup
 import views.support.IdentityUser
 
-case object RemovePasswordRequirement extends ABTest("remove-password-requirement", FullAudience) {
+case object RemovePasswordRequirement extends ABTest("remove-ss-password-requirement", FullAudience) {
 
   case class Variant(slug: String, requireGuardianPasswordForSocialSignInUsers: Boolean) extends BaseVariant {
-    def requirePasswordFor(identityUser: Option[IdentityUser]) =
-      identityUser.map(u => requireGuardianPasswordForSocialSignInUsers && !u.passwordExists).getOrElse(true)
+    def requirePasswordFor(identityUser: Option[IdentityUser], cg: CountryGroup) = identityUser match {
+      case None => true
+      case Some(user) =>
+        val canWaivePasswordRequirement = (cg == CountryGroup.UK) && !requireGuardianPasswordForSocialSignInUsers
+        !(user.passwordExists || canWaivePasswordRequirement)
+    }
   }
 
   val variants = Seq(

--- a/frontend/app/controllers/Contributor.scala
+++ b/frontend/app/controllers/Contributor.scala
@@ -66,7 +66,7 @@ object Contributor extends Controller with ActivityTracking with PaymentGatewayE
         plans,
         identityUser,
         pageInfo,
-        Some(countryGroup),
+        countryGroup,
         resolution,
         Pricing.bigDecimalToPrice(contributionValue.getOrElse(5))))
     }).andThen { case Failure(e) => logger.error(s"User ${request.user.user.id} could not enter details for paid tier supporter: ${identityRequest.trackingParameters}", e) }

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -140,7 +140,7 @@ object Joiner extends Controller with ActivityTracking with PaymentGatewayErrorH
       identityUserOpt <- userOpt.map(user => identityService.getIdentityUserView(user, identityRequest).map(Option(_))).getOrElse(Future.successful[Option[IdentityUser]](None))
     } yield {
       for (identityUser <- identityUserOpt) {
-        logger.info(s"signed-in-enter-details tier=${tier.slug} testUser=${identityUser.isTestUser} passwordExists=${identityUser.passwordExists}")
+        logger.info(s"signed-in-enter-details tier=${tier.slug} testUser=${identityUser.isTestUser} passwordExists=${identityUser.passwordExists} ${ABTest.allTests.map(_.describeParticipation).mkString(" ")}")
       }
 
       tier match {

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -168,7 +168,7 @@ object Joiner extends Controller with ActivityTracking with PaymentGatewayErrorH
         countryCurrencyWhitelist,
         identityUserOpt,
         pageInfo,
-        Some(countryGroup),
+        countryGroup,
         resolution))
     }).andThen { case Failure(e) => logger.error(s"User ${userOpt.map(_.id)} could not enter details for paid tier ${tier.name}: ${identityRequest.trackingParameters}", e)}
   }

--- a/frontend/app/views/fragments/form/terms.scala.html
+++ b/frontend/app/views/fragments/form/terms.scala.html
@@ -2,17 +2,16 @@
 @import com.gu.i18n.CountryGroup
 @import configuration.CopyConfig.usLegalTerms
 
-@(countryGroup: Option[CountryGroup] = None, monthlyContribution: Boolean = false)
+@(countryGroup: CountryGroup, monthlyContribution: Boolean = false)
 
 <p class="ts-and-cs">@if(monthlyContribution){By proceeding,} else {By joining Guardian Members,} you are agreeing to our
-    <a href="@if(monthlyContribution){@Links.monthlyContributionTerms}else{@Links.membershipTerms(countryGroup)}" class="text-link" target="_blank">Terms and Conditions</a> and
+    <a href="@if(monthlyContribution){@Links.monthlyContributionTerms}else{@Links.membershipTerms(Some(countryGroup))}" class="text-link" target="_blank">Terms and Conditions</a> and
     <a href="@Links.guardianPrivacyPolicy" class="text-link" target="_blank">Privacy Policy</a>.
 </p>
 
-@countryGroup.map{ cg =>
-    @if(Seq("us","um","vi").contains(cg.id.toLowerCase)) {
-        <div class="us-legal">@usLegalTerms</div>
-    } else {
-        <div class="us-legal is-hidden">@usLegalTerms</div>
-    }
+
+@if(Seq("us","um","vi").contains(countryGroup.id.toLowerCase)) {
+    <div class="us-legal">@usLegalTerms</div>
+} else {
+    <div class="us-legal is-hidden">@usLegalTerms</div>
 }

--- a/frontend/app/views/joiner/form/monthlyContribution.scala.html
+++ b/frontend/app/views/joiner/form/monthlyContribution.scala.html
@@ -7,7 +7,7 @@
 @(plans: Contributor,
     idUser: IdentityUser,
     pageInfo: PageInfo,
-    countryGroup: Option[CountryGroup],
+    countryGroup: CountryGroup,
     touchpointBackendResolution: services.TouchpointBackend.Resolution,
     contributionValue: String)(implicit token: play.filters.csrf.CSRF.Token, request: actions.AuthRequest[_])
 

--- a/frontend/app/views/joiner/form/payment.scala.html
+++ b/frontend/app/views/joiner/form/payment.scala.html
@@ -14,7 +14,7 @@
     countriesWithCurrencies: List[CountryWithCurrency],
     idUser: Option[IdentityUser],
     pageInfo: PageInfo,
-    countryGroup: Option[CountryGroup],
+    countryGroup: CountryGroup,
     touchpointBackendResolution: services.TouchpointBackend.Resolution
 )(implicit token: play.filters.csrf.CSRF.Token, request: RequestHeader)
 
@@ -92,7 +92,7 @@
                         </div>
 
 
-                        @if(abtests.RemovePasswordRequirement.testVariantOrElseControl.requirePasswordFor(idUser)){
+                        @if(abtests.RemovePasswordRequirement.testVariantOrElseControl.requirePasswordFor(idUser, countryGroup)){
                             @fragments.form.createPassword()
                         }
 

--- a/frontend/app/views/joiner/form/payment.scala.html
+++ b/frontend/app/views/joiner/form/payment.scala.html
@@ -9,6 +9,7 @@
 @import views.support.MembershipCompat._
 @import views.support.{CountryWithCurrency, IdentityUser, PageInfo}
 @import views.support.IdentityUser.BlankAddress
+@import abtests.RemovePasswordRequirement
 @(plans: PaidMembershipPlans[PaidMemberTier],
     countriesWithCurrencies: List[CountryWithCurrency],
     idUser: Option[IdentityUser],
@@ -90,7 +91,8 @@
                             </div>
                         </div>
 
-                        @if(!idUser.exists(_.passwordExists)) {
+
+                        @if(abtests.RemovePasswordRequirement.testVariantOrElseControl.requirePasswordFor(idUser)){
                             @fragments.form.createPassword()
                         }
 


### PR DESCRIPTION
## Why are you doing this?

Conversion is [much worse for socially-signed-in users](
https://docs.google.com/a/guardian.co.uk/spreadsheets/d/19PEz3bK7T3cSIyBfF85ScV_n62LKx25i53DY1Zqt144/edit?usp=sharing) and it's possible that this is because we force them to assign a Guardian-password to their identity account, on the Membership checkout page:

![image](https://cloud.githubusercontent.com/assets/52038/26643550/99c96b10-4629-11e7-9438-b3ed7966b0e3.png)

This AB test removes that requirement for 50% of the audience.


