### PR TITLE
Fix bugs in remove-social-signin-password-requirement AB test

### DIFF
--- a/frontend/app/abtests/RemovePasswordRequirement.scala
+++ b/frontend/app/abtests/RemovePasswordRequirement.scala
@@ -4,22 +4,26 @@ import abtests.AudienceRange.FullAudience
 import com.gu.i18n.CountryGroup
 import views.support.IdentityUser
 
-case object RemovePasswordRequirement extends ABTest("remove-ss-password-requirement", FullAudience) {
+case object RemovePasswordRequirement extends ABTest("ss-no-password", FullAudience) {
 
   val EligibilitySessionKey = s"$abSlug-eligible"
 
-  def userEligibleForTest(identityUser: IdentityUser, cg: CountryGroup) = (cg == CountryGroup.UK) && !identityUser.passwordExists
-
-  case class Variant(slug: String, requireGuardianPasswordForSocialSignInUsers: Boolean) extends BaseVariant {
-
-    def requirePasswordFor(identityUser: Option[IdentityUser], cg: CountryGroup) = identityUser match {
-      case None => true
-      case Some(user) => userEligibleForTest(user, cg) && !requireGuardianPasswordForSocialSignInUsers
-    }
+  def userEligibleForTest(identityUser: Option[IdentityUser], cg: CountryGroup) = identityUser match {
+    case None => false
+    case Some(user) => (cg == CountryGroup.UK) && !user.passwordExists
   }
 
+
+  case class Variant(slug: String, waivePasswordRequirement: Boolean) extends BaseVariant {
+
+    def requirePasswordFor(identityUser: Option[IdentityUser], cg: CountryGroup) =
+      !(userEligibleForTest(identityUser, cg) && waivePasswordRequirement)
+  }
+
+  val PasswordNotRequiredVariant = Variant("password-not-required", waivePasswordRequirement = true)
+
   val variants = Seq(
-    Variant("control", requireGuardianPasswordForSocialSignInUsers = true),
-    Variant("password-not-required",  requireGuardianPasswordForSocialSignInUsers = false)
+    Variant("control", waivePasswordRequirement = false),
+    PasswordNotRequiredVariant
   )
 }

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -140,7 +140,7 @@ object Joiner extends Controller with ActivityTracking with PaymentGatewayErrorH
       identityUserOpt <- userOpt.map(user => identityService.getIdentityUserView(user, identityRequest).map(Option(_))).getOrElse(Future.successful[Option[IdentityUser]](None))
     } yield {
 
-      val eligibleForRemovePasswordRequirementTest = RemovePasswordRequirement.testVariantOrElseControl.requirePasswordFor(identityUserOpt, countryGroup)
+      val eligibleForRemovePasswordRequirementTest = RemovePasswordRequirement.userEligibleForTest(identityUserOpt, countryGroup)
       for (identityUser <- identityUserOpt) {
         logger.info(s"signed-in-enter-details tier=${tier.slug} testUser=${identityUser.isTestUser} passwordExists=${identityUser.passwordExists} ${ABTest.allTests.map(_.describeParticipation).mkString(" ")} eligibleForRemovePasswordRequirementTest=$eligibleForRemovePasswordRequirementTest")
       }

--- a/frontend/test/abtests/RemovePasswordRequirementTest.scala
+++ b/frontend/test/abtests/RemovePasswordRequirementTest.scala
@@ -1,0 +1,47 @@
+package abtests
+
+import com.gu.i18n.CountryGroup
+import com.gu.identity.play.{IdUser, PublicFields}
+import org.specs2.mutable.Specification
+import views.support.IdentityUser
+import RemovePasswordRequirement.userEligibleForTest
+import com.gu.i18n.CountryGroup.UK
+
+class RemovePasswordRequirementTest extends Specification {
+
+  val idUser = IdUser("1","foo@gu.com", PublicFields(None), None, None)
+  val UserWithPassword = IdentityUser(idUser, passwordExists = true)
+  val UserWithNoPassword = IdentityUser(idUser, passwordExists = false)
+
+  "user" should {
+    "be eligible for the AB test if they have no password and are in the UK" in {
+      userEligibleForTest(Some(UserWithNoPassword), UK) must beTrue
+    }
+
+    "not be eligible for the AB test if they have a password" in {
+      forall(CountryGroup.allGroups) { cg =>
+        userEligibleForTest(Some(UserWithPassword), cg) must beFalse
+      }
+    }
+
+    "not be eligible for the AB test if they are not in the UK" in {
+      forall(CountryGroup.allGroups.toSet - UK) { cg =>
+        userEligibleForTest(Some(UserWithNoPassword), cg) must beFalse
+      }
+    }
+  }
+
+  "control variant" should {
+    "always require password" in {
+      forall(CountryGroup.allGroups) { cg =>
+        RemovePasswordRequirement.control.requirePasswordFor(Some(UserWithNoPassword), cg) must beTrue
+      }
+    }
+  }
+
+  "new variant" should {
+    "not require password for a user if they have no password and are in the UK" in {
+      RemovePasswordRequirement.PasswordNotRequiredVariant.requirePasswordFor(Some(UserWithNoPassword), UK) must beFalse
+    }
+  }
+}


### PR DESCRIPTION
## Why are you doing this?
There were several mistakes in the code I pushed out on Friday (PR #1660 & dbe0a0500), so- *gasp* I've actually written unit tests for this updated version, and I'm now confident these will actually work!

The mistakes were mostly around logging appropriate data- I wasn't logging the actual information I needed to judge test conversion properly - so unfortunately the test will have to start again.
