### PR TITLE
add logging for thank you success

### DIFF
--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -294,8 +294,10 @@ object Joiner extends Controller with ActivityTracking with PaymentGatewayErrorH
     } yield {
       tier match {
         case t: Tier.Supporter if !upgrade => {salesforceService.metrics.putThankYou(tier)
+          logger.info(s"thank you page displayed ${tier.name}")
           MembersDataAPI.Service.removeBehaviour(request.user)}
-        case t: Tier if !upgrade => salesforceService.metrics.putThankYou(tier)
+        case t: Tier if !upgrade => {salesforceService.metrics.putThankYou(tier)
+          logger.info(s"thank you page displayed ${tier.name}")}
         case _ =>
       }
       Ok({views.html.joiner.thankyou(

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -294,12 +294,11 @@ object Joiner extends Controller with ActivityTracking with PaymentGatewayErrorH
     } yield {
       tier match {
         case t: Tier.Supporter if !upgrade => {salesforceService.metrics.putThankYou(tier)
-          logger.info(s"thank you page displayed ${tier.name}")
           MembersDataAPI.Service.removeBehaviour(request.user)}
-        case t: Tier if !upgrade => {salesforceService.metrics.putThankYou(tier)
-          logger.info(s"thank you page displayed ${tier.name}")}
+        case t: Tier if !upgrade => salesforceService.metrics.putThankYou(tier)
         case _ =>
       }
+      logger.info(s"thank you displayed for user: ${request.user.user.id} subscription: ${request.subscriber.subscription.accountId.get} tier: ${tier.name}")
       Ok({views.html.joiner.thankyou(
         request.subscriber,
         paymentSummary,


### PR DESCRIPTION
## Why are you doing this?
nvestigating why cloudwatch metrics show a gap between successful member creation and sending of thank you page.
Extra logging needed to target these events so I can be sure I am looking at the correct examples

## Changes
* Add logging to Joiner.scala to track when thank you method has been successful for new memberships
