### PR TITLE
Updating the maintenance schedule to cover the Salesforce Summer '17 release

### DIFF
--- a/frontend/app/controllers/Outages.scala
+++ b/frontend/app/controllers/Outages.scala
@@ -3,7 +3,7 @@ package controllers
 import play.api.mvc.Controller
 
 object Outages extends Controller {
-  def maintenanceMessage = CachedAction {
+  def maintenanceMessage = NoCacheAction {
     Ok(views.html.info.maintenanceMessage())
   }
 

--- a/frontend/app/utils/PlannedOutage.scala
+++ b/frontend/app/utils/PlannedOutage.scala
@@ -19,9 +19,19 @@ object PlannedOutage {
     new DateTime(2016,11, 6, 4,45, UTC)
   )
 
+  /*
+  Salesforce is performing their Summer '17 Major Release on Friday 9 June 2017 at 10pm BST.
+  The maintenance window is expected to last 5 minutes. Typical releases like this usually result in one minute's downtime.
+   */
+  val salesforceUpgrade = new Interval(
+    new DateTime(2017, 6, 9, 21, 0, UTC),
+    new DateTime(2017, 6, 9, 21, 5, UTC)
+  )
+
   val outages = Seq(
     // rightNow,
-    salesforceOutage
+    salesforceOutage,
+    salesforceUpgrade
   ).sortBy(_.getStartMillis)
 
   def currentOutage = outages.find(_.containsNow)

--- a/frontend/app/utils/PlannedOutage.scala
+++ b/frontend/app/utils/PlannedOutage.scala
@@ -1,7 +1,7 @@
 package utils
 
 import org.joda.time.DateTimeZone.UTC
-import org.joda.time.{DateTime, Interval}
+import org.joda.time.{DateTime, DateTimeZone, Interval}
 
 
 object PlannedOutage {
@@ -22,10 +22,12 @@ object PlannedOutage {
   /*
   Salesforce is performing their Summer '17 Major Release on Friday 9 June 2017 at 10pm BST.
   The maintenance window is expected to last 5 minutes. Typical releases like this usually result in one minute's downtime.
+  https://status.salesforce.com/status/maintenances/22710
    */
+  private val BST = DateTimeZone.forID("Europe/London")
   val salesforceUpgrade = new Interval(
-    new DateTime(2017, 6, 9, 21, 0, UTC),
-    new DateTime(2017, 6, 9, 21, 5, UTC)
+    new DateTime(2017, 6, 9, 22, 0, BST),
+    new DateTime(2017, 6, 9, 22, 5, BST)
   )
 
   val outages = Seq(


### PR DESCRIPTION
Updating the maintenance schedule to cover the Salesforce Summer '17 release this evening: https://status.salesforce.com/status/maintenances/22710
https://releasenotes.docs.salesforce.com/en-us/summer17/release-notes/salesforce_release_notes.htm

## Why are you doing this?
Better experience for our readers rather than a failing checkout flow.

## Changes
* Updating the maintenance schedule to cover the Salesforce Summer '17 release

<!--
If you are making heavy client-side changes, consider manual test the following
critical flow before merging
## Tested in
| Browser | Supporter Stripe checkout | Supporter Paypal checkout | Stripe Monthly Contribution |  Paypal Monthly Contribution| Upgrade from Friend to Supporter  |
|---------|---------------------------|---------------------------|-----------------------------|-----------------------------|-----------------------------------|
| IE      |                           |                           |                             |                             |                                   |
| Firefox |                           |                           |                             |                             |                                   |
| Safari  |                           |                           |                             |                             |                                   |
| Chrome  |                           |                           |                             |                             |                                   |

-->

## Screenshot
<img width="1146" alt="picture 114" src="https://user-images.githubusercontent.com/1515970/26969022-232e9780-4cfc-11e7-9aa7-314c87b55a55.png">
 
cc @rtyley @dominickendrick @johnduffell @jacobwinch @michaelwmcnamara 

