### PR TITLE
Fix acceptance test broken with 

### DIFF
--- a/frontend/app/views/fragments/joiner/signedInAs.scala.html
+++ b/frontend/app/views/fragments/joiner/signedInAs.scala.html
@@ -5,7 +5,7 @@
 
 @for(displayName <- user.publicFields.displayName) {
     <p class="text-note">
-        You're signed in as <strong>@displayName</strong>.
+        You're signed in as <strong class="qa-user-displayname">@displayName</strong>.
     @if(!inline) {
         </p>
         <p class="text-note">

--- a/frontend/test/acceptance/pages/EnterDetails.scala
+++ b/frontend/test/acceptance/pages/EnterDetails.scala
@@ -162,7 +162,7 @@ case class EnterDetails(val testUser: TestUser) extends Page with Browser {
 
   }
 
-  private val userDisplayName = cssSelector(".js-user-displayname")
+  private val userDisplayName = cssSelector(".qa-user-displayname")
 
   private val payButton = className("js-submit-input")
 


### PR DESCRIPTION
## Why are you doing this?

I removed the `js-user-displayname` css class in PR #1664 because I thought it was only used by the display-or-hide-username JS, but it turns out it was used for the QA tests too :)

https://travis-ci.org/guardian/membership-frontend/builds/241203618#L282