### PR TITLE
Patch up campaign code tracking

### DIFF
--- a/frontend/app/utils/ReferralData.scala
+++ b/frontend/app/utils/ReferralData.scala
@@ -6,15 +6,16 @@ case class ReferralData(campaignCode: Option[String], url: Option[String], pagev
 
 object ReferralData {
 
-  val CampaignCodeKey = "mem_campaign_code"
+  val CampaignCodeKey =  "mem_campaign_code"
   val UrlKey = "gu_mem_ref_url"
   val PageviewIdKey = "gu_refpvid"
 
   def makeCookies(implicit request: RequestHeader): Seq[Cookie] = {
     val refUrl = request.headers.get("referer").map(Cookie(ReferralData.UrlKey, _))
     val refPvid = request.getQueryString("REFPVID").map(Cookie(ReferralData.PageviewIdKey, _))
+    val campaignCode = request.getQueryString("INTCMP").map(Cookie(ReferralData.CampaignCodeKey, _))
 
-    (refUrl ++: refPvid).toList
+    (refUrl ++: refPvid ++: campaignCode).toList
   }
 
   def fromRequest(implicit request: RequestHeader): ReferralData = {


### PR DESCRIPTION
## Why are you doing this?
<!--
Remember, PRs are documentation for future contributors

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->


Currently, 20% of our supporters are recorded as not having a campaign code. This is clearly wrong, as half of these people who come in without a campaign code have a` referer_pageview_id `stored. This `referer_pageview_id` is passed through as a query string parameter, and the only places it is passed through from frontend is on the epic and the banner , so if they have a referer_pageview_id, they must have come through with a campaign code. 

This PR adds the setting of the campaign code cookie to the `makeCookies` funciton in the  `ReferralData` class, where we store a session cookie for `referer_url` and `referer_pageview_id` when they hit the supporter landing page, which is later read when tracking 

This won't fix everything, but it will fix the campaign code reporting for _atleast_ **50%** of these cases, as we have a `referer_pageview_id` for 50% of the people who we don't have a campaign code for, and as mentioned previously, if they have a `referer_pageview_id`, they **must** have come in with a campaign code. For the remaining 50%, we know that over half of them came from the Guardian by looking at the `referer_url`, which we now store (see #1652). This means that they probably came in off one of our other non-epic-or-banner channels, one that doesn't yet pass through the pageview id. Therefore, optimistically this will fix up to **75%** of cases where we don't store the campaign code. 

The result of this change is that we will be able to attribute more of the signups to the channels/tests they came from, which will mean we can run our tests quicker as our conversion rate will go up for these tests, and will give us a clearer picture of our supporter signups. 

Note: there is already some javascript that attempts (and succeeds, most of the time), to set the campaign code cookie. For whatever reason that isn't working. This change is additive in that there is only ever one INTCMP in the url when you hit the page, so we don't have a problem where we could be overwriting the correct campaign code. 

This attempt at setting the cookie happens in `setup.js`, as part of the `setUpAnalytics` function. For whatever reason, this clearly isn't being fired all of the time, or if it is, it the campaign code has been lost by that stage. From looking a little closely, it seems that this relies on the following conditions to be ran: 

`guardian.analyticsEnabled &&
        !isDNT &&
        !cookie.getCookie('ANALYTICS_OFF_KEY')`

where isDNT is ` navigator.doNotTrack == '1' || window.doNotTrack == '1';`

Would be interested in some expert opinion on why that could be, @rtyley @Ap0c @rupertbates ? 

@guardian/contributions 


<!--
If you are making heavy client-side changes, consider manual test the following
critical flow before merging
## Tested in
| Browser | Supporter Stripe checkout | Supporter Paypal checkout | Stripe Monthly Contribution |  Paypal Monthly Contribution| Upgrade from Friend to Supporter  |
|---------|---------------------------|---------------------------|-----------------------------|-----------------------------|-----------------------------------|
| IE      |                           |                           |                             |                             |                                   |
| Firefox |                           |                           |                             |                             |                                   |
| Safari  |                           |                           |                             |                             |                                   |
| Chrome  |                           |                           |                             |                             |                                   |

-->

## Screenshots
