### PR TITLE
Remove cookie init from set up analytics

### DIFF
--- a/frontend/assets/javascripts/src/modules/analytics/setup.js
+++ b/frontend/assets/javascripts/src/modules/analytics/setup.js
@@ -38,7 +38,6 @@ define([
         ophan.init();
         ophan.loaded.then(ga.init,ga.init);
         uet.init();
-        campaignCode.init();
     }
 
     function setupThirdParties() {
@@ -48,6 +47,7 @@ define([
 
     function init() {
 
+        campaignCode.init();
         if (analyticsEnabled) {
             setupAnalytics();
         }


### PR DESCRIPTION
## Why are you doing this?
<!--
Remember, PRs are documentation for future contributors

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

This check is stopping 20% of campaign codes coming through, so we are removing the check for cookies. See https://github.com/guardian/membership-frontend/pull/1670 for detailed explanation 

@guardian/contributions 

## Changes
* Change 1
* Change 2

<!--
If you are making heavy client-side changes, consider manual test the following
critical flow before merging
## Tested in
| Browser | Supporter Stripe checkout | Supporter Paypal checkout | Stripe Monthly Contribution |  Paypal Monthly Contribution| Upgrade from Friend to Supporter  |
|---------|---------------------------|---------------------------|-----------------------------|-----------------------------|-----------------------------------|
| IE      |                           |                           |                             |                             |                                   |
| Firefox |                           |                           |                             |                             |                                   |
| Safari  |                           |                           |                             |                             |                                   |
| Chrome  |                           |                           |                             |                             |                                   |

-->

## Screenshots
