### PR TITLE
Ensure that only UK can see the benefits about a weekly look inside the Guardain

### DIFF
--- a/frontend/app/views/info/supporter.scala.html
+++ b/frontend/app/views/info/supporter.scala.html
@@ -56,9 +56,11 @@
                         <li class="elevated-closer-guardian-body__list_item">
                             An ad-free experience on our mobile app
                         </li>
-                        <li class="elevated-closer-guardian-body__list_item">
-                            A weekly look "Inside the Guardian" for our Members
-                        </li>
+                        @if(countryGroup.name == "UK") {
+                            <li class="elevated-closer-guardian-body__list_item">
+                                A weekly look "Inside the Guardian" for our Members
+                            </li>
+                        }
                         <li class="elevated-closer-guardian-body__list_item">
                             Joining the global Guardian Members community
                         </li>


### PR DESCRIPTION
## Why are you doing this?
<!--
Remember, PRs are documentation for future contributors

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

Because we have decided not to promote this benefit outside the UK. 


<!--
If you are making heavy client-side changes, consider manual test the following
critical flow before merging
## Tested in
| Browser | Supporter Stripe checkout | Supporter Paypal checkout | Stripe Monthly Contribution |  Paypal Monthly Contribution| Upgrade from Friend to Supporter  |
|---------|---------------------------|---------------------------|-----------------------------|-----------------------------|-----------------------------------|
| IE      |                           |                           |                             |                             |                                   |
| Firefox |                           |                           |                             |                             |                                   |
| Safari  |                           |                           |                             |                             |                                   |
| Chrome  |                           |                           |                             |                             |                                   |

-->

## Screenshots

UK: 
![uk](https://user-images.githubusercontent.com/2844554/27088751-7b7c9732-5050-11e7-96d6-8fb6e15c0d14.png)

Everywhere else:
![int](https://user-images.githubusercontent.com/2844554/27088753-7bc0f58a-5050-11e7-9038-548013200656.png)

@guardian/contributions 
