### PR TITLE
Record CMP for supporters

### DIFF
--- a/frontend/assets/javascripts/src/modules/analytics/campaignCode.es6
+++ b/frontend/assets/javascripts/src/modules/analytics/campaignCode.es6
@@ -25,7 +25,7 @@ function recordCampaign () {
 	} catch (ex) {
 		console.log('Failed to retrieve campaign code:', ex.message);
 	} finally {
-        var campaignCode = intcmp || cmp;
+        let campaignCode = intcmp || cmp;
 		if (campaignCode) {
 			setCookie('mem_campaign_code', campaignCode);
 		}

--- a/frontend/assets/javascripts/src/modules/analytics/campaignCode.es6
+++ b/frontend/assets/javascripts/src/modules/analytics/campaignCode.es6
@@ -10,19 +10,22 @@ import URLSearchParams from 'URLSearchParams';
 // Checks the querystring for INTCMP (internal campaign) and records in cookie.
 function recordCampaign () {
 
-	let campaignCode;
+	let intcmp;
+    let cmp;
 
 	// Don't want JS to break if there is a problem reading query params.
 	// Just don't set the cookie if this happens.
 	try {
 
 		let urlParams = new URLSearchParams(window.location.search.slice(1));
-		campaignCode = urlParams.get('INTCMP');
+		intcmp = urlParams.get('INTCMP');
+        cmp = urlParams.get('CMP');
+
 
 	} catch (ex) {
 		console.log('Failed to retrieve campaign code:', ex.message);
 	} finally {
-
+        var campaignCode = intcmp || cmp;
 		if (campaignCode) {
 			setCookie('mem_campaign_code', campaignCode);
 		}


### PR DESCRIPTION
## Why are you doing this?
<!--
Remember, PRs are documentation for future contributors

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

Currently, any campaign code that is passed through as CMP instead of INTCMP, doesn't get recorded. This is often used for email campaigns. This PR makes sure that we check for CMP codes when there isn't an INTCMP provided. 

## Trello card: [Here](https://trello.com)

## Changes
* Change 1
* Change 2

<!--
If you are making heavy client-side changes, consider manual test the following
critical flow before merging
## Tested in
| Browser | Supporter Stripe checkout | Supporter Paypal checkout | Stripe Monthly Contribution |  Paypal Monthly Contribution| Upgrade from Friend to Supporter  |
|---------|---------------------------|---------------------------|-----------------------------|-----------------------------|-----------------------------------|
| IE      |                           |                           |                             |                             |                                   |
| Firefox |                           |                           |                             |                             |                                   |
| Safari  |                           |                           |                             |                             |                                   |
| Chrome  |                           |                           |                             |                             |                                   |

-->

## Screenshots
