### PR TITLE
Rename bundle price test and cookie

### DIFF
--- a/frontend/app/abtests/BundleVariant.scala
+++ b/frontend/app/abtests/BundleVariant.scala
@@ -63,9 +63,9 @@ object Distribution {
   val VARIANT = Distribution("MEMBERSHIP_A_ADX_THRASHER_UK_VARIANT")
   val PDCPRE = Distribution("MEMBERSHIP_A_PDCOM_PRE")
   val PDCPOST = Distribution("MEMBERSHIP_A_PDCOM_POST")
-  val DIGIPRICE1A = Distribution("BUNDLE_PRICE_TEST_1M_UK_A")
-  val DIGIPRICE1B = Distribution("BUNDLE_PRICE_TEST_1M_UK_B")
-  val DIGIPRICE1C = Distribution("BUNDLE_PRICE_TEST_1M_UK_C")
+  val DIGIPRICE1A = Distribution("BUNDLE_PRICE_TEST_1M_E_UK_A")
+  val DIGIPRICE1B = Distribution("BUNDLE_PRICE_TEST_1M_E_UK_B")
+  val DIGIPRICE1C = Distribution("BUNDLE_PRICE_TEST_1M_E_UK_C")
 }
 
 case class Distribution(name: String)

--- a/frontend/assets/javascripts/src/modules/landingBundles.es6
+++ b/frontend/assets/javascripts/src/modules/landingBundles.es6
@@ -18,7 +18,7 @@ const SEE_MORE_CTA = document.querySelector(SEE_MORE_CTA_SELECTOR);
 const PRINT_OPTIONS = document.querySelectorAll(PRINT_OPTIONS_SELECTOR);
 const PRINT_CTA = document.querySelector(PRINT_CTA_SELECTOR);
 const COMMIT_CTAS = document.querySelectorAll(COMMIT_BUTTON_SELECTOR);
-const COMMIT_COOKIE_NAME = 'GU_DBPT1M';
+const COMMIT_COOKIE_NAME = 'GU_DBPT1ME';
 const COMMIT_COOKIE_DAYS = 30;
 
 const cookieDomain = () => {


### PR DESCRIPTION
## Why are you doing this?
As described in https://github.com/guardian/frontend/pull/17179, if we don't change the test name, the audience that had been participating in that test would remain 'opted in' when we activate the new epic-driven version, leading to a consumption of 35% of audience, not the 10% intended.

This change alters the name of the test and of the cookie that is dropped at the point of purchase intent (buy the digital pack or make a donation) to end that reader's participation in the test. 

## Trello card: [move-bundle-price-test-from-thrasher-driven-to-epic-driven](https://trello.com/c/BxPeP62X/599-move-bundle-price-test-from-thrasher-driven-to-epic-driven)

## Screenshots
To follow
