### PR TITLE
Removing the thankyou page survey

### DIFF
--- a/frontend/app/views/joiner/thankyou.scala.html
+++ b/frontend/app/views/joiner/thankyou.scala.html
@@ -148,17 +148,6 @@
 
         <section class="page-section page-section--bordered">
             <div class="page-section__lead-in">
-                <h2 class="page-section__headline">Before you go...</h2>
-            </div>
-            <div class="page-section__content">
-                <p>...we would love to know a little bit more about your decision to support us.
-                    We have a few questions that should take only a couple of minutes to complete.</p>
-                <a class="action" href="https://www.surveymonkey.co.uk/r/J6Q2MX8">Share your thoughts</a>
-            </div>
-        </section>
-
-        <section class="page-section page-section--bordered">
-            <div class="page-section__lead-in">
                 <h2 class="page-section__headline">Tell your friends</h2>
             </div>
             <div class="page-section__content">


### PR DESCRIPTION
## Why are you doing this?
<!--
Remember, PRs are documentation for future contributors

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->
This removes the thank you page survey (added here https://github.com/guardian/membership-frontend/pull/1662) 👋 

Look, No survey! --v
<img width="984" alt="screen shot 2017-06-19 at 11 17 12" src="https://user-images.githubusercontent.com/1289259/27280739-f5df067e-54e0-11e7-8b21-e33cfa2a07d8.png">


@guardian/contributions 