### PR TITLE
Focus Masterclasses SEO on DotCom rather than Membership

### DIFF
--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -5,6 +5,7 @@ Disallow: /whats-on
 Disallow: /join-challenger
 Disallow: /bundles
 Disallow: /monthly-contribution
+Disallow: /masterclasses
 
 Allow: /
 


### PR DESCRIPTION
## Why are you doing this?

Currently we have 2 different event-listing pages for every Masterclasses event. E.g for this event:

* https://www.theguardian.com/guardian-masterclasses/2015/sep/18/how-to-use-instagram-to-build-your-brand-julie-falconer-digital-business-course1
* https://membership.theguardian.com/event/how-to-use-instagram-to-build-your-brand-31962993173

This splits Google Page ranking between the two pages - ideally we would only have one page. If you search [`instagram class guardian`](https://www.google.co.uk/search?q=instagram+guardian+class&oq=instagram+guardian+class&aqs=chrome..69i57.4895j0j1&sourceid=chrome&ie=UTF-8) you currently get the Membership page as the top result.

Unfortunately, this isn't the page Masterclasses would prefer users to see- the Membership page forces users to become members before booking, and that obviously reduces take up. Sherri Jordan (Direct marketing manager - Biddable, Extensions) asked if we could stop search engines from indexing the Membership pages. I had a quick chat with Kirsty Buck (Head of programming, learning) and she confirmed that they don't want that impedance.

## Changes

Remove the Masterclasses index page (https://membership.theguardian.com/masterclasses) from sites indexed by search engines, which should also hopefully stop event pages under Masterclasses from getting indexed.
