### PR TITLE
adds cloudwatch tracking for contributions payments

### DIFF
--- a/frontend/app/monitoring/ContributorMetrics.scala
+++ b/frontend/app/monitoring/ContributorMetrics.scala
@@ -11,31 +11,31 @@ class ContributorMetrics(val backendEnv: String) extends TouchpointBackendMetric
 
   val service = "Contributor"
 
-  def putAttemptedSignUp: Unit ={
+  def putAttemptedSignUp: Unit = {
     put(s"contributor-attempted-sign-up")
   }
 
-  def putSignUp: Unit ={
+  def putSignUp: Unit = {
     put(s"contributor-sign-up")
   }
 
-  def putThankYou: Unit ={
+  def putThankYou: Unit = {
     put(s"contributor-sign-up-thank-you")
   }
 
-  def putFailSignUp: Unit ={
+  def putFailSignUp: Unit = {
     put(s"contributor-failed-sign-up")
   }
 
-  def putFailSignUpGatewayError: Unit ={
+  def putFailSignUpGatewayError: Unit = {
     put(s"contributor-failed-sign-up-gateway-error")
   }
 
-  def putFailSignUpStripe: Unit ={
+  def putFailSignUpStripe: Unit = {
     put(s"contributor-failed-sign-up-stripe")
   }
 
-  private def put(metricName: String) {
+  private def put(metricName: String): Unit = {
     put(metricName, 1)
   }
 }

--- a/frontend/app/monitoring/ContributorMetrics.scala
+++ b/frontend/app/monitoring/ContributorMetrics.scala
@@ -1,0 +1,41 @@
+package monitoring
+
+import com.gu.salesforce.Tier
+import com.gu.zuora.soap.models.Commands.PaymentMethod
+import com.amazonaws.services.cloudwatch.model.Dimension
+import com.gu.memsub.subsv2.SubscriptionPlan
+import controllers.Subscription
+import model.{ContributionPlanChoice, PlanChoice}
+
+class ContributorMetrics(val backendEnv: String) extends TouchpointBackendMetrics {
+
+  val service = "Contributor"
+
+  def putAttemptedSignUp: Unit ={
+    put(s"contributor-attempted-sign-up")
+  }
+
+  def putSignUp: Unit ={
+    put(s"contributor-sign-up")
+  }
+
+  def putThankYou: Unit ={
+    put(s"contributor-sign-up-thank-you")
+  }
+
+  def putFailSignUp: Unit ={
+    put(s"contributor-failed-sign-up")
+  }
+
+  def putFailSignUpGatewayError: Unit ={
+    put(s"contributor-failed-sign-up-gateway-error")
+  }
+
+  def putFailSignUpStripe: Unit ={
+    put(s"contributor-failed-sign-up-stripe")
+  }
+
+  private def put(metricName: String) {
+    put(metricName, 1)
+  }
+}

--- a/frontend/app/services/SalesforceService.scala
+++ b/frontend/app/services/SalesforceService.scala
@@ -8,7 +8,7 @@ import dispatch.Defaults.timer
 import dispatch._
 import forms.MemberForm.{CommonForm, JoinForm, MonthlyContributorForm}
 import model.GenericSFContact
-import monitoring.MemberMetrics
+import monitoring.{ContributorMetrics, MemberMetrics}
 import play.api.Play.current
 import play.api.libs.concurrent.Akka
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
@@ -28,12 +28,16 @@ class SalesforceService(salesforceConfig: SalesforceConfig) extends api.Salesfor
 
   val metricsVal = new MemberMetrics(salesforceConfig.envName)
 
+  val contributorMetricsVal = new ContributorMetrics(salesforceConfig.envName)
+
   private val repository = new SimpleContactRepository(salesforceConfig, system.scheduler, "membership")
 
   override def getMember(userId: UserId): Future[Option[GenericSFContact]] =
     repository.get(userId)
 
   override def metrics = metricsVal
+
+  override def contributorMetrics = contributorMetricsVal
 
   override def upsert(user: IdUser, joinData: CommonForm): Future[ContactId] =
     upsert(user.id, initialData(user, joinData))

--- a/frontend/app/services/api/SalesforceService.scala
+++ b/frontend/app/services/api/SalesforceService.scala
@@ -5,7 +5,7 @@ import com.gu.salesforce.{ContactId, Tier}
 import com.gu.stripe.Stripe.Customer
 import forms.MemberForm.{CommonForm, JoinForm}
 import model.GenericSFContact
-import monitoring.MemberMetrics
+import monitoring.{ContributorMetrics, MemberMetrics}
 import services.FrontendMemberRepository.UserId
 
 import scala.concurrent.Future
@@ -13,6 +13,7 @@ import scala.concurrent.Future
 trait SalesforceService {
   def getMember(userId: UserId): Future[Option[GenericSFContact]]
   def metrics: MemberMetrics
+  def contributorMetrics: ContributorMetrics
   def upsert(user: IdUser, userData: CommonForm): Future[ContactId]
   def updateMemberStatus(user: IdMinimalUser, tier: Tier, customer: Option[Customer]): Future[ContactId]
   def isAuthenticated: Boolean


### PR DESCRIPTION
## Why are you doing this?
This is so that we can start to track payment attempt vs completion on contributions

## Changes
Add cloudwatch metrics for payment attempt, payment success and payment failure
