### PR TITLE
Fix Stripe Error Option Type

### DIFF
--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -265,13 +265,13 @@ object Joiner extends Controller with ActivityTracking with PaymentGatewayErrorH
 
         case error: PaymentGatewayError =>
           salesforceService.metrics.putFailSignUpGatewayError(tier)
-          setBehaviourNote(tier.name, error.code, userOpt)
+          setBehaviourNote(tier.name, Some(error.code), userOpt)
           handlePaymentGatewayError(error, user.id, tier.name, formData.deliveryAddress.countryName)
 
         case error =>
           salesforceService.metrics.putFailSignUp(tier)
           logger.error(s"${s"User id=${userOpt.map(_.id).mkString}"} could not become ${tier.name} member", error)
-          setBehaviourNote(tier.name, "card_error", userOpt)
+          setBehaviourNote(tier.name, Some("card_error"), userOpt)
           Forbidden
       }
     }
@@ -312,9 +312,9 @@ object Joiner extends Controller with ActivityTracking with PaymentGatewayErrorH
 
   def thankyouStaff = thankyou(Tier.partner)
 
-  private def setBehaviourNote(tier: String, errorCode: String, userOpt: Option[AuthenticatedIdUser]) = for (user <- userOpt) {
+  private def setBehaviourNote(tier: String, errorCode: Option[String], userOpt: Option[AuthenticatedIdUser]) = for (user <- userOpt) {
     if (tier.toLowerCase == "supporter") {
-      MembersDataAPI.Service.upsertBehaviour(user, note = Some(errorCode))
+      MembersDataAPI.Service.upsertBehaviour(user, note = errorCode)
     }
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "8.0.3"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.9" // v0.9 is the latest version published for Play 2.4...
-  val membershipCommon = "com.gu" %% "membership-common" % "0.418"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.425"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playFilters = PlayImport.filters


### PR DESCRIPTION
## Why are you doing this?

[Changes](https://github.com/guardian/membership-common/pull/493) in membership-common converted Stripe errors from a `String` to an `Option[String]`. The code in `Joiner.scala` is expecting a `String`, and thus bumping membership-common resulted in failing builds, as in #1679.

This changes `setBehaviourNote` to expect an `Option[String]` instead, and tweaks the calls in `Joiner.scala` to reflect that.

**Note:** I've bumped membership-common to the latest version here. Running through the checkout flow seems to work ok, but if anyone can think of any recent changes that might cause issues please let me know (@rupertbates @AWare @paulbrown1982 @alexduf).

## Changes

- Bump membership-common to 0.425.
- Switch to using an `Option[String]` instead of a `String` for error messages.
