### PR TITLE
Setup bundle variants for engagement banner-based price test

### DIFF
--- a/frontend/app/abtests/BundleVariant.scala
+++ b/frontend/app/abtests/BundleVariant.scala
@@ -18,7 +18,10 @@ object BundleVariant {
     BundleVariant(DIGIPRICE1C, Map((Supporter, 6.5), (DigitalPack, 9.99), (Saturday, 18), (GuardianWeekly, 18), (Weekend, 25), (SatGW, 25), (SixDay, 45), (SevenDay, 50)), hasAdFree = true, hasPaidComments = false, hasContributions = true, hasDigital = true, hasPrintAndDigital = false),
     BundleVariant(DIGIPRICE1TA, Map((Supporter, 6.5), (DigitalPack, 11.99), (Saturday, 18), (GuardianWeekly, 18), (Weekend, 25), (SatGW, 25), (SixDay, 45), (SevenDay, 50)), hasAdFree = true, hasPaidComments = false, hasContributions = true, hasDigital = true, hasPrintAndDigital = false),
     BundleVariant(DIGIPRICE1TB, Map((Supporter, 6.5), (DigitalPack, 14.99), (Saturday, 18), (GuardianWeekly, 18), (Weekend, 25), (SatGW, 25), (SixDay, 45), (SevenDay, 50)), hasAdFree = true, hasPaidComments = false, hasContributions = true, hasDigital = true, hasPrintAndDigital = false),
-    BundleVariant(DIGIPRICE1TC, Map((Supporter, 6.5), (DigitalPack, 9.99), (Saturday, 18), (GuardianWeekly, 18), (Weekend, 25), (SatGW, 25), (SixDay, 45), (SevenDay, 50)), hasAdFree = true, hasPaidComments = false, hasContributions = true, hasDigital = true, hasPrintAndDigital = false)
+    BundleVariant(DIGIPRICE1TC, Map((Supporter, 6.5), (DigitalPack, 9.99), (Saturday, 18), (GuardianWeekly, 18), (Weekend, 25), (SatGW, 25), (SixDay, 45), (SevenDay, 50)), hasAdFree = true, hasPaidComments = false, hasContributions = true, hasDigital = true, hasPrintAndDigital = false),
+    BundleVariant(DIGIPRICE1BA, Map((Supporter, 6.5), (DigitalPack, 11.99), (Saturday, 18), (GuardianWeekly, 18), (Weekend, 25), (SatGW, 25), (SixDay, 45), (SevenDay, 50)), hasAdFree = true, hasPaidComments = false, hasContributions = true, hasDigital = true, hasPrintAndDigital = false),
+    BundleVariant(DIGIPRICE1BB, Map((Supporter, 6.5), (DigitalPack, 14.99), (Saturday, 18), (GuardianWeekly, 18), (Weekend, 25), (SatGW, 25), (SixDay, 45), (SevenDay, 50)), hasAdFree = true, hasPaidComments = false, hasContributions = true, hasDigital = true, hasPrintAndDigital = false),
+    BundleVariant(DIGIPRICE1BC, Map((Supporter, 6.5), (DigitalPack, 9.99), (Saturday, 18), (GuardianWeekly, 18), (Weekend, 25), (SatGW, 25), (SixDay, 45), (SevenDay, 50)), hasAdFree = true, hasPaidComments = false, hasContributions = true, hasDigital = true, hasPrintAndDigital = false)
   )
 
   def lookup(name: String): Option[BundleVariant] = {
@@ -74,6 +77,10 @@ object Distribution {
   val DIGIPRICE1TA = Distribution("BUNDLE_PRICE_TEST_1M_T_UK_A")
   val DIGIPRICE1TB = Distribution("BUNDLE_PRICE_TEST_1M_T_UK_B")
   val DIGIPRICE1TC = Distribution("BUNDLE_PRICE_TEST_1M_T_UK_C")
+  // banner variants
+  val DIGIPRICE1BA = Distribution("BUNDLE_PRICE_TEST_1M_B_UK_A")
+  val DIGIPRICE1BB = Distribution("BUNDLE_PRICE_TEST_1M_B_UK_B")
+  val DIGIPRICE1BC = Distribution("BUNDLE_PRICE_TEST_1M_B_UK_C")
 }
 
 case class Distribution(name: String)

--- a/frontend/app/views/fragments/bundle/bundleThankYouExplainer.scala.html
+++ b/frontend/app/views/fragments/bundle/bundleThankYouExplainer.scala.html
@@ -17,7 +17,7 @@
             <p><a href="/uk?INTCMP=@bundleVariant.testId">Subscribing to our current digital pack</a></p>
         </li>
         <li>
-            <p><a href="/uk?INTCMP=@bundleVariant.testId">Making a one-off or regular contribution</a></p>
+            <p><a href="/uk?INTCMP=@bundleVariant.testId">Making a contribution</a></p>
         </li>
     </ul>
     <p>Or you can <a href="https://www.theguardian.com">return to the front page to continue reading</a></p>


### PR DESCRIPTION
## Why are you doing this?
We're planning to utilise the engagement banner to drive traffic to the bundle price test. This sets up the additional variants needed to respond to the new campaign codes.

I also used this opportunity to remove the reference to making a regular contribution.

## Trello card: [667-set-up-bundles-landing-page-to-accept-campaign-code-from-engagement-banner-driven-price-test](https://trello.com/c/E0mXe3Tf/667-set-up-bundles-landing-page-to-accept-campaign-code-from-engagement-banner-driven-price-test)

## Screenshots
See the Trello card

cc @svillafe @rupertbates @davidfurey 