### PR TITLE
Add social-signin buttons to merged-checkout

### DIFF
--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -44,6 +44,12 @@ object Config {
 
   private val idSkipConfirmation: (String, String) = "skipConfirmation" -> "true"
 
+  def googleSigninUrl = oauthWebAppSigninUrl("google")(_)
+  def facebookSigninUrl = oauthWebAppSigninUrl("facebook")(_)
+
+  private def oauthWebAppSigninUrl(socialProvider: String)(uri: String): String =
+    ("https://oauth.theguardian.com" / socialProvider / "signin") ? ("returnUrl" -> s"$membershipUrl$uri") & idSkipConfirmation & idMember
+
   def idWebAppSigninUrl(uri: String): String =
     (idWebAppUrl / "signin") ? ("returnUrl" -> s"$membershipUrl$uri") & idSkipConfirmation & idMember
 

--- a/frontend/app/views/fragments/joiner/signIn.scala.html
+++ b/frontend/app/views/fragments/joiner/signIn.scala.html
@@ -1,6 +1,18 @@
+@import configuration.Config.googleSigninUrl
+@import configuration.Config.facebookSigninUrl
 @(returnUri: String)
 
-@import configuration.Config.idWebAppSigninUrl
+<div class="text-note">
+<p >Create a new Guardian account, or sign-in</p>
 
-<p class="text-note">Already have a Guardian account? <a class="s-prose" href="@idWebAppSigninUrl(returnUri)" class="text-link">Sign in</a>
-</p>
+<div class="action-group">
+    <a class="action action--slim action--no-icon signin-facebook" href="@facebookSigninUrl(returnUri)">
+        Facebook
+        @fragments.actionIcon("share-facebook")
+    </a>
+    <a class="action action--slim action--no-icon signin-gplus" href="@googleSigninUrl(returnUri)">
+        Google
+        @fragments.actionIcon("share-gplus")
+    </a>
+</div>
+</div>

--- a/frontend/assets/stylesheets/_vars.scss
+++ b/frontend/assets/stylesheets/_vars.scss
@@ -85,6 +85,7 @@ $c-flash-success-background: #faffe5;
 // Thirdparty
 $c-thirdparty-twitter: #55acee;
 $c-thirdparty-facebook: #3b5998;
+$c-thirdparty-gplus: #da4f49;
 
 /**
  * Clip paths are used for shape cuts and

--- a/frontend/assets/stylesheets/components/_payment-paypal.scss
+++ b/frontend/assets/stylesheets/components/_payment-paypal.scss
@@ -264,6 +264,33 @@
     }
 
     /* ==========================================================================
+       Social sign-in: buttons
+       ========================================================================== */
+
+    .signin-facebook {
+        background-color: $c-thirdparty-facebook;
+        border-color: $c-thirdparty-facebook;
+    }
+
+    .signin-facebook {
+        &:hover {
+            background-color: darken($c-thirdparty-facebook, 10);
+        }
+    }
+
+    .signin-gplus {
+        background-color: $c-thirdparty-gplus;
+        border-color: $c-thirdparty-gplus;
+    }
+
+    .signin-gplus {
+        &:hover {
+            background-color: darken($c-thirdparty-gplus, 10);
+        }
+    }
+
+
+    /* ==========================================================================
        Forms: Buttons
        ========================================================================== */
 


### PR DESCRIPTION
## Why are you doing this?

The initial Merged-Registration test [indicated that merging registration damaged conversion](https://github.com/guardian/membership-frontend/pull/1654), and we've made various improvements in the hope that we can get a positive result instead! The final change before turning on a new A/B test is to add the social-sign-in buttons which were missing from the previous merged-registration experience - we found that about a third of users who come to our normal checkout page have used social-sign-in to login.

These buttons won't be visible to the general public yet, as there's no active AB test running, but you'll be able to review them by turning on the merged-registration feature:

https://membership.theguardian.com/feature/MergedRegistration/On

The oauth links are hard-coded to production, as I haven't had time to get the [Identity OAuth application](https://github.com/guardian/identity-federation-api) running in dev- we'll test them in prod!

## Trello card: [Here](https://trello.com/c/3ger5ZML/663-complete-work-on-merged-registration-checkout)

## Screenshots

![image](https://user-images.githubusercontent.com/52038/27744716-8462c6ee-5db8-11e7-961a-2a1163622cf1.png)
![image](https://user-images.githubusercontent.com/52038/27744738-9f7b86be-5db8-11e7-8e8f-78ecfd450dd6.png)

If anyone thinks they can do a better layout for the social-sign-in buttons, please go ahead, this was the best I could do with my limited css layout abilities.