### PR TITLE
Make Monthly Contributions More Yellow

### DIFF
--- a/frontend/assets/stylesheets/components/_payment-monthly-contribution.scss
+++ b/frontend/assets/stylesheets/components/_payment-monthly-contribution.scss
@@ -1,5 +1,13 @@
 
 .skin-monthly-contribution {
+    background-color: guss-colour(multimedia-main-2);
+
+    &:after {
+        height: 30vh;
+        width: 100%;
+        background-color: guss-colour(multimedia-main-2);
+    }
+
     .sign-in-required .text-note {
         margin: 0;
     }


### PR DESCRIPTION
## Why are you doing this?

There is a concern that the current checkout page looks a bit broken, which could cause drop-offs where payments are concerned. This makes the whole monthly contributions checkout page yellow, instead of just the box in the middle. It brings it more into line with the equivalent page in support frontend [here](https://github.com/guardian/support-frontend/pull/83), which will eventually supersede the page in membership. It will also keep @superfrank happy 🐧.

## Changes

- Made the area surrounding the checkout form yellow.
- Added a hacky after pseudo-element, to make the previously white section further down the page also appear yellow.

## Screenshots

**Before:**

![old-checkout](https://user-images.githubusercontent.com/5131341/27827614-0753a7cc-60b0-11e7-8f8f-565d90babe39.png)

**After:**

![new-checkout](https://user-images.githubusercontent.com/5131341/27827622-0f086a20-60b0-11e7-9b97-582bae188038.png)
