### PR TITLE
Limit Max Monthly Contributions

### DIFF
--- a/frontend/app/views/joiner/form/monthlyContribution.scala.html
+++ b/frontend/app/views/joiner/form/monthlyContribution.scala.html
@@ -103,7 +103,7 @@
                                 <label class="label" for="monthly-contribution">Your monthly contribution</label>
                                 <input type="hidden" name="payment.amount" id="monthly-contribution" value="@contributionValue" data-validation="validContributionValue"/>
                                 <span class="monthly-contribution__amount">£@contributionValue</span>
-                                @fragments.form.errorMessage("The minimum monthly contribution is £5.")
+                                @fragments.form.errorMessage("Sorry, we are only able to accept contributions of £5-£2000")
                             </div>
 
                             <!-- Payment Options -->

--- a/frontend/assets/javascripts/src/modules/form/validation/validationProfiles.js
+++ b/frontend/assets/javascripts/src/modules/form/validation/validationProfiles.js
@@ -13,7 +13,8 @@ define([
      * @returns {*}
      */
     var validContributionValue = function (contributionElem) {
-        return parseFloat(contributionElem.value) >= 5;
+        var contribValue = parseFloat(contributionElem.value);
+        return contribValue >= 5 && contribValue <= 2000;
     };
 
     /**


### PR DESCRIPTION
## Why are you doing this?

We can only take contributions up to £2000.

## Changes

- Updated the monthly contribution validation profile to include a top limit of £2000.
- Updated the error message to include the contribution range.

## Screenshots

**Too Much:**

URL: https://membership.theguardian.com/monthly-contribution?contributionValue=2001

![too-much](https://user-images.githubusercontent.com/5131341/27912280-3a7b53e8-6254-11e7-9589-601c62ec3970.png)

**Too Little:**

URL: https://membership.theguardian.com/monthly-contribution?contributionValue=2

![too-little](https://user-images.githubusercontent.com/5131341/27912289-40bec492-6254-11e7-851e-cca1f3d251e3.png)