### PR TITLE
Reinstate AB test for Merged Registration

### DIFF
--- a/frontend/app/abtests/ABTest.scala
+++ b/frontend/app/abtests/ABTest.scala
@@ -53,7 +53,9 @@ object ABTest {
 
   val CookieAge = ofDays(365).getSeconds.toInt
 
-  lazy val allTests: Set[ABTest] = Set()
+  lazy val allTests: Set[ABTest] = Set(
+    MergedSocialRegistration
+  )
 
   def allocations(request: Request[_]): Map[ABTest, BaseVariant] = (for {
     test <- allTests

--- a/frontend/app/abtests/MergedSocialRegistration.scala
+++ b/frontend/app/abtests/MergedSocialRegistration.scala
@@ -1,0 +1,18 @@
+package abtests
+
+import abtests.AudienceRange.FullAudience
+import services.AuthenticationService.authenticatedIdUserProvider
+
+case object MergedSocialRegistration extends ABTest(
+  "merged-social-registration",
+  FullAudience,
+  req => req.path.startsWith("/join/supporter/enter-details") && authenticatedIdUserProvider(req).isEmpty
+) {
+
+  case class Variant(slug: String, canWaiveAuth: Boolean) extends BaseVariant
+
+  val variants = Seq(
+    Variant("control", canWaiveAuth = false),
+    Variant("merged",  canWaiveAuth = true)
+  )
+}


### PR DESCRIPTION
## Why are you doing this?

This is a redo of the AB test created in PR #1631, but this time with social-sign-in icons as refined in PR #1687.

## Trello card: [Here](https://trello.com/c/3ger5ZML/663-complete-work-on-merged-registration-checkout)

## Changes
I've tweaked the `canRun` for the AB test so that it only activates for non-signed-in users (because the experience does not vary for signed-in users). The AB test cookie will only get dropped for non-signed-in cookies, and will persist for those users. So this test is measuring the conversion of people who have either:

* *control* variant: always been forced to profile.theguardian.com/register
* *merged* variant : seen the merged-registration page at membership.theguardian.com/join/supporter/enter-details?ab.merged-social-registration=merged at least once
