### PR TITLE
Update membership common

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "8.0.3"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.9" // v0.9 is the latest version published for Play 2.4...
-  val membershipCommon = "com.gu" %% "membership-common" % "0.427"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.431"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playFilters = PlayImport.filters


### PR DESCRIPTION
## Why are you doing this?
* To keep membership-common up to date.
* To resolve a customer issue, by re-introducing the missing US Armed Forces states added here: https://github.com/guardian/membership-common/pull/506

## Trello card: 
N/A

## Changes
* Updates membership-common to the latest version.

## Testing
* Ran through sign-up flow for Supporter (selecting one of the Armed Forces states for Delivery Address)

## Screenshots

![image](https://user-images.githubusercontent.com/19384074/28260081-59f9e8ee-6ad1-11e7-90eb-5288b4d23c60.png)
