### PR TITLE
update membership common to better report sf lookup errors

### DIFF
--- a/frontend/app/actions/package.scala
+++ b/frontend/app/actions/package.scala
@@ -4,6 +4,7 @@ import com.gu.memsub.Subscriber.{FreeMember, Member, PaidMember}
 import com.gu.memsub.subsv2.{Subscription, SubscriptionPlan}
 import com.gu.salesforce._
 import com.gu.memsub.util.Timing
+import model.GenericSFContact
 import monitoring.MemberAuthenticationMetrics
 import play.api.mvc.Security.AuthenticatedRequest
 import play.api.mvc.{Cookie, Request, WrappedRequest}
@@ -24,11 +25,11 @@ package object actions {
   implicit class RichAuthRequest[A](req: AuthRequest[A]) extends BackendProvider {
     lazy val touchpointBackend = TouchpointBackend.forUser(req.user)
 
-    def forMemberOpt[T](f: Option[Contact] => T)(implicit executor: ExecutionContext): Future[T] =
+    def forMemberOpt(implicit executor: ExecutionContext): Future[String \/ Option[GenericSFContact]] =
       Timing.record(MemberAuthenticationMetrics, s"${req.method} ${req.path}") {
         for {
           memberOpt <- touchpointBackend.salesforceService.getMember(req.user.id)
-        } yield f(memberOpt)
+        } yield memberOpt
       }
     }
 

--- a/frontend/app/services/SalesforceService.scala
+++ b/frontend/app/services/SalesforceService.scala
@@ -17,6 +17,7 @@ import services.FrontendMemberRepository._
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import scalaz.\/
 
 object FrontendMemberRepository {
   type UserId = String
@@ -32,7 +33,7 @@ class SalesforceService(salesforceConfig: SalesforceConfig) extends api.Salesfor
 
   private val repository = new SimpleContactRepository(salesforceConfig, system.scheduler, "membership")
 
-  override def getMember(userId: UserId): Future[Option[GenericSFContact]] =
+  override def getMember(userId: UserId): Future[String \/ Option[GenericSFContact]] =
     repository.get(userId)
 
   override def metrics = metricsVal

--- a/frontend/app/services/api/SalesforceService.scala
+++ b/frontend/app/services/api/SalesforceService.scala
@@ -9,9 +9,10 @@ import monitoring.{ContributorMetrics, MemberMetrics}
 import services.FrontendMemberRepository.UserId
 
 import scala.concurrent.Future
+import scalaz.\/
 
 trait SalesforceService {
-  def getMember(userId: UserId): Future[Option[GenericSFContact]]
+  def getMember(userId: UserId): Future[String \/ Option[GenericSFContact]]
   def metrics: MemberMetrics
   def contributorMetrics: ContributorMetrics
   def upsert(user: IdUser, userData: CommonForm): Future[ContactId]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "8.0.3"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.9" // v0.9 is the latest version published for Play 2.4...
-  val membershipCommon = "com.gu" %% "membership-common" % "0.431"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.432"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playFilters = PlayImport.filters


### PR DESCRIPTION
## Why are you doing this?
We would like to have a better idea when things go wrong with salesforce lookup.  At the moment, regardless of what happens, memberhship common will return a None for lookup found no user or lookup had an error.  This was hindering our ability to find out why users were not getting their membership fulfilled by members-data-api.

As a result, I have updated membership-common to return an Either where the left is an error, and the right is an Option of whether the user existed.

This PR pulls those changes into membership.

@pvighi check it out!