### PR TITLE
don't log scheduled task success message as error

### DIFF
--- a/frontend/app/monitoring/HealthMonitoringTask.scala
+++ b/frontend/app/monitoring/HealthMonitoringTask.scala
@@ -74,7 +74,7 @@ object Scheduler extends StrictLogging {
     system.scheduler.schedule(initialDelay, interval) {
       task.task().onComplete {
         case Success(t) =>
-          logger.error(s"Scheduled task $task.name succeeded. This task will retry in: $interval")
+          logger.info(s"Scheduled task $task.name succeeded. This task will repeat in: $interval")
         case Failure(e) =>
           logger.error(s"Scheduled task $task.name failed due to: $e. This task will retry in: $interval")
       }


### PR DESCRIPTION
## Why are you doing this?
in the previous PR I slipped in a logger.error on the happy path.  This upsets sentry a lot, which panics.
For further info, see https://github.com/guardian/membership-frontend/pull/1702/files#r129042332
@jacobwinch 