### PR TITLE
make snowplow emitter a singleton so it doesn't leak http async pools

### DIFF
--- a/frontend/app/tracking/ActivityTracking.scala
+++ b/frontend/app/tracking/ActivityTracking.scala
@@ -307,17 +307,19 @@ trait ActivityTracking {
     }
   }
 
-  private def getTracker: Tracker = {
-    val emitter = new Emitter(ActivityTracking.url, HttpMethod.GET)
-    emitter.setRequestMethod(RequestMethod.Asynchronous)
-    val subject = new Subject
-    new Tracker(emitter, subject, "membership", "membership-frontend")
-  }
+  def getTracker: Tracker = ActivityTracking.getTracker
 
 }
 
 object ActivityTracking {
   val url = Config.trackerUrl
+
+  val getTracker: Tracker = {
+    val emitter = new Emitter(ActivityTracking.url, HttpMethod.GET)
+    emitter.setRequestMethod(RequestMethod.Asynchronous)
+    val subject = new Subject
+    new Tracker(emitter, subject, "membership", "membership-frontend")
+  }
 
   def setSubMap(in:Map[String, Any]): JMap[String, Object] =
     mapAsJavaMap(in).asInstanceOf[java.util.Map[java.lang.String, java.lang.Object]]

--- a/frontend/app/tracking/ActivityTracking.scala
+++ b/frontend/app/tracking/ActivityTracking.scala
@@ -298,7 +298,7 @@ trait ActivityTracking {
 
   private def executeTracking(data: TrackerData) {
     try {
-      val tracker = getTracker
+      val tracker = ActivityTracking.getTracker
       val dataMap = data.toMap
       tracker.trackUnstructuredEvent(dataMap)
     } catch {
@@ -306,8 +306,6 @@ trait ActivityTracking {
       Logger.error(s"Activity tracking error: ${error.getMessage}")
     }
   }
-
-  def getTracker: Tracker = ActivityTracking.getTracker
 
 }
 


### PR DESCRIPTION
## Why are you doing this?
Recently we have noticed that membership instances have been cycling every number of hours, but sometimes recovering.
![image](https://user-images.githubusercontent.com/7304387/28576663-5ca5c0aa-714c-11e7-86d2-cfb90720f139.png)

After some investigation, it seemed that the thread count was increasing every hour by around 300, coinciding with a spike in requests to the events endpoint.  Then once it reached around 7000+, the thread count was reducing to around 150 after a short blip.
![image](https://user-images.githubusercontent.com/7304387/28576732-9070d6cc-714c-11e7-9d9e-45e4c3c9ae00.png)

Looking at the logs, it seemed like the jvm was terminating and restarting at that time, and if that didn't happen quickly enough, the healthcheck was failing and recycling the instance.
We tried hitting a specific event endpoint around 4000 times on an instance we borrowed from prod, and the JVM died with an error in the system log saying the OS had killed it due to no remaining OS memory.  At this point the JVM was using almost 3GB ram, but the heap size was still around 80MB used.
![image](https://user-images.githubusercontent.com/7304387/28576828-df0c6f94-714c-11e7-8e98-3713197f3af3.png)

We ran the same code locally, and found every request to /event/:id added several threads to the count.
After turning off analytics - https://github.com/guardian/membership-frontend/blob/master/frontend/app/controllers/Event.scala#L53 we found the leak stopped.

Further investigation showed that we were creating a new snowplow Emitter every time we logged something.  This creates a new java aync http client which has a thread pool.  https://github.com/snowplow/snowplow-java-tracker/blob/java-0.5.2/snowplow-java-tracker-core/src/main/java/com/snowplowanalytics/snowplow/tracker/core/emitter/Emitter.java#L133

## Changes
The quick solution is to make the emitter a singleton.

But in the long term it seems strange we are running analytics on the server side on an endpoint that is cached for 60 seconds.  Would it make more sense to use GA for this?  The data going in is useless because someone is crawling the whole site every hour at about 5 past anyway.
![image](https://user-images.githubusercontent.com/7304387/28577014-6a140232-714d-11e7-9bc9-eaad18fa54f8.png)


@jacobwinch thanks for pairing on that one
@dominickendrick @guardian/membership-and-subscriptions any knowledge/suggestions on the snowplow thing?