### PR TITLE
don't try to reuse the snowplow tracker and subject

### DIFF
--- a/frontend/app/tracking/ActivityTracking.scala
+++ b/frontend/app/tracking/ActivityTracking.scala
@@ -298,7 +298,9 @@ trait ActivityTracking {
 
   private def executeTracking(data: TrackerData) {
     try {
-      val tracker = ActivityTracking.getTracker
+      val emitter = ActivityTracking.getEmitter
+      val subject = new Subject
+      val tracker = new Tracker(emitter, subject, "membership", "membership-frontend")
       val dataMap = data.toMap
       tracker.trackUnstructuredEvent(dataMap)
     } catch {
@@ -312,11 +314,10 @@ trait ActivityTracking {
 object ActivityTracking {
   val url = Config.trackerUrl
 
-  val getTracker: Tracker = {
+  val getEmitter: Emitter = {
     val emitter = new Emitter(ActivityTracking.url, HttpMethod.GET)
     emitter.setRequestMethod(RequestMethod.Asynchronous)
-    val subject = new Subject
-    new Tracker(emitter, subject, "membership", "membership-frontend")
+    emitter
   }
 
   def setSubMap(in:Map[String, Any]): JMap[String, Object] =


### PR DESCRIPTION
## Why are you doing this?
Since https://github.com/guardian/membership-frontend/pull/1704 the snowplow events have slowed to glacial pace (i.e. only a few today)
This is probably due to the snowplow java library not being pure functional in many ways, therefore making it hard to refactor our use of.

Since the documentation isn't brill, this is kind of an educated stab in the dark swinging closer back to what we had originally.  I.e. only reusing the emitter which is the thing that creates the async client, but not reusing the subject or tracker.

If that fails, it seems like not many people know much about this library, so we'll have to find a third way.  I'm very much reluctant to prioritise analytics over actual site stability for the core user need of signing up, even though it's not a complete breakage.

But fingers crossed this will work and everyone will be happy again!

@jacobwinch @dominickendrick 