### PR TITLE
synchronise calls to tracker between threads

### DIFF
--- a/frontend/app/tracking/ActivityTracking.scala
+++ b/frontend/app/tracking/ActivityTracking.scala
@@ -302,7 +302,9 @@ trait ActivityTracking {
       val subject = new Subject
       val tracker = new Tracker(emitter, subject, "membership", "membership-frontend")
       val dataMap = data.toMap
-      tracker.trackUnstructuredEvent(dataMap)
+      tracker.synchronized {
+        tracker.trackUnstructuredEvent(dataMap)
+      }
     } catch {
       case error: Throwable =>
       Logger.error(s"Activity tracking error: ${error.getMessage}")


### PR DESCRIPTION
## Why are you doing this?
So as per the problem reported in https://github.com/guardian/membership-frontend/pull/1707#issuecomment-318320866
I couldn't update the client due to some [weird java generics trick](https://github.com/snowplow/snowplow-java-tracker/blob/7b2eb085acc47288222bd58df042c3ffd6d4b407/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitter.java#L66) that scalac can't handle.
Anyway in the end since these figures are quite important for populating the data lake, I've decided to go for the next dirty hack short of rolling back.

## Changes
Wrap the track call (that uses an ArrayList) in a synchronised block.

## Screenshots (of my face)
![image](https://user-images.githubusercontent.com/7304387/28674438-4ba5d7da-72dd-11e7-871d-8baa9b96b4db.png)

@dominickendrick @jranks123 @paulbrown1982 