### PR TITLE
log the actual exception

### DIFF
--- a/frontend/app/tracking/ActivityTracking.scala
+++ b/frontend/app/tracking/ActivityTracking.scala
@@ -307,7 +307,7 @@ trait ActivityTracking {
       }
     } catch {
       case error: Throwable =>
-      Logger.error(s"Activity tracking error: ${error.getMessage}")
+      Logger.error(s"Activity tracking error", error)
     }
   }
 


### PR DESCRIPTION
## Why are you doing this?
Bad logging... we're only logging the message (i.e. "null") rather than the whole exception.  This makes it hard to know what really went wrong.

@paulbrown1982 @dominickendrick @davidfurey @jranks123 