### PR TITLE
synchronise on the right object!

### DIFF
--- a/frontend/app/tracking/ActivityTracking.scala
+++ b/frontend/app/tracking/ActivityTracking.scala
@@ -302,7 +302,7 @@ trait ActivityTracking {
       val subject = new Subject
       val tracker = new Tracker(emitter, subject, "membership", "membership-frontend")
       val dataMap = data.toMap
-      tracker.synchronized {
+      emitter.synchronized {
         tracker.trackUnstructuredEvent(dataMap)
       }
     } catch {
@@ -318,7 +318,11 @@ object ActivityTracking {
 
   val getEmitter: Emitter = {
     val emitter = new Emitter(ActivityTracking.url, HttpMethod.GET)
-    emitter.setRequestMethod(RequestMethod.Asynchronous)
+//    emitter.setRequestMethod(RequestMethod.Asynchronous)
+    // if you use "Asynchronous", it blocks until the async operation finishes....!!
+    // so all the thread pools we were leaking were for nothing.
+    // https://github.com/snowplow/snowplow-java-tracker/blob/java-0.5.2/snowplow-java-tracker-core/src/main/java/com/snowplowanalytics/snowplow/tracker/core/emitter/Emitter.java#L212
+
     emitter
   }
 


### PR DESCRIPTION
## Why are you doing this?
So the snowplow logging keeps breaking.  The solution [was to synchronise on the track call](https://github.com/guardian/membership-frontend/pull/1708), but I synchronised on the wrong object.  This fixes that.

In related news, along my journey through the snowplow code, I found that the snowplow client "async" mode basically [blocks the current thread while it's doing an async request](https://github.com/snowplow/snowplow-java-tracker/blob/java-0.5.2/snowplow-java-tracker-core/src/main/java/com/snowplowanalytics/snowplow/tracker/core/emitter/Emitter.java#L212), meaning the thread pools we/it were leaking were all useless (especially given the code that uses the pool is not itself threadsafe!)  So a whole pool was being created just so that the main thread could block waiting for the single possible concurrent request.  seriously!

I would recommend against updating the latest client as it's not much better, just don't use it!  As is the plan...

@jranks123 @dominickendrick @paulbrown1982 @davidfurey 