### PR TITLE
Set referrer to null if user comes via fb oath

### DIFF
--- a/frontend/assets/javascripts/src/modules/analytics/ga.es6
+++ b/frontend/assets/javascripts/src/modules/analytics/ga.es6
@@ -111,6 +111,11 @@ export function init() {
     if (guardian.ophan) {
         wrappedGa('set', dimensions.ophanPageViewId, guardian.ophan.pageViewId);
     }
+    // The hash on the url is set in identity-federation-api to indicate user has come via facebook login, this identifies that and stops the referrer being counted as www.facebook.com
+    if(document.location.hash === '#fbLogin') {
+        wrappedGa('set', 'referrer', null);
+        document.location.hash = '';
+    }
 
     if("productData" in guardian) {
 


### PR DESCRIPTION
## Why are you doing this?
- Users coming via facebook login were being reported in Google Analytics as having a referrer of 'www.facebook.com' incorrectly. Advise form google was to set the referrer to null when coming via facebook oauth. 
- We set a hash in the url in https://github.com/guardian/identity-federation-api to indicate user has come via facebook login.
- This identifies this and send a null to GA.

Linked to : 
https://github.com/guardian/identity-federation-api/pull/228
https://github.com/guardian/frontend/pull/17534

@jfsoul @johnduffell 