### PR TITLE
Reduce log noise from health monitoring task

### DIFF
--- a/frontend/app/monitoring/HealthMonitoringTask.scala
+++ b/frontend/app/monitoring/HealthMonitoringTask.scala
@@ -72,8 +72,11 @@ object Scheduler extends StrictLogging {
   )(implicit system: ActorSystem, executionContext: ExecutionContext) = {
     logger.info(s"Starting $task.name scheduled task with an initial delay of: $initialDelay. This task will refresh every: $interval")
     system.scheduler.schedule(initialDelay, interval) {
-      task.task().onFailure {
-        case error => logger.error(s"Scheduled task $task.name failed due to: $error. This task will retry in: $interval")
+      task.task().onComplete {
+        case Success(t) =>
+          logger.debug(s"Scheduled task $task.name succeeded. This task will repeat in: $interval")
+        case Failure(e) =>
+          logger.error(s"Scheduled task $task.name failed due to: $e. This task will retry in: $interval")
       }
     }
   }

--- a/frontend/app/monitoring/HealthMonitoringTask.scala
+++ b/frontend/app/monitoring/HealthMonitoringTask.scala
@@ -72,11 +72,8 @@ object Scheduler extends StrictLogging {
   )(implicit system: ActorSystem, executionContext: ExecutionContext) = {
     logger.info(s"Starting $task.name scheduled task with an initial delay of: $initialDelay. This task will refresh every: $interval")
     system.scheduler.schedule(initialDelay, interval) {
-      task.task().onComplete {
-        case Success(t) =>
-          logger.info(s"Scheduled task $task.name succeeded. This task will repeat in: $interval")
-        case Failure(e) =>
-          logger.error(s"Scheduled task $task.name failed due to: $e. This task will retry in: $interval")
+      task.task().onFailure {
+        case error => logger.error(s"Scheduled task $task.name failed due to: $error. This task will retry in: $interval")
       }
     }
   }


### PR DESCRIPTION
## Why are you doing this?
* The health monitoring task currently logs every time it completes successfully (at the moment this is every 10 seconds). This means there is a lot of noise in the logs, which is making it harder to debug problems in production.

## Trello card: N/A

## Changes
* Log success case at debug level so it does not appear in CloudWatch logs.

cc @johnduffell 