### PR TITLE
Revert "Reduce log noise from health monitoring task"

### DIFF
--- a/frontend/app/monitoring/HealthMonitoringTask.scala
+++ b/frontend/app/monitoring/HealthMonitoringTask.scala
@@ -74,7 +74,7 @@ object Scheduler extends StrictLogging {
     system.scheduler.schedule(initialDelay, interval) {
       task.task().onComplete {
         case Success(t) =>
-          logger.debug(s"Scheduled task $task.name succeeded. This task will repeat in: $interval")
+          logger.info(s"Scheduled task $task.name succeeded. This task will repeat in: $interval")
         case Failure(e) =>
           logger.error(s"Scheduled task $task.name failed due to: $e. This task will retry in: $interval")
       }


### PR DESCRIPTION
Reverts guardian/membership-frontend#1713

No idea how/why... but merging guardian/membership-frontend#1713 seems to have been preventing the healthcheck from passing. I'd like to revert this while I investigate...

