### PR TITLE
Revert "Revert "Reduce log noise from health monitoring task""

### DIFF
--- a/frontend/app/monitoring/HealthMonitoringTask.scala
+++ b/frontend/app/monitoring/HealthMonitoringTask.scala
@@ -74,7 +74,7 @@ object Scheduler extends StrictLogging {
     system.scheduler.schedule(initialDelay, interval) {
       task.task().onComplete {
         case Success(t) =>
-          logger.info(s"Scheduled task $task.name succeeded. This task will repeat in: $interval")
+          logger.debug(s"Scheduled task $task.name succeeded. This task will repeat in: $interval")
         case Failure(e) =>
           logger.error(s"Scheduled task $task.name failed due to: $e. This task will retry in: $interval")
       }


### PR DESCRIPTION
The issues with deployment seem to have been related to a bad AMI. We noticed the following error in /var/log/cloud-init-output.log:

```
# install and start play app and create frontend user
dpkg -i /dist/frontend_1.0-SNAPSHOT_all.deb
dpkg: error: dpkg status database is locked by another process
```

After successfully re-deploying the AMI which was baked on 31/07, we re-baked in Amigo and deployed again without issue.

As the problem was unrelated to guardian/membership-frontend#1713 I'm going to try shipping it again.

Thanks for the help @johnduffell 