### PR TITLE
Check that dpkg lock is free before installing app

### DIFF
--- a/cloud-formation/membership-app.cf.yaml
+++ b/cloud-formation/membership-app.cf.yaml
@@ -129,7 +129,8 @@ Resources:
             export stage='${Stage}'
             export region='${AWS::Region}'
             aws s3 cp --region ${AWS::Region} s3://membership-dist/${Stack}/${Stage}/frontend/init-instance.sh .
-            . init-instance.sh
+            chmod o+x init-instance.sh
+            ./init-instance.sh
   MembershipAppRole:
     Type: AWS::IAM::Role
     Properties:

--- a/frontend/instance/frontend/init-instance.sh
+++ b/frontend/instance/frontend/init-instance.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ev
+#!/bin/bash -v
 # this script is called by all instances when they first start.
 # you can test it standalone by exporting the stack/stage/app/region variables and running it manually
 

--- a/frontend/instance/frontend/init-instance.sh
+++ b/frontend/instance/frontend/init-instance.sh
@@ -15,11 +15,11 @@ lsof /var/lib/dpkg/lock
 rc=$?
 echo "Return code is $rc"
 until [ "$rc" -eq "1" ]; do
-echo "Waiting for dpkg lock to become free"
-sleep 1s;
-lsof /var/lib/dpkg/lock
-rc=$?
-echo "Return code is $rc"
+  echo "Waiting for dpkg lock to become free"
+  sleep 1s;
+  lsof /var/lib/dpkg/lock
+  rc=$?
+  echo "Return code is $rc"
 done
 echo "dpkg lock is free, ready to install application"
 

--- a/frontend/instance/frontend/init-instance.sh
+++ b/frontend/instance/frontend/init-instance.sh
@@ -10,6 +10,19 @@ aws --region $region s3 cp --recursive s3://membership-dist/${stack}/${stage}/fr
 mkdir /etc/gu
 aws --region $region s3 cp s3://membership-private/${stage}/membership.private.conf /etc/gu
 
+# wait for dpkg lock to become free
+lsof /var/lib/dpkg/lock
+rc=$?
+echo "Return code is $rc"
+until [ "$rc" -eq "1" ]; do
+echo "Waiting for dpkg lock to become free"
+sleep 1s;
+lsof /var/lib/dpkg/lock
+rc=$?
+echo "Return code is $rc"
+done
+echo "dpkg lock is free, ready to install application"
+
 # install and start play app and create frontend user
 dpkg -i /dist/frontend_1.0-SNAPSHOT_all.deb
 


### PR DESCRIPTION
## Why are you doing this?
We had some issues with deploys this morning (see https://github.com/guardian/membership-frontend/pull/1715 and related PRs).

After some investigation with @johnduffell we traced this back to the fact that an automated update process (https://help.ubuntu.com/lts/serverguide/automatic-updates.html) had a lock on the dpkg status database.

This led to the following error when attempting to install and startup the app:

```
# install and start play app and create frontend user
dpkg -i /dist/frontend_1.0-SNAPSHOT_all.deb
dpkg: error: dpkg status database is locked by another process
```

...which obviously meant that the healthcheck was never going to pass!

For some reason the following AMI seems to significantly increase the chances of falling foul of this race condition:
https://amigo.gutools.co.uk/recipes/xenial-membership/bakes/306

However, it's quite possible that we have been hitting this issue on individual instances before without seeing a major impact. (It's fairly tricky to debug this problem because it requires detaching a dying instance from the ASG before AWS terminates it).

This change means that we wait for the dpkg lock to be free before attempting to install/start the app.

## Trello card: 
N/A

## Changes
* Add a check to ensure that dpkg lock is free before attempting to install the app
* Tweak bash options and user data to stop the script from being abandoned when lsof exits with return code of 1.

## Testing
* Deployed to code using the troublesome AMI and the existing scripts, in order to confirm that boxes consistently failed to come into service.
* Cloudformed the CODE stack to confirm that the script changes successfully avoid this race condition and allow instances to come into service.

cc @rupertbates @paulbrown1982 @davidfurey 