### PR TITLE
Cache 404s for event/id/buy

### DIFF
--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -123,7 +123,9 @@ trait Event extends Controller with MemberServiceProvider with ActivityTracking 
           redirectSignedInMemberToEventbrite(event)
         }
       case _ =>
-        Action(NotFound)
+        // We seem to have a crawler(?) hitting the buy urls for past events
+        logger.info(s"User hit the buy url for event $id - neither a GuLiveEvent or Masterclass could be retrieved, returning 404...")
+        CachedAction(NotFound)
     }
 
   private def suggestUserUpgrades(implicit request: SubReqWithSub[AnyContent]) =


### PR DESCRIPTION
## Why are you doing this?
* In order to fix the following Sentry issue:
https://sentry.io/the-guardian/membership/issues/312841446/events/6527908813/
* To stop us from unnecessarily throwing 500s which add noise to our AWS alerting.

It looks like this was introduced with: https://github.com/guardian/membership-frontend/pull/1697

I spot checked a number of the event ids that are listed in the Sentry issue to make sure that there wasn't a genuine issue selling events. All of the events returning NotFound seem to be in the past, and many are Guardian Local events, which have now been dropped (see https://github.com/guardian/membership-frontend/pull/1606).

Consequently I am assuming that this is not a real problem, and that these urls are being hit by some kind of crawler (rather than a genuine user) - although alternative theories are welcome here!

## Trello card: 
N/A

## Changes
* Add minor logging
* Use CachedAction when returning NotFound

cc @rtyley @paulbrown1982 @johnduffell @davidfurey 