### PR TITLE
Use profile.thegulocal.com instead profile-origin

### DIFF
--- a/frontend/conf/DEV.public.conf
+++ b/frontend/conf/DEV.public.conf
@@ -29,7 +29,7 @@ members-data-api.url="https://members-data-api.thegulocal.com"
 
 identity {
     api.url="https://idapi.code.dev-theguardian.com"
-    webapp.url="https://profile-origin.thegulocal.com"
+    webapp.url="https://profile.thegulocal.com"
     production.keys=false
 }
 


### PR DESCRIPTION
## Why are you doing this?

For the rational, or if you are wondering if this will cause conflicts with Dotcom Identity Frontend, please see the following pull request:

https://github.com/guardian/identity-platform/pull/170

Please note that [Identity Frontend](https://github.com/guardian/identity-frontend) should now be accessible in DEV at 
```
profile.thegulocal.com
```
instead of 
```
profile-origin.thegulocal.com
```

May I ask you please to fresh pull `identity-frontend` and `identity-platform` and update your bookmarks to point to the new domain. You may also wish to remove profile-origin from `/etc/hosts`

Also reload Nginx config with

```
sudo nginx -s reload
```



Please let me know if you encounter any problems.

@guardian/membership-and-subscriptions
