### PR TITLE
remove non sanitised cookies from cached method

### DIFF
--- a/frontend/app/controllers/Info.scala
+++ b/frontend/app/controllers/Info.scala
@@ -98,8 +98,6 @@ trait Info extends Controller with LazyLogging {
     val detailImage = detailImageFor(countryGroup)
     val detailImageOrientated = OrientatedImages(portrait = detailImage, landscape = detailImage)
 
-    val refererCookies = ReferralData.makeCookies
-
     val template = countryGroup match {
       case US => views.html.info.supporterUSA.apply _
       case Australia => views.html.info.supporterAustralia.apply _
@@ -115,7 +113,6 @@ trait Info extends Controller with LazyLogging {
         description = Some(CopyConfig.copyDescriptionSupporters)
       ),
       detailImageOrientated))
-      .withCookies(refererCookies:_*)
   }
 
   def patron() = CachedAndOutageProtected { implicit request =>


### PR DESCRIPTION
## Why are you doing this?
Recently we have been having a few alerts from pagerduty about 5xx errors, <2 per week

I have tracked this down to a bit of code that's trying to put the contents of the referer header into a cookie.  Unfortunately this doesn't work because the referer header isn't encoded in any way and play validates the cookie before sending the response, meaning we get a 500 error instead.

After further investigation, I found it's actually tracking of some kind for the /uk/supporter (or /us/supporter etc) page, but since these pages are cached, the users will be getting each others cookies anyway unless we have >60 seconds between hits.  So it's probably not doing what people were hoping regarding tracking.

As such, in the interests of a quiet life re pagerduty, I'm proposing we take this tracking out and someone can reimplement it possibly on the client side so that it can be correct.

The original PR is here: https://github.com/guardian/membership-frontend/pull/1652 cc @jranks123 @rtyley @dominickendrick @mike-j-ruane 
@desbo 

[here are some example logs](https://membership-logs.gutools.co.uk/app/kibana#/discover?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:'2017-08-08T10:40:18.447Z',mode:absolute,to:'2017-08-08T10:42:30.116Z'))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:app,negate:!f,type:phrase,value:membership-frontend),query:(match:(app:(query:membership-frontend,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:level,negate:!t,type:phrase,value:INFO),query:(match:(level:(query:INFO,type:phrase))))),index:'logstash-*',interval:auto,query:(query_string:(analyze_wildcard:!t,query:'*')),sort:!('@timestamp',desc)))