### PR TITLE
Remove email permission blocks for recurring contributors

### DIFF
--- a/frontend/app/services/SalesforceService.scala
+++ b/frontend/app/services/SalesforceService.scala
@@ -6,7 +6,7 @@ import com.gu.salesforce._
 import com.gu.stripe.Stripe.Customer
 import dispatch.Defaults.timer
 import dispatch._
-import forms.MemberForm.{CommonForm, JoinForm}
+import forms.MemberForm.{CommonForm, JoinForm, MonthlyContributorForm}
 import model.GenericSFContact
 import monitoring.{ContributorMetrics, MemberMetrics}
 import play.api.Play.current
@@ -78,7 +78,7 @@ class SalesforceService(salesforceConfig: SalesforceConfig) extends api.Salesfor
         Keys.EMAIL -> user.primaryEmailAddress,
         Keys.FIRST_NAME -> formData.name.first,
         Keys.LAST_NAME -> formData.name.last,
-        Keys.ALLOW_MEMBERSHIP_MAIL -> true
+        Keys.ALLOW_MEMBERSHIP_MAIL -> !formData.isInstanceOf[MonthlyContributorForm] // yes, if not monthly contributor
       )) ++ Map(
         Keys.ALLOW_THIRD_PARTY_EMAIL -> formData.marketingChoices.thirdParty,
         Keys.ALLOW_GU_RELATED_MAIL -> formData.marketingChoices.gnm


### PR DESCRIPTION
## Why are you doing this?
We intercepted and blocked all email preferences for recurring contributors during the initial exploration phase of the project (see https://github.com/guardian/membership-frontend/pull/1579).

We have since had legal clearance that we don't need to do that any more and so can restore the preferences indicated during the sign-up process.

## Trello card: [Remove email preference blocks for recurring contributors](https://trello.com/c/tLS01txH/799-remove-email-preference-blocks-for-recurring-contributors)

cc @rupertbates @davidfurey 