### PR TITLE
Redirect Membership Bundles Page To Support

### DIFF
--- a/frontend/app/controllers/Redirects.scala
+++ b/frontend/app/controllers/Redirects.scala
@@ -9,6 +9,8 @@ trait Redirects extends Controller {
   def supporterRedirect = CachedAction {
     MovedPermanently(routes.Info.supporterRedirect(None).path)
   }
+
+  def supportRedirect = CachedAction(MovedPermanently("https://support.theguardian.com/"))
 }
 
 object Redirects extends Redirects

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -105,7 +105,7 @@ GET            /offers-competitions                   controllers.Info.offersAnd
 # Bundles - deprecated - TODO: remove
 GET            /bundles                               controllers.Bundle.get(INTCMP: abtests.BundleVariant)
 GET            /bundles/thankyou                      controllers.Bundle.thankYou(INTCMP: abtests.BundleVariant, selectedOption: String)
-GET            /uk                                    controllers.Bundle.landing
+GET            /uk                                    controllers.Redirects.supportRedirect
 
 # Styleguide
 GET            /patterns                              controllers.PatternLibrary.patterns


### PR DESCRIPTION
## Why are you doing this?

The bundles landing page on membership still exists. This redirects the route to support, so that the membership version is no longer accessible.

[**Trello Card**](https://trello.com/c/A0lyPPgb/946-get-rid-of-the-membership-bundles-landing-page)

## Changes

- Redirect `/uk` to support.

## Screenshots

![ancient-bundles](https://user-images.githubusercontent.com/5131341/31130291-e28eaacc-a84e-11e7-8dec-5bc5e2d02859.png)
