### PR TITLE
Revert "Invoice template override"

### DIFF
--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -1,11 +1,9 @@
 package configuration
 import com.getsentry.raven.dsn.Dsn
 import com.gu.config._
-import com.gu.i18n.Country
 import com.gu.identity.cookie.{PreProductionKeys, ProductionKeys}
 import com.gu.memsub.auth.common.MemSub.Google._
 import com.gu.salesforce.Tier
-import com.gu.zuora.api.{InvoiceTemplate, InvoiceTemplates}
 import com.netaporter.uri.Uri
 import com.netaporter.uri.dsl._
 import com.typesafe.config.ConfigFactory
@@ -170,9 +168,6 @@ object Config {
 
   def productIds(env: String): com.gu.memsub.subsv2.reads.ChargeListReads.ProductIds =
     SubsV2ProductIds(config.getConfig(s"touchpoint.backend.environments.$env.zuora.productIds"))
-
-  def invoiceTemplateOverrides(env: String): Map[Country, InvoiceTemplate] =
-    InvoiceTemplates.fromConfig(config.getConfig(s"touchpoint.backend.environments.$env.zuora.invoiceTemplateIds")).map(it => (it.country, it)).toMap
 
   object Logstash {
     private val param = Try{config.getConfig("param.logstash")}.toOption

--- a/frontend/app/services/TouchpointBackend.scala
+++ b/frontend/app/services/TouchpointBackend.scala
@@ -78,7 +78,6 @@ object TouchpointBackend extends LazyLogging {
     val zuoraRestService = new ZuoraRestService[Future]()
 
     val pids = Config.productIds(restBackendConfig.envName)
-
     val newCatalogService = new subsv2.services.CatalogService[Future](pids, simpleRestClient, Await.result(_, 10.seconds), restBackendConfig.envName)
     val futureCatalog: Future[CatalogMap] = newCatalogService.catalog.map(_.fold[CatalogMap](error => {println(s"error: ${error.list.mkString}"); Map()}, _.map))
     val newSubsService = new subsv2.services.SubscriptionService[Future](pids, futureCatalog, simpleRestClient, zuoraService.getAccountIds)
@@ -87,20 +86,8 @@ object TouchpointBackend extends LazyLogging {
     val salesforceService = new SalesforceService(config.salesforce)
     val identityService = IdentityService(IdentityApi)
     val memberService = new MemberService(
-      identityService = identityService,
-      salesforceService = salesforceService,
-      zuoraService = zuoraService,
-      zuoraRestService = zuoraRestService,
-      ukStripeService = stripeUKMembershipService,
-      auStripeService = stripeAUMembershipService,
-      payPalService = payPalService,
-      subscriptionService = newSubsService,
-      catalogService = newCatalogService,
-      paymentService = paymentService,
-      discounter = discounter,
-      discountIds = Config.discountRatePlanIds(config.zuoraEnvName),
-      invoiceIdsByCountry = Config.invoiceTemplateOverrides(config.zuoraEnvName)
-    )
+      identityService, salesforceService, zuoraService, zuoraRestService, stripeUKMembershipService, stripeAUMembershipService, payPalService, newSubsService, newCatalogService, paymentService, discounter,
+        Config.discountRatePlanIds(config.zuoraEnvName))
 
     TouchpointBackend(
       config.environmentName,

--- a/frontend/app/views/fragments/user/cardSummary.scala.html
+++ b/frontend/app/views/fragments/user/cardSummary.scala.html
@@ -3,9 +3,9 @@
 
 <div class="card-summary">
     <div class="card-summary__type">
-        <i class="sprite-card sprite-card--small sprite-card--@(card.cardType.mkString.toLowerCase())"></i>
+        <i class="sprite-card sprite-card--small sprite-card--@(card.cardType.toLowerCase())"></i>
     </div>
     <div class="card-summary__digits">
-        @card.paymentCardDetails.map(_.lastFourDigits).mkString
+        @card.lastFourDigits
     </div>
 </div>

--- a/frontend/app/views/joiner/thankyou.scala.html
+++ b/frontend/app/views/joiner/thankyou.scala.html
@@ -137,7 +137,7 @@
 
                     @{paymentMethod match {
                         case Some(card : PaymentCard) =>
-                            paymentRow("Card", s"•••• •••• •••• ${card.paymentCardDetails.map(_.lastFourDigits).getOrElse("••••")}")
+                            paymentRow("Card", "•••• •••• •••• •••• " + card.lastFourDigits)
                         case Some(payPal : PayPalMethod) =>
                             paymentRow("Payment method", "You are paying with PayPal")
                         case _ =>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "8.0.3"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "0.9" // v0.9 is the latest version published for Play 2.4...
-  val membershipCommon = "com.gu" %% "membership-common" % "0.471"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.462"
   val contentAPI = "com.gu" %% "content-api-client" % "8.5"
   val playWS = PlayImport.ws
   val playFilters = PlayImport.filters


### PR DESCRIPTION
Reverts guardian/membership-frontend#1727
Reverting due to issue when matching PayPal or Direct Debit payment methods and sequence of option doesn't work either for AU cards: 

https://sentry.io/the-guardian/members-data-api/issues/364700303/

cc @pvighi 