### PR TITLE
DO NOT MERGE: Optimise for new members-data-api approach

### DIFF
--- a/frontend/app/controllers/User.scala
+++ b/frontend/app/controllers/User.scala
@@ -18,7 +18,6 @@ trait User extends Controller {
 
   def me = AjaxSubscriptionAction { implicit request =>
     val json = basicDetails(request.subscriber)
-    MembersDataAPI.Service.checkMatchesResolvedMemberIn(request)
     Ok(json).withCookies(GuMemCookie.getAdditionCookie(json))
   }
 

--- a/frontend/app/services/MembersDataAPI.scala
+++ b/frontend/app/services/MembersDataAPI.scala
@@ -1,6 +1,5 @@
 package services
 
-import actions.ActionRefiners.SubReqWithSub
 import com.gu.identity.play.{AccessCredentials, AuthenticatedIdUser}
 import com.gu.memsub.Subscriber.Member
 import com.gu.memsub.util.WebServiceHelper
@@ -18,7 +17,6 @@ import play.api.libs.functional.syntax._
 import play.api.libs.json.Reads._
 import play.api.libs.json._
 import views.support.MembershipCompat._
-
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
@@ -72,24 +70,6 @@ object MembersDataAPI {
   }
 
   object Service  {
-    def checkMatchesResolvedMemberIn(memberRequest: SubReqWithSub[_]) = memberRequest.user.credentials match {
-      case cookies: AccessCredentials.Cookies =>
-        getAttributes(cookies).onComplete {
-          case Success(memDataApiAttrs) =>
-            val prefix = s"members-data-api-check identity=${memberRequest.user.id} salesforce=${memberRequest.subscriber.contact.salesforceContactId} : "
-            val salesforceAttrs = Attributes.fromMember(memberRequest.subscriber)
-            if (memDataApiAttrs != salesforceAttrs) {
-              val message = s"$prefix MISMATCH salesforce=$salesforceAttrs mem-data-api=$memDataApiAttrs"
-              if (memDataApiAttrs.tier != salesforceAttrs.tier) Logger.error(message) else Logger.warn(message)
-              MembersDataAPIMetrics.put("members-data-api-mismatch", 1)
-            } else {
-              Logger.debug(s"$prefix MATCH")
-              MembersDataAPIMetrics.put("members-data-api-match", 1)
-            }
-          case Failure(err) => Logger.error(s"Failed to get membership attributes from membership-data-api for user ${memberRequest.user.id} (OK in dev)", err)
-        }
-      case _ => Logger.error(s"Unexpected credentials for getAttributes! ${memberRequest.user.credentials}")
-    }
 
     def upsertBehaviour(user: AuthenticatedIdUser, activity: Option[String] = None, note: Option[String] = None, emailed: Option[Boolean] = None) = {
       user.credentials match {

--- a/frontend/app/services/SalesforceService.scala
+++ b/frontend/app/services/SalesforceService.scala
@@ -43,9 +43,6 @@ class SalesforceService(salesforceConfig: SalesforceConfig) extends api.Salesfor
   override def upsert(user: IdUser, joinData: CommonForm): Future[ContactId] =
     upsert(user.id, initialData(user, joinData))
 
-  override def updateMemberStatus(user: IdMinimalUser, tier: Tier, customer: Option[Customer]): Future[ContactId] =
-    upsert(user.id, memberData(tier, customer))
-
   override def isAuthenticated = repository.salesforce.isAuthenticated
 
   private def memberData(tier: Tier, customerOpt: Option[Customer]): JsObject = Json.obj(

--- a/frontend/app/services/api/SalesforceService.scala
+++ b/frontend/app/services/api/SalesforceService.scala
@@ -16,6 +16,5 @@ trait SalesforceService {
   def metrics: MemberMetrics
   def contributorMetrics: ContributorMetrics
   def upsert(user: IdUser, userData: CommonForm): Future[ContactId]
-  def updateMemberStatus(user: IdMinimalUser, tier: Tier, customer: Option[Customer]): Future[ContactId]
   def isAuthenticated: Boolean
 }

--- a/frontend/test/acceptance/util/Browser.scala
+++ b/frontend/test/acceptance/util/Browser.scala
@@ -4,7 +4,6 @@ import org.openqa.selenium.support.ui.{ExpectedCondition, ExpectedConditions, We
 import org.openqa.selenium.By
 import org.openqa.selenium.support.ui.ExpectedConditions.numberOfWindowsToBe
 import org.scalatest.selenium.WebBrowser
-
 import scala.util.Try
 import scala.collection.JavaConverters.asScalaSetConverter
 
@@ -96,12 +95,10 @@ trait Browser extends WebBrowser {
    * */
   def switchWindow() {
     waitUntil(numberOfWindowsToBe(2))
-
     for {
       winHandle <- driver.getWindowHandles.asScala
       if winHandle != parentWindow
     } driver.switchTo().window(winHandle)
-
   }
 
   // Switches back to the first window opened by the driver.


### PR DESCRIPTION
## Why are you doing this?
members-data-api now uses Zuora as it's primary data source. 

The members-data-api changes that @lmath has been working on mean that updating tier information in Salesforce (in order to trigger a webhook which was used to populate Dynamo) is now unnecessary. 

In fact, having Salesforce amending membership data in a Dynamo table which is now used more like a cache is a bad thing - from now on we only want members-data-api to read or write from/to this DB.

## Changes
* Remove membership/members-data-api comparison code. Since both now use Zuora as the data source, this check feels redundant.
* Remove any code which writes tier information into Salesforce.
* Remove some whitespace from tests

## Checklist
- [x] Disable outbound message in Salesforce
- [x] Tidy up outbound message receiver from members-data-api
- [ ] Confirm that there are no other SF dependencies on these API calls (need to do this before merging)