### PR TITLE
Add QA team to authorised testers list

### DIFF
--- a/frontend/app/controllers/Testing.scala
+++ b/frontend/app/controllers/Testing.scala
@@ -27,6 +27,7 @@ object Testing extends Controller with LazyLogging {
       "membership.testusers@guardian.co.uk",
       "touchpoint@guardian.co.uk",
       "crm@guardian.co.uk",
+      "dig.qa@guardian.co.uk",
       "identitydev@guardian.co.uk"
     ), unauthorisedStaff(views.html.fragments.oauth.staffWrongGroup())(_))
 


### PR DESCRIPTION
## Why are you doing this?
So that all members of the QA team (including userhelp) can access /test-users.

## Changes
* Add dig.qa to AuthorisedTesters list.