### PR TITLE
Client-side Dependencies Upgrade - Part 2 - Babel

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,10 +16,10 @@
   },
   "devDependencies": {
     "autoprefixer-core": "^5.2.0",
-    "babel-core": "^6.23.1",
+    "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
-    "babel-polyfill": "^6.9.1",
-    "babel-preset-es2015": "^6.22.0",
+    "babel-polyfill": "^6.26.0",
+    "babel-preset-es2015": "^6.24.1",
     "bean": "~1.0.6",
     "bonzo": "~2.0.0",
     "bower": "^1.5.3",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -323,7 +323,7 @@ babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-core@^6.23.1, babel-core@^6.26.0:
+babel-core@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.0.tgz#af32f78b31a6fcef119c87b0fd8d9753f03a0bb8"
   dependencies:
@@ -636,7 +636,7 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
-babel-polyfill@^6.9.1:
+babel-polyfill@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
   dependencies:
@@ -644,7 +644,7 @@ babel-polyfill@^6.9.1:
     core-js "^2.5.0"
     regenerator-runtime "^0.10.5"
 
-babel-preset-es2015@^6.22.0:
+babel-preset-es2015@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz#d44050d6bc2c9feea702aaf38d727a0210538939"
   dependencies:


### PR DESCRIPTION
## Why are you doing this?

Part of the ongoing effort to bring our client-side dependencies up-to-date. Next up: babel.

**Note:** Babel recommend switching to `babel-preset-env` from `babel-preset-es2015`. This is worth looking into for support-frontend, and if it's successful there we should maybe make the switch in membership-frontend too. However, for now the priority is just getting membership-frontend up-to-date.

[**Trello Card**](https://trello.com/c/bgQzNQas/1045-update-babel)

## Changes

- Upgrade the babel libraries up to the latest versions:
  + `babel-core`
  + `babel-polyfill`
  + `babel-preset-es2015`
