### PR TITLE
Remove HTTP access from the security groups

### DIFF
--- a/cloud-formation/membership-app.cf.yaml
+++ b/cloud-formation/membership-app.cf.yaml
@@ -232,28 +232,15 @@ Resources:
   LoadBalancerSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: Permit incoming HTTP access on port 80, egress to port 9000
+      GroupDescription: Permit incoming HTTPS access on port 443, egress to port 9000
       VpcId:
         Ref: VpcId
       SecurityGroupIngress:
-      - IpProtocol: tcp
-        FromPort: '80'
-        ToPort: '80'
-        CidrIp:
-          Ref: AllowedIngressIps
       - IpProtocol: tcp
         FromPort: '443'
         ToPort: '443'
         CidrIp:
           Ref: AllowedIngressIps
-      - IpProtocol: tcp
-        FromPort: '80'
-        ToPort: '80'
-        CidrIp: 80.254.158.92/32
-      - IpProtocol: tcp
-        FromPort: '80'
-        ToPort: '80'
-        CidrIp: 80.254.146.68/32
       SecurityGroupEgress:
       - IpProtocol: tcp
         FromPort: '9000'


### PR DESCRIPTION
## Why are you doing this?
As part of our GDPR work I've been checking the security group access on our apps to make sure we aren't allowing any more than we need to. 
We now use Fastly to force a redirect from HTTP to HTTPS for all traffic so the port 80 ingress points should never be used.

## Trello card: [Here](https://trello.com/c/QVxm5eYS/1014-check-that-security-groups-for-support-frontend-and-membership-frontend-expose-the-minimum-entry-and-exit-ports)