### PR TITLE
Remove shared ssh key access

### DIFF
--- a/cloud-formation/membership-app.cf.yaml
+++ b/cloud-formation/membership-app.cf.yaml
@@ -12,10 +12,6 @@ Parameters:
   Stack:
     Description: Applied directly as a tag ('membership', or 'memb-masterclasses')
     Type: String
-  KeyName:
-    Description: The EC2 Key Pair to allow SSH access to the instance
-    Type: String
-    Default: aws-membership
   Stage:
     Description: Applied directly as a tag
     Type: String
@@ -115,8 +111,6 @@ Resources:
       - Ref: VulnerabilityScanningSecurityGroup
       InstanceType:
         Ref: InstanceType
-      KeyName:
-        Ref: KeyName
       IamInstanceProfile:
         Ref: MembershipAppInstanceProfile
       AssociatePublicIpAddress: true


### PR DESCRIPTION
## Why are you doing this?
More GDPR work, removing access to running instances using the aws-membership key pair as all
ssh access for team members should be managed by github teams via [github-keys-to-s3-lambda](https://github.com/guardian/github-keys-to-s3-lambda)

## Trello card: [Here](https://trello.com/c/WLCRICJv/1017-check-that-support-frontend-and-membership-frontend-is-not-accessible-via-a-shared-ssh-key)