### PR TITLE
Switch 'devDependencies' Block to 'dependencies'

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,7 @@
     "test": "grunt validate && grunt karma",
     "postinstall": "npm run bowerSetup"
   },
-  "devDependencies": {
+  "dependencies": {
     "autoprefixer-core": "^6.0.1",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",


### PR DESCRIPTION
## Why are you doing this?

Snyk provides two ways that you can analyse a `package.json` file:

- A straightforward **GitHub integration**, which picks up the file from the online repo
- A **CLI integration** using the `snyk monitor` command.

The Yarn site has a [quick description](https://yarnpkg.com/lang/en/docs/dependency-types/) of the meaning of different dependency types in a `package.json`. By default Snyk only looks at the `dependencies` section of `package.json`, and ignores the `devDependencies`. Unfortunately, all of our dependencies for this project are listed as `devDependencies`, so neither integration was analysing them by default.

The CLI integration has a `--dev` flag that forces Snyk to include the `devDependencies`, but the GitHub integration doesn't seem to have an option for checking them. So far I have been using the CLI integration manually on my locally machine, and I started passing the `--dev` flag to force Snyk to pick up the `devDependencies`. This is not an ideal solution, as we'd like Snyk to analyse the repo automatically and regularly.

There are two possible solutions:

1. Move all dependencies to the `dependencies` section from `devDependencies`, and use the GitHub integration.
2. Set up a TeamCity script to monitor changes to master and run `snyk monitor` with the `--dev` flag every time there is a change.

I went with the first option because it's simpler, and because I don't think we really care whether our deps sit in the `dependencies` or `devDependencies` section of `package.json`.

[**Trello Card**](https://trello.com/c/7iyLEByk/1051-run-snyk-on-membership-frontend-and-fix-vulnerabilities)

## Changes

- Rename `devDependencies` to `dependencies`.
