### PR TITLE
Restrict egress traffic to https only.

### DIFF
--- a/cloud-formation/membership-app.cf.yaml
+++ b/cloud-formation/membership-app.cf.yaml
@@ -261,6 +261,11 @@ Resources:
         ToPort: '9000'
         SourceSecurityGroupId:
           Ref: LoadBalancerSecurityGroup
+      SecurityGroupEgress:
+      - IpProtocol: tcp
+        FromPort: 443
+        ToPort: 443
+        CidrIp: 0.0.0.0/0
   FrontendELBDNSrecord:
     Type: AWS::Route53::RecordSet
     Properties:

--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -14,7 +14,7 @@ membership.supporter.url="https://membership.theguardian.com/supporter"
 
 event.discountMultiplier=0.8
 
-eventbrite.url="http://www.eventbrite.co.uk"
+eventbrite.url="https://www.eventbrite.co.uk"
 
 eventbrite.api.url="https://eventbrite-proxy.guardianapis.com/v3"
 
@@ -24,7 +24,7 @@ eventbrite.api.refresh-time-priority-events-seconds=29
 eventbrite.waitlist.url="https://www.eventbrite.co.uk/waitlist"
 eventbrite.limitedAvailabilityCutoff=15
 
-event.ordering.json="http://s3-eu-west-1.amazonaws.com/membership-eb-images/order/order.json"
+event.ordering.json="https://s3-eu-west-1.amazonaws.com/membership-eb-images/order/order.json"
 
 staff.authorised.emails.groups = "permanent.ftc.staff,all.staff.usa,all.staff.australia,freestaff.membership,membership.dev"
 


### PR DESCRIPTION
## Why are you doing this?

To ensure that all the outgoing connections from our EC2 instances are under `https`

## Trello card: [Here](https://trello.com/c/05jyLRpI/1015-check-that-all-outgoing-connections-from-support-frontend-and-membership-frontend-use-https-or-other-encrypted-connection)

## Tested in CODE

| Browser | Supporter Stripe checkout | Supporter Paypal checkout |Upgrade from Friend to Supporter  |
|---------|---------------------------|---------------------------|-----------------------------|
| Chrome  |              ✅              |              ✅              |             ✅                 |                             |                                   


Note: After merge, we need to manually deploy the cloud formation changes.