### PR TITLE
[Do Not Merge] Added an updated version of cloud formation's yaml

### DIFF
--- a/cloud-formation/membership-app.cf.yaml
+++ b/cloud-formation/membership-app.cf.yaml
@@ -261,6 +261,15 @@ Resources:
         ToPort: '9000'
         SourceSecurityGroupId:
           Ref: LoadBalancerSecurityGroup
+      SecurityGroupEgress:
+      - IpProtocol: tcp
+        FromPort: 443
+        ToPort: 443
+        CidrIp: 0.0.0.0/0
+      - IpProtocol: udp
+        FromPort: 123
+        ToPort: 123
+        CidrIp: 0.0.0.0/0
   FrontendELBDNSrecord:
     Type: AWS::Route53::RecordSet
     Properties:


### PR DESCRIPTION
# Do not merge
Before merging this PR we need to wait for the acquisition team to remove snowplow from membership. 
See related PR: https://github.com/guardian/membership-frontend/pull/1744


## Why are you doing this?
To be sure that all of our outgoing connections are secured. 
