### PR TITLE
Skip decoding session data with play-json for now

### DIFF
--- a/frontend/app/tracking/AcquisitionTracking.scala
+++ b/frontend/app/tracking/AcquisitionTracking.scala
@@ -24,21 +24,21 @@ trait AcquisitionTracking extends LazyLogging {
     else OphanService(OphanService.prodEndpoint)(RequestRunners.client)
   }
 
-  private def decodeAcquisitionData(session: Session): Option[ReferrerAcquisitionData] = {
-    import ReferrerAcquisitionData._
-    import cats.syntax.either._
-
-    val decodeAttempt: Either[String, ReferrerAcquisitionData] = for {
-      json <- Either.fromOption(session.get("acquisitionData"), "Session does not contain acquisitionData")
-      jsValue <- Either.catchNonFatal(Json.parse(json)).leftMap(_.getMessage)
-      acquisitionData <- Json.fromJson(jsValue).fold(
-        errs => Left(s"Unable to decode JSON $jsValue to an instance of ReferrerAcquisitionData. ${JsError.toJson(errs)}"),
-        acquisitionData => Right(acquisitionData)
-      )
-    } yield acquisitionData
-
-    decodeAttempt.leftMap(error => logger.warn(error)).toOption
-  }
+//  private def decodeAcquisitionData(session: Session): Option[ReferrerAcquisitionData] = {
+//    import ReferrerAcquisitionData._
+//    import cats.syntax.either._
+//
+//    val decodeAttempt: Either[String, ReferrerAcquisitionData] = for {
+//      json <- Either.fromOption(session.get("acquisitionData"), "Session does not contain acquisitionData")
+//      jsValue <- Either.catchNonFatal(Json.parse(json)).leftMap(_.getMessage)
+//      acquisitionData <- Json.fromJson(jsValue).fold(
+//        errs => Left(s"Unable to decode JSON $jsValue to an instance of ReferrerAcquisitionData. ${JsError.toJson(errs)}"),
+//        acquisitionData => Right(acquisitionData)
+//      )
+//    } yield acquisitionData
+//
+//    decodeAttempt.leftMap(error => logger.warn(error)).toOption
+//  }
 
   def trackAcquisition(
     summary: ThankyouSummary,
@@ -59,7 +59,7 @@ trait AcquisitionTracking extends LazyLogging {
       request.session.get("pageviewId"),
       cookieValue("vsid"),
       cookieValue("bwid"),
-      decodeAcquisitionData(request.session)
+      None // Temporary workaround for play-json incompatibility issue
     ))
   }
 }


### PR DESCRIPTION
This is a temporary workaround that I'll need to deploy now until I can
fix it properly tomorrow.

## Why are you doing this?
A part of `acquisition-event-producer` uses a json feature from Play 2.4 that doesn't exist in 2.5.
This causes a fatal exception when we try to decode the data on line 34. Thankfully, this will not affect PROD at the moment as there's an issue where the session data isn't passed along to this method, so it never gets as far as the `fromJson` call.

This PR is just to be on the safe side so that the dangerous code isn't included at all until I fix it properly tomorrow. 