### PR TITLE
Use latest acquisition-event-producer and add test

### DIFF
--- a/frontend/app/actions/CommonActions.scala
+++ b/frontend/app/actions/CommonActions.scala
@@ -99,10 +99,12 @@ trait CommonActions extends LazyLogging {
   val AjaxPaidSubscriptionAction = AjaxSubscriptionAction andThen paidSubscriptionRefiner(onFreeMember = _ => Forbidden)
 
   val StoreAcquisitionDataAction = new ActionBuilder[Request] {
+    import CommonActions._
+
     def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]): Future[Result] =
       block(request).map { result =>
-        request.getQueryString("acquisitionData").fold(result)(acquisitionData =>
-          result.withSession(request.session + ("acquisitionData" -> acquisitionData))
+        request.getQueryString(acquisitionDataSessionKey).fold(result)(acquisitionData =>
+          result.withSession(request.session + (acquisitionDataSessionKey -> acquisitionData))
         )
       }
   }
@@ -114,6 +116,10 @@ trait CommonActions extends LazyLogging {
     }
 
   def ChangeToPaidAction(targetTier: PaidTier) = SubscriptionAction andThen checkTierChangeTo(targetTier)
+}
+
+object CommonActions {
+  val acquisitionDataSessionKey: String = "acquisitionData"
 }
 
 trait OAuthActions extends googleauth.Actions with googleauth.Filters {

--- a/frontend/test/tracking/AcquisitionTrackingTest.scala
+++ b/frontend/test/tracking/AcquisitionTrackingTest.scala
@@ -1,0 +1,35 @@
+package tracking
+
+import actions.CommonActions
+import com.gu.acquisition.model.ReferrerAcquisitionData
+import ophan.thrift.componentEvent.ComponentType.AcquisitionsEpic
+import ophan.thrift.event.AbTest
+import ophan.thrift.event.AcquisitionSource.Social
+import org.specs2.matcher.OptionMatchers
+import org.specs2.mutable.Specification
+import play.api.libs.json.Json
+import play.api.mvc.Session
+
+class AcquisitionTrackingTest extends Specification with OptionMatchers
+  with AcquisitionTracking {
+
+  val referrerAcquisitionData = ReferrerAcquisitionData(
+    campaignCode = Some("campaign_code"),
+    referrerPageviewId = Some("pvid"),
+    referrerUrl = Some("askjeeves.com"),
+    componentId = Some("banner1"),
+    componentType = Some(AcquisitionsEpic),
+    source = Some(Social),
+    abTest = Some(AbTest("test1", "variant1")),
+    abTests = Some(Set(AbTest("test2", "variant2"), AbTest("test3", "variant3")))
+  )
+
+  "AcquisitionTracking" should {
+    "decode ReferrerAcquisitionData from Play session" in {
+      val json = Json.toJson(referrerAcquisitionData)
+      val session = Session(Map(CommonActions.acquisitionDataSessionKey -> json.toString))
+
+      decodeAcquisitionData(session) should beSome(referrerAcquisitionData)
+    }
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,7 +33,7 @@ object Dependencies {
   val kinesisLogbackAppender = "com.gu" % "kinesis-logback-appender" % "1.4.0"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"
   val dataFormat = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % "2.8.10"
-  val acquisitionEventProducer = "com.gu" %% "acquisition-event-producer" % "2.0.1" % "compile" excludeAll(
+  val acquisitionEventProducer = "com.gu" %% "acquisition-event-producer-play25" % "2.0.4" % "compile" excludeAll(
     ExclusionRule(organization = "org.scalatest"),
     ExclusionRule(organization = "org.scalactic")
   )


### PR DESCRIPTION
This is a proper fix for the workaround I added here: https://github.com/guardian/membership-frontend/pull/1754

`acquisition-event-producer` is now published for Play 2.5, so the JSON decoding works.