### PR TITLE
Include both referrer abTest fields in Acquisition submission

### DIFF
--- a/frontend/app/model/MembershipAcquisitionData.scala
+++ b/frontend/app/model/MembershipAcquisitionData.scala
@@ -67,7 +67,7 @@ object MembershipAcquisitionData {
       amount = data.amountPaidToday.amount.toDouble,
       paymentProvider = data.paymentProvider,
       campaignCode = data.referrerAcquisitionData.map(_.campaignCode.toSet),
-      abTests = data.referrerAcquisitionData.map(data => AbTestInfo(data.abTest.toSet)),
+      abTests = data.referrerAcquisitionData.map(data => AbTestInfo(data.abTests.toSet.flatten ++ data.abTest)),
       countryCode = data.countryCode,
       referrerPageViewId = data.referrerAcquisitionData.flatMap(_.referrerPageviewId),
       referrerUrl = data.referrerAcquisitionData.flatMap(_.referrerUrl),


### PR DESCRIPTION
## Why are you doing this?
Slight tweak to the acquisitions tracking code to combine A/B tests from both `abTest` and `abTests` fields in referrer data. 
