### PR TITLE
Fixing hamburger menu on mobile and smooth scroll

### DIFF
--- a/frontend/assets/javascripts/src/modules/sectionNav.js
+++ b/frontend/assets/javascripts/src/modules/sectionNav.js
@@ -23,7 +23,7 @@ define([
             activeClass: ACTIVE_CLASS,
             offset: navOffset + 100
         });
-        smoothScroll.init({
+        new smoothScroll('a[href*="#"]', {
             speed: 500,
             easing: 'easeInQuad',
             offset: navOffset + 20


### PR DESCRIPTION
## Why are you doing this?

The smooth scroll API has changed.  Using it the old way threw an exception, which meant that smooth scroll didn't work and the hamburger menu on mobile resolutions was broken

## Trello card: [Here](https://trello.com/c/JH8noJMA/1067-weird-membership-error-on)

## Screenshots

Old scroll behaviour:

![not-smooth-scroll](https://user-images.githubusercontent.com/2619836/33177332-2b912848-d05a-11e7-8caf-764723ae35d4.gif)

New scroll behaviour:

![smooth-scroll3](https://user-images.githubusercontent.com/2619836/33177333-2ba5e490-d05a-11e7-8ad8-3be61e7b9fde.gif)

Hamburger menu:

![screen shot 2017-11-23 at 14 23 42](https://user-images.githubusercontent.com/2619836/33177337-31e3d286-d05a-11e7-996b-54143cf83c64.png)

