### PR TITLE
bump membership common to 0.488 to update gnm membership stripe version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "1.2"
   val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "1.3"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.478"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.488"
   val contentAPI = "com.gu" %% "content-api-client" % "11.40"
   val playWS = PlayImport.ws
   val playFilters = PlayImport.filters


### PR DESCRIPTION
## Why are you doing this?
<!--
Remember, PRs are documentation for future contributors

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[PR 550](https://github.com/guardian/membership-common/pull/550) in membership-common makes it possible to send a Stripe-Version header to Stripe and I'm bumping the membership common-version so that I can send the latest Stripe-Version header to Stripe and ensure it works app by app.

Pre-merge:
- [x] with the app running locally, set a version header in the DEV conf and verify that joining as a member still works as expected and that we are sending that version header
- [x]  In s3://membership-private/PROD/membership.private.conf I shall add the stripe version 2017-08-15 to the config

We will send header Stripe-Version -> 2017-08-15 in each request to stripe

Later, when we change the api version for GNM membership-stripe globally in the stripe dashboard, this version can be removed from the config.

If something goes wrong using this stripe version I shall:

Use s3://membership-private/PROD/membership.private.conf.backup as ../membership.private.conf (removing the version from the config again)
redeploy the app


## Trello card: [Here](https://trello.com/c/OZ8I3TEN/3-auto-update-card-details-when-card-is-replaced)

## Changes
* Bump membership-common version

<!--
If you are making heavy client-side changes, consider manual test the following
critical flow before merging
## Tested in
| Browser | Supporter Stripe checkout | Supporter Paypal checkout | Stripe Monthly Contribution |  Paypal Monthly Contribution| Upgrade from Friend to Supporter  |
|---------|---------------------------|---------------------------|-----------------------------|-----------------------------|-----------------------------------|
| IE      |                           |                           |                             |                             |                                   |
| Firefox |                           |                           |                             |                             |                                   |
| Safari  |                           |                           |                             |                             |                                   |
| Chrome  |                           |                           |                             |                             |                                   |

-->

## Screenshots

cc @paulbrown1982 @AWare @pvighi @jacobwinch @johnduffell 