### PR TITLE
Reduce the length of the marketing consent text

### DIFF
--- a/frontend/app/views/joiner/form/payment.scala.html
+++ b/frontend/app/views/joiner/form/payment.scala.html
@@ -138,14 +138,14 @@
                         )
                             <!-- Marketing consent -->
                         <div class="fieldset__heading">
-                            <h2 class="fieldset__headline">Membership, supporting and subscribing to the Guardian</h2>
-                            <div class="fieldset__note">
-                                <p class="u-margin-bottom">
-                                    Whether you’re a subscriber, a member or you support us via a regular or one-off contribution, opt in here so we can keep sending you news, updates and more. Make sure you opt in so you don’t miss out.</p>
-                                <p class="u-margin-top">
-                                    If you’d like to hear about our wide range of subscription offers - or you’re interested in helping to secure our future with a recurring, or one-off contribution, then you’ll need to opt in here, too. Don’t worry, you can opt out at any time.</p>
-                            </div>
-                            <label><input type="checkbox" name="marketing.supporter" id="marketing-consent"></label>
+                            <h2 class="fieldset__headline">We would like to stay in touch</h2>
+                        </div>
+                        <div class="fieldset__fields">
+                            <label for="marketing-consent" class="fieldset__note">
+                                <input type="checkbox" class="marketing-checkbox" name="marketing.supporter" id="marketing-consent">
+                                Whether you’re a subscriber, a member or you support us via a regular or one-off contribution, opt in here so we can keep sending you news,
+                                updates and more. Don't worry you can opt out at any time.
+                            </label>
                         </div>
 
                         <button class="action form-panel__continue js-continue-name-address" type="button">Continue</button>

--- a/frontend/assets/stylesheets/components/_payment-paypal.scss
+++ b/frontend/assets/stylesheets/components/_payment-paypal.scss
@@ -128,7 +128,7 @@
 
     .fieldset__heading, .fieldset__fields {
         display: block;
-        margin: 0 0 ($gs-baseline * 2);
+        margin: 0 0 ($gs-baseline);
 
         @include mq(tablet) {
             display: block;

--- a/frontend/assets/stylesheets/components/_payment.scss
+++ b/frontend/assets/stylesheets/components/_payment.scss
@@ -61,6 +61,10 @@ $current-indicator: rem(72px);
     margin-right: rem($gs-baseline / 2);
 }
 
+.marketing-checkbox {
+    margin-right: rem($gs-baseline / 2);
+}
+
 /* Payment Cards Sprite
    ========================================================================== */
 


### PR DESCRIPTION
## Why are you doing this?
Because the original marketing consent text we were given was ridiculously long and looked silly

## Screenshots
<img width="397" alt="screen shot 2018-01-12 at 13 33 00" src="https://user-images.githubusercontent.com/181371/34877233-27625cc8-f79d-11e7-96ed-b14081483850.png">
