### PR TITLE
Update Stripe Roundel

### DIFF
--- a/frontend/app/views/fragments/form/stripeCheckout.scala.html
+++ b/frontend/app/views/fragments/form/stripeCheckout.scala.html
@@ -2,7 +2,7 @@
 <script>
     guardian.stripeCheckout = {
         key: guardian.getStripePublicKeyForCountry(),
-        image: 'https://uploads.guim.co.uk/2018/01/10/gu.png',
+        image: 'https://uploads.guim.co.uk/2018/01/15/gu.png',
         locale: 'auto',
         name: 'Guardian',
         zipCode: false,


### PR DESCRIPTION
## Why are you doing this?

Updating the stripe roundel to use the new roundel asset.

## Changes

- Updated the asset link for the roundel.

## Screenshots

**Before:**

<img width="316" alt="roundel-old" src="https://user-images.githubusercontent.com/5131341/34930841-7cb6c204-f9c3-11e7-8d79-75e13cb3efdf.png">

**After:**

<img width="314" alt="roundel-new" src="https://user-images.githubusercontent.com/5131341/34930847-83109a08-f9c3-11e7-9087-4955a593b9c6.png">
