### PR TITLE
Removed Old Roundels

### DIFF
--- a/frontend/app/views/fragments/tier/tierTrail.scala.html
+++ b/frontend/app/views/fragments/tier/tierTrail.scala.html
@@ -8,7 +8,6 @@
 
 <div class="tier-trail">
     <h3 class="tier-trail__name">
-        @fragments.inlineIcon("g-mark", List("icon-inline--medium", "tone-fill-" + tier.slug))
         @tier.name
     </h3>
     @if(showCaption) {


### PR DESCRIPTION
## Why are you doing this?

There were some old roundels on the membership landing page.

[**Trello Card**](https://trello.com/c/W4MPuUTW/1230-membership-page-roundels)

## Changes

- Removed the roundels.

## Screenshots

**Before:**

![roundel-before](https://user-images.githubusercontent.com/5131341/35224707-d096956a-ff7d-11e7-8965-ea82e975353a.png)

**After:**

![roundel-after](https://user-images.githubusercontent.com/5131341/35224714-d677e632-ff7d-11e7-93fc-9e036346c200.png)
