### PR TITLE
Fix event price enhancements for members (bug introduced in jQuery PR)

### DIFF
--- a/frontend/assets/javascripts/src/modules/events/eventPriceEnhance.js
+++ b/frontend/assets/javascripts/src/modules/events/eventPriceEnhance.js
@@ -18,7 +18,7 @@ define(['$', 'src/utils/user'], function ($, userUtil) {
 
     var enhanceWithTier = function (memberDetail) {
         if (memberDetail && memberDetail.benefits && memberDetail.benefits.discountedEventTickets) {
-            events.each(function(el) {
+            events.each(function(_, el) {
                 updateEventPricing(el);
             });
         }


### PR DESCRIPTION
## Why are you doing this?
I introduced a bug in https://github.com/guardian/membership-frontend/pull/1776 that prevents event prices from displaying correctly for members.

## Trello card: [1276-fix-pricing-enhancement-in-membership-frontend](https://trello.com/c/YLhndoPf/1276-fix-pricing-enhancement-in-membership-frontend)

## Screenshots
Before:
<img width="1280" alt="screen shot 2018-02-09 at 11 14 57" src="https://user-images.githubusercontent.com/690395/36025498-2d57748e-0d8b-11e8-952f-529d6d6256d0.png">

After:
![screen shot 2018-02-09 at 11 15 30](https://user-images.githubusercontent.com/690395/36025511-36abaf46-0d8b-11e8-8ebf-fab9648ebcf6.png)
