### PR TITLE
Stop using deprecated default play execution context

### DIFF
--- a/frontend/app/controllers/CachedAssets.scala
+++ b/frontend/app/controllers/CachedAssets.scala
@@ -2,9 +2,10 @@ package controllers
 
 import play.Logger
 import play.api.mvc.{Action, Controller}
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
-class CachedAssets(assets: Assets) extends Controller {
+import scala.concurrent.ExecutionContext
+
+class CachedAssets(assets: Assets, implicit val ec: ExecutionContext) extends Controller {
 
   def at(path: String, file: String, aggressiveCaching: Boolean = false) = Action.async { request =>
     assets.at(path, file, aggressiveCaching).apply(request).recover {

--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -15,7 +15,6 @@ import model.Eventbrite.{EBCode, EBEvent, EBOrder}
 import model.RichEvent.{RichEvent, _}
 import model._
 import org.joda.time.format.ISODateTimeFormat
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json.Json
 import play.api.libs.ws.WSClient
 import play.api.mvc._
@@ -34,7 +33,7 @@ class Event(
   touchpointActionRefiners: TouchpointActionRefiners,
   touchpointCommonActions: TouchpointCommonActions,
   implicit val parser: BodyParser[AnyContent],
-  executionContext: ExecutionContext,
+  override implicit val executionContext: ExecutionContext,
   googleAuthConfig: GoogleAuthConfig,
   commonActions: CommonActions,
   actionRefiners: ActionRefiners
@@ -53,7 +52,7 @@ class Event(
 
     override def parser = Event.this.parser
 
-    override protected def executionContext: ExecutionContext = Event.this.executionContext
+    override protected implicit def executionContext: ExecutionContext = Event.this.executionContext
 
     override def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]): Future[Result] = {
       eventbriteService.getEvent(eventId).map { event =>

--- a/frontend/app/controllers/Info.scala
+++ b/frontend/app/controllers/Info.scala
@@ -8,7 +8,6 @@ import com.typesafe.scalalogging.LazyLogging
 import configuration.CopyConfig
 import forms.FeedbackForm
 import model.{ContentItemOffer, FlashMessage, OrientatedImages}
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.mvc.Controller
 import services._
 import tracking.RedirectWithCampaignCodes._
@@ -16,9 +15,16 @@ import utils.ReferralData
 import utils.RequestCountry._
 import views.support.PageInfo
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
-class Info(val identityApi: IdentityApi, guardianContentService: GuardianContentService, touchpointBackends: TouchpointBackends, commonActions: CommonActions, actionRefiners: ActionRefiners) extends Controller with LazyLogging {
+class Info(
+  val identityApi: IdentityApi,
+  guardianContentService: GuardianContentService,
+  touchpointBackends: TouchpointBackends,
+  commonActions: CommonActions,
+  actionRefiners: ActionRefiners,
+  implicit val executionContext: ExecutionContext
+) extends Controller with LazyLogging {
 
   import commonActions.{CachedAction, NoCacheAction, StoreAcquisitionDataAction}
   import actionRefiners.PlannedOutageProtection

--- a/frontend/app/controllers/MemberOnlyContent.scala
+++ b/frontend/app/controllers/MemberOnlyContent.scala
@@ -8,15 +8,14 @@ import com.netaporter.uri.dsl._
 import com.typesafe.scalalogging.LazyLogging
 import configuration.Config
 import model._
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.mvc._
 import play.cache.CachedAction
 import services.{GuardianContentService, _}
 import views.support.PageInfo
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
-class MemberOnlyContent(contentApiService: GuardianContentService, commonActions: CommonActions) extends Controller with LazyLogging {
+class MemberOnlyContent(contentApiService: GuardianContentService, commonActions: CommonActions, implicit val executionContext: ExecutionContext) extends Controller with LazyLogging {
 
   import commonActions.CachedAction
 

--- a/frontend/app/controllers/MembershipStatus.scala
+++ b/frontend/app/controllers/MembershipStatus.scala
@@ -8,7 +8,6 @@ import com.gu.stripe.Stripe
 import configuration.Config
 import com.gu.stripe.Stripe.Serializer._
 import forms.MemberForm.supportForm
-import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.json.{JsArray, JsString, Json}
 import play.api.mvc._
 import services.{AuthenticationService, TouchpointBackend}
@@ -22,7 +21,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class MembershipStatus(
   override val wsClient: WSClient,
   parser: BodyParser[AnyContent],
-  executionContext: ExecutionContext,
+  override implicit val executionContext: ExecutionContext,
   googleAuthConfig: GoogleAuthConfig,
   commonActions: CommonActions
 ) extends OAuthActions(parser, executionContext, googleAuthConfig, commonActions) with Controller {

--- a/frontend/app/controllers/OAuth.scala
+++ b/frontend/app/controllers/OAuth.scala
@@ -5,7 +5,6 @@ import com.gu.googleauth.GoogleAuthFilters.LOGIN_ORIGIN_KEY
 import com.gu.googleauth.{GoogleAuth, GoogleAuthConfig, UserIdentity}
 import configuration.Config
 import model.FlashMessage
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json.Json
 import play.api.libs.ws.WSClient
 import play.api.mvc._
@@ -13,7 +12,7 @@ import play.api.mvc._
 import scala.concurrent.{ExecutionContext, Future}
 
 
-class OAuth(override val wsClient: WSClient, parser: BodyParser[AnyContent], executionContext: ExecutionContext, googleAuthConfig: GoogleAuthConfig, commonActions: CommonActions)
+class OAuth(override val wsClient: WSClient, parser: BodyParser[AnyContent], override implicit val executionContext: ExecutionContext, googleAuthConfig: GoogleAuthConfig, commonActions: CommonActions)
   extends OAuthActions(parser, executionContext, googleAuthConfig, commonActions) with Controller {
 
   import commonActions.NoCacheAction

--- a/frontend/app/controllers/SubscriptionController.scala
+++ b/frontend/app/controllers/SubscriptionController.scala
@@ -2,12 +2,13 @@ package controllers
 
 import actions.TouchpointCommonActions
 import model.FreeEventTickets
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json.Json
 import play.api.mvc._
 import services.TouchpointBackends
 
-class SubscriptionController(touchpointCommonActions: TouchpointCommonActions, implicit val touchpointBackends: TouchpointBackends) extends Controller with MemberServiceProvider {
+import scala.concurrent.ExecutionContext
+
+class SubscriptionController(touchpointCommonActions: TouchpointCommonActions, implicit val touchpointBackends: TouchpointBackends, implicit val executionContext: ExecutionContext) extends Controller with MemberServiceProvider {
 
   import touchpointCommonActions._
 

--- a/frontend/app/controllers/Testing.scala
+++ b/frontend/app/controllers/Testing.scala
@@ -6,12 +6,11 @@ import com.gu.googleauth.GoogleAuthConfig
 import com.typesafe.scalalogging.LazyLogging
 import play.api.mvc.{AnyContent, BodyParser, Controller, Cookie}
 import utils.TestUsers.testUsers
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.ws.WSClient
 
 import scala.concurrent.ExecutionContext
 
-class Testing(override val wsClient: WSClient, parser: BodyParser[AnyContent], executionContext: ExecutionContext, googleAuthConfig: GoogleAuthConfig, commonActions: CommonActions)
+class Testing(override val wsClient: WSClient, parser: BodyParser[AnyContent], override implicit val executionContext: ExecutionContext, googleAuthConfig: GoogleAuthConfig, commonActions: CommonActions)
   extends OAuthActions(parser, executionContext, googleAuthConfig, commonActions) with Controller with LazyLogging {
 
   import commonActions.CachedAction

--- a/frontend/app/controllers/TierController.scala
+++ b/frontend/app/controllers/TierController.scala
@@ -17,7 +17,6 @@ import com.typesafe.scalalogging.LazyLogging
 import forms.MemberForm._
 import model._
 import org.joda.time.LocalDate
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json.Json
 import play.api.mvc.{Controller, Result}
 import services.{IdentityApi, IdentityService, TouchpointBackends}
@@ -28,14 +27,21 @@ import views.support.MembershipCompat._
 import views.support.Pricing._
 import views.support.{CheckoutForm, CountryWithCurrency, PageInfo, PaidToPaidUpgradeSummary}
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.language.implicitConversions
 import scalaz.std.scalaFuture._
 import scalaz.syntax.monad._
 import scalaz.syntax.std.option._
 import scalaz.{EitherT, \/}
 
-class TierController(val joinerController: Joiner, val identityApi: IdentityApi, touchpointCommonActions: TouchpointCommonActions, implicit val touchpointBackends: TouchpointBackends, commonActions: CommonActions) extends Controller with ActivityTracking
+class TierController(
+  val joinerController: Joiner,
+  val identityApi: IdentityApi,
+  touchpointCommonActions: TouchpointCommonActions,
+  implicit val touchpointBackends: TouchpointBackends,
+  commonActions: CommonActions,
+  implicit val executionContext: ExecutionContext
+) extends Controller with ActivityTracking
   with LazyLogging
   with CatalogProvider
   with SubscriptionServiceProvider

--- a/frontend/app/controllers/User.scala
+++ b/frontend/app/controllers/User.scala
@@ -14,7 +14,7 @@ import views.support.MembershipCompat._
 
 import scala.concurrent.ExecutionContext
 
-class User(val identityApi: IdentityApi, touchpointCommonActions: TouchpointCommonActions, implicit val executionContext: ExecutionContext, commonActions: CommonActions) extends Controller {
+class User(val identityApi: IdentityApi, touchpointCommonActions: TouchpointCommonActions, implicit val executionContext: ExecutionContext, commonActions: CommonActions, membersDataAPI: MembersDataAPI) extends Controller {
   val standardFormat = ISODateTimeFormat.dateTime.withZoneUTC
   implicit val writesInstant = Writes[Instant] { instant => JsString(instant.toString(standardFormat)) }
 
@@ -23,7 +23,7 @@ class User(val identityApi: IdentityApi, touchpointCommonActions: TouchpointComm
 
   def me = AjaxSubscriptionAction { implicit request =>
     val json = basicDetails(request.subscriber)
-    MembersDataAPI.Service.checkMatchesResolvedMemberIn(request)
+    membersDataAPI.Service.checkMatchesResolvedMemberIn(request)
     Ok(json).withCookies(GuMemCookie.getAdditionCookie(json))
   }
 

--- a/frontend/app/controllers/WhatsOn.scala
+++ b/frontend/app/controllers/WhatsOn.scala
@@ -10,11 +10,10 @@ import play.api.mvc.Controller
 import services._
 import tracking.ActivityTracking
 import views.support.PageInfo
-import play.api.libs.concurrent.Execution.Implicits._
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
-class WhatsOn(eventbriteService: EventbriteCollectiveServices, touchpointBackends: TouchpointBackends, commonActions: CommonActions) extends Controller with ActivityTracking {
+class WhatsOn(eventbriteService: EventbriteCollectiveServices, touchpointBackends: TouchpointBackends, commonActions: CommonActions, implicit val executionContext: ExecutionContext) extends Controller with ActivityTracking {
 
   import commonActions.CachedAction
 

--- a/frontend/app/controllers/package.scala
+++ b/frontend/app/controllers/package.scala
@@ -9,7 +9,6 @@ import com.gu.zuora.api.ZuoraService
 import com.typesafe.scalalogging.LazyLogging
 import play.api.data.Form
 import play.api.http.HeaderNames.USER_AGENT
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.mvc.Results.Redirect
 import play.api.mvc.{AnyContent, RequestHeader, Result}
 import services.{PayPalService, TouchpointBackends}
@@ -78,6 +77,6 @@ package object controllers extends LazyLogging {
     lazy val errors = form.errors.map { e => s"  - ${e.key}: ${e.messages.mkString(", ")}"}.mkString("\n")
     logger.error(s"Server-side form errors on joining indicates a Javascript problem: ${req.headers.get(USER_AGENT)}")
     logger.error(s"Server-side form errors : Failed to bind from form ${classTag[T]}:\n$errors")
-    Future(Redirect(routes.Joiner.unsupportedBrowser()))
+    Future.successful(Redirect(routes.Joiner.unsupportedBrowser()))
   }
 }

--- a/frontend/app/filters/AddEC2InstanceHeader.scala
+++ b/frontend/app/filters/AddEC2InstanceHeader.scala
@@ -4,13 +4,12 @@ import javax.inject.Inject
 
 import akka.stream.Materializer
 import configuration.Config
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.ws.WSClient
 import play.api.mvc._
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
-class AddEC2InstanceHeader(wsClient: WSClient)(implicit val mat: Materializer) extends Filter {
+class AddEC2InstanceHeader(wsClient: WSClient)(implicit val mat: Materializer, implicit val ec: ExecutionContext) extends Filter {
 
   // http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
   lazy val instanceIdOptF = if (Config.stageProd)

--- a/frontend/app/filters/CheckCacheHeadersFilter.scala
+++ b/frontend/app/filters/CheckCacheHeadersFilter.scala
@@ -4,11 +4,10 @@ package filters
 import akka.stream.Materializer
 import play.api.mvc._
 
-import scala.concurrent.Future
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import scala.concurrent.{ExecutionContext, Future}
 import controllers.Cached.suitableForCaching
 
-class CheckCacheHeadersFilter(implicit val mat: Materializer) extends Filter {
+class CheckCacheHeadersFilter(implicit val mat: Materializer, implicit val ec: ExecutionContext) extends Filter {
 
   def apply(nextFilter: RequestHeader => Future[Result])(requestHeader: RequestHeader): Future[Result] = {
     nextFilter(requestHeader).map { result =>

--- a/frontend/app/monitoring/ErrorHandler.scala
+++ b/frontend/app/monitoring/ErrorHandler.scala
@@ -13,17 +13,17 @@ import play.api.mvc.Results._
 import play.api.mvc._
 import play.api.routing.Router
 import services.AuthenticationService
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.core.SourceMapper
 
 import scala.concurrent._
 
 class ErrorHandler(
-                               env: Environment,
-                               config: Configuration,
-                               sourceMapper: Option[SourceMapper],
-                               router: => Option[Router]
-                               ) extends DefaultHttpErrorHandler(env, config, sourceMapper, router) {
+  env: Environment,
+  config: Configuration,
+  sourceMapper: Option[SourceMapper],
+  router: => Option[Router],
+  implicit val executionContext: ExecutionContext
+) extends DefaultHttpErrorHandler(env, config, sourceMapper, router) {
 
   override def logServerError(request: RequestHeader, usefulException: UsefulException) {
     try {

--- a/frontend/app/services/EmailService.scala
+++ b/frontend/app/services/EmailService.scala
@@ -17,8 +17,7 @@ import model.ContributorRow
 import play.api.libs.json.Json
 import utils.AwsAsyncHandler
 
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 import scalaz.\/
 import scalaz.syntax.either._
@@ -73,7 +72,7 @@ trait ThankYouEmailService extends LazyLogging {
 
   private val thankYouQueueUrl = sqsClient.getQueueUrl(Config.thankYouEmailQueue).getQueueUrl
 
-  def thankYou(row: ContributorRow): Future[\/[Throwable, SendMessageResult]] = {
+  def thankYou(row: ContributorRow)(implicit ec: ExecutionContext): Future[\/[Throwable, SendMessageResult]] = {
     val payload = Json.stringify(Json.toJson(row))
 
     val handler = new AwsAsyncHandler[SendMessageRequest, SendMessageResult]

--- a/frontend/app/services/EventbriteService.scala
+++ b/frontend/app/services/EventbriteService.scala
@@ -127,13 +127,14 @@ abstract class EventbriteService(implicit val ec: ExecutionContext, system: Acto
   def getOrder(id: String): Future[EBOrder] = get[EBOrder](s"orders/$id/", "expand" -> EBOrder.expansions.mkString(","))
 }
 
-abstract class LiveService(implicit ec: ExecutionContext, system: ActorSystem, contentApiService: GuardianContentService) extends EventbriteService {
+abstract class LiveService(implicit ec: ExecutionContext, system: ActorSystem, contentApiService: GuardianContentService, gridService: GridService) extends EventbriteService {
 
   def gridImageFor(event: EBEvent) =
-    event.mainImageGridId.fold[Future[Option[GridImage]]](Future.successful(None))(GridService.getRequestedCrop)
+    event.mainImageGridId.fold[Future[Option[GridImage]]](Future.successful(None))(gridService.getRequestedCrop)
 }
 
-class GuardianLiveEventService(executionContext: ExecutionContext, actorSystem: ActorSystem, contentApiService: GuardianContentService) extends LiveService()(executionContext, actorSystem, contentApiService) {
+class GuardianLiveEventService(executionContext: ExecutionContext, actorSystem: ActorSystem, contentApiService: GuardianContentService, gridService: GridService)
+  extends LiveService()(executionContext, actorSystem, contentApiService, gridService) {
 
   implicit private val as = actorSystem
 

--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -1,6 +1,6 @@
 package services
 
-import _root_.services.api.MemberService.{MemberError, PendingAmendError, CreateMemberResult}
+import _root_.services.api.MemberService.{CreateMemberResult, MemberError, PendingAmendError}
 import _root_.services.paymentmethods._
 import com.gu.config.DiscountRatePlanIds
 import com.gu.i18n.Country.UK
@@ -34,14 +34,13 @@ import model.Eventbrite.{EBCode, EBOrder, EBTicketClass}
 import model.RichEvent.RichEvent
 import model.{Benefit => _, _}
 import org.joda.time.{DateTime, DateTimeZone}
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import tracking._
 import utils.ReferralData
 import views.support.MembershipCompat._
 import views.support.ThankyouSummary
 import views.support.ThankyouSummary.NextPayment
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 import scalaz._
 import scalaz.std.scalaFuture._
@@ -71,19 +70,22 @@ object MemberService {
   }
 }
 
-class MemberService(identityService: IdentityService,
-                    salesforceService: api.SalesforceService,
-                    zuoraService: ZuoraService,
-                    zuoraRestService: ZuoraRestService[Future],
-                    ukStripeService: StripeService,
-                    auStripeService: StripeService,
-                    payPalService: PayPalService,
-                    subscriptionService: SubscriptionService[Future],
-                    catalogService: CatalogService[Future],
-                    paymentService: PaymentService,
-                    discounter: Discounter,
-                    discountIds: DiscountRatePlanIds,
-                    invoiceIdsByCountry: Map[Country, InvoiceTemplate])
+class MemberService(
+  identityService: IdentityService,
+  salesforceService: api.SalesforceService,
+  zuoraService: ZuoraService,
+  zuoraRestService: ZuoraRestService[Future],
+  ukStripeService: StripeService,
+  auStripeService: StripeService,
+  payPalService: PayPalService,
+  subscriptionService: SubscriptionService[Future],
+  catalogService: CatalogService[Future],
+  paymentService: PaymentService,
+  discounter: Discounter,
+  discountIds: DiscountRatePlanIds,
+  invoiceIdsByCountry: Map[Country, InvoiceTemplate],
+  implicit val ec: ExecutionContext
+)
   extends api.MemberService with ActivityTracking with LazyLogging {
 
   import EventbriteService._

--- a/frontend/app/services/SalesforceService.scala
+++ b/frontend/app/services/SalesforceService.scala
@@ -10,11 +10,10 @@ import forms.MemberForm.{CommonForm, JoinForm}
 import model.GenericSFContact
 import monitoring.{ContributorMetrics, MemberMetrics}
 import akka.actor.ActorSystem
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json._
 import services.FrontendMemberRepository._
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 import scalaz.\/
 
@@ -22,7 +21,7 @@ object FrontendMemberRepository {
   type UserId = String
 }
 
-class SalesforceService(salesforceConfig: SalesforceConfig)(implicit val system: ActorSystem) extends api.SalesforceService {
+class SalesforceService(salesforceConfig: SalesforceConfig)(implicit val system: ActorSystem, implicit val executionContext: ExecutionContext) extends api.SalesforceService {
 
   val metricsVal = new MemberMetrics(salesforceConfig.envName)
 

--- a/frontend/app/services/TouchpointBackend.scala
+++ b/frontend/app/services/TouchpointBackend.scala
@@ -83,7 +83,7 @@ object TouchpointBackend {
 
     val paymentService = new PaymentService(zuoraService, newCatalogService.unsafeCatalog.productMap)
     val salesforceService = new SalesforceService(config.salesforce)
-    val identityService = IdentityService(new IdentityApi(wsClient))
+    val identityService = IdentityService(new IdentityApi(wsClient, executionContext))
     val memberService = new MemberService(
       identityService = identityService,
       salesforceService = salesforceService,
@@ -97,7 +97,8 @@ object TouchpointBackend {
       paymentService = paymentService,
       discounter = discounter,
       discountIds = Config.discountRatePlanIds(config.zuoraEnvName),
-      invoiceIdsByCountry = Config.invoiceTemplateOverrides(config.zuoraEnvName)
+      invoiceIdsByCountry = Config.invoiceTemplateOverrides(config.zuoraEnvName),
+      ec = executionContext
     )
 
     TouchpointBackend(

--- a/frontend/app/utils/RequestCountry.scala
+++ b/frontend/app/utils/RequestCountry.scala
@@ -4,8 +4,9 @@ import actions._
 import com.gu.i18n.CountryGroup
 import controllers.IdentityRequest
 import play.api.mvc.Request
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import services.TouchpointBackends
+
+import scala.concurrent.ExecutionContext
 
 object RequestCountry {
   implicit class RequestWithFastlyCountry(r: Request[_]) {
@@ -14,7 +15,7 @@ object RequestCountry {
   }
   implicit class AuthenticatedRequestWithIdentity(r:AuthRequest[_])
   {
-    def getIdentityCountryGroup(implicit touchpointBackends: TouchpointBackends) = {
+    def getIdentityCountryGroup(implicit touchpointBackends: TouchpointBackends, ec: ExecutionContext) = {
       implicit val identityRequest = IdentityRequest(r)
       r.touchpointBackend.identityService
         .getFullUserDetails(r.user)

--- a/frontend/test/services/GridServiceTest.scala
+++ b/frontend/test/services/GridServiceTest.scala
@@ -4,11 +4,12 @@ import com.netaporter.uri.Uri
 import com.netaporter.uri.dsl._
 import com.gu.memsub.images.Grid.GridResult
 import com.gu.memsub.images.GridDeserializer._
+import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mutable.Specification
 import services.GridService.ImageIdWithCrop.fromGuToolsUri
 import utils.Resource
 
-class GridServiceTest extends Specification {
+class GridServiceTest(implicit ev: ExecutionEnv) extends Specification {
   import GridService.ImageIdWithCrop
 
   val validGridUrl: Uri = "https://media.gutools.co.uk/images/aef2fb1db22f7cd20683548719a2849b3c9962ec?crop=0_19_480_288"
@@ -26,7 +27,8 @@ class GridServiceTest extends Specification {
       val gridResponse = grid.as[GridResult]
       val exports = gridResponse.data.exports.get
       val requestedCrop = "0_130_1703_1022"
-      val export = GridService.findExport(exports, requestedCrop)
+      val gridService = new GridService(ev.executionContext)
+      val export = gridService.findExport(exports, requestedCrop)
 
       export must beSome
       export.get.assets.size mustEqual(3)

--- a/frontend/test/services/IdentityServiceTest.scala
+++ b/frontend/test/services/IdentityServiceTest.scala
@@ -8,13 +8,14 @@ import com.gu.memsub.BillingPeriod.Year
 import com.gu.salesforce.Tier.partner
 import controllers.IdentityRequest
 import forms.MemberForm._
+import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import play.api.libs.json.{JsObject, Json}
 import services.IdentityService.DisregardResponseContent
 import utils.Resource
 
-class IdentityServiceTest extends Specification with Mockito {
+class IdentityServiceTest(implicit ev: ExecutionEnv) extends Specification with Mockito {
 
   val ip = "8.8.8.8"
   val user = new IdMinimalUser("4444", Some("Joe Bloggs"))


### PR DESCRIPTION
## Why are you doing this?

The default Play execution context is deprecated, so we should stop using it.  This will make keeping up to date with the Play framework easier.

## Trello card: [Here](https://trello.com/c/OqOfINff/1229-upgrade-membership-frontend-to-play-26)