### PR TITLE
Workaround legacy hashing warning

### DIFF
--- a/frontend/app/services/EmailService.scala
+++ b/frontend/app/services/EmailService.scala
@@ -7,7 +7,7 @@ import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClientBuilder
 import com.amazonaws.services.simpleemail.model._
 import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder
 import com.amazonaws.services.sqs.model.{SendMessageRequest, SendMessageResult}
-import com.google.common.hash.Hashing
+import utils.LegacyHashing
 import com.gu.aws.CredentialsProvider
 import com.gu.identity.play.IdMinimalUser
 import com.typesafe.scalalogging.LazyLogging
@@ -31,7 +31,7 @@ trait FeedbackEmailService extends LazyLogging {
     .build()
 
   def md5(input: String): String = {
-    val hf = Hashing.md5()
+    val hf = LegacyHashing.md5()
     util.Arrays.toString(hf.newHasher().putBytes(input.getBytes("UTF-8")).hash().asBytes())
   }
   def sendFeedback(feedback: FeedbackForm, userOpt: Option[IdMinimalUser], userEmail:Option[String], uaOpt: Option[String]) = {

--- a/frontend/app/utils/LegacyHashing.java
+++ b/frontend/app/utils/LegacyHashing.java
@@ -1,0 +1,21 @@
+package utils;
+
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hashing;
+
+/**
+ * Provides an md5 and sha1 hash function without producing deprecation warnings.
+ * From: https://github.com/google/guava/issues/2841
+ */
+
+public class LegacyHashing {
+    @SuppressWarnings("deprecation")
+    public static HashFunction md5() {
+        return Hashing.md5();
+    }
+
+    @SuppressWarnings("deprecation")
+    public static HashFunction sha1() {
+        return Hashing.sha1();
+    }
+}


### PR DESCRIPTION
## Why are you doing this?

Having warnings that we don't need to worry about is noise that hides genuine warnings.  This PR masks Google's deprecation of md5

## Trello card: [Here](https://trello.com/c/OqOfINff/1229-upgrade-membership-frontend-to-play-26)