### PR TITLE
Minor changes to wsClient API

### DIFF
--- a/frontend/app/services/IdentityService.scala
+++ b/frontend/app/services/IdentityService.scala
@@ -175,7 +175,7 @@ class IdentityApi(val wsClient: WSClient) {
     val endpoint = "user/password-exists"
     val url = s"${Config.idApiUrl}/$endpoint"
     Timing.record(IdentityApiMetrics, "get-user-password-exists") {
-      wsClient.url(url).withHeaders(headers: _*).withQueryString(parameters: _*).withRequestTimeout(1000 milli).get().map { response =>
+      wsClient.url(url).withHttpHeaders(headers: _*).withQueryStringParameters(parameters: _*).withRequestTimeout(1000 milli).get().map { response =>
         recordAndLogResponse(response.status, "GET user-password-exists", endpoint)
         (response.json \ "passwordExists").asOpt[Boolean].getOrElse(throw new IdentityApiError(s"$url did not return a boolean"))
       }
@@ -188,7 +188,7 @@ class IdentityApi(val wsClient: WSClient) {
     parameters: List[(String, String)],
     metricName: String)(func: WSResponse => Either[String, A]): EitherT[Future, String, A] = {
     execute(endpoint, metricName, func,
-      wsClient.url(s"${Config.idApiUrl}/$endpoint").withHeaders(headers: _*).withQueryString(parameters: _*).withRequestTimeout(1000 milli).withMethod("GET"))
+      wsClient.url(s"${Config.idApiUrl}/$endpoint").withHttpHeaders(headers: _*).withQueryStringParameters(parameters: _*).withRequestTimeout(1000 milli).withMethod("GET"))
   }
 
   def post[A](
@@ -197,7 +197,7 @@ class IdentityApi(val wsClient: WSClient) {
     parameters: List[(String, String)],
     metricName: String)(func: WSResponse => Either[String, A]): EitherT[Future, String, A] = {
     execute(endpoint, metricName, func,
-      wsClient.url(s"${Config.idApiUrl}/$endpoint").withHeaders(headers: _*).withQueryString(parameters: _*)
+      wsClient.url(s"${Config.idApiUrl}/$endpoint").withHttpHeaders(headers: _*).withQueryStringParameters(parameters: _*)
         .withRequestTimeout(5000 milli).withMethod("POST").withBody(data.getOrElse(JsNull)))
   }
 


### PR DESCRIPTION
## Why are you doing this?

Some of the methods on WSClient have been renamed, so we should use the new name.  This will make keeping up to date with the Play framework easier.

## Trello card: [Here](https://trello.com/c/OqOfINff/1229-upgrade-membership-frontend-to-play-26)