### PR TITLE
Remove Sentry Tags with (soon to be) PII and stop logging bad requests incorrectly

### DIFF
--- a/frontend/app/monitoring/SentryLogging.scala
+++ b/frontend/app/monitoring/SentryLogging.scala
@@ -13,8 +13,6 @@ import scala.util.{Failure, Success, Try}
 
 object SentryLogging {
 
-  val AllMDCTags = Seq()
-
   def init() {
     Try(new Dsn(Config.config.getString("sentry.dsn"))) match {
       case Failure(ex) =>
@@ -32,7 +30,6 @@ object SentryLogging {
           addFilter(filter)
           setTags(tagsString)
           setRelease(app.BuildInfo.gitCommitId)
-          setExtraTags(AllMDCTags.mkString(","))
           setContext(LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext])
         }
         sentryAppender.start()

--- a/frontend/app/monitoring/SentryLogging.scala
+++ b/frontend/app/monitoring/SentryLogging.scala
@@ -13,10 +13,7 @@ import scala.util.{Failure, Success, Try}
 
 object SentryLogging {
 
-  val UserIdentityId = "userIdentityId"
-  val UserGoogleId = "userGoogleId"
-  val PlayErrorId = "playErrorId"
-  val AllMDCTags = Seq(UserIdentityId, UserGoogleId,PlayErrorId)
+  val AllMDCTags = Seq()
 
   def init() {
     Try(new Dsn(Config.config.getString("sentry.dsn"))) match {


### PR DESCRIPTION
## Why are you doing this?
This is the first in a series of PRs which aims to improve/sanitize our Sentry logging, in order to help us to attain GDPR compliance.

As a bonus, this PR also fixes a problem which meant that we were logging bad requests as internal server errors. 

## Trello card: [Here](https://trello.com/c/y9MSfvxo/235-gdpr-sprint-goal-sentry-server-side)

## Changes
* Remove tags which contain ids, as we no longer want to send this information to Sentry
* Log bad requests as a warning (note: this means that they will no longer be sent to Sentry)