### PR TITLE
Use latest membership common

### DIFF
--- a/frontend/app/controllers/package.scala
+++ b/frontend/app/controllers/package.scala
@@ -4,7 +4,7 @@ import com.gu.memsub.services.api.PaymentService
 import com.gu.memsub.subsv2.Catalog
 import com.gu.memsub.subsv2.services._
 import com.gu.stripe.StripeService
-import com.gu.zuora.ZuoraRestService
+import com.gu.zuora.rest.ZuoraRestService
 import com.gu.zuora.api.ZuoraService
 import com.typesafe.scalalogging.LazyLogging
 import play.api.data.Form
@@ -49,8 +49,8 @@ package object controllers extends LazyLogging {
       request.touchpointBackend.payPalService
   }
 
-  trait ZuoraServiceProvider {
-    def zuoraService(implicit request: BackendProvider, tpbs: TouchpointBackends): ZuoraService =
+  trait ZuoraSoapServiceProvider {
+    def zuoraSoapService(implicit request: BackendProvider, tpbs: TouchpointBackends): ZuoraService =
       request.touchpointBackend.zuoraService
   }
 

--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -21,7 +21,7 @@ import com.gu.salesforce._
 import com.gu.stripe.Stripe.Customer
 import com.gu.stripe.StripeService
 import com.gu.subscriptions.Discounter
-import com.gu.zuora.ZuoraRestService
+import com.gu.zuora.rest.ZuoraRestService
 import com.gu.zuora.api._
 import com.gu.zuora.soap.models.Commands.{PaymentMethod, _}
 import com.gu.zuora.soap.models.Results.{CreateResult, SubscribeResult, UpdateResult}
@@ -39,7 +39,6 @@ import utils.ReferralData
 import views.support.MembershipCompat._
 import views.support.ThankyouSummary
 import views.support.ThankyouSummary.NextPayment
-
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 import scalaz._

--- a/frontend/conf/logback.xml
+++ b/frontend/conf/logback.xml
@@ -5,6 +5,13 @@
     <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>logs/frontend.log</file>
 
+        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+            <evaluator class="ch.qos.logback.classic.boolex.OnMarkerEvaluator">
+                <marker>SENTRY</marker>
+            </evaluator>
+            <onMatch>DENY</onMatch>
+        </filter>
+
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>logs/frontend.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
             <maxHistory>30</maxHistory>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "8.0.3"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "2.1"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.497"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.1-SNAPSHOT"
   val contentAPI = "com.gu" %% "content-api-client" % "11.40"
   val playWS = PlayImport.ws
   val playFilters = PlayImport.filters

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "8.0.3"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "2.1"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.1-SNAPSHOT"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.501"
   val contentAPI = "com.gu" %% "content-api-client" % "11.40"
   val playWS = PlayImport.ws
   val playFilters = PlayImport.filters


### PR DESCRIPTION
## Why are you doing this?
In order to use the latest version of membership-common, which brings in SafeLogger. This is a continuation of the work started in https://github.com/guardian/membership-frontend/pull/1786.

The next PR will actually start using the SafeLogger in this project (and will apply the appropriate Sentry filters).

## Trello card: [Here](https://trello.com/c/y9MSfvxo/235-gdpr-sprint-goal-sentry-server-side)

## Changes
* Upgrades membership-common version
* Minor re-factor to use [recently split Zuora services](https://github.com/guardian/membership-common/pull/564).
* Add log filter due to changes made in https://github.com/guardian/membership-common/pull/565