### PR TITLE
Delete old log metric filters from CFN

### DIFF
--- a/cloud-formation/membership-app.cf.yaml
+++ b/cloud-formation/membership-app.cf.yaml
@@ -274,28 +274,6 @@ Resources:
         - FrontendElasticLoadBalancer
         - DNSName
 
-  monthlyContributorAttempts:
-    Type: AWS::Logs::MetricFilter
-    Condition: IsProd
-    Properties:
-      LogGroupName: !Sub membership-frontend-${Stage}
-      FilterPattern: "attempting to become a monthly contributor"
-      MetricTransformations:
-      - MetricNamespace: !Sub ${Stage}/contributions
-        MetricName: new-monthly-contributor-attempt
-        MetricValue: 1
-
-  monthlyContributorSuccess:
-    Type: AWS::Logs::MetricFilter
-    Condition: IsProd
-    Properties:
-      LogGroupName: !Sub membership-frontend-${Stage}
-      FilterPattern: "successfully became monthly contributor"
-      MetricTransformations:
-      - MetricNamespace: !Sub ${Stage}/contributions
-        MetricName: new-monthly-contributor-success
-        MetricValue: 1
-
 Outputs:
   URL:
     Description: URL of the Frontend website


### PR DESCRIPTION
## Why are you doing this?
These metric filters are a hangover from the days when monthly contributions were sold via the membership site.

## Changes
* Delete unused metric filters