### PR TITLE
Use SafeLogger

### DIFF
--- a/frontend/app/actions/ActionRefiners.scala
+++ b/frontend/app/actions/ActionRefiners.scala
@@ -9,7 +9,7 @@ import com.gu.memsub.util.Timing
 import com.gu.memsub.{Status => SubStatus, Subscription => Sub, _}
 import com.gu.monitoring.CloudWatch
 import com.gu.salesforce._
-import com.typesafe.scalalogging.LazyLogging
+import com.gu.monitoring.SafeLogger
 import controllers.IdentityRequest
 import play.api.mvc.Results._
 import play.api.mvc.Security.{AuthenticatedBuilder, AuthenticatedRequest}
@@ -40,7 +40,7 @@ object ActionRefiners {
   type SubReqWithContributor[A] = SubscriptionRequest[A] with Contributor
 }
 
-class ActionRefiners(parser: BodyParser[AnyContent], implicit val executionContext: ExecutionContext) extends LazyLogging {
+class ActionRefiners(parser: BodyParser[AnyContent], implicit val executionContext: ExecutionContext) {
   import ActionRefiners._
   import model.TierOrdering.upgradeOrdering
   implicit val pf: ProductFamily = Membership
@@ -93,7 +93,7 @@ class ActionRefiners(parser: BodyParser[AnyContent], implicit val executionConte
     case _ => {
       // Log cancelled members attempting to re-join.
       if (req.subscriber.subscription.isCancelled) {
-        logger.info(s"Cancelled member with ID: ${req.subscriber.contact.identityId} attempted to re-join.")
+        SafeLogger.info(s"Cancelled member with ID: ${req.subscriber.contact.identityId} attempted to re-join.")
       }
       Ok(views.html.tier.upgrade.unavailableUpgradePath(req.subscriber.subscription.plan.tier, selectedTier))
     }

--- a/frontend/app/actions/CommonActions.scala
+++ b/frontend/app/actions/CommonActions.scala
@@ -5,7 +5,7 @@ import actions.Fallbacks._
 import com.gu.googleauth
 import com.gu.googleauth.GoogleAuthConfig
 import com.gu.salesforce.PaidTier
-import com.typesafe.scalalogging.LazyLogging
+import com.gu.monitoring.SafeLogger
 import configuration.Config
 import controllers._
 import play.api.http.HeaderNames._
@@ -19,7 +19,7 @@ import utils.TestUsers.{PreSigninTestCookie, isTestUser}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class CommonActions(parser: BodyParser[AnyContent], implicit val executionContext: ExecutionContext, actionRefiners: ActionRefiners) extends LazyLogging {
+class CommonActions(parser: BodyParser[AnyContent], implicit val executionContext: ExecutionContext, actionRefiners: ActionRefiners) {
 
   import actionRefiners.{authenticated, resultModifier}
 
@@ -34,7 +34,7 @@ class CommonActions(parser: BodyParser[AnyContent], implicit val executionContex
         val newABTestCookies = ABTest.cookiesWhichShouldBeDropped(request)
         if (newABTestCookies.nonEmpty) {
           val testUser = isTestUser(PreSigninTestCookie, request.cookies)(request).isDefined
-          logger.info(s"dropping-new-ab-test-cookies (path=${request.path} testUser=$testUser) : ${newABTestCookies.map(c => s"${c.name}=${c.value}").mkString(" ")}")
+          SafeLogger.info(s"dropping-new-ab-test-cookies (path=${request.path} testUser=$testUser) : ${newABTestCookies.map(c => s"${c.name}=${c.value}").mkString(" ")}")
         }
         result.withCookies(newABTestCookies ++ AudienceId.cookieWhichShouldBeDropped(request) :_*)
       }

--- a/frontend/app/actions/TouchpointActionRefiners.scala
+++ b/frontend/app/actions/TouchpointActionRefiners.scala
@@ -10,7 +10,7 @@ import services.{AuthenticationService, TouchpointBackends}
 import com.gu.memsub.subsv2.reads.ChargeListReads._
 import com.gu.memsub.subsv2.reads.SubPlanReads._
 import com.gu.memsub.subsv2.{Subscription, _}
-import com.typesafe.scalalogging.LazyLogging
+import com.gu.monitoring.SafeLogger
 import play.api.mvc.Security.AuthenticatedRequest
 import play.api.mvc._
 import views.support.MembershipCompat._
@@ -21,7 +21,7 @@ import scalaz.std.scalaFuture._
 import scala.concurrent.{ExecutionContext, Future}
 import scalaz.{-\/, \/, \/-}
 
-class TouchpointActionRefiners(touchpointBackends: TouchpointBackends, executionContext: ExecutionContext) extends LazyLogging {
+class TouchpointActionRefiners(touchpointBackends: TouchpointBackends, executionContext: ExecutionContext) {
 
   implicit private val ec = executionContext
   implicit private val tpbs = touchpointBackends
@@ -60,7 +60,7 @@ class TouchpointActionRefiners(touchpointBackends: TouchpointBackends, execution
     override def refine[A](request: AuthRequest[A]): SubRequestOrResult[A] = {
       getSubRequest(request).map {
         case -\/(message) =>
-          logger.warn(s"error while sub refining: $message")
+          SafeLogger.warn(s"error while sub refining: $message")
           Left(InternalServerError(views.html.error500(new Throwable)))
         case \/-(maybeMember) => maybeMember toRight onNonMember(request)}
     }
@@ -73,7 +73,7 @@ class TouchpointActionRefiners(touchpointBackends: TouchpointBackends, execution
     override def refine[A](request: AuthRequest[A]): SubRequestWithContributorOrResult[A] = {
       getContributorRequest(request).map {
         case -\/(message) =>
-          logger.warn(s"error while contribution refining: $message")
+          SafeLogger.warn(s"error while contribution refining: $message")
           Left(InternalServerError(views.html.error500(new Throwable)))
         case \/-(maybeMember) => maybeMember toRight onNonContributor(request)
       }
@@ -87,7 +87,7 @@ class TouchpointActionRefiners(touchpointBackends: TouchpointBackends, execution
     override def filter[A](request: Request[A]) =
       getSubRequest(request).map {
         case -\/(message) =>
-          logger.warn(s"error while filtering: $message")
+          SafeLogger.warn(s"error while filtering: $message")
           Some(InternalServerError(views.html.error500(new Throwable)))
         case \/-(maybeSub) => maybeSub.map(onMember)
       }
@@ -100,7 +100,7 @@ class TouchpointActionRefiners(touchpointBackends: TouchpointBackends, execution
     override def filter[A](request: AuthRequest[A]) =
       getSubRequest(request).map {
         case -\/(message) =>
-          logger.warn(s"error while filtering: $message")
+          SafeLogger.warn(s"error while filtering: $message")
           Some(InternalServerError(views.html.error500(new Throwable)))
         case \/-(maybeSub) => maybeSub.map(onMember)
       }
@@ -113,7 +113,7 @@ class TouchpointActionRefiners(touchpointBackends: TouchpointBackends, execution
     override def filter[A](request: AuthRequest[A]) =
       getContributorRequest(request).map {
         case -\/(message) =>
-          logger.warn(s"error while filtering contributors: $message")
+          SafeLogger.warn(s"error while filtering contributors: $message")
           Some(InternalServerError(views.html.error500(new Throwable)))
         case \/-(maybeSub) => maybeSub.map(onContributor)
       }

--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -10,13 +10,11 @@ import com.netaporter.uri.Uri
 import com.netaporter.uri.dsl._
 import com.typesafe.config.ConfigFactory
 import model.Eventbrite.EBEvent
-import play.api.Logger
 import services._
 
 import scala.util.Try
 
 object Config {
-  val logger = Logger(this.getClass)
 
   val config = ConfigFactory.load()
 

--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -9,7 +9,7 @@ import com.gu.memsub.Subscriber.Member
 import com.gu.memsub.util.Timing
 import com.netaporter.uri.Uri
 import com.netaporter.uri.dsl._
-import com.typesafe.scalalogging.LazyLogging
+import com.gu.monitoring.SafeLogger
 import model.EmbedSerializer._
 import model.Eventbrite.{EBCode, EBEvent, EBOrder}
 import model.RichEvent.{RichEvent, _}
@@ -42,7 +42,7 @@ class Event(
   with BaseController
   with MemberServiceProvider
   with ActivityTracking
-  with LazyLogging {
+  {
 
   import touchpointActionRefiners._
   import touchpointCommonActions._
@@ -149,7 +149,7 @@ class Event(
         }
       case _ =>
         // We seem to have a crawler(?) hitting the buy urls for past events
-        logger.info(s"User hit the buy url for event $id - neither a GuLiveEvent or Masterclass could be retrieved, returning 404...")
+        SafeLogger.info(s"User hit the buy url for event $id - neither a GuLiveEvent or Masterclass could be retrieved, returning 404...")
         CachedAction(NotFound)
     }
 

--- a/frontend/app/controllers/FeatureOptIn.scala
+++ b/frontend/app/controllers/FeatureOptIn.scala
@@ -1,12 +1,10 @@
 package controllers
 
-
 import actions.CommonActions
-import com.typesafe.scalalogging.LazyLogging
 import play.api.mvc.{BaseController, ControllerComponents}
 import utils.{Feature, OnOrOff}
 
-class FeatureOptIn(commonActions: CommonActions, override protected val controllerComponents: ControllerComponents) extends BaseController with LazyLogging {
+class FeatureOptIn(commonActions: CommonActions, override protected val controllerComponents: ControllerComponents) extends BaseController {
 
   import commonActions.NoCacheAction
 

--- a/frontend/app/controllers/Healthcheck.scala
+++ b/frontend/app/controllers/Healthcheck.scala
@@ -2,7 +2,7 @@ package controllers
 
 import com.github.nscala_time.time.Imports._
 import com.gu.monitoring.CloudWatchHealth
-import play.api.Logger.warn
+import com.gu.monitoring.SafeLogger.warn
 import play.api.mvc.{Action, BaseController, ControllerComponents}
 import services.{EventbriteCollectiveServices, GuardianLiveEventService, TouchpointBackend, TouchpointBackends}
 

--- a/frontend/app/controllers/Info.scala
+++ b/frontend/app/controllers/Info.scala
@@ -4,7 +4,7 @@ import actions.{ActionRefiners, CommonActions}
 import com.gu.i18n.CountryGroup
 import com.gu.i18n.CountryGroup._
 import com.gu.memsub.images.{Grid, ResponsiveImageGenerator, ResponsiveImageGroup}
-import com.typesafe.scalalogging.LazyLogging
+import com.gu.monitoring.SafeLogger
 import configuration.CopyConfig
 import forms.FeedbackForm
 import model.{ContentItemOffer, FlashMessage, OrientatedImages}
@@ -24,7 +24,7 @@ class Info(
   commonActions: CommonActions,
   actionRefiners: ActionRefiners,
   implicit val executionContext: ExecutionContext
-, override protected val controllerComponents: ControllerComponents) extends BaseController with LazyLogging {
+, override protected val controllerComponents: ControllerComponents) extends BaseController {
 
   import commonActions.{CachedAction, NoCacheAction, StoreAcquisitionDataAction}
   import actionRefiners.PlannedOutageProtection

--- a/frontend/app/controllers/MemberOnlyContent.scala
+++ b/frontend/app/controllers/MemberOnlyContent.scala
@@ -5,7 +5,6 @@ import com.gu.contentapi.client.model.v1.{MembershipTier => ContentAccess}
 import com.gu.i18n.CountryGroup._
 import com.netaporter.uri.Uri
 import com.netaporter.uri.dsl._
-import com.typesafe.scalalogging.LazyLogging
 import configuration.Config
 import model._
 import play.api.mvc._
@@ -15,7 +14,7 @@ import views.support.PageInfo
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class MemberOnlyContent(contentApiService: GuardianContentService, commonActions: CommonActions, implicit val executionContext: ExecutionContext, override protected val controllerComponents: ControllerComponents) extends BaseController with LazyLogging {
+class MemberOnlyContent(contentApiService: GuardianContentService, commonActions: CommonActions, implicit val executionContext: ExecutionContext, override protected val controllerComponents: ControllerComponents) extends BaseController {
 
   import commonActions.CachedAction
 

--- a/frontend/app/controllers/PayPal.scala
+++ b/frontend/app/controllers/PayPal.scala
@@ -1,7 +1,8 @@
 package controllers
 
 import actions.CommonActions
-import com.typesafe.scalalogging.LazyLogging
+import com.gu.monitoring.SafeLogger
+import com.gu.monitoring.SafeLogger._
 import play.api.libs.json.Json.toJson
 import play.api.libs.json._
 import play.api.mvc.{BaseController, ControllerComponents, Request}
@@ -21,7 +22,7 @@ object PayPal {
   implicit val readsBillingDetails = Json.reads[PayPalBillingDetails]
 }
 
-class PayPal(touchpointBackends: TouchpointBackends, implicit val executionContext: ExecutionContext, commonActions: CommonActions, override protected val controllerComponents: ControllerComponents) extends BaseController with LazyLogging with PayPalServiceProvider {
+class PayPal(touchpointBackends: TouchpointBackends, implicit val executionContext: ExecutionContext, commonActions: CommonActions, override protected val controllerComponents: ControllerComponents) extends BaseController with PayPalServiceProvider {
 
   import commonActions.NoCacheAction
   import PayPal._
@@ -51,14 +52,14 @@ class PayPal(touchpointBackends: TouchpointBackends, implicit val executionConte
   // The endpoint corresponding to the PayPal return url, hit if the user is
   // redirected and needs to come back.
   def returnUrl = NoCacheAction {
-    logger.error("User hit the PayPal returnUrl.")
+    SafeLogger.error(scrub"User hit the PayPal returnUrl.")
     Ok(views.html.paypal.errorPage())
   }
 
   // The endpoint corresponding to the PayPal cancel url, hit if the user is
   // redirected and the payment fails.
   def cancelUrl = NoCacheAction {
-    logger.error("User hit the PayPal cancelUrl, something went wrong.")
+    SafeLogger.error(scrub"User hit the PayPal cancelUrl, something went wrong.")
     Ok(views.html.paypal.errorPage())
   }
 }

--- a/frontend/app/controllers/PaymentGatewayErrorHandler.scala
+++ b/frontend/app/controllers/PaymentGatewayErrorHandler.scala
@@ -1,16 +1,16 @@
 package controllers
 
 import com.gu.zuora.soap.models.errors._
-import com.typesafe.scalalogging.LazyLogging
+import com.gu.monitoring.SafeLogger
 import play.api.libs.json.Json
 import play.api.mvc.Results.Forbidden
 
-trait PaymentGatewayErrorHandler extends LazyLogging {
+trait PaymentGatewayErrorHandler {
 
   def handlePaymentGatewayError(e: PaymentGatewayError, userId: String, tier: String, country: String = "") = {
 
     def handleError(code: String) = {
-      logger.warn(s"User $userId could not become $tier member due to payment gateway failed transaction: \n\terror=$e \n\tuser=$userId \n\tcountry=$country")
+      SafeLogger.warn(s"User $userId could not become $tier member due to payment gateway failed transaction: \n\terror=$e \n\tuser=$userId \n\tcountry=$country")
       Forbidden(Json.obj("type" -> "PaymentGatewayError", "code" -> code))
     }
 

--- a/frontend/app/controllers/SiteMap.scala
+++ b/frontend/app/controllers/SiteMap.scala
@@ -2,14 +2,13 @@ package controllers
 
 import actions.CommonActions
 import com.gu.i18n.CountryGroup
-import com.typesafe.scalalogging.LazyLogging
 import model.ActiveCountryGroups
 import play.api.mvc._
 import utils.CountryGroupLang
 
 import scala.xml.Elem
 
-class SiteMap(commonActions: CommonActions, override protected val controllerComponents: ControllerComponents) extends BaseController with LazyLogging {
+class SiteMap(commonActions: CommonActions, override protected val controllerComponents: ControllerComponents) extends BaseController {
 
   import commonActions.CachedAction
 

--- a/frontend/app/controllers/Testing.scala
+++ b/frontend/app/controllers/Testing.scala
@@ -3,7 +3,7 @@ package controllers
 import actions.Fallbacks._
 import actions._
 import com.gu.googleauth.GoogleAuthConfig
-import com.typesafe.scalalogging.LazyLogging
+import com.gu.monitoring.SafeLogger
 import play.api.mvc._
 import utils.TestUsers.testUsers
 import play.api.libs.ws.WSClient
@@ -17,7 +17,7 @@ class Testing(
   googleAuthConfig: GoogleAuthConfig,
   commonActions: CommonActions,
   override protected val controllerComponents: ControllerComponents
-) extends OAuthActions(parser, executionContext, googleAuthConfig, commonActions) with BaseController with LazyLogging {
+) extends OAuthActions(parser, executionContext, googleAuthConfig, commonActions) with BaseController {
 
   import commonActions.CachedAction
 
@@ -41,7 +41,7 @@ class Testing(
 
   def testUser = AuthorisedTester { implicit request =>
     val testUserString = testUsers.generate()
-    logger.info(s"Generated test user string $testUserString for ${request.user.email}")
+    SafeLogger.info(s"Generated test user string $testUserString for ${request.user.email}")
     val testUserCookie = Cookie(PreSigninTestCookieName, testUserString, Some(30 * 60), httpOnly = true)
     Ok(views.html.testing.testUsers(testUserString)).withCookies(testUserCookie, analyticsOffCookie)
   }

--- a/frontend/app/controllers/package.scala
+++ b/frontend/app/controllers/package.scala
@@ -6,7 +6,8 @@ import com.gu.memsub.subsv2.services._
 import com.gu.stripe.StripeService
 import com.gu.zuora.rest.ZuoraRestService
 import com.gu.zuora.api.ZuoraService
-import com.typesafe.scalalogging.LazyLogging
+import com.gu.monitoring.SafeLogger
+import com.gu.monitoring.SafeLogger._
 import play.api.data.Form
 import play.api.http.HeaderNames.USER_AGENT
 import play.api.mvc.Results.Redirect
@@ -17,7 +18,7 @@ import services.api.{MemberService, SalesforceService}
 import scala.concurrent.Future
 import scala.reflect.{ClassTag, classTag}
 
-package object controllers extends LazyLogging {
+package object controllers {
 
   trait MemberServiceProvider {
     def memberService(implicit request: BackendProvider, tpbs: TouchpointBackends): MemberService =
@@ -75,8 +76,8 @@ package object controllers extends LazyLogging {
 
   def redirectToUnsupportedBrowserInfo[T: ClassTag](form: Form[T])(implicit req: RequestHeader): Future[Result] = {
     lazy val errors = form.errors.map { e => s"  - ${e.key}: ${e.messages.mkString(", ")}"}.mkString("\n")
-    logger.error(s"Server-side form errors on joining indicates a Javascript problem: ${req.headers.get(USER_AGENT)}")
-    logger.error(s"Server-side form errors : Failed to bind from form ${classTag[T]}:\n$errors")
+    SafeLogger.error(scrub"Server-side form errors on joining indicates a Javascript problem: ${req.headers.get(USER_AGENT)}")
+    SafeLogger.error(scrub"Server-side form errors : Failed to bind from form ${classTag[T]}:\n$errors")
     Future.successful(Redirect(routes.Joiner.unsupportedBrowser()))
   }
 }

--- a/frontend/app/controllers/rest/EventApi.scala
+++ b/frontend/app/controllers/rest/EventApi.scala
@@ -2,7 +2,6 @@ package controllers.rest
 
 import actions.CommonActions
 import controllers._
-import com.typesafe.scalalogging.LazyLogging
 import play.api.libs.json.Json
 import play.api.libs.json.Json.toJson
 import play.api.mvc.{BaseController, ControllerComponents}
@@ -16,7 +15,7 @@ object EventApi {
   }
 }
 
-class EventApi(eventbriteService: EventbriteCollectiveServices, commonActions: CommonActions, override protected val controllerComponents: ControllerComponents) extends BaseController with LazyLogging {
+class EventApi(eventbriteService: EventbriteCollectiveServices, commonActions: CommonActions, override protected val controllerComponents: ControllerComponents) extends BaseController {
 
   import commonActions.CachedAction
   import EventApi._

--- a/frontend/app/loghandling/Logstash.scala
+++ b/frontend/app/loghandling/Logstash.scala
@@ -5,7 +5,7 @@ import com.amazonaws.util.EC2MetadataUtils
 import configuration.Config
 import play.api.Configuration
 import com.gu.aws.CredentialsProvider
-import com.typesafe.scalalogging.StrictLogging
+import com.gu.monitoring.SafeLogger
 
 case class LogStashConf(enabled: Boolean,
                         stream: String,
@@ -13,7 +13,7 @@ case class LogStashConf(enabled: Boolean,
                         awsCredentialsProvider: AWSCredentialsProvider,
                         customFields: Map[String, String])
 
-object Logstash extends StrictLogging {
+object Logstash {
 
   def customFields(playConfig: Config.type) = Map(
     "app" -> playConfig.appName,
@@ -37,7 +37,7 @@ object Logstash extends StrictLogging {
   }
 
   def init(playConfig: Config.type): Unit = {
-    config(playConfig).fold(logger.info("Logstash config is missing"))(LogbackConfig.init)
+    config(playConfig).fold(SafeLogger.info("Logstash config is missing"))(LogbackConfig.init)
   }
 
 }

--- a/frontend/app/model/Eventbrite.scala
+++ b/frontend/app/model/Eventbrite.scala
@@ -9,7 +9,8 @@ import com.netaporter.uri.dsl._
 import configuration.Config
 import org.joda.time.Instant
 import org.joda.time.format.ISODateTimeFormat
-import play.api.Logger
+import com.gu.monitoring.SafeLogger
+import com.gu.monitoring.SafeLogger._
 import play.api.data.validation.ValidationError
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
@@ -288,7 +289,7 @@ object Eventbrite {
       uri <- Try(Uri.parse(m.group(1))) match {
         case Success(uri) => Some(uri)
         case Failure(e) =>
-          Logger.error(s"Event $id - can't parse main-image url from text '${m.matched}'", e)
+          SafeLogger.error(scrub"Event $id - can't parse main-image url from text '${m.matched}'", e)
           None
       }
     } yield uri

--- a/frontend/app/services/EventbriteService.scala
+++ b/frontend/app/services/EventbriteService.scala
@@ -13,7 +13,7 @@ import model.RichEvent._
 import monitoring.EventbriteMetrics
 import okhttp3.Request
 import org.joda.time.{DateTime, Interval}
-import play.api.Logger
+import com.gu.monitoring.SafeLogger
 import play.api.cache.AsyncCacheApi
 import play.api.libs.json.{Json, Reads}
 import utils.StringUtils._
@@ -68,7 +68,7 @@ abstract class EventbriteService(implicit val ec: ExecutionContext, system: Acto
   lazy val draftEventsTask =  eventsTaskFor("draft", 59.seconds, Config.eventbriteRefreshTime.seconds)
 
   def start() {
-    Logger.info(s"Starting EventbriteService background tasks for ${this.getClass.getSimpleName}")
+    SafeLogger.info(s"Starting EventbriteService background tasks for ${this.getClass.getSimpleName}")
     eventsTask.start()
     draftEventsTask.start()
     archivedEventsTask.start()
@@ -170,7 +170,7 @@ class GuardianLiveEventService(executionContext: ExecutionContext, actorSystem: 
   override def getFeaturedEvents: Seq[RichEvent] = EventbriteServiceHelpers.getFeaturedEvents(eventsOrderingTask.get(), events)
   override def start() {
     super.start()
-    Logger.info("Starting EventsOrdering background task")
+    SafeLogger.info("Starting EventsOrdering background task")
     val timeout = (Config.eventbriteRefreshTimeForPriorityEvents - 3).seconds
     eventsOrderingTask.start()
   }

--- a/frontend/app/services/GridService.scala
+++ b/frontend/app/services/GridService.scala
@@ -12,7 +12,8 @@ import com.gu.monitoring.StatusMetrics
 import com.gu.okhttp.RequestRunners
 import com.gu.okhttp.RequestRunners.LoggingHttpClient
 import com.netaporter.uri.Uri
-import com.typesafe.scalalogging.LazyLogging
+import com.gu.monitoring.SafeLogger
+import com.gu.monitoring.SafeLogger._
 import configuration.Config
 import model.RichEvent.GridImage
 import monitoring.GridApiMetrics
@@ -44,7 +45,7 @@ object GridService {
   }
 }
 
-class GridService(executionContext: ExecutionContext) extends WebServiceHelper[GridObject, Grid.Error]()(executionContext) with LazyLogging {
+class GridService(executionContext: ExecutionContext) extends WebServiceHelper[GridObject, Grid.Error]()(executionContext) {
 
   import GridService._
 
@@ -65,7 +66,7 @@ class GridService(executionContext: ExecutionContext) extends WebServiceHelper[G
           val image = GridImage(export.assets, grid.data.metadata, export.master)
           atomicReference.updateAndGet({ oldImageData: Map[ImageIdWithCrop, GridImage] =>
             val newImageData = oldImageData + (gridId -> image)
-            logger.trace(s"Adding image $gridId to the event image map")
+            SafeLogger.debug(s"Adding image $gridId to the event image map")
             newImageData
           })
           image
@@ -73,7 +74,7 @@ class GridService(executionContext: ExecutionContext) extends WebServiceHelper[G
       }
     }
   }.recover { case e =>
-    logger.error(s"Error getting crop for $gridId", e)
+    SafeLogger.error(scrub"Error getting crop for $gridId", e)
     None
   } // We should return no image, rather than die
 

--- a/frontend/app/services/GuardianContentService.scala
+++ b/frontend/app/services/GuardianContentService.scala
@@ -10,7 +10,8 @@ import com.gu.memsub.util.ScheduledTask
 import configuration.Config
 import monitoring.ContentApiMetrics
 import org.joda.time.DateTime
-import play.api.Logger
+import com.gu.monitoring.SafeLogger
+import com.gu.monitoring.SafeLogger._
 import play.api.libs.iteratee.{Enumerator, Iteratee}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -107,7 +108,7 @@ trait GuardianContent {
       ContentApiMetrics.putResponseCode(200, "GET content")
     case Failure(GuardianContentApiError(status, message, _)) =>
       ContentApiMetrics.putResponseCode(status, "GET content")
-      Logger.error(s"Error response from Content API $status")
+      SafeLogger.error(scrub"Error response from Content API $status")
   }
 
   def masterclassesQuery(page: Int): Future[ItemResponse] = {

--- a/frontend/app/services/TouchpointBackend.scala
+++ b/frontend/app/services/TouchpointBackend.scala
@@ -19,7 +19,7 @@ import com.gu.zuora.rest.{SimpleClient, ZuoraRestService}
 import com.gu.zuora.soap.ClientWithFeatureSupplier
 import com.gu.zuora.{soap, ZuoraSoapService => ZuoraSoapServiceImpl}
 import com.netaporter.uri.Uri
-import com.typesafe.scalalogging.LazyLogging
+import com.gu.monitoring.SafeLogger
 import configuration.Config
 import model.FeatureChoice
 import monitoring.TouchpointBackendMetrics
@@ -126,7 +126,7 @@ object TouchpointBackend {
   )
 }
 
-class TouchpointBackends(actorSystem: ActorSystem, executionContext: ExecutionContext, wsClient: WSClient) extends LazyLogging {
+class TouchpointBackends(actorSystem: ActorSystem, executionContext: ExecutionContext, wsClient: WSClient) {
 
   import TouchpointBackend._
   import TouchpointBackendConfig.BackendType
@@ -156,9 +156,9 @@ class TouchpointBackends(actorSystem: ActorSystem, executionContext: ExecutionCo
   }
 
   Future {
-    logger.info(s"TouchpointBackend.TestUser is lazily initialised to ensure bad UAT settings can not block deployment to PROD. Initalisation starting...")
+    SafeLogger.info(s"TouchpointBackend.TestUser is lazily initialised to ensure bad UAT settings can not block deployment to PROD. Initalisation starting...")
     val amountOfPlans = TestUser.catalog.allMembership.size
-    logger.info(s"TouchpointBackend.TestUser initalisation complete: $amountOfPlans membership plans in UAT")
+    SafeLogger.info(s"TouchpointBackend.TestUser initalisation complete: $amountOfPlans membership plans in UAT")
   }
 
   def forUser(user: IdMinimalUser): TouchpointBackend = if (isTestUser(user)) TestUser else Normal

--- a/frontend/app/services/checkout/identitystrategy/ExistingSignedInUser.scala
+++ b/frontend/app/services/checkout/identitystrategy/ExistingSignedInUser.scala
@@ -2,7 +2,6 @@ package services.checkout.identitystrategy
 
 import com.gu.identity.play.idapi.UpdateIdUser
 import com.gu.identity.play.{IdMinimalUser, IdUser}
-import com.typesafe.scalalogging.LazyLogging
 import controllers.IdentityRequest
 import forms.MemberForm.CommonForm
 import play.api.mvc.{RequestHeader, Result}
@@ -11,7 +10,7 @@ import services.IdentityService
 
 import scala.concurrent.{ExecutionContext, Future}
 
-case class ExistingSignedInUser(userId: IdMinimalUser, formData: CommonForm)(implicit idReq: IdentityRequest, identityService: IdentityService) extends Strategy with LazyLogging {
+case class ExistingSignedInUser(userId: IdMinimalUser, formData: CommonForm)(implicit idReq: IdentityRequest, identityService: IdentityService) extends Strategy {
 
   def ensureIdUser(checkoutFunc: (IdUser) => Future[Result])(implicit executionContext: ExecutionContext) = {
     val fieldsFromForm = Some(IdentityService.privateFieldsFor(formData))

--- a/frontend/app/services/paymentmethods/AvailablePaymentMethods.scala
+++ b/frontend/app/services/paymentmethods/AvailablePaymentMethods.scala
@@ -3,20 +3,20 @@ package services.paymentmethods
 import com.gu.i18n.Country
 import com.gu.identity.play.IdMinimalUser
 import com.gu.zuora
-import com.typesafe.scalalogging.LazyLogging
+import com.gu.monitoring.SafeLogger
+import com.gu.monitoring.SafeLogger._
 import forms.MemberForm.CommonPaymentForm
-
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
 
-case class InitialiserAndToken(initialiser: PaymentMethodInitialiser[_ <: zuora.soap.models.Commands.PaymentMethod], token: String) extends LazyLogging {
+case class InitialiserAndToken(initialiser: PaymentMethodInitialiser[_ <: zuora.soap.models.Commands.PaymentMethod], token: String) {
   def initialiseUsing(user: IdMinimalUser)(implicit executionContext: ExecutionContext): Future[zuora.soap.models.Commands.PaymentMethod] = {
     val initialiserName = initialiser.getClass.getSimpleName
-    logger.info(s"Initialising payment token for user ${user.id} with $initialiserName...")
+    SafeLogger.info(s"Initialising payment token for user ${user.id} with $initialiserName...")
     initialiser.initialiseWith(token, user).andThen {
-      case Success(_) => logger.info(s"...successfully initialised payment token for user ${user.id}")
-      case Failure(e) => logger.error(s"...failed to initialise payment token with $initialiserName", e)
+      case Success(_) => SafeLogger.info(s"...successfully initialised payment token for user ${user.id}")
+      case Failure(e) => SafeLogger.error(scrub"...failed to initialise payment token with $initialiserName", e)
     }
   }
 }

--- a/frontend/app/tracking/AcquisitionTracking.scala
+++ b/frontend/app/tracking/AcquisitionTracking.scala
@@ -8,7 +8,7 @@ import com.gu.acquisition.services.{MockOphanService, OphanService}
 import com.gu.memsub.PaymentMethod
 import com.gu.okhttp.RequestRunners
 import com.gu.salesforce.Tier
-import com.typesafe.scalalogging.LazyLogging
+import com.gu.monitoring.SafeLogger
 import model.MembershipAcquisitionData
 import play.api.libs.json.{JsError, Json}
 import play.api.mvc.{Session}
@@ -17,7 +17,7 @@ import views.support.ThankyouSummary
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait AcquisitionTracking extends LazyLogging {
+trait AcquisitionTracking {
 
   private def ophanService(isTestUser: Boolean): OphanService = {
     if (isTestUser) MockOphanService
@@ -37,7 +37,7 @@ trait AcquisitionTracking extends LazyLogging {
       )
     } yield acquisitionData
 
-    decodeAttempt.leftMap(error => logger.warn(error)).toOption
+    decodeAttempt.leftMap(error => SafeLogger.warn(error)).toOption
   }
 
   def trackAcquisition(

--- a/frontend/app/tracking/ActivityTracking.scala
+++ b/frontend/app/tracking/ActivityTracking.scala
@@ -1,6 +1,6 @@
 package tracking
-import java.util.{Map => JMap}
 
+import java.util.{Map => JMap}
 import com.github.t3hnar.bcrypt._
 import com.gu.identity.play.IdMinimalUser
 import com.gu.memsub.BillingPeriod
@@ -15,7 +15,8 @@ import model.Eventbrite.{EBOrder, EBTicketClass}
 import model.GenericSFContact
 import model.RichEvent.{GuLiveEvent, MasterclassEvent, RichEvent}
 import org.joda.time._
-import play.api.Logger
+import com.gu.monitoring.SafeLogger
+import com.gu.monitoring.SafeLogger._
 import play.api.mvc.RequestHeader
 import services.EventbriteService
 import com.gu.memsub.subsv2._
@@ -23,9 +24,7 @@ import _root_.services.EventbriteCollectiveServices
 import utils.ReferralData
 import utils.TestUsers.isTestUser
 import views.support.MembershipCompat._
-
 import scala.collection.JavaConversions._
-
 
 case class MemberActivity (source: String, member: MemberData) extends TrackerData {
   def toMap: JMap[String, Object] =
@@ -296,7 +295,7 @@ trait ActivityTracking {
       }
     } catch {
       case error: Throwable =>
-      Logger.error(s"Activity tracking error", error)
+      SafeLogger.error(scrub"Activity tracking error", error)
     }
   }
 

--- a/frontend/app/views/support/CheckoutForm.scala
+++ b/frontend/app/views/support/CheckoutForm.scala
@@ -3,13 +3,13 @@ package views.support
 import com.gu.i18n.Currency.GBP
 import com.gu.i18n._
 import com.gu.memsub.BillingPeriod
-import com.typesafe.scalalogging.LazyLogging
+import com.gu.monitoring.SafeLogger
 
 case class CheckoutForm(defaultCountry: Option[Country],
                         currency: Currency,
                         billingPeriod: BillingPeriod)
 
-object CheckoutForm extends LazyLogging {
+object CheckoutForm {
   def forIdentityUser(userCountry: Option[Country], plans: TierPlans, requestCountryGroup: Option[CountryGroup]): CheckoutForm = {
     val (country, countryGroup) = (requestCountryGroup, userCountry) match {
       case (Some(cg), _) =>
@@ -31,7 +31,7 @@ object CheckoutForm extends LazyLogging {
    def countryGroupOf(country: Country): CountryGroup = CountryGroup.allGroups
     .find(_.countries.contains(country))
     .getOrElse {
-      logger.warn(s"Could not find country $country in any CountryGroup, defaulting to UK")
+      SafeLogger.warn(s"Could not find country $country in any CountryGroup, defaulting to UK")
       CountryGroup.UK
     }
 }


### PR DESCRIPTION
## Why are you doing this?
I am migrating this project over to using a new SafeLogger object (imported [here](https://github.com/guardian/membership-frontend/pull/1787)), with the ultimate aim of keeping PII out of Sentry.

Note that error messages won't actually be filtered out until the next PR is finished. The (final PR) will add the filters to the Sentry appender and override Play's default error handling.

## Trello card: [Here](https://trello.com/c/y9MSfvxo/235-gdpr-sprint-goal-sentry-server-side)

## Changes
* Stop inheriting logging traits, and use SafeLogger object (from membership-common) instead
* Simplify Salesforce vs Members-Data-API comparison, and remove metrics