### PR TITLE
Add filters to Sentry appender

### DIFF
--- a/frontend/app/monitoring/ErrorHandler.scala
+++ b/frontend/app/monitoring/ErrorHandler.scala
@@ -2,19 +2,16 @@ package monitoring
 
 import java.lang.Long
 import java.lang.System.currentTimeMillis
-
-import com.gu.googleauth.UserIdentity
+import com.gu.monitoring.SafeLogger
+import com.typesafe.scalalogging.StrictLogging
 import controllers.{Cached, NoCache}
-import monitoring.SentryLogging.{UserGoogleId, UserIdentityId}
-import org.slf4j.MDC
+import play.api.PlayException.ExceptionSource
 import play.api._
 import play.api.http.DefaultHttpErrorHandler
 import play.api.mvc.Results._
 import play.api.mvc._
 import play.api.routing.Router
-import services.AuthenticationService
 import play.core.SourceMapper
-
 import scala.concurrent._
 
 class ErrorHandler(
@@ -23,16 +20,20 @@ class ErrorHandler(
   sourceMapper: Option[SourceMapper],
   router: => Option[Router],
   implicit val executionContext: ExecutionContext
-) extends DefaultHttpErrorHandler(env, config, sourceMapper, router) {
+) extends DefaultHttpErrorHandler(env, config, sourceMapper, router) with StrictLogging {
 
-  override def logServerError(request: RequestHeader, usefulException: UsefulException) {
-    try {
-      for (identityUser <- AuthenticationService.authenticatedUserFor(request)) { MDC.put(UserIdentityId, identityUser.id) }
-      for (googleUser <- UserIdentity.fromRequest(request)) { MDC.put(UserGoogleId, googleUser.email.split('@').head) }
+  override protected def logServerError(request: RequestHeader, usefulException: UsefulException): Unit = {
+    val lineInfo = usefulException match {
+      case source: ExceptionSource => s"${source.sourceName()} at line ${source.line()}"
+      case _ => "unknown line number, please check the logs"
+    }
+    val sanitizedExceptionDetails = s"Caused by: ${usefulException.cause} in $lineInfo"
+    val requestDetails = s"(${request.method}) [${request.path}]" // Use path, not uri, as query strings often contain things like ?api-key=my_secret
 
-      super.logServerError(request, usefulException)
+    // We are deliberately bypassing the SafeLogger here, because we need to use standard string interpolation to make this exception handling useful.
+    logger.error(SafeLogger.sanitizedLogMessage, s"Internal server error, for $requestDetails. $sanitizedExceptionDetails")
 
-    } finally MDC.clear()
+    super.logServerError(request, usefulException) // We still want the full uri and stack trace in our logs, just not in Sentry
   }
 
   override def onClientError(request: RequestHeader, statusCode: Int, message: String = ""): Future[Result] = {

--- a/frontend/app/monitoring/SentryLogging.scala
+++ b/frontend/app/monitoring/SentryLogging.scala
@@ -1,15 +1,33 @@
 package monitoring
 
 import ch.qos.logback.classic.filter.ThresholdFilter
+import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.classic.{Logger, LoggerContext}
+import ch.qos.logback.core.filter.Filter
+import ch.qos.logback.core.spi.FilterReply
 import com.getsentry.raven.RavenFactory
 import com.getsentry.raven.dsn.Dsn
 import com.getsentry.raven.logback.SentryAppender
+import com.gu.monitoring.SafeLogger
 import configuration.Config
 import org.slf4j.Logger.ROOT_LOGGER_NAME
 import org.slf4j.LoggerFactory
-
 import scala.util.{Failure, Success, Try}
+
+object SentryFilters {
+
+  class PiiFilter extends Filter[ILoggingEvent] {
+    override def decide(event: ILoggingEvent): FilterReply = if (event.getMarker.contains(SafeLogger.sanitizedLogMessage)) FilterReply.ACCEPT
+    else FilterReply.DENY
+  }
+
+  val errorLevelFilter = new ThresholdFilter { setLevel("ERROR") }
+  val piiFilter = new PiiFilter
+
+  errorLevelFilter.start()
+  piiFilter.start()
+
+}
 
 object SentryLogging {
 
@@ -21,18 +39,15 @@ object SentryLogging {
   def init() {
     Try(new Dsn(Config.config.getString("sentry.dsn"))) match {
       case Failure(ex) =>
-        play.api.Logger.warn("No server-side Sentry logging configured (OK for dev)")
+        SafeLogger.warn("No server-side Sentry logging configured (OK for dev)")
       case Success(dsn) =>
-        play.api.Logger.info(s"Initialising Sentry logging for ${dsn.getHost}")
+        SafeLogger.info(s"Initialising Sentry logging for ${dsn.getHost}")
         val buildInfo: Map[String, Any] = app.BuildInfo.toMap
         val tags = Map("stage" -> Config.stage) ++ buildInfo
         val tagsString = tags.map { case (key, value) => s"$key:$value"}.mkString(",")
-
-        val filter = new ThresholdFilter { setLevel("ERROR") }
-        filter.start() // OMG WHY IS THIS NECESSARY LOGBACK?
-
         val sentryAppender = new SentryAppender(RavenFactory.ravenInstance(dsn)) {
-          addFilter(filter)
+          addFilter(SentryFilters.errorLevelFilter)
+          addFilter(SentryFilters.piiFilter)
           setTags(tagsString)
           setRelease(app.BuildInfo.gitCommitId)
           setExtraTags(AllMDCTags.mkString(","))


### PR DESCRIPTION
## Why are you doing this?
This follows on from https://github.com/guardian/membership-frontend/pull/1786, https://github.com/guardian/membership-frontend/pull/1787 and https://github.com/guardian/membership-frontend/pull/1789. 

The filters added in this PR mean that we will only send error messages which have been marked as sanitized into Sentry.

## Trello card: [Here](https://trello.com/c/y9MSfvxo/235-gdpr-sprint-goal-sentry-server-side)

## Changes
* Override Play's default error logging for uncaught exceptions
* Apply appropriate filters to the Sentry appender