### PR TITLE
Only compare tier information when checking members-data-api response

### DIFF
--- a/frontend/app/services/MembersDataAPI.scala
+++ b/frontend/app/services/MembersDataAPI.scala
@@ -82,10 +82,9 @@ class MembersDataAPI(executionContext: ExecutionContext) {
       case cookies: AccessCredentials.Cookies =>
         getAttributes(cookies).onComplete {
           case Success(memDataApiAttrs) =>
-            val prefix = s"members-data-api-check identity=${memberRequest.user.id} salesforce=${memberRequest.subscriber.contact.salesforceContactId} : "
             val salesforceAttrs = Attributes.fromMember(memberRequest.subscriber)
-            if (memDataApiAttrs != salesforceAttrs) {
-              SafeLogger.error(scrub"$prefix MISMATCH salesforce=$salesforceAttrs mem-data-api=$memDataApiAttrs")
+            if (memDataApiAttrs.tier != salesforceAttrs.tier) {
+              SafeLogger.error(scrub"${memberRequest.user.id} Salesforce and members-data-api had differing Tier info: salesforce=${salesforceAttrs.tier} mem-data-api=${memDataApiAttrs.tier}")
             }
           case Failure(err) => SafeLogger.error(scrub"Failed to get membership attributes from membership-data-api for user ${memberRequest.user.id} (OK in dev)", err)
         }


### PR DESCRIPTION
## Why are you doing this?
This [change](https://github.com/guardian/membership-frontend/pull/1789/files/0e46c0cb47da9d0e7addda9803dd719e2fb457c0#diff-c978671788c98af3d5b98e03e2f6e252) is generating a lot of noise, because we have accidentally started logging errors when members-data-api doesn't return a membership number.