### PR TITLE
Add sbt-dependency-graph plugin 

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,3 +14,5 @@ addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.3")
 addSbtPlugin("net.vonbuchholtz" % "sbt-dependency-check" % "0.2.0")
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.3")
+
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")


### PR DESCRIPTION
So that we can run snyk monitor on teamcity to get vulnerability reports for JVM libraries