### PR TITLE
Remove bean and use jquery events instead

### DIFF
--- a/frontend/assets/javascripts/src/modules/dropdown.js
+++ b/frontend/assets/javascripts/src/modules/dropdown.js
@@ -7,7 +7,7 @@
  *     <div id="js-foo" class="js-dropdown-menu is-hidden">all the foo (initially hidden)</div>
  *
  */
-define(['$', 'bean'], function ($, bean) {
+define(['$'], function ($) {
     'use strict';
 
     var DROPDOWN_CLASS = 'js-dropdown',
@@ -16,7 +16,7 @@ define(['$', 'bean'], function ($, bean) {
         DROPDOWN_DISABLED_CLASS = 'js-dropdown-disabled';
 
     function bindHandlers() {
-        bean.on(document, 'click', function(event) {
+        $(document).on('click', function(event) {
             var dropdown = closest(event.target, DROPDOWN_CLASS);
             var isHidden;
 

--- a/frontend/assets/javascripts/src/modules/form/accordion.es6
+++ b/frontend/assets/javascripts/src/modules/form/accordion.es6
@@ -8,7 +8,7 @@ checkout form. The user can only continue if the previous section validates.
 // ----- Imports ----- //
 
 import * as payment from 'src/modules/payment';
-
+import formUtil from 'src/modules/form/helper/formUtil';
 
 // ----- Functions ----- //
 
@@ -111,7 +111,7 @@ function benefitsListeners (panels) {
 function nameAddressListeners (panels) {
 
 	panels.nameAddress.continue.addEventListener('click', () => {
-
+        formUtil.flush();
 		if (payment.validateForm()) {
 			closePanel(panels.nameAddress, true);
 			openPanel(panels.payment);

--- a/frontend/assets/javascripts/src/modules/form/billingPeriodChoice.js
+++ b/frontend/assets/javascripts/src/modules/form/billingPeriodChoice.js
@@ -1,13 +1,12 @@
 define(
     [
         '$',
-        'bean',
         'lodash/template',
         'src/modules/form/submitButton',
         'src/modules/form/ongoingCardPayments',
         'text-loader!src/templates/checkout/billingPeriodChoice.html'
     ],
-    function($, bean, template, submitButton, ongoingCardPayments, billingPeriodChoiceTemplate) {
+    function($, template, submitButton, ongoingCardPayments, billingPeriodChoiceTemplate) {
         'use strict';
 
         var checkoutForm = guardian.membership.checkoutForm,
@@ -43,7 +42,7 @@ define(
         return {
             init: function() {
                 if (billingPeriods && $BILLING_PERIOD_CONTAINER.length > 0) {
-                    bean.on($BILLING_PERIOD_CONTAINER[0], 'change', '[type=radio]', function (el) {
+                    $BILLING_PERIOD_CONTAINER.on('change', '[type=radio]', function (el) {
                         el.target.checked = true;
                         checkoutForm.billingPeriod = el.target.value;
                         notifyOtherModulesToRender(el.target.value);

--- a/frontend/assets/javascripts/src/modules/form/options.js
+++ b/frontend/assets/javascripts/src/modules/form/options.js
@@ -37,7 +37,7 @@ define([
 
     function renderTermsAndConditions() {
         var usLegalSelector = $('.us-legal');
-        var territory = territoryFromCountry(checkoutForm.billingCountry)
+        var territory = territoryFromCountry(checkoutForm.billingCountry);
         if (usLegalSelector[0]) {
             switch (territory) {
                 case 'US':

--- a/frontend/assets/javascripts/src/modules/form/options.js
+++ b/frontend/assets/javascripts/src/modules/form/options.js
@@ -1,12 +1,10 @@
 define([
     '$',
-    'bean',
     'src/modules/form/billingPeriodChoice',
     'src/modules/form/validation/display',
     'src/modules/form/helper/formUtil'
 ], function (
     $,
-    bean,
     billingPeriodChoice,
     validationDisplay,
     form
@@ -109,7 +107,7 @@ define([
         selectCountry(DELIVERY_COUNTRY_EL, checkoutForm.deliveryCountry);
         if (!checkoutForm.showBillingAddress && checkoutForm.selectedBillingCountry !== checkoutForm.billingCountry) {
             selectCountry(BILLING_COUNTRY_EL, checkoutForm.billingCountry);
-            bean.fire(BILLING_COUNTRY_EL, 'change');
+            $(BILLING_COUNTRY_EL).trigger('change');
         }
     }
 
@@ -136,12 +134,12 @@ define([
         }
 
         if (DELIVERY_COUNTRY_EL) {
-            bean.fire(DELIVERY_COUNTRY_EL, 'change');
+            $(DELIVERY_COUNTRY_EL).trigger('change');
         }
     }
 
     function addListeners() {
-        bean.on(DELIVERY_COUNTRY_EL, 'change', function(e) {
+        $(DELIVERY_COUNTRY_EL).on('change', function(e) {
             var input = e.target;
             var selectedCountry = $(input).val();
 
@@ -153,7 +151,7 @@ define([
             renderPrices();
         });
 
-        bean.on(BILLING_COUNTRY_EL, 'change', function(e) {
+        $(BILLING_COUNTRY_EL).on('change', function(e) {
             var input = e.target;
             var selectedCountry = $(input).val();
             var selectedEl = toArray($('option', input)).filter(function (el) {
@@ -173,14 +171,14 @@ define([
             renderPrices();
         });
 
-        bean.on(USE_BILLING_ADDRESS_EL, 'click', function() {
+        $(USE_BILLING_ADDRESS_EL).on('click', function() {
             checkoutForm.showBillingAddress = true;
 
             renderPrices();
             form.flush();
         });
 
-        bean.on(USE_DELIVERY_ADDRESS_EL, 'click', function() {
+        $(USE_DELIVERY_ADDRESS_EL).on('click', function() {
             checkoutForm.showBillingAddress = false;
             checkoutForm.billingCountry = checkoutForm.deliveryCountry;
 

--- a/frontend/assets/javascripts/src/modules/form/payment/listeners.js
+++ b/frontend/assets/javascripts/src/modules/form/payment/listeners.js
@@ -1,8 +1,8 @@
 define([
-    'bean',
+    '$',
     'src/utils/masker',
     'src/modules/form/payment/displayCardImg'
-], function (bean, masker, displayCardImg) {
+], function ($, masker, displayCardImg) {
     'use strict';
 
     var CREDIT_CARD_NUMBER_ELEM = document.querySelector('.js-credit-card-number');
@@ -11,9 +11,9 @@ define([
      * add listeners for the credit card elem for masker and display credit card image interactivity
      */
     var addPaymentListeners = function () {
-        bean.on(CREDIT_CARD_NUMBER_ELEM, 'keyup blur', masker(' ', 4));
+        $(CREDIT_CARD_NUMBER_ELEM).on('keyup blur', masker(' ', 4));
 
-        bean.on(CREDIT_CARD_NUMBER_ELEM, 'keyup blur', function (e) {
+        $(CREDIT_CARD_NUMBER_ELEM).on('keyup blur', function (e) {
             var input = e && e.target;
             displayCardImg(input.value);
         });

--- a/frontend/assets/javascripts/src/modules/form/stripe.es6
+++ b/frontend/assets/javascripts/src/modules/form/stripe.es6
@@ -1,11 +1,10 @@
 import * as payment from 'src/modules/payment';
-import bean from 'bean'
 import $ from '$'
 export function init() {
     let handler = window.StripeCheckout.configure(guardian.stripeCheckout);
     let success = false;
     const button = $('.js-stripe-checkout');
-    bean.on(window, 'popstate', handler.close);
+    $(document).on('popstate', handler.close);
     const amount = () => {
 
         let billingPeriod = guardian.membership.checkoutForm.billingPeriods[guardian.membership.checkoutForm.billingPeriod];
@@ -42,5 +41,5 @@ export function init() {
         e.preventDefault();
     };
 
-    bean.on(button[0], 'click', open);
+    $(button).on('click', open);
 }

--- a/frontend/assets/javascripts/src/modules/form/stripe.es6
+++ b/frontend/assets/javascripts/src/modules/form/stripe.es6
@@ -1,10 +1,10 @@
 import * as payment from 'src/modules/payment';
-import $ from '$'
+import $ from '$';
 export function init() {
     let handler = window.StripeCheckout.configure(guardian.stripeCheckout);
     let success = false;
     const button = $('.js-stripe-checkout');
-    $(document).on('popstate', handler.close);
+    window.addEventListener('popstate', handler.close);
     const amount = () => {
 
         let billingPeriod = guardian.membership.checkoutForm.billingPeriods[guardian.membership.checkoutForm.billingPeriod];
@@ -41,5 +41,5 @@ export function init() {
         e.preventDefault();
     };
 
-    $(button).on('click', open);
+    button.on('click', open);
 }

--- a/frontend/assets/javascripts/src/modules/form/validation/actions.js
+++ b/frontend/assets/javascripts/src/modules/form/validation/actions.js
@@ -1,10 +1,9 @@
 define([
     '$',
-    'bean',
     'src/utils/helper',
     'src/modules/form/helper/formUtil',
     'src/modules/form/validation/listeners'
-], function ($, bean, utilsHelper, form, listeners) {
+], function ($, utilsHelper, form, listeners) {
     'use strict';
 
     var FORM_FIELD_CLASSNAME = 'form-field';
@@ -50,7 +49,7 @@ define([
 
             $elem.removeAttr('data-validation').removeAttr(ARIA_REQUIRED_ATTRIBUTE_NAME).removeAttr(REQUIRED_ATTRIBUTE_NAME);
             $(LABEL_CLASSNAME, $formField).addClass(OPTIONAL_MARKER_CLASSNAME).removeClass('form-field--error');
-            bean.off(elem, 'blur');
+            $(elem).off('blur');
         });
         form.flush();
     };

--- a/frontend/assets/javascripts/src/modules/form/validation/listeners.js
+++ b/frontend/assets/javascripts/src/modules/form/validation/listeners.js
@@ -1,9 +1,9 @@
 define([
-    'bean',
+    '$',
     'src/modules/form/helper/formUtil',
     'src/modules/form/helper/loader',
     'src/modules/form/validation/validity'
-], function (bean, form, loader, validity) {
+], function ($, form, loader, validity) {
     'use strict';
 
     var SUBMIT_ELEM = document.querySelector('.js-submit-input');
@@ -12,7 +12,7 @@ define([
         // blur and change events for select elems, just blur for everything else (which is just text inputs at present)
         var event = elem.nodeName.toLowerCase() === 'select' ? 'blur change' : 'blur';
 
-        bean.on(elem, event, function () {
+        $(elem).on(event, function () {
             validity.check(elem);
         });
     };
@@ -30,7 +30,7 @@ define([
             return;
         }
 
-        bean.on(SUBMIT_ELEM, 'click', function (e) {
+        $(SUBMIT_ELEM).on('click', function (e) {
             e.preventDefault();
 
             form.elems.map(function (elem) {

--- a/frontend/assets/javascripts/src/modules/form/validation/validity.js
+++ b/frontend/assets/javascripts/src/modules/form/validation/validity.js
@@ -13,7 +13,7 @@ define([
     var check = function (elem) {
         var valid = testValidity(elem);
         display.toggleErrorState({
-            isValid: testValidity(elem),
+            isValid: valid,
             elem: elem
         });
         return valid;

--- a/frontend/assets/javascripts/src/modules/identityMenu/identityPopup.js
+++ b/frontend/assets/javascripts/src/modules/identityMenu/identityPopup.js
@@ -5,13 +5,13 @@
  * Sets the identity icon returnUrl when a user needs to sign in (controlled via JavaScript for caching reasons)
  */
 define([
-    'bean',
+    '$',
     'src/utils/user'
-], function (bean, userUtil) {
+], function ($, userUtil) {
     'use strict';
 
-    var IDENTITY_MENU_CTA_ELEM = document.querySelector('.js-identity-menu-toggle');
-    var IDENTITY_MENU_CTA_URL = document.querySelector('.js-identity-menu-url');
+    var IDENTITY_MENU_CTA_ELEM = $('.js-identity-menu-toggle');
+    var IDENTITY_MENU_CTA_URL = $('.js-identity-menu-url');
     var DROPDOWN_DISABLED_CLASS = 'js-dropdown-disabled';
 
     function init() {
@@ -24,13 +24,13 @@ define([
     }
 
     function disableLink() {
-        bean.on(IDENTITY_MENU_CTA_ELEM, 'click', function(e) {
+        IDENTITY_MENU_CTA_ELEM.on('click', function(e) {
             e.preventDefault();
         });
     }
 
     function disableMenu() {
-        IDENTITY_MENU_CTA_ELEM.classList.add(DROPDOWN_DISABLED_CLASS);
+        IDENTITY_MENU_CTA_ELEM.addClass(DROPDOWN_DISABLED_CLASS);
     }
 
     function setIdentityCtaReturnUrl() {
@@ -38,8 +38,8 @@ define([
         var currentUrl = windowLocation.pathname + windowLocation.search;
 
         if (IDENTITY_MENU_CTA_URL) {
-            IDENTITY_MENU_CTA_URL.setAttribute('href',
-                populateReturnUrl(IDENTITY_MENU_CTA_ELEM.getAttribute('href'), currentUrl)
+            IDENTITY_MENU_CTA_URL.prop('href',
+                populateReturnUrl(IDENTITY_MENU_CTA_ELEM.attr('href'), currentUrl)
             );
         }
     }

--- a/frontend/assets/javascripts/src/modules/identityMenu/identityPopup.js
+++ b/frontend/assets/javascripts/src/modules/identityMenu/identityPopup.js
@@ -10,8 +10,8 @@ define([
 ], function ($, userUtil) {
     'use strict';
 
-    var IDENTITY_MENU_CTA_ELEM = $('.js-identity-menu-toggle');
-    var IDENTITY_MENU_CTA_URL = $('.js-identity-menu-url');
+    var IDENTITY_MENU_CTA_ELEM = document.querySelector('.js-identity-menu-toggle');
+    var IDENTITY_MENU_CTA_URL = document.querySelector('.js-identity-menu-url');
     var DROPDOWN_DISABLED_CLASS = 'js-dropdown-disabled';
 
     function init() {
@@ -24,13 +24,13 @@ define([
     }
 
     function disableLink() {
-        IDENTITY_MENU_CTA_ELEM.on('click', function(e) {
+        $(IDENTITY_MENU_CTA_ELEM).on('click', function(e) {
             e.preventDefault();
         });
     }
 
     function disableMenu() {
-        IDENTITY_MENU_CTA_ELEM.addClass(DROPDOWN_DISABLED_CLASS);
+        IDENTITY_MENU_CTA_ELEM.classList.add(DROPDOWN_DISABLED_CLASS);
     }
 
     function setIdentityCtaReturnUrl() {
@@ -38,8 +38,8 @@ define([
         var currentUrl = windowLocation.pathname + windowLocation.search;
 
         if (IDENTITY_MENU_CTA_URL) {
-            IDENTITY_MENU_CTA_URL.prop('href',
-                populateReturnUrl(IDENTITY_MENU_CTA_ELEM.attr('href'), currentUrl)
+            IDENTITY_MENU_CTA_URL.setAttribute('href',
+                populateReturnUrl(IDENTITY_MENU_CTA_ELEM.getAttribute('href'), currentUrl)
             );
         }
     }

--- a/frontend/assets/javascripts/src/modules/metrics/forms.js
+++ b/frontend/assets/javascripts/src/modules/metrics/forms.js
@@ -1,9 +1,9 @@
 define([
-    'bean',
+    '$',
     'src/modules/metrics/logger',
     'src/modules/form/helper/formUtil',
     'src/modules/analytics/setup'
-], function (bean, logMetric, formUtil, analytics) {
+], function ($, logMetric, formUtil, analytics) {
     'use strict';
 
     /**
@@ -80,15 +80,15 @@ define([
 
             formAction = formUtil.elem.getAttribute('action');
 
-            bean.on(window, 'beforeunload.formMetrics', function() {
+            $(document).on('beforeunload.formMetrics', function() {
                 recordAbandonedForm(formAction);
             });
 
             var formSubmit = formUtil.elem.querySelector('[type="submit"]');
             if(formSubmit) {
-                bean.on(formSubmit, 'click', function() {
+                $(formSubmit).on('click', function() {
                     // Unbind `beforeunload` listener as form submission counts as `beforeunload`
-                    bean.off(window, 'beforeunload.formMetrics');
+                    $(document).off('beforeunload.formMetrics');
                     if (formUtil.errs.length) {
                         recordFormWithErrors(formAction);
                     } else {

--- a/frontend/assets/javascripts/src/modules/metrics/forms.js
+++ b/frontend/assets/javascripts/src/modules/metrics/forms.js
@@ -73,26 +73,28 @@ define([
             });
     }
 
-    function init() {
-        var formAction;
+    function getFormAction() {
+        return formUtil.elem.getAttribute('action');
+    }
 
+    function beforeUnloadFormMetrics() {
+        recordAbandonedForm(getFormAction());
+    }
+
+    function init() {
         if (analytics.enabled && typeof formUtil.elems != 'undefined') {
 
-            formAction = formUtil.elem.getAttribute('action');
-
-            $(document).on('beforeunload.formMetrics', function() {
-                recordAbandonedForm(formAction);
-            });
+            window.addEventListener('beforeunload.formMetrics', beforeUnloadFormMetrics);
 
             var formSubmit = formUtil.elem.querySelector('[type="submit"]');
             if(formSubmit) {
                 $(formSubmit).on('click', function() {
                     // Unbind `beforeunload` listener as form submission counts as `beforeunload`
-                    $(document).off('beforeunload.formMetrics');
+                    window.removeEventListener('beforeunload.formMetrics', beforeUnloadFormMetrics);
                     if (formUtil.errs.length) {
-                        recordFormWithErrors(formAction);
+                        recordFormWithErrors(getFormAction());
                     } else {
-                        recordFormSuccess(formAction);
+                        recordFormSuccess(getFormAction());
                     }
                 });
             }

--- a/frontend/assets/javascripts/src/modules/modal.js
+++ b/frontend/assets/javascripts/src/modules/modal.js
@@ -16,9 +16,8 @@
  * attribute. The confirm within the modal will perform the buttons forms action, the cancel will remove the modal.
  */
 define([
-    '$',
-    'bean'
-], function ($, bean) {
+    '$'
+], function ($) {
     'use strict';
 
     var MODAL_SELECTOR = '.js-modal';
@@ -32,17 +31,17 @@ define([
     var addListeners = function () {
 
         function removeHtmlListener() {
-            bean.off(document.documentElement, 'click.modal');
-            bean.off(document, 'keydown.modal');
+            $(document.documentElement).off('click.modal');
+            $(document).off('keydown.modal');
         }
 
         function addHtmlListener() {
-            bean.on(document.documentElement, 'click.modal', function () {
+            $(document.documentElement).on('click.modal', function () {
                 $(MODAL_SELECTOR).addClass(IS_HIDDEN);
                 removeHtmlListener();
             });
 
-            bean.on(document, 'keydown.modal', function(e) {
+            $(document).on('keydown.modal', function(e) {
                 var $modals = $(MODAL_SELECTOR);
                 if (!$modals.hasClass(IS_HIDDEN) && e.keyCode === ESC_KEY_CODE) {
                     $modals.addClass(IS_HIDDEN);
@@ -55,14 +54,14 @@ define([
             $(elem).toggleClass(className);
         }
 
-        $(MODAL_CTA_SELECTOR).map(function (button) {
+        $(MODAL_CTA_SELECTOR).map(function (_, button) {
 
             var modalElem = document.querySelector('.' + button.getAttribute(MODAL_DATA_ATTRIBUTE));
             var modalConfirmElem = modalElem.querySelector(MODAL_CONFIRM_SELECTOR);
             var form;
 
-            bean.on(button, 'click', function (e) {
-                e.stop();
+            $(button).on('click', function (e) {
+                e.stopPropagation();
                 toggleClass(modalElem, IS_HIDDEN);
                 addHtmlListener();
 
@@ -70,17 +69,17 @@ define([
             });
 
             // stop propagation when clicking modal element
-            bean.on(modalElem, 'click.modal', function (e) {
-                e.stop();
+            $(modalElem).on('click.modal', function (e) {
+                e.stopPropagation();
             });
 
-            bean.on(modalConfirmElem, 'click.modal', function (e) {
-                e.stop();
+            $(modalConfirmElem).on('click.modal', function (e) {
+                e.stopPropagation();
                 form.submit();
             });
 
-            bean.on(modalElem, 'click.modal', MODAL_CANCEL_SELECTOR, function (e) {
-                e.stop();
+            $(modalElem).on('click.modal', MODAL_CANCEL_SELECTOR, function (e) {
+                e.stopPropagation();
                 toggleClass(modalElem, IS_HIDDEN);
                 removeHtmlListener();
             });

--- a/frontend/assets/javascripts/src/modules/toggle.js
+++ b/frontend/assets/javascripts/src/modules/toggle.js
@@ -12,7 +12,7 @@
  *     * data-toggle-label is optional
  *     * data-toggle-hidden should be added to toggle elements which should be hidden on pageload
  */
-define(['$', 'bean'], function ($, bean) {
+define(['$'], function ($) {
     'use strict';
 
     var TOGGLE_BTN_SELECTOR = '.js-toggle',
@@ -69,7 +69,7 @@ define(['$', 'bean'], function ($, bean) {
     var bindToggles = function() {
         var $toggles = $(TOGGLE_BTN_SELECTOR);
         $toggles.each(function (i, elem) {
-            bean.on(elem, 'click', toggleElement($(elem)));
+            $(elem).on('click', toggleElement($(elem)));
         });
     };
 

--- a/frontend/assets/javascripts/src/utils/component.js
+++ b/frontend/assets/javascripts/src/utils/component.js
@@ -1,4 +1,4 @@
-define(['bean', '$'], function(bean, $) {
+define(['$'], function($) {
     'use strict';
 
     var Component = function() {};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,6 @@
     "babel-loader": "^7.1.2",
     "babel-polyfill": "^6.26.0",
     "babel-preset-es2015": "^6.24.1",
-    "bean": "^1.0.15",
     "bower": "^1.8.2",
     "curl-amd": "~0.8.10",
     "domready": "^1.0.8",

--- a/frontend/webpack.conf.js
+++ b/frontend/webpack.conf.js
@@ -15,7 +15,6 @@ module.exports = function(debug) { return {
         alias: {
             '$$': 'jquery/dist/jquery.min',
             'lodash': 'lodash-amd',
-            'bean': 'bean/bean',
             'respimage': 'respimage/respimage',
             'lazySizes': 'lazysizes/lazysizes',
             'smoothScroll': 'smooth-scroll/dist/js/smooth-scroll',


### PR DESCRIPTION

## Why are you doing this?
As part of our ongoing commitment to remove unsupported/outdated and/or insecure libraries, we're removing Bean on the grounds that it falls into the former category.

See also: https://github.com/guardian/membership-frontend/pull/1776
and: https://github.com/guardian/membership-frontend/pull/1785 

## Trello card: [1357](https://trello.com/c/RS4GJzHt/1357-explore-swapping-out-bean-for-jquery-events-in-membership-frontend)

## Changes
* Remove references to the Bean library
* Switch over to jQuery's `.on()` and `.off()` methods instead
 
## Screenshots
![beanfree](https://user-images.githubusercontent.com/690395/37150850-46009ff6-22cb-11e8-932d-653bbf730ac2.jpg)

## Tested on CODE?
Yes. Have tested signing up from friend -> supporter -> partner -> patron and finally -> cancel: ALL OK.

Also, the build tests all passed too, obvs.

