### PR TITLE
Have the option of using a t2.small instead of t2.medium

### DIFF
--- a/cloud-formation/membership-app.cf.yaml
+++ b/cloud-formation/membership-app.cf.yaml
@@ -33,6 +33,7 @@ Parameters:
     Type: String
     AllowedValues:
     - t2.micro
+    - t2.small
     - t2.medium
     - m3.medium
     ConstraintDescription: must be a valid EC2 instance type.


### PR DESCRIPTION
Now that membership is getting less traffic in favour of support, lets have the option of using a t2.small instead of t2.medium

## Why are you doing this?
<!--
Please do not forget to log the amount of hours you spent in this PR here:
https://docs.google.com/spreadsheets/d/1DO24_EkHI3emwTSXpnkwWGhKf7n_9VDcGu0g4kdfUD0/edit#gid=0
-->
Cost savings.
<!--
Remember, PRs are documentation for future contributors

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->
 cc @davidfurey 
