### PR TITLE
Do not use black on black for events menu

### DIFF
--- a/frontend/assets/stylesheets/components/_global-header.scss
+++ b/frontend/assets/stylesheets/components/_global-header.scss
@@ -92,6 +92,9 @@ $global-header-height-mobile: 116px;
 .live-header__inner ~ .global-navigation {
     .global-navigation__link {
         color: #000;
+        @include mq($until: tablet) {
+            color: $white;
+        }
     }
 }
 


### PR DESCRIPTION
## Why are you doing this?

The menu items on membership.theguardian.com/events were black on black on mobile devices.

Before (desktop):
![screen shot 2018-03-20 at 12 09 25](https://user-images.githubusercontent.com/2619836/37653683-9c3be70c-2c37-11e8-9a5a-5a486e87aa11.png)

Before (mobile):
![screen shot 2018-03-20 at 12 09 41](https://user-images.githubusercontent.com/2619836/37653685-9c6206a8-2c37-11e8-8901-181ece719315.png)

After (desktop):
![screen shot 2018-03-20 at 12 09 31](https://user-images.githubusercontent.com/2619836/37653684-9c501326-2c37-11e8-8eb0-c9630151e37b.png)

After (mobile):
![screen shot 2018-03-20 at 12 09 46](https://user-images.githubusercontent.com/2619836/37653686-9c73f8cc-2c37-11e8-8691-17e2b419537f.png)

