### PR TITLE
Use a long timeout when fetching the catalog

### DIFF
--- a/frontend/app/services/TouchpointBackend.scala
+++ b/frontend/app/services/TouchpointBackend.scala
@@ -77,7 +77,8 @@ object TouchpointBackend {
 
     val pids = Config.productIds(restBackendConfig.envName)
 
-    val newCatalogService = new subsv2.services.CatalogService[Future](pids, simpleRestClient, Await.result(_, 10.seconds), restBackendConfig.envName)
+    val catalogRestClient: SimpleClient[Future] = new SimpleClient[Future](restBackendConfig, RequestRunners.configurableFutureRunner(60.seconds))
+    val newCatalogService = new subsv2.services.CatalogService[Future](pids, catalogRestClient, Await.result(_, 60.seconds), restBackendConfig.envName)
     val futureCatalog: Future[CatalogMap] = newCatalogService.catalog.map(_.fold[CatalogMap](error => {println(s"error: ${error.list.toList.mkString}"); Map()}, _.map))
     val newSubsService = new subsv2.services.SubscriptionService[Future](pids, futureCatalog, simpleRestClient, zuoraSoapService.getAccountIds)
 


### PR DESCRIPTION
## Why are you doing this?
A recent incident with members-data-api alerted us to a potential risk concerning the startup for this app. If the catalog cannot be loaded on startup, a failed future is kept, which causes errors downstream. This is a quick fix to decrease the likelihood of the request to get the catalog failing.

## Changes
* Use a 60 second timeout when loading the catalog.
