### PR TITLE
Stop Sending Identity ID To Stripe

### DIFF
--- a/frontend/app/services/MemberService.scala
+++ b/frontend/app/services/MemberService.scala
@@ -507,7 +507,7 @@ class MemberService(
     val paymentGateway = RegionalStripeGateways.getGatewayForCountry(transactingCountry)
     val stripeService = stripeServicesByPaymentGateway.getOrElse(paymentGateway, ukStripeService)
     for {
-      customer <- stripeService.Customer.create(contact.identityId, stripeToken)
+      customer <- stripeService.Customer.create(stripeToken)
       sub <- subscriptionService.current[SubscriptionPlan.Member](contact).map(_.head)
       result <- zuoraService.createCreditCardPaymentMethod(sub.accountId, customer, stripeService.paymentGateway, None)
     } yield result

--- a/frontend/app/services/paymentmethods/PaymentMethodInitialiser.scala
+++ b/frontend/app/services/paymentmethods/PaymentMethodInitialiser.scala
@@ -34,7 +34,7 @@ class StripeInitialiser(stripeService: StripeService) extends
 
   def initialiseWith(stripeToken: String, user: IdMinimalUser)(implicit executionContext: ExecutionContext): Future[CreditCardReferenceTransaction] = {
     for {
-      stripeCustomer <- stripeService.Customer.create(user.id, stripeToken).andThen {
+      stripeCustomer <- stripeService.Customer.create(stripeToken).andThen {
         case Failure(e) => SafeLogger.warn(s"Could not create Stripe customer for user ${user.id}", e)
       }
     } yield {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "8.0.3"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "2.1"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.505"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.509"
   val contentAPI = "com.gu" %% "content-api-client" % "11.40"
   val playWS = PlayImport.ws
   val playFilters = PlayImport.filters


### PR DESCRIPTION
# Why are you doing this?

We want to stop sending the identity ID and any other user information through to Stripe in the description field.

[**Trello Card**](https://trello.com/c/lSfuILct/1426-stop-sending-personal-data-to-stripe-membership)

# Changes

- Bumped [membership-common](https://github.com/guardian/membership-common/pull/574).
- Stopped sending identity ID through to Stripe on Customer creation.
