### PR TITLE
Remove abandoned cart tracking

### DIFF
--- a/frontend/app/services/MembersDataAPI.scala
+++ b/frontend/app/services/MembersDataAPI.scala
@@ -1,7 +1,7 @@
 package services
 
 import actions.ActionRefiners.SubReqWithSub
-import com.gu.identity.play.{AccessCredentials, AuthenticatedIdUser}
+import com.gu.identity.play.AccessCredentials
 import com.gu.memsub.Subscriber.Member
 import com.gu.memsub.util.WebServiceHelper
 import com.gu.okhttp.RequestRunners
@@ -10,15 +10,12 @@ import com.gu.salesforce.Tier
 import configuration.Config
 import monitoring.DummyMetrics
 import okhttp3.Request
-import org.joda.time.DateTime
-import org.joda.time.format.ISODateTimeFormat
 import com.gu.monitoring.SafeLogger
 import com.gu.monitoring.SafeLogger._
 import play.api.libs.functional.syntax._
 import play.api.libs.json.Reads._
 import play.api.libs.json._
 import views.support.MembershipCompat._
-
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
@@ -47,13 +44,6 @@ object MembersDataAPI {
       (JsPath \ "details").read[String]
     )(ApiError)
 
-  implicit val behaviourReads: Reads[Behaviour] = (
-    (JsPath \ "userId").read[String] and
-      (JsPath \ "activity").readNullable[String] and
-      (JsPath \ "lastObserved").readNullable[String] and
-      (JsPath \ "note").readNullable[String] and
-      (JsPath \ "emailed").readNullable[Boolean]
-    )(Behaviour.apply _)
 }
 
 class MembersDataAPI(executionContext: ExecutionContext) {
@@ -70,15 +60,8 @@ class MembersDataAPI(executionContext: ExecutionContext) {
     override val httpClient: LoggingHttpClient[Future] = RequestRunners.loggingRunner(DummyMetrics)
   }
 
-  private case class BehaviourHelper(accessCredentials: AccessCredentials.Cookies) extends WebServiceHelper[Behaviour, ApiError] {
-    override val wsUrl: String = Config.membersDataAPIUrl
-    override def wsPreExecute(req: Request.Builder): Request.Builder = {
-      req.addHeader("Cookie", accessCredentials.cookies.map(c => s"${c.name}=${c.value}").mkString("; "))
-    }
-    override val httpClient: LoggingHttpClient[Future] = RequestRunners.loggingRunner(DummyMetrics)
-  }
-
   object Service  {
+
     def checkMatchesResolvedMemberIn(memberRequest: SubReqWithSub[_]) = memberRequest.user.credentials match {
       case cookies: AccessCredentials.Cookies =>
         getAttributes(cookies).onComplete {
@@ -92,44 +75,7 @@ class MembersDataAPI(executionContext: ExecutionContext) {
       case _ => SafeLogger.error(scrub"Unexpected credentials for getAttributes! ${memberRequest.user.credentials}")
     }
 
-    def upsertBehaviour(user: AuthenticatedIdUser, activity: Option[String] = None, note: Option[String] = None, emailed: Option[Boolean] = None)(implicit ec: ExecutionContext) = {
-      user.credentials match {
-        case cookies: AccessCredentials.Cookies =>
-          setBehaviour(cookies, user.id, activity, note).onComplete {
-            case Success(result) => SafeLogger.info(s"Upserted ${user.id}")
-            case Failure(err) => SafeLogger.error(scrub"Failed to upsert membership-data-api behaviour for user ${user.id}", err)
-          }
-        case _ => SafeLogger.error(scrub"Unexpected credentials for addBehaviour ($activity) for ${user.credentials}")
-      }
-    }
-
-    def removeBehaviour(user: AuthenticatedIdUser, activity: Option[String] = None)(implicit ec: ExecutionContext) = user.credentials match {
-      case cookies: AccessCredentials.Cookies =>
-        deleteBehaviour(cookies, user.id, activity).onComplete {
-          case Success(result) => SafeLogger.info(s"Cleared behaviours for ${user.user.id}")
-          case Failure(err) => SafeLogger.error(scrub"Failed to remove behaviour events via membership-data-api for user ${user.id}", err)
-        }
-      case _ => SafeLogger.error(scrub"Unexpected credentials for removeBehaviour for ${user.credentials}")
-    }
-
     private def getAttributes(cookies: AccessCredentials.Cookies) = AttributeHelper(cookies).get[Attributes]("user-attributes/me/membership")
 
-    private def setBehaviour(cookies: AccessCredentials.Cookies, userId: String, activity: Option[String], note: Option[String]) = {
-      val json: JsValue = Json.obj(
-        "userId" -> userId,
-        "activity" -> activity,
-        "lastObserved" -> DateTime.now.toString(ISODateTimeFormat.dateTime.withZoneUTC),
-        "note" -> note
-      )
-      BehaviourHelper(cookies).post[Behaviour]("user-behaviour/capture", json)
-    }
-
-    private def deleteBehaviour(cookies: AccessCredentials.Cookies, userId: String, activity: Option[String]) = {
-      val json: JsValue = Json.obj(
-        "userId" -> userId,
-        "activity" -> activity
-      )
-      BehaviourHelper(cookies).post[Behaviour]("user-behaviour/remove", json)
-    }
   }
 }

--- a/frontend/app/services/MembersDataAPI.scala
+++ b/frontend/app/services/MembersDataAPI.scala
@@ -61,7 +61,6 @@ class MembersDataAPI(executionContext: ExecutionContext) {
   }
 
   object Service  {
-
     def checkMatchesResolvedMemberIn(memberRequest: SubReqWithSub[_]) = memberRequest.user.credentials match {
       case cookies: AccessCredentials.Cookies =>
         getAttributes(cookies).onComplete {


### PR DESCRIPTION
## Why are you doing this?
There are no plans to use this functionality, so we should remove this tracking. Once this PR has been merged I'll also remove the code from members-data-api and any associated data.

## Trello card: [Here](https://trello.com/c/8Gno1f3I/1430-gdpr-membership-frontend-stop-sending-abandon-checkout-information-to-members-data-api)

## Changes
* Delete code related to behaviour tracking

## Screenshots
N/A