### PR TITLE
Allow non-Members to go straight through to EventBrite rather than see a sign-up screen

### DIFF
--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -140,17 +140,14 @@ class Event(
       // They, and any ineligible-tier Members will get a "SOLD OUT" EventBrite page if the event has membership-only tickets.
       // Previously ineligible-tier Members would get a suggested upgrade page.
       case Some(event@(_: RichEvent)) =>
-        BuyAction(id, onUnauthenticated = redirectAnonUserToEventbrite(event)(_)).async { implicit request =>
-          redirectSignedInMemberToEventbrite(event)
+        BuyAction(id, onUnauthenticated = redirectNonMemberToEventbrite(event)(_)).async { implicit request =>
+          redirectMemberToEventbrite(event)
         }
       case _ =>
         // We seem to have a crawler(?) hitting the buy urls for past events
         SafeLogger.info(s"User hit the buy url for event $id - neither a GuLiveEvent or Masterclass could be retrieved, returning 404...")
         CachedAction(NotFound)
     }
-
-  private def suggestUserUpgrades(implicit request: SubReqWithSub[AnyContent]) =
-    Future.successful(Redirect(routes.TierController.change()).addingToSession("preJoinReturnUrl" -> request.uri))
 
   private def eventCookie(event: RichEvent) = s"mem-event-${event.id}"
 
@@ -159,14 +156,14 @@ class Event(
     req.cookies.get("_ga").map(_.value.replaceFirst("GA\\d+\\.\\d+\\.", "")).fold(uri)(value => uri & ("_eboga", value))
   }
 
-  private def redirectSignedInMemberToEventbrite(event: RichEvent)(implicit req: SubscriptionRequest[AnyContent] with Subscriber): Future[Result] =
+  private def redirectMemberToEventbrite(event: RichEvent)(implicit req: SubscriptionRequest[AnyContent] with Subscriber): Future[Result] =
     Timing.record(event.service.wsMetrics, s"user-sent-to-eventbrite-${req.subscriber.subscription.plan.tier}") {
       memberService.createEBCode(req.subscriber, event).map { codeOpt =>
         eventbriteRedirect(event, codeOpt)
       }
     }
 
-  private def redirectAnonUserToEventbrite(event: RichEvent)(implicit req: RequestHeader): Result = {
+  private def redirectNonMemberToEventbrite(event: RichEvent)(implicit req: RequestHeader): Result = {
     eventbriteRedirect(event, None)
   }
 

--- a/frontend/conf/CODE.public.conf
+++ b/frontend/conf/CODE.public.conf
@@ -3,3 +3,6 @@ include "DEV.public"
 logstash.enabled=true
 
 stage="CODE"
+
+google.oauth.callback="https://membership.code.dev-theguardian.com/oauth2callback"
+identity.webapp.url="https://profile.code.dev-theguardian.com"


### PR DESCRIPTION
Currently only logged in Members can buy tickets to [Live Events](https://membership.theguardian.com/events). Partner and Patron members get a promo code when linking through for up to 2 free tickets.

This change lets any reader through to the standard EventBrite page, rather than bringing up a 'Become a member', with no discounted tickets that they can go on to buy through EventBrite. The logic does not change if they are logged in as a Partner/Patron.

## Why are you doing this?
<!--
Please do not forget to log the amount of hours you spent in this PR here:
https://docs.google.com/spreadsheets/d/1DO24_EkHI3emwTSXpnkwWGhKf7n_9VDcGu0g4kdfUD0/edit#gid=0
-->
To increase the number of tickets being sold.

cc @jacobwinch @johnduffell 