### PR TITLE
Use default CSRF settings and contentType whitelist

### DIFF
--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -7,19 +7,9 @@ play.http.session.secure=true
 
 play.http.errorHandler = "monitoring.ErrorHandler"
 
+play.filters.enabled += "play.filters.csrf.CSRFFilter"
+
 play.filters.csrf {
-    header {
-        bypassHeaders {
-            X-Requested-With = "*"
-            Csrf-Token = "nocheck"
-        }
-        protectHeaders = null
-    }
-    bypassCorsTrustedOrigins = false
-    method {
-        whiteList = []
-        blackList = ["POST"]
-    }
     contentType.blackList = ["application/x-www-form-urlencoded", "multipart/form-data", "text/plain"]
 }
 

--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -7,10 +7,8 @@ play.http.session.secure=true
 
 play.http.errorHandler = "monitoring.ErrorHandler"
 
-play.filters.enabled += "play.filters.csrf.CSRFFilter"
-
 play.filters.csrf {
-    contentType.blackList = ["application/x-www-form-urlencoded", "multipart/form-data", "text/plain"]
+    contentType.whiteList = ["application/json", "text/html"]
 }
 
 play.filters.headers.contentSecurityPolicy = "default-src * 'unsafe-eval' data: wss: 'unsafe-inline'"


### PR DESCRIPTION
## Why are you doing this?
To paraphrase the Trello card;
> The upgrade of Play on membership-frontend left the CSRF restrictions the same as 2.4. It would be good to remove this more lax behaviour and go with the default Play 2.6 behaviour

By removing _all_ of the older config settings, loading the PayPal checkout window returned a `403 Forbidden` response due to the content type. Reapplying just the `contentType.blackList` settings, everything seems to work just fine in tests (locally and during the build) for PayPal and Stripe payments.

However, even better is to specify a `contentType.whiteList` to restrict the types of data we expect to handle. These are currently `application/json` and `text/html`

## Trello card: [1085-tighten-csrf-behaviour-on-membership-frontend](https://trello.com/c/ZBMXzrRh/1085-tighten-csrf-behaviour-on-membership-frontend)
