### PR TITLE
Stop sending identity id to membership-client-side sentry.

### DIFF
--- a/frontend/assets/javascripts/src/modules/raven.js
+++ b/frontend/assets/javascripts/src/modules/raven.js
@@ -1,21 +1,13 @@
-define(['src/utils/user','raven-js'], function (user, Raven) {
+define(['raven-js'], function (Raven) {
     'use strict';
 
     function init(dsn) {
-
-        var tags = { build_number: guardian.membership.buildNumber };
-        var cookieUser = user.getUserFromCookie();
-
-        if (cookieUser) {
-            tags.userIdentityId = cookieUser.id;
-        }
-
         /**
          * Set up Raven, which speaks to Sentry to track errors
          */
         Raven.config(dsn, {
             whitelistUrls: [ /membership\.theguardian\.com/, /mem\.thegulocal\.com/, /localhost/ ],
-            tags: tags,
+            tags: { build_number: guardian.membership.buildNumber },
             ignoreErrors: [ /duplicate define: jquery/ ],
             ignoreUrls: [ /platform\.twitter\.com/ ],
             shouldSendCallback: function(data) {


### PR DESCRIPTION
## Why are you doing this?
<!--
Please do not forget to log the amount of hours you spent in this PR here:
https://docs.google.com/spreadsheets/d/1DO24_EkHI3emwTSXpnkwWGhKf7n_9VDcGu0g4kdfUD0/edit#gid=0
-->
To stop sending PII to Sentry. 
<!--
Remember, PRs are documentation for future contributors

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Trello card: [Here](https://trello.com/c/1S9yuKp2/1499-audit-client-side-sentry-projects-and-remove-any-collection-of-pii-eg-ip-address)

## Changes
* Stopping sending identityId to Sentry

<!--
If you are making heavy client-side changes, consider manual test the following
critical flow before merging
## Tested in
| Browser | Supporter Stripe checkout | Supporter Paypal checkout | Stripe Monthly Contribution |  Paypal Monthly Contribution| Upgrade from Friend to Supporter  |
|---------|---------------------------|---------------------------|-----------------------------|-----------------------------|-----------------------------------|
| IE      |                           |                           |                             |                             |                                   |
| Firefox |                           |                           |                             |                             |                                   |
| Safari  |                           |                           |                             |                             |                                   |
| Chrome  |                           |                           |                             |                             |                                   |

-->

## Screenshots
n/a