### PR TITLE
Updated Terms Copy

### DIFF
--- a/frontend/app/views/fragments/form/submit.scala.html
+++ b/frontend/app/views/fragments/form/submit.scala.html
@@ -30,8 +30,8 @@
     <div class="fieldset__fields fieldset__fields--no-padding">
 
         @if(membershipTermsAndConditions){
-            <p class="ts-and-cs">By joining Guardian Members, you are agreeing to our
-                <a href="@Links.membershipTerms(countryGroup)" class="text-link" target="_blank">Terms and Conditions</a> and
+            <p class="ts-and-cs">By joining Guardian Members, you agree to our
+                <a href="@Links.membershipTerms(countryGroup)" class="text-link" target="_blank">Terms and Conditions</a>. To find out what personal data we collect and how we use it, please visit our
                 <a href="@Links.guardianPrivacyPolicy" class="text-link" target="_blank">Privacy Policy</a>.
             </p>
         }

--- a/frontend/app/views/fragments/form/terms.scala.html
+++ b/frontend/app/views/fragments/form/terms.scala.html
@@ -4,8 +4,8 @@
 
 @(countryGroup: CountryGroup, monthlyContribution: Boolean = false)
 
-<p class="ts-and-cs">@if(monthlyContribution){By proceeding,} else {By joining Guardian Members,} you are agreeing to our
-    <a href="@if(monthlyContribution){@Links.monthlyContributionTerms}else{@Links.membershipTerms(Some(countryGroup))}" class="text-link" target="_blank">Terms and Conditions</a> and
+<p class="ts-and-cs">@if(monthlyContribution){By proceeding,} else {By joining Guardian Members,} you agree to our
+    <a href="@if(monthlyContribution){@Links.monthlyContributionTerms}else{@Links.membershipTerms(Some(countryGroup))}" class="text-link" target="_blank">Terms and Conditions</a>. To find out what personal data we collect and how we use it, please visit our
     <a href="@Links.guardianPrivacyPolicy" class="text-link" target="_blank">Privacy Policy</a>.
 </p>
 

--- a/frontend/app/views/fragments/form/terms.scala.html
+++ b/frontend/app/views/fragments/form/terms.scala.html
@@ -2,10 +2,10 @@
 @import com.gu.i18n.CountryGroup
 @import configuration.CopyConfig.usLegalTerms
 
-@(countryGroup: CountryGroup, monthlyContribution: Boolean = false)
+@(countryGroup: CountryGroup)
 
-<p class="ts-and-cs">@if(monthlyContribution){By proceeding,} else {By joining Guardian Members,} you agree to our
-    <a href="@if(monthlyContribution){@Links.monthlyContributionTerms}else{@Links.membershipTerms(Some(countryGroup))}" class="text-link" target="_blank">Terms and Conditions</a>. To find out what personal data we collect and how we use it, please visit our
+<p class="ts-and-cs">By joining Guardian Members, you agree to our
+    <a href="@Links.membershipTerms(Some(countryGroup))" class="text-link" target="_blank">Terms and Conditions</a>. To find out what personal data we collect and how we use it, please visit our
     <a href="@Links.guardianPrivacyPolicy" class="text-link" target="_blank">Privacy Policy</a>.
 </p>
 


### PR DESCRIPTION
## Why are you doing this?

We had a request to update the wording on the supporter checkout. This is actually the fragment for all paid checkouts, so it will also update Patrons etc. In addition, there's another fragment used on the Friends checkout that has the same copy, so I've updated that too.

[**Trello Card**](https://trello.com/c/wJmiLSCC/1558-update-tc-text-on-supporter-member-flow)

cc @JustinPinner 

## Changes

- Updated copy in both T&Cs fragments.
- Removed logic around monthly contributions, as they're not on this site any more as of #1725.

## Screenshots

**Supporter - Before**

![terms-supporter-before](https://user-images.githubusercontent.com/5131341/40234431-b87cf56a-5a9e-11e8-8c5b-a9fbd14bf5e6.png)

**Supporter - After**

![terms-supporter-after](https://user-images.githubusercontent.com/5131341/40234430-b86455a0-5a9e-11e8-84df-ecc85784f163.png)

**Friends - Before**

![terms-friends-before](https://user-images.githubusercontent.com/5131341/40234471-e309a04e-5a9e-11e8-93c9-329861db0dce.png)

**Friends - After**

![terms-friends-after](https://user-images.githubusercontent.com/5131341/40234470-e2aea022-5a9e-11e8-8a5d-f284982e87ea.png)
