### PR TITLE
Disable logstash while we decommission the ELK stack

### DIFF
--- a/frontend/conf/CODE.public.conf
+++ b/frontend/conf/CODE.public.conf
@@ -1,6 +1,6 @@
 include "DEV.public"
 
-logstash.enabled=true
+logstash.enabled=false
 
 stage="CODE"
 

--- a/frontend/conf/PROD.public.conf
+++ b/frontend/conf/PROD.public.conf
@@ -51,4 +51,4 @@ google.adwords.joiner.conversion {
   patron="8OIRCKrKtFYQ-fOZzQM"
 }
 
-logstash.enabled=true
+logstash.enabled=false


### PR DESCRIPTION
## Why are you doing this?
We're going to remove the ELK stack that we're shipping logs to as part of GDPR changes. This PR stops the application from attempting to communicate with the Kinesis stream that will disappear when the stack is deleted.

Later on, we'll have created a new Kinesis stream that sends fully GDPR-compliant data to a new backend. Then we can re-enable (or revert this PR) when the new stream is available and configured for this application.

## Trello card: [Here](https://trello.com/c/BPgeI0BP/1553-delete-elk-stack-for-supporter-experience)

## Changes
* Change `logstash.enabled` to `false` in PROD and CODE conf files 

## Screenshots
![screen shot 2018-05-23 at 11 22 29](https://user-images.githubusercontent.com/690395/40419279-b7fb4768-5e7c-11e8-8af0-bef4f9f8f9af.png)
