### PR TITLE
Fixed Flaky User Test

### DIFF
--- a/frontend/assets/javascripts/tests/spec/userDetails.spec.js
+++ b/frontend/assets/javascripts/tests/spec/userDetails.spec.js
@@ -28,6 +28,11 @@ define([
 
         removeCookies = function () {
             cookie.removeCookie(GU_USER_COOKIE_KEY);
+        },
+
+        removeClasses = function () {
+            $(document.documentElement).removeClass(userDetails._.CLASS_NAMES.signedIn);
+            $(document.documentElement).removeClass(userDetails._.CLASS_NAMES.hasTier);
         };
 
     describe('User state classes', function () {
@@ -35,11 +40,6 @@ define([
         var addClasses = function (member) {
                 // This is hardcoded in main.scala.html
                 $(document.documentElement).addClass(userDetails._.CLASS_NAMES.signedOut);
-            },
-
-            removeClasses = function () {
-                $(document.documentElement).removeClass(userDetails._.CLASS_NAMES.signedIn);
-                $(document.documentElement).removeClass(userDetails._.CLASS_NAMES.hasTier);
             };
 
         beforeEach(function () {
@@ -102,6 +102,7 @@ define([
         afterEach(function () {
             removeFixtures();
             removeCookies();
+            removeClasses();
         });
 
         it('Should not attempt to inject user details for anonymous users', function () {


### PR DESCRIPTION
## Why are you doing this?

@svillafe this was the reason I was running the same code over and over again and expecting different results... usually that *is* a sign of madness, but not where flaky tests are concerned 🙂.

### The Problem

The `userDetails` test suite has a total of 7 tests in blocks of 4 and 3, and the first block has a couple of flaky tests in it. Every now and again the following two tests fail:

- "Should not add any classes for anonymous users"
- "Should not add member tier class for authenticated non-members"

All the tests in this suite rely on `userDetails.init`, which adds classes to the document element depending on whether the user is signed in and/or has membership cookies. These two tests make sure that these classes are *not* added if the user is not signed in and/or does not have membership. The fact that the tests are failing means that sometimes these classes are present when they shouldn't be, which in turn suggests that they're being added by another test and not being cleaned up correctly.

The tests in the first block shouldn't be responsible for this, as they have an `afterEach` function that drops these classes after every test. However, it turns out that the second block of tests do *not* correctly clean up after themselves. They don't remove these classes after each test runs. This isn't a problem for the tests in this block, as they aren't checking for the presence or absence of these classes. On the other hand, it *would* be a problem for the tests in the first block.

This is important because Jasmine runs individual tests within a test block in a random order, *and* runs the test blocks themselves in a random order. What this means is that sometimes the **second** block of tests runs *before* the **first** block. Therefore, tests in the second block are running, adding classes to the document without removing them, and then allowing the tests in the first block to run, picking up on these classes.

Due to the fact that that tests in the first block *do* clean up after themselves, only the **first running** test in the first block will be affected by this, as it *will* clean up after itself and allow the rest of the tests to run as normal. Therefore, whenever one of the two tests mentioned above runs first, it will fail. Furthermore, whenever one of the other two tests in the first block runs it will probably pass incorrectly, because it's seeing classes that were added by the second test block.

### The Solution

Make the tests in the second block clean up after themselves by removing the classes after each test run.

### Why?

As to why this only recently started to generate failed builds, I think bumping the testing libraries in #1815 was responsible. Part of this upgrade involved going from Jasmine 2.8.0 to Jasmine 3.1.0. The [release notes](https://github.com/jasmine/jasmine/blob/master/release_notes/3.0.md) for Jasmine 3 include the line "Default to running tests in random order". I think that previously our tests and test suites were running in source code order, and therefore this problem was not visible in the test output.

cc @JustinPinner 

## Changes

- Made the `removeClasses` function available to the whole test suite, and used it after every test run in the second test block.
