### PR TITLE
Remove ELK Kinesis stream refs

### DIFF
--- a/cloud-formation/membership-app.cf.yaml
+++ b/cloud-formation/membership-app.cf.yaml
@@ -47,9 +47,6 @@ Parameters:
     Description: Security group that grants access to the account's Vulnerability
       Scanner
     Type: AWS::EC2::SecurityGroup::Id
-  LoggingPolicy:
-    Description: Policy needed to access the kinesis stream
-    Type: String
 Mappings:
   StageVariables:
     PROD:
@@ -195,7 +192,6 @@ Resources:
             Resource:
               Fn::FindInMap: [ StageVariables, { Ref: Stage }, DynamoDBTables ]
       ManagedPolicyArns:
-            - !Ref 'LoggingPolicy'
             - !Sub arn:aws:iam::${AWS::AccountId}:policy/guardian-ec2-role-for-ssm
   MembershipAppInstanceProfile:
     Type: AWS::IAM::InstanceProfile


### PR DESCRIPTION
This is probably starting to look pretty familiar now. Again, it's almost an exact copy of https://github.com/guardian/members-data-api/pull/326

### Why do we need this?
We're removing the ELK stack in the membership account, and this application is holding on to a policy reference, preventing the stack from being fully deleted

### The changes
Remove the cloudformation references that attach the application to the Kinesis publisher policy

### trello card/screenshot/json/related PRs etc
[delete-elk-stack-for-supporter-experience](https://trello.com/c/BPgeI0BP/1553-delete-elk-stack-for-supporter-experience)

### Tested on CODE
Yes
