### PR TITLE
Fresh Sentry projects and use sentry-logback

### DIFF
--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -1,5 +1,4 @@
 package configuration
-import com.getsentry.raven.dsn.Dsn
 import com.gu.config._
 import com.gu.i18n.Country
 import com.gu.identity.cookie.{PreProductionKeys, ProductionKeys}
@@ -22,7 +21,7 @@ object Config {
 
   lazy val siteTitle = config.getString("site.title")
 
-  lazy val sentryDsn = Try(new Dsn(config.getString("sentry.dsn")))
+  lazy val sentryDsn = Try(config.getString("sentry.dsn"))
 
   lazy val awsAccessKey = config.getString("aws.access.key")
   lazy val awsSecretKey = config.getString("aws.secret.key")

--- a/frontend/app/monitoring/SentryLogging.scala
+++ b/frontend/app/monitoring/SentryLogging.scala
@@ -34,7 +34,6 @@ object SentryLogging {
           case Failure(e) => SafeLogger.error(scrub"Something went wrong when setting up Sentry logging ${e.getStackTrace}")
         }
     }
-    SafeLogger.error(scrub"*TEST* more spam courtesy of Leigh-Anne. You are just the cat's pyjamas!")
   }
 }
 

--- a/frontend/app/monitoring/SentryLogging.scala
+++ b/frontend/app/monitoring/SentryLogging.scala
@@ -18,7 +18,7 @@ class PiiFilter extends Filter[ILoggingEvent] {
 
 object SentryLogging {
 
-  def init() = {
+  def init(): Unit = {
     Config.sentryDsn match {
       case Failure(ex) =>
         SafeLogger.warn("No server-side Sentry logging configured (OK for dev)")

--- a/frontend/app/monitoring/SentryLogging.scala
+++ b/frontend/app/monitoring/SentryLogging.scala
@@ -1,54 +1,40 @@
 package monitoring
 
-import ch.qos.logback.classic.filter.ThresholdFilter
 import ch.qos.logback.classic.spi.ILoggingEvent
-import ch.qos.logback.classic.{Logger, LoggerContext}
 import ch.qos.logback.core.filter.Filter
 import ch.qos.logback.core.spi.FilterReply
-import com.getsentry.raven.RavenFactory
-import com.getsentry.raven.dsn.Dsn
-import com.getsentry.raven.logback.SentryAppender
 import com.gu.monitoring.SafeLogger
+import com.gu.monitoring.SafeLogger._
 import configuration.Config
-import org.slf4j.Logger.ROOT_LOGGER_NAME
-import org.slf4j.LoggerFactory
+import io.sentry.Sentry
+import scala.collection.JavaConverters._
+
 import scala.util.{Failure, Success, Try}
 
-object SentryFilters {
-
-  class PiiFilter extends Filter[ILoggingEvent] {
-    override def decide(event: ILoggingEvent): FilterReply = if (event.getMarker.contains(SafeLogger.sanitizedLogMessage)) FilterReply.ACCEPT
-    else FilterReply.DENY
-  }
-
-  val errorLevelFilter = new ThresholdFilter { setLevel("ERROR") }
-  val piiFilter = new PiiFilter
-
-  errorLevelFilter.start()
-  piiFilter.start()
-
+class PiiFilter extends Filter[ILoggingEvent] {
+  override def decide(event: ILoggingEvent): FilterReply = if (event.getMarker.contains(SafeLogger.sanitizedLogMessage)) FilterReply.ACCEPT
+  else FilterReply.DENY
 }
 
 object SentryLogging {
 
-  def init() {
-    Try(new Dsn(Config.config.getString("sentry.dsn"))) match {
+  def init() = {
+    Config.sentryDsn match {
       case Failure(ex) =>
         SafeLogger.warn("No server-side Sentry logging configured (OK for dev)")
       case Success(dsn) =>
-        SafeLogger.info(s"Initialising Sentry logging for ${dsn.getHost}")
-        val buildInfo: Map[String, Any] = app.BuildInfo.toMap
-        val tags = Map("stage" -> Config.stage) ++ buildInfo
-        val tagsString = tags.map { case (key, value) => s"$key:$value"}.mkString(",")
-        val sentryAppender = new SentryAppender(RavenFactory.ravenInstance(dsn)) {
-          addFilter(SentryFilters.errorLevelFilter)
-          addFilter(SentryFilters.piiFilter)
-          setTags(tagsString)
-          setRelease(app.BuildInfo.gitCommitId)
-          setContext(LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext])
+        SafeLogger.info(s"Initialising Sentry logging.")
+        Try {
+          val sentryClient = Sentry.init(dsn)
+          val buildInfo: Map[String, String] = app.BuildInfo.toMap.mapValues(_.toString)
+          val tags = Map("stage" -> Config.stage.toString) ++ buildInfo
+          sentryClient.setTags(tags.asJava)
+        } match {
+          case Success(_) => SafeLogger.debug("Sentry logging configured.")
+          case Failure(e) => SafeLogger.error(scrub"Something went wrong when setting up Sentry logging ${e.getStackTrace}")
         }
-        sentryAppender.start()
-        LoggerFactory.getLogger(ROOT_LOGGER_NAME).asInstanceOf[Logger].addAppender(sentryAppender)
     }
+    SafeLogger.error(scrub"*TEST* more spam courtesy of Leigh-Anne. You are just the cat's pyjamas!")
   }
 }
+

--- a/frontend/assets/javascripts/src/main.js
+++ b/frontend/assets/javascripts/src/main.js
@@ -62,7 +62,7 @@ require([
     'use strict';
 
     ajax.init({page: {ajaxUrl: ''}});
-    raven.init('https://8ad435f4fefe468eb59b19fd81a06ea9@app.getsentry.com/56405');
+    raven.init('https://d35a3ab8382a49889557d312e75b2179@sentry.io/1218929');
 
     analytics.init();
 

--- a/frontend/conf/logback.xml
+++ b/frontend/conf/logback.xml
@@ -21,11 +21,20 @@
             <pattern>%date [%.-30thread] %logger[%file:%L] %highlight(%level: %msg%n%xException{3})</pattern>
         </encoder>
     </appender>
+    <appender name="Sentry" class="io.sentry.logback.SentryAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+        <filter class="monitoring.PiiFilter">
+            <level>ERROR</level>
+        </filter>
+    </appender>
 
     <logger name="com.google.api.client.http" level="WARN" />
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
+        <appender-ref ref="Sentry"/>
     </root>
 
 </configuration>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   //versions
   val awsClientVersion = "1.11.226"
   //libraries
-  val sentryRavenLogback = "com.getsentry.raven" % "raven-logback" % "8.0.3"
+  val sentryRavenLogback = "io.sentry" % "sentry-logback" % "1.7.5"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "2.1"
   val membershipCommon = "com.gu" %% "membership-common" % "0.509"


### PR DESCRIPTION
### Why do we need this? 
We scrubbed PII here:
https://github.com/guardian/membership-frontend/pull/1789
https://github.com/guardian/membership-frontend/pull/1790

As we stop sending PII, to sentry, we are also deleting old sentry projects and starting anew. 

While we're starting anew, we might as well use sentry-logback rather than raven-logback (deprecated).

Both membership and membership-client-side shall point to new Sentry projects in conjunction with this PR. 

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
* Pointing to the DSN of the new project for membership-client-side
* Update the DSN configured in the config for the new sentry project for membership
* Move to using sentry-logback (raven-logback is deprecated). 
* Wrap Sentry.init in a try 

TODO:
Pre-merge
- [x] Test in CODE that error logs go to the new project
- [x] Add the DSN for the new sentry project to the PROD config 
- [x] Remove the DSN from the CODE config

Post-merge
- [ ] Delete the existing sentry project
- [ ] Rename the new sentry projects back to membership and membership-client-side as before


### trello card/screenshot/json/related PRs etc
[**Trello Card**](https://trello.com/c/LiojyKYR/1555-delete-all-projects-which-contain-pii-from-sentry-and-replace-with-a-clean-project)
https://github.com/guardian/membership-frontend/pull/1789
https://github.com/guardian/membership-frontend/pull/1790