### PR TITLE
Remove the Qualys Vulnerability Scanner security group as we now use AWS Inspector

### DIFF
--- a/cloud-formation/membership-app.cf.yaml
+++ b/cloud-formation/membership-app.cf.yaml
@@ -43,10 +43,6 @@ Parameters:
   ELBSSLCertificate:
     Description: ELB SSL Certificate ARN
     Type: String
-  VulnerabilityScanningSecurityGroup:
-    Description: Security group that grants access to the account's Vulnerability
-      Scanner
-    Type: AWS::EC2::SecurityGroup::Id
 Mappings:
   StageVariables:
     PROD:
@@ -106,7 +102,6 @@ Resources:
         Ref: ImageId
       SecurityGroups:
       - Ref: InstanceSecurityGroup
-      - Ref: VulnerabilityScanningSecurityGroup
       InstanceType:
         Ref: InstanceType
       IamInstanceProfile:


### PR DESCRIPTION
## Why are you doing this?
<!--
Please do not forget to log the amount of hours you spent in this PR here:
https://docs.google.com/spreadsheets/d/1DO24_EkHI3emwTSXpnkwWGhKf7n_9VDcGu0g4kdfUD0/edit#gid=0
-->
Save a bit of money.

<!--
Remember, PRs are documentation for future contributors

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->
## Changes
* Remove security group from this instance so I can deprovision the vulnerability scanner cloudformation stack.
