### PR TITLE
Configure the Sentry appender and the filters in the code again

### DIFF
--- a/frontend/app/monitoring/SentryLogging.scala
+++ b/frontend/app/monitoring/SentryLogging.scala
@@ -47,7 +47,6 @@ object SentryLogging {
           case Success(_) => SafeLogger.debug("Sentry logging configured.")
           case Failure(e) => SafeLogger.error(scrub"Something went wrong when setting up Sentry logging ${e.getStackTrace}")
         }
-        SafeLogger.error(scrub"*TEST* from membership-frontend. Ignore me. ")
     }
   }
 }

--- a/frontend/app/monitoring/SentryLogging.scala
+++ b/frontend/app/monitoring/SentryLogging.scala
@@ -47,6 +47,7 @@ object SentryLogging {
           case Success(_) => SafeLogger.debug("Sentry logging configured.")
           case Failure(e) => SafeLogger.error(scrub"Something went wrong when setting up Sentry logging ${e.getStackTrace}")
         }
+        SafeLogger.error(scrub"*TEST* from membership-frontend. Ignore me. ")
     }
   }
 }

--- a/frontend/conf/logback.xml
+++ b/frontend/conf/logback.xml
@@ -21,20 +21,11 @@
             <pattern>%date [%.-30thread] %logger[%file:%L] %highlight(%level: %msg%n%xException{3})</pattern>
         </encoder>
     </appender>
-    <appender name="Sentry" class="io.sentry.logback.SentryAppender">
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>ERROR</level>
-        </filter>
-        <filter class="monitoring.PiiFilter">
-            <level>ERROR</level>
-        </filter>
-    </appender>
 
     <logger name="com.google.api.client.http" level="WARN" />
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
-        <appender-ref ref="Sentry"/>
     </root>
 
 </configuration>


### PR DESCRIPTION
Otherwise, we get ugly errors in the console when running in DEV mode. 

I introduced this when updating to sentry-logback 1.7.5 in https://github.com/guardian/membership-frontend/pull/1824

Read more here:
https://github.com/guardian/support-frontend/pull/703

Tested Sentry config still works in CODE, and checked while running locally that this resolved the ClassNotFound exception.