### PR TITLE
Revert "Redirect all cancellation pages to new cancellation flow on `manage.theguardian.com`"

### DIFF
--- a/frontend/app/controllers/TierController.scala
+++ b/frontend/app/controllers/TierController.scala
@@ -78,9 +78,32 @@ class TierController(
       case err => throw err
     }, identity)
 
-  def redirectToNewCancellationFlow() = AuthenticatedAction(
-    Redirect(url = "https://manage.theguardian.com/cancel/membership")
+
+  def cancelTier() = SubscriptionAction { implicit request =>
+    Ok(views.html.tier.cancel.confirm(request.subscriber.subscription.plan.tier, catalog))
+  }
+
+  def cancelTierConfirm() = SubscriptionAction.async { implicit request =>
+    //If we can't get a cancellation reason, it's not really a problem.
+    val reason = cancellationReasonFrom.bindFromRequest.value.getOrElse(CancellationReason("mma_none"))
+
+    handleErrors(memberService.cancelSubscription(request.subscriber, reason)) {
+      if (request.subscriber.subscription.plan.isPaid) {
+        Redirect(routes.TierController.cancelFreeTierSummary())
+      } else {
+        Redirect(routes.TierController.cancelPaidTierSummary())
+      }
+    }
+  }
+
+  def cancelFreeTierSummary = AuthenticatedAction(
+    Ok(views.html.tier.cancel.summaryFree())
   )
+
+  def cancelPaidTierSummary = PaidSubscriptionAction { implicit request =>
+    implicit val c = catalog
+    Ok(views.html.tier.cancel.summaryPaid(request.subscriber.subscription)).discardingCookies(TierChangeCookies.deletionCookies: _*)
+  }
 
   def paymentSummary(subscriber: PaidMember, targetPlans: PaidMembershipPlans[PaidMemberTier])
     (implicit b: BackendProvider, c: Catalog, r: IdentityRequest): Future[MemberError \/ PaidToPaidUpgradeSummary] = {

--- a/frontend/app/views/tier/cancel/confirm.scala.html
+++ b/frontend/app/views/tier/cancel/confirm.scala.html
@@ -1,0 +1,87 @@
+@import com.gu.salesforce.Tier
+@import views.support.MembershipCompat._
+@import com.gu.memsub.subsv2.Catalog
+@(tier: Tier, catalog: Catalog)(implicit request: RequestHeader)
+
+@import com.gu.salesforce.Tier.Friend
+@import views.html.helper._
+@import views.support.DisplayText._
+
+@currentTierDetails = {
+    <h3 class="h-stack">As a Guardian member, you also have access to...</h3>
+@fragments.tier.tierTrail(tier, showCaption = false)
+    <div class="copy">
+        <ul>
+        @for(benefit <- tier.benefits) {
+            <li>@benefit.title</li>
+        }
+        </ul>
+    </div>
+}
+
+
+@main("Cancel Tier") {
+
+    <main role="main" class="page-content l-constrained">
+
+        @fragments.page.pageHeader("We don't like goodbyes…",
+            Some("So instead we're going to try to tempt you to stay by reminding you that your ongoing financial support helps to make our independent journalism possible in the long-term."))
+
+        <div class="page-section">
+            <div class="page-section__content">
+                @if(tier == Friend()) {
+                    <a href="@routes.TierController.change" class="action action--secondary u-margin-bottom">
+                        @fragments.actionIcon("arrow-left", leftIcon = true)
+                        <span class="action__label">Stay as a Friend</span>
+                    </a>
+                    @currentTierDetails
+                } else {
+                    <ul class="grid grid--2up-stacked grid--bordered grid--stretch">
+                        <li class="grid__item">
+                            <a href="@routes.TierController.change" class="action action--secondary u-margin-bottom">
+                                @fragments.actionIcon("arrow-left", leftIcon = true)
+                                <span class="action__label">Stay as a @tier.name</span>
+                            </a>
+                            @currentTierDetails
+                        </li>
+                    </ul>
+                }
+                <div class="action-group u-divider-neutral u-margin-top">
+
+                    <form method="POST" action="@routes.TierController.cancelTierConfirm" class="js-processing-form">
+                        @CSRF.formField
+                        <div class="form-field">
+
+                            <p>
+                                We value your feedback. Please take a moment to tell us why you are cancelling.
+                            </p>
+                        </div>
+                        <div class="form-field">
+
+                            <select name="reason">
+                                <option disabled selected value> -- select an option -- </option>
+                                <option value="mma_financial_circumstances">A change in my financial circumstances</option>
+                                <option value="mma_not_value">It is poor value for money</option>
+                                <option value="mma_editorial">I disagree with editorial decisions</option>
+                                <option value="mma_benefits">None of the benefits were of interest to me</option>
+                                <option value="mma_support_another_way">
+                                    I want to support the Guardian in another way eg. subscription</option>
+                                <option value="mma_health">Ill-health</option>
+                                <option value="mma_none">None of the above</option>
+                            </select>
+                        </div>
+                        <div class="form-field">
+
+                            <button id="qa-confirm-cancel" class="action js-processing-form-submit u-align-right" type="submit">
+                                Cancel membership
+                            </button>
+
+                            <div class="loader js-loader">Processing&hellip;</div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+
+    </main>
+}

--- a/frontend/app/views/tier/cancel/summaryFree.scala.html
+++ b/frontend/app/views/tier/cancel/summaryFree.scala.html
@@ -1,0 +1,15 @@
+@import configuration.Config
+@main("Cancel Tier summary") {
+    <main role="main" class="page-content l-constrained">
+        <section class="page-section page-section--bordered">
+            <div class="page-section__lead-in">
+                <h2 class="page-section__headline">Current Membership summary</h2>
+            </div>
+            <div class="page-section__content">
+                <p>We are processing your cancellation and will send a confirmation email shortly.</p>
+                <p>Your Guardian profile will remain active so you can continue to participate in the Guardian community.</p>
+                <a href="@Config.idWebAppUrl/membership/edit" class="action">My Profile</a>
+            </div>
+        </section>
+    </main>
+}

--- a/frontend/app/views/tier/cancel/summaryPaid.scala.html
+++ b/frontend/app/views/tier/cancel/summaryPaid.scala.html
@@ -1,0 +1,28 @@
+@import configuration.Config
+@import com.gu.memsub.subsv2._
+@import com.gu.memsub.BillingPeriod
+@import com.gu.memsub.Status
+@import views.support.Dates._
+
+@(subscription: Subscription[SubscriptionPlan.PaidMember])
+
+@main("Cancel Tier summary") {
+    <main role="main" class="page-content l-constrained">
+
+        @fragments.page.pageHeader("Sorry to see you go…", Some("You will continue to receive all the great Membership benefits until " + subscription.termEndDate.toDateTimeAtCurrentTime.pretty))
+        <section class="page-section page-section--bordered">
+            <div class="page-section__lead-in">
+                <h2 class="page-section__headline">Current Membership summary</h2>
+            </div>
+            <div class="page-section__content">
+
+                @fragments.tier.summary(subscription)
+
+                <p>Your Guardian profile will remain active so you can continue to participate in the Guardian community.</p>
+
+                <a href="@Config.idWebAppUrl/membership/edit" class="action">My Profile</a>
+            </div>
+        </section>
+
+    </main>
+}

--- a/frontend/app/views/tier/change.scala.html
+++ b/frontend/app/views/tier/change.scala.html
@@ -52,7 +52,7 @@
                 @* Help & cancellation links *@
                 <ul class="o-inline-list o-inline-list--bordered copy">
                     <li class="o-inline-list__item"><a href="@routes.Info.help">Help</a></li>
-                    <li class="o-inline-list__item"><a href="@routes.TierController.redirectToNewCancellationFlow" id="qa-cancel-membership">Cancel Guardian membership</a></li>
+                    <li class="o-inline-list__item"><a href="@routes.TierController.cancelTier" id="qa-cancel-membership">Cancel Guardian membership</a></li>
                 </ul>
             </div>
             }

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -77,10 +77,10 @@ GET         /preview-masterclass/:id                   controllers.Event.preview
 
 # Tier
 GET         /tier/change                               controllers.TierController.change
-GET         /tier/cancel                               controllers.TierController.redirectToNewCancellationFlow
-POST        /tier/cancel/confirm                       controllers.TierController.redirectToNewCancellationFlow
-GET         /tier/cancel/paid/summary                  controllers.TierController.redirectToNewCancellationFlow
-GET         /tier/cancel/free/summary                  controllers.TierController.redirectToNewCancellationFlow
+GET         /tier/cancel                               controllers.TierController.cancelTier
+POST        /tier/cancel/confirm                       controllers.TierController.cancelTierConfirm
+GET         /tier/cancel/paid/summary                  controllers.TierController.cancelPaidTierSummary
+GET         /tier/cancel/free/summary                  controllers.TierController.cancelFreeTierSummary
 GET         /tier/change/:tier                         controllers.TierController.upgrade(tier: PaidTier)
 POST        /tier/change/:tier                         controllers.TierController.upgradeConfirm(tier: PaidTier)
 GET         /tier/change/:tier/summary                 controllers.TierController.upgradeThankyou(tier: PaidTier)


### PR DESCRIPTION
Reverts guardian/membership-frontend#1833