### PR TITLE
Fix Missing State Dropdown

### DIFF
--- a/frontend/assets/javascripts/src/modules/form/address/rules.js
+++ b/frontend/assets/javascripts/src/modules/form/address/rules.js
@@ -26,7 +26,7 @@ define([
         var $usStateSelectParent = $(utilsHelper.getSpecifiedParent(context.querySelector(US_STATE_SELECTOR), FORM_FIELD_CLASSNAME));
         var $caProvinceSelectParent = $(utilsHelper.getSpecifiedParent(context.querySelector(CA_PROVINCE_SELECTOR), FORM_FIELD_CLASSNAME));
         var $ausStateSelectParent = $(utilsHelper.getSpecifiedParent(context.querySelector(AUS_STATE_SELECTOR), FORM_FIELD_CLASSNAME));
-        countrySelect.addEventListener('change', function (e) {
+        $(context).find(COUNTRY_SELECTOR).on('change', function (e) {
             var select = e && e.target;
             implementRules(context, select, $countySelectParent, $usStateSelectParent, $caProvinceSelectParent, $ausStateSelectParent);
         });


### PR DESCRIPTION
## Why are you doing this?

If a user arrives on the supporter checkout with a country that requires a State/Province dropdown (US, CA, AU), the dropdown doesn't appear on the page. It would only appear on manually changing the country to something else and then back again (for both delivery and billing country).

I think this is happening because the `init` function in `options.js` uses the jQuery `trigger` method to artificially create this `change` event on page load. However, the event listener itself is set up with the standard (non-jQuery) `addEventListener`. According to the [jQuery docs](https://learn.jquery.com/events/triggering-event-handlers/) this `trigger` method *doesn't* trigger normal browser events, it only applies to the jQuery event layer.

cc @JustinPinner 

[**Trello Card**](https://trello.com/c/YiysxhtG/1840-fix-membership-missing-state-dropdown)

## Changes

- Switch to using jQuery's `on` to set up the country field event listener.
