### PR TITLE
Update post-deployment tests

### DIFF
--- a/frontend/test/acceptance/JoinSupporterSpec.scala
+++ b/frontend/test/acceptance/JoinSupporterSpec.scala
@@ -49,7 +49,7 @@ class JoinSupporterSpec extends FeatureSpec with Browser
       And("they proceed to the next step,")
       firstRegistrationPage.submit()
 
-      Then("they should be redirected to register as an Identity user")
+      Then("they should be asked to finish registering for an Identity account")
       val secondRegistrationPage = pages.SecondRegistrationStep(testUser)
       assert(secondRegistrationPage.pageHasLoaded)
 
@@ -135,7 +135,7 @@ class JoinSupporterSpec extends FeatureSpec with Browser
       And("they proceed to the next step,")
       firstRegistrationPage.submit()
 
-      Then("they should be redirected to register as an Identity user")
+      Then("they should be asked to finish registering for an Identity account")
       val secondRegistrationPage = pages.SecondRegistrationStep(testUser)
       assert(secondRegistrationPage.pageHasLoaded)
 

--- a/frontend/test/acceptance/JoinSupporterSpec.scala
+++ b/frontend/test/acceptance/JoinSupporterSpec.scala
@@ -31,6 +31,7 @@ class JoinSupporterSpec extends FeatureSpec with Browser
   feature("Become a Supporter in UK and US") {
 
     scenario("User joins as Supporter using Stripe in US", Acceptance) {
+
       checkDependenciesAreAvailable
 
       val testUser = new TestUser
@@ -38,15 +39,25 @@ class JoinSupporterSpec extends FeatureSpec with Browser
       Given("users click 'Become a Supporter' button on Membership homepage")
 
       When("They land on 'Identity Frontend' page,")
-      val register = pages.Register(testUser)
-      go.to(register)
-      assert(register.pageHasLoaded)
+      val firstRegistrationPage = pages.FirstRegistrationStep(testUser)
+      go.to(firstRegistrationPage)
+      assert(firstRegistrationPage.pageHasLoaded)
 
-      And("fill in personal details,")
-      register.fillInPersonalDetails()
+      And("fill in their email address,")
+      firstRegistrationPage.fillInEmail()
 
-      And("submit the form to create their Identity account,")
-      register.submit()
+      And("they proceed to the next step,")
+      firstRegistrationPage.submit()
+
+      Then("they should be redirected to register as an Identity user")
+      val secondRegistrationPage = pages.SecondRegistrationStep(testUser)
+      assert(secondRegistrationPage.pageHasLoaded)
+
+      Given("that the user fills in their personal details correctly")
+      secondRegistrationPage.fillInPersonalDetails()
+
+      When("they submit the form to create their Identity account,")
+      secondRegistrationPage.submit()
 
       Then("they should land on 'Enter Details' page,")
       val enterDetails = pages.EnterDetails(testUser)
@@ -114,15 +125,25 @@ class JoinSupporterSpec extends FeatureSpec with Browser
       Given("users click 'Become a Supporter' button on Membership homepage")
 
       When("They land on 'Identity Frontend' page,")
-      val register = pages.Register(testUser)
-      go.to(register)
-      assert(register.pageHasLoaded)
+      val firstRegistrationPage = pages.FirstRegistrationStep(testUser)
+      go.to(firstRegistrationPage)
+      assert(firstRegistrationPage.pageHasLoaded)
 
-      And("fill in personal details,")
-      register.fillInPersonalDetails()
+      And("fill in their email address,")
+      firstRegistrationPage.fillInEmail()
 
-      And("submit the form to create their Identity account,")
-      register.submit()
+      And("they proceed to the next step,")
+      firstRegistrationPage.submit()
+
+      Then("they should be redirected to register as an Identity user")
+      val secondRegistrationPage = pages.SecondRegistrationStep(testUser)
+      assert(secondRegistrationPage.pageHasLoaded)
+
+      Given("that the user fills in their personal details correctly")
+      secondRegistrationPage.fillInPersonalDetails()
+
+      When("they submit the form to create their Identity account,")
+      secondRegistrationPage.submit()
 
       Then("they should land on 'Enter Details' page,")
       val enterDetails = pages.EnterDetails(testUser)

--- a/frontend/test/acceptance/pages/Identity.scala
+++ b/frontend/test/acceptance/pages/Identity.scala
@@ -47,7 +47,3 @@ case class SecondRegistrationStep(testUser: TestUser) extends IdentityStep {
   override val submitButton = id("tssf-create-account")
 
 }
-
-
-
-

--- a/frontend/test/acceptance/pages/Identity.scala
+++ b/frontend/test/acceptance/pages/Identity.scala
@@ -5,29 +5,49 @@ import Config._
 import org.scalatest.selenium.Page
 import java.net.URLEncoder
 
-case class Register(testUser: TestUser) extends Page with Browser {
-  private val returnUrlParam = URLEncoder.encode(s"${baseUrl}/join/supporter/enter-details", "UTF-8")
-  val url = s"${identityFrontendUrl}/register?returnUrl=${returnUrlParam}&skipConfirmation=true&clientId=members"
+trait IdentityStep extends Page with Browser {
 
-  def fillInPersonalDetails() { RegisterFields.fillIn() }
+  private val returnUrlParam = URLEncoder.encode(s"${baseUrl}/join/supporter/enter-details", "UTF-8")
+  val url = s"${identityFrontendUrl}/signin?returnUrl=${returnUrlParam}&skipConfirmation=true&clientId=members"
+
+  val submitButton: IdQuery
 
   def submit() { clickOn(submitButton) }
 
   def pageHasLoaded: Boolean = pageHasElement(submitButton)
 
+}
+
+case class FirstRegistrationStep(testUser: TestUser) extends IdentityStep {
+
+  private val email = id("tssf-email")
+
+  override val submitButton = id("tssf-submit")
+
+  def fillInEmail() = setValue(email, s"${testUser.username}@gu.com", clear=true)
+
+}
+
+case class SecondRegistrationStep(testUser: TestUser) extends IdentityStep {
+
+  def fillInPersonalDetails() { RegisterFields.fillIn() }
+
   private object RegisterFields {
     val firstName = id("register_field_firstname")
     val lastName = id("register_field_lastname")
-    val email = id("register_field_email")
     val password = id("register_field_password")
 
     def fillIn() {
       setValue(firstName, testUser.username, clear=true)
       setValue(lastName, testUser.username, clear=true)
-      setValue(email, s"${testUser.username}@gu.com", clear=true)
       setValue(password, testUser.username, clear=true)
     }
   }
 
-  private val submitButton = id("register_submit")
+  override val submitButton = id("tssf-create-account")
+
 }
+
+
+
+

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,9 +19,8 @@ object Dependencies {
   val sqs = "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion
   val scalaTest =  "org.scalatestplus" %% "play" % "1.4.0" % "test"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.7"
-  val selenium = "org.seleniumhq.selenium" % "selenium-java" % "3.5.3" % "test"
-  val seleniumHtmlUnitDriver = "org.seleniumhq.selenium" % "htmlunit-driver" % "2.29.0" % "test"
-  val seleniumManager = "io.github.bonigarcia" % "webdrivermanager" % "2.1.0" % "test"
+  val selenium = "org.seleniumhq.selenium" % "selenium-java" % "3.14.0" % "test"
+  val seleniumManager = "io.github.bonigarcia" % "webdrivermanager" % "2.2.5" % "test"
   val specs2Extra = "org.specs2" %% "specs2-matcher-extra" % "3.6.6" % "test"
   val pegdown = "org.pegdown" % "pegdown" % "1.6.0"
   val enumPlay = "com.beachape" %% "enumeratum-play" % "1.3.7"
@@ -45,6 +44,6 @@ object Dependencies {
     PlayImport.specs2 % "test", specs2Extra, identityPlayAuth, catsCore, scalaLogging, kinesisLogbackAppender, logstash, dataFormat, dataBind,
     acquisitionEventProducer, bcprovJdk15on)
 
-  val acceptanceTestDependencies = Seq(scalaTest, selenium, seleniumHtmlUnitDriver, seleniumManager)
+  val acceptanceTestDependencies = Seq(scalaTest, selenium, seleniumManager)
 
 }


### PR DESCRIPTION
## Why are you doing this?
These tests are currently broken due to changes to the default Identity flow. (See a similar PR here: https://github.com/guardian/support-frontend/pull/789). 

## Changes
* Change Selenium tests to cope with two-step identity flow.
* Update test dependencies
