### PR TITLE
Bump Play From 2.6.18 To 2.6.19

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ logLevel := Level.Warn
 
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.18")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.19")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
 


### PR DESCRIPTION
## Why are you doing this?

Keeping Play up-to-date. Release notes [here](https://github.com/playframework/playframework/releases/tag/2.6.19); the focus is updating Akka. It includes a breaking change in Akka, but it compiles and seems to be working ok.

## Changes

- Bump Play.
