### PR TITLE
Bump jackson-databind, jackson-core and jackson-annotations to 2.9.7 

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,7 +30,9 @@ object Dependencies {
   val dataFormat = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % "2.8.11"
   val bcprovJdk15on = "org.bouncycastle" % "bcprov-jdk15on" % "1.60"  //-- added explicitly - snyk report avoid logback vulnerability
   // This is required to force aws libraries to use the latest version of jackson
-  val dataBind = "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.1"
+  val jacksonDataBind =  "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.7"
+  val jacksonAnnotations = "com.fasterxml.jackson.core" % "jackson-annotations" % "2.9.7"
+  var jacksonCore = "com.fasterxml.jackson.core" % "jackson-core" % "2.9.7"
   val acquisitionEventProducer = "com.gu" %% "acquisition-event-producer-play26" % "3.0.0" % "compile" excludeAll(
     ExclusionRule(organization = "org.scalatest"),
     ExclusionRule(organization = "org.scalactic")
@@ -40,8 +42,8 @@ object Dependencies {
 
   val frontendDependencies =  Seq(googleAuth, scalaUri, membershipCommon, enumPlay,
     contentAPI, playWS, playFilters, playCache, playIteratees, sentryRavenLogback, awsSimpleEmail, scalaz, pegdown,
-    PlayImport.specs2 % "test", specs2Extra, identityPlayAuth, catsCore, scalaLogging, kinesisLogbackAppender, logstash, dataFormat, dataBind,
-    acquisitionEventProducer, bcprovJdk15on)
+    PlayImport.specs2 % "test", specs2Extra, identityPlayAuth, catsCore, scalaLogging, kinesisLogbackAppender, logstash, dataFormat, jacksonDataBind,
+    jacksonAnnotations, jacksonCore, acquisitionEventProducer, bcprovJdk15on)
 
   val acceptanceTestDependencies = Seq(scalaTest, selenium, seleniumManager)
 


### PR DESCRIPTION
https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-31507

We are pulling in old versions of jackson-databind primarily via aws-sdks. It's suggested here that this shouldn't be a breaking change for the aws sdks, and indeed when I tested it on CODE, it wasn't. I have tested putting through a Membership Supporter and everything was fine. 

Also upgrading jackson-annotations as in other projects it has broken when databind and annotations aren't in sync, and upgrading core for completeness.

Any other suggested checks?

 Inspired by Snyk.