### PR TITLE
Upgrade to Scala 2.12

### DIFF
--- a/frontend/build.sbt
+++ b/frontend/build.sbt
@@ -24,7 +24,7 @@ organization := "com.gu"
 
 version := "1.0-SNAPSHOT"
 
-scalaVersion := "2.11.12"
+scalaVersion := "2.12.6"
 
 resolvers ++= Seq(
     "Guardian Github Releases" at "https://guardian.github.io/maven/repo-releases",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,21 +8,21 @@ object Dependencies {
   //libraries
   val sentryRavenLogback = "io.sentry" % "sentry-logback" % "1.7.5"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
-  val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "2.4"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.519"
+  val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "2.5"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.527"
   val contentAPI = "com.gu" %% "content-api-client" % "11.40"
   val playWS = PlayImport.ws
   val playFilters = PlayImport.filters
   val playCache = PlayImport.ehcache
   val playIteratees = "com.typesafe.play" %% "play-iteratees" % "2.6.1"
   val awsSimpleEmail = "com.amazonaws" % "aws-java-sdk-ses" % awsClientVersion
-  val scalaTest =  "org.scalatestplus" %% "play" % "1.4.0" % "test"
+  val scalaTest =  "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % "test"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.7"
   val selenium = "org.seleniumhq.selenium" % "selenium-java" % "3.14.0" % "test"
   val seleniumManager = "io.github.bonigarcia" % "webdrivermanager" % "2.2.5" % "test"
-  val specs2Extra = "org.specs2" %% "specs2-matcher-extra" % "3.6.6" % "test"
+  val specs2Extra = "org.specs2" %% "specs2-matcher-extra" % "3.8.6" % "test"
   val pegdown = "org.pegdown" % "pegdown" % "1.6.0"
-  val enumPlay = "com.beachape" %% "enumeratum-play" % "1.3.7"
+  val enumPlay = "com.beachape" %% "enumeratum-play" % "1.5.14"
   val catsCore = "org.typelevel" %% "cats-core" % "1.0.1"
   val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2"
   val kinesisLogbackAppender = "com.gu" % "kinesis-logback-appender" % "1.4.0"
@@ -33,7 +33,7 @@ object Dependencies {
   val jacksonDataBind =  "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.7"
   val jacksonAnnotations = "com.fasterxml.jackson.core" % "jackson-annotations" % "2.9.7"
   var jacksonCore = "com.fasterxml.jackson.core" % "jackson-core" % "2.9.7"
-  val acquisitionEventProducer = "com.gu" %% "acquisition-event-producer-play26" % "3.0.0" % "compile" excludeAll(
+  val acquisitionEventProducer = "com.gu" %% "acquisition-event-producer-play26" % "4.0.0" % "compile" excludeAll(
     ExclusionRule(organization = "org.scalatest"),
     ExclusionRule(organization = "org.scalactic")
   )


### PR DESCRIPTION
## Why are you doing this?

This project depends on a couple of libraries which have now dropped 2.11 support. This PR brings the project up to date, which allows us to pick up: guardian/membership-common#585

This is required so that this app can continue to load the catalog after some planned changes.

## Changes
* Upgrade to Scala 2.12
* Upgrade various libraries
* Remove retry wrappers, since dispatch was dropped by: https://github.com/guardian/membership-common/pull/584
