### PR TITLE
Remove PayPal test

### DIFF
--- a/frontend/test/acceptance/JoinSupporterSpec.scala
+++ b/frontend/test/acceptance/JoinSupporterSpec.scala
@@ -28,7 +28,7 @@ class JoinSupporterSpec extends FeatureSpec with Browser
         "\nPlease run identity-frontend server before running tests.")
   }
 
-  feature("Become a Supporter in UK and US") {
+  feature("Become a Supporter in US") {
 
     scenario("User joins as Supporter using Stripe in US", Acceptance) {
 
@@ -116,89 +116,7 @@ class JoinSupporterSpec extends FeatureSpec with Browser
       assert(ThankYou.userIsSignedInAsSupporter)
     }
 
-    scenario("User joins as Supporter using PayPal in UK", Acceptance) {
-
-      checkDependenciesAreAvailable
-
-      val testUser = new TestUser
-
-      Given("users click 'Become a Supporter' button on Membership homepage")
-
-      When("They land on 'Identity Frontend' page,")
-      val firstRegistrationPage = pages.FirstRegistrationStep(testUser)
-      go.to(firstRegistrationPage)
-      assert(firstRegistrationPage.pageHasLoaded)
-
-      And("fill in their email address,")
-      firstRegistrationPage.fillInEmail()
-
-      And("they proceed to the next step,")
-      firstRegistrationPage.submit()
-
-      Then("they should be asked to finish registering for an Identity account")
-      val secondRegistrationPage = pages.SecondRegistrationStep(testUser)
-      assert(secondRegistrationPage.pageHasLoaded)
-
-      Given("that the user fills in their personal details correctly")
-      secondRegistrationPage.fillInPersonalDetails()
-
-      When("they submit the form to create their Identity account,")
-      secondRegistrationPage.submit()
-
-      Then("they should land on 'Enter Details' page,")
-      val enterDetails = pages.EnterDetails(testUser)
-      assert(enterDetails.pageHasLoaded)
-
-      And("they should have Identity cookies,")
-      Seq("GU_U", "SC_GU_U", "SC_GU_LA").foreach { idCookie =>
-        assert(Driver.cookiesSet.map(_.getName).contains(idCookie))
-      }
-
-      And("should be logged in with their Identity account.")
-      assert(enterDetails.userIsSignedIn)
-
-      When("Users select USA delivery country,")
-      enterDetails.changeCountry("US")
-
-      Then("the currency should change.")
-      assert(enterDetails.currencyHasChangedTo("US$"))
-
-      When("Users fill in delivery address details,")
-      enterDetails.fillInDeliveryAddressUK()
-
-      And("click Continue")
-      enterDetails.clickContinue()
-
-      And("click PayPal button,")
-      enterDetails.payPal
-
-      Then("the PayPal Express Checkout mini-browser should display")
-      enterDetails.switchToPayPal
-      assert(enterDetails.payPalCheckoutHasLoaded)
-
-      When("Users fill in their PayPal credentials")
-      enterDetails.payPalFillInDetails
-
-      And("click 'Log In'")
-      enterDetails.payPalLogin
-
-      Then("payment summary appears")
-      assert(enterDetails.payPalHasPaymentSummary)
-
-      And("it displays the correct amount")
-      assert(enterDetails.payPalSummaryHasCorrectAmount)
-
-      When("User agrees to payment")
-      enterDetails.acceptPayPalPayment
-
-      Then("they should land on 'Thank You' page,")
-      assert(ThankYou.pageHasLoaded)
-
-      And("should be signed in as Supporter.")
-      assert(ThankYou.userIsSignedInAsSupporter)
-
-    }
-
   }
+
 }
 


### PR DESCRIPTION
## Why are you doing this?

This test consistently fails even though the flow is stable. Investigating these failures is a waste of our time, and since we are intending to deprecate this old flow anyway, I don't think it's worth investing the time to make this more robust.

## Trello card: [Here](https://trello.com/c/1m6PSzS1/2049-the-paypal-tests-in-membership-are-unreliable-and-should-die-jacob-winch-october-2018)

## Changes
* Delete unstable test