### PR TITLE
Stop keeping membership number

### DIFF
--- a/frontend/app/services/MembersDataAPI.scala
+++ b/frontend/app/services/MembersDataAPI.scala
@@ -24,16 +24,13 @@ object MembersDataAPI {
     case _ => JsError("Expected a string representation of a tier")
   }
 
-  implicit val attributesReads: Reads[Attributes] = (
-    (JsPath \ "tier").read[Tier] and
-      (JsPath \ "membershipNumber").readNullable[String]
-    )(Attributes.apply _)
+  implicit val attributesReads: Reads[Attributes] = Json.reads[Attributes]
 
-  case class Attributes(tier: Tier, membershipNumber: Option[String])
+  case class Attributes(tier: Tier)
   case class Behaviour(userId: String, activity: Option[String], lastObserved: Option[String], note: Option[String], emailed: Option[Boolean])
 
   object Attributes {
-    def fromMember(member: Member) = Attributes(member.subscription.plan.tier, member.contact.regNumber)
+    def fromMember(member: Member) = Attributes(member.subscription.plan.tier)
   }
 
   case class ApiError(message: String, details: String) extends RuntimeException(s"$message - $details")
@@ -73,7 +70,7 @@ class MembersDataAPI(executionContext: ExecutionContext) {
       case _ => SafeLogger.error(scrub"Unexpected credentials for getAttributes! ${memberRequest.user.credentials}")
     }
 
-    private def getAttributes(cookies: AccessCredentials.Cookies) = AttributeHelper(cookies).get[Attributes]("user-attributes/me/membership")
+    private def getAttributes(cookies: AccessCredentials.Cookies) = AttributeHelper(cookies).get[Attributes]("user-attributes/me")
 
   }
 }

--- a/frontend/test/services/MembersDataAPITest.scala
+++ b/frontend/test/services/MembersDataAPITest.scala
@@ -15,12 +15,11 @@ class MembersDataAPITest extends FreeSpec {
 
   "Attributes can be deserialized" in {
     assertResult(
-      JsSuccess(Attributes(patron, Some("1234567abcdef")))
+      JsSuccess(Attributes(patron))
     )(
       Json.parse(
         """
           |{
-          |  "membershipNumber": "1234567abcdef",
           |  "tier": "Patron"
           |}
         """.stripMargin).validate[Attributes](MembersDataAPI.attributesReads)


### PR DESCRIPTION
## Why are you doing this?
<!--
Please do not forget to log the amount of hours you spent in this PR here:
https://docs.google.com/spreadsheets/d/1DO24_EkHI3emwTSXpnkwWGhKf7n_9VDcGu0g4kdfUD0/edit#gid=0
-->

I'm on a mission to remove ad-free code from members-data-api. The code for `/user-atrributes/me` gets a fair bit simpler if we can stop keeping any state only in Dynamo. But there was a snag! `/user-atrributes/me` seems to return membershipNumber even though it's not really used by any callers of this endpoint. 

Membership-frontend's `/user/me` calls `/user-attributes/me/membership` just to get Tier information. So, I'm going to stop parsing membership number (it's not used here) and call members-data-api's  `/user-attributes/me`endpoint instead. We are planning to phase out `/user-attributes/me/membership` already.
 
<!--
Remember, PRs are documentation for future contributors

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Trello card: [Here](https://trello.com/c/Qripsnpx/2100-christmas-tech-debt-challenge-remove-ad-free-trial-code-from-the-members-data-api)

## Changes
* Changes members-data-api call from `/user-attributes/me/membership` to `/user-attributes/me` (it only gets the tier which is returned in both calls)
* Stops getting membershipNumber on the call to `/user-attributes/me` (it was not being used)

<!--
If you are making heavy client-side changes, consider manual test the following
critical flow before merging
## Tested in
| Browser | Supporter Stripe checkout | Supporter Paypal checkout | Stripe Monthly Contribution |  Paypal Monthly Contribution| Upgrade from Friend to Supporter  |
|---------|---------------------------|---------------------------|-----------------------------|-----------------------------|-----------------------------------|
| IE      |                           |                           |                             |                             |                                   |
| Firefox |                           |                           |                             |                             |                                   |
| Safari  |                           |                           |                             |                             |                                   |
| Chrome  |                           |                           |                             |                             |                                   |

-->

## Screenshots
