### PR TITLE
Bump jackson version.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,8 @@ import sbt._
 object Dependencies {
 
   //versions
-  val awsClientVersion = "1.11.226"
+  val awsClientVersion = "1.11.478"
+  val jacksonVersion = "2.9.8"
   //libraries
   val sentryRavenLogback = "io.sentry" % "sentry-logback" % "1.7.5"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
@@ -30,9 +31,9 @@ object Dependencies {
   val dataFormat = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % "2.8.11"
   val bcprovJdk15on = "org.bouncycastle" % "bcprov-jdk15on" % "1.60"  //-- added explicitly - snyk report avoid logback vulnerability
   // This is required to force aws libraries to use the latest version of jackson
-  val jacksonDataBind =  "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.7"
-  val jacksonAnnotations = "com.fasterxml.jackson.core" % "jackson-annotations" % "2.9.7"
-  var jacksonCore = "com.fasterxml.jackson.core" % "jackson-core" % "2.9.7"
+  val jacksonDataBind =  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion
+  val jacksonAnnotations = "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion
+  var jacksonCore = "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion
   val acquisitionEventProducer = "com.gu" %% "acquisition-event-producer-play26" % "4.0.0" % "compile" excludeAll(
     ExclusionRule(organization = "org.scalatest"),
     ExclusionRule(organization = "org.scalactic")


### PR DESCRIPTION
## Why are you doing this?
<!--
Please do not forget to log the amount of hours you spent in this PR here:
https://docs.google.com/spreadsheets/d/1DO24_EkHI3emwTSXpnkwWGhKf7n_9VDcGu0g4kdfUD0/edit#gid=0
-->
Updating the version of jackson-databind, jackson-annotations, jackson-core because of these issues reported by Snyk:
https://app.snyk.io/org/the-guardian-cuu/project/17832d7d-f280-403b-9d17-4065dc14d89a/

Also updated the AWS client version while I was there because a new version was available. 

I'm not in the business of encouraging membership signups, but I'm also not in the business of breaking them. I bumped the versions, ran the app locally, signed up a test user, and saw that I still got the welcome email (the main thing we are pulling in the aws sdk for afaik), and that the membership was created in Zuora. I also skimmed around the membership site as a logged in new member and checked I didn't see anything awry.

<!--
Remember, PRs are documentation for future contributors

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Trello card:
N/A - raised by Snyk.

## Changes
* Jackson-databind version bumps

<!--
If you are making heavy client-side changes, consider manual test the following
critical flow before merging
## Tested in
| Browser | Supporter Stripe checkout | Supporter Paypal checkout | Stripe Monthly Contribution |  Paypal Monthly Contribution| Upgrade from Friend to Supporter  |
|---------|---------------------------|---------------------------|-----------------------------|-----------------------------|-----------------------------------|
| IE      |                           |                           |                             |                             |                                   |
| Firefox |                           |                           |                             |                             |                                   |
| Safari  |                           |                           |                             |                             |                                   |
| Chrome  |                           |                           |                             |                             |                                   |

-->

## Screenshots
