### PR TITLE
Update copy on Events page to remove reference to members

### DIFF
--- a/frontend/app/views/event/eventsList.scala.html
+++ b/frontend/app/views/event/eventsList.scala.html
@@ -30,7 +30,7 @@
     <main>
         <div class="l-constrained">
             @fragments.event.headerBar(
-                title="Discussions, debates, interviews, festivals and special events exclusively for Guardian members"
+                title="Discussions, debates, interviews and festivals that bring The Guardian's award-winning journalism to life"
             )
         </div>
 


### PR DESCRIPTION
## Why are you doing this?
<!--
Please do not forget to log the amount of hours you spent in this PR here:
https://docs.google.com/spreadsheets/d/1DO24_EkHI3emwTSXpnkwWGhKf7n_9VDcGu0g4kdfUD0/edit#gid=0
-->

<!--
Remember, PRs are documentation for future contributors

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->
The h2 on the Events page currently still suggests that events are exclusive to Guardian members, which hasn't been the case for some time now. This reference needs to be updated with the copy Rebecca Pizzey in the Events team has supplied.
## Trello card: [Here](https://trello.com/c/o2bLOSOY)

## Changes
* Change 'Discussions, debates, interviews, festivals and special events exclusively for Guardian members' to: 'Discussions, debates, interviews and festivals that bring The Guardian's award-winning journalism to life'

<!--
If you are making heavy client-side changes, consider manual test the following
critical flow before merging
## Tested in
| Browser | Supporter Stripe checkout | Supporter Paypal checkout | Stripe Monthly Contribution |  Paypal Monthly Contribution| Upgrade from Friend to Supporter  |
|---------|---------------------------|---------------------------|-----------------------------|-----------------------------|-----------------------------------|
| IE      |                           |                           |                             |                             |                                   |
| Firefox |                           |                           |                             |                             |                                   |
| Safari  |                           |                           |                             |                             |                                   |
| Chrome  |                           |                           |                             |                             |                                   |

-->

## Screenshots
Current:
![image](https://user-images.githubusercontent.com/45856485/52116421-fe53a800-2608-11e9-9a73-840c86068d6c.png)

New:
![image](https://user-images.githubusercontent.com/45856485/52116383-e714ba80-2608-11e9-94b1-f9b9b5f57285.png)
