### PR TITLE
Don't serve a 500 if membership content is not found

### DIFF
--- a/frontend/app/controllers/MemberOnlyContent.scala
+++ b/frontend/app/controllers/MemberOnlyContent.scala
@@ -11,7 +11,6 @@ import play.api.mvc._
 import services.{GuardianContentService, _}
 import views.support.PageInfo
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.Failure
 
 class MemberOnlyContent(contentApiService: GuardianContentService, commonActions: CommonActions, implicit val executionContext: ExecutionContext, override protected val controllerComponents: ControllerComponents) extends BaseController {
 

--- a/frontend/app/controllers/MemberOnlyContent.scala
+++ b/frontend/app/controllers/MemberOnlyContent.scala
@@ -1,18 +1,17 @@
 package controllers
 
 import actions.CommonActions
-import com.gu.contentapi.client.model.v1.{MembershipTier => ContentAccess}
+import com.gu.contentapi.client.GuardianContentApiError
 import com.gu.i18n.CountryGroup._
 import com.netaporter.uri.Uri
 import com.netaporter.uri.dsl._
 import configuration.Config
 import model._
 import play.api.mvc._
-import play.cache.CachedAction
 import services.{GuardianContentService, _}
 import views.support.PageInfo
-
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Failure
 
 class MemberOnlyContent(contentApiService: GuardianContentService, commonActions: CommonActions, implicit val executionContext: ExecutionContext, override protected val controllerComponents: ControllerComponents) extends BaseController {
 
@@ -21,36 +20,37 @@ class MemberOnlyContent(contentApiService: GuardianContentService, commonActions
   def membershipContentRedirect = Action { Redirect("/supporter") }
 
   def membershipContent(referringContentOpt: Option[String] = None) = CachedAction.async { implicit request =>
-
-
     referringContentOpt.fold(Future(Redirect((routes.Info.supporterRedirect(None))))){
         referringContent =>
         contentApiService.contentItemQuery(Uri.parse(referringContent).path.stripPrefix("/")).map { response =>
-        val signInUrl = ((Config.idWebAppUrl / "signin") ? ("returnUrl" -> ("https://theguardian.com/" + referringContent)) ? ("skipConfirmation" -> "true")).toString
-        implicit val countryGroup = UK
+          val signInUrl = ((Config.idWebAppUrl / "signin") ? ("returnUrl" -> ("https://theguardian.com/" + referringContent)) ? ("skipConfirmation" -> "true")).toString
+          implicit val countryGroup = UK
 
-        (for {
-          content <- response.content
-        } yield {
-          if (content.fields.exists(_.membershipAccess.nonEmpty)) {
-            val capiContent: CapiContent = CapiContent(content)
-            val headline: String = capiContent.headline
-            val pageInfo = PageInfo(
-              title = headline,
-              url = request.path,
-              description = capiContent.trailText,
-              customSignInUrl = Some(signInUrl),
-              image = capiContent.mainPicture.map(_.defaultImage)
-            )
-            Ok(views.html.joiner.membershipContent(pageInfo, signInUrl, capiContent, s"Exclusive Members Content: $headline")).
-              withSession(request.session + (DestinationService.JoinReferrer -> ("https://" + Config.guardianHost + "/" + referringContent)))
-          } else {
-            Redirect(("https://theguardian.com/" + referringContent))
-          }
-        }).getOrElse(
-          Redirect(routes.Joiner.tierChooser())
-        )
-      }
-      }
+          (for {
+            content <- response.content
+          } yield {
+            if (content.fields.exists(_.membershipAccess.nonEmpty)) {
+              val capiContent: CapiContent = CapiContent(content)
+              val headline: String = capiContent.headline
+              val pageInfo = PageInfo(
+                title = headline,
+                url = request.path,
+                description = capiContent.trailText,
+                customSignInUrl = Some(signInUrl),
+                image = capiContent.mainPicture.map(_.defaultImage)
+              )
+              Ok(views.html.joiner.membershipContent(pageInfo, signInUrl, capiContent, s"Exclusive Members Content: $headline")).
+                withSession(request.session + (DestinationService.JoinReferrer -> ("https://" + Config.guardianHost + "/" + referringContent)))
+            } else {
+              Redirect(("https://theguardian.com/" + referringContent))
+            }
+          }).getOrElse(
+            Redirect(routes.Joiner.tierChooser())
+          )
+      }.recoverWith {
+          case GuardianContentApiError(404, _, _) => Future.successful(NotFound)
+          case _ => Future.successful(InternalServerError)
+        }
+    }
   }
 }

--- a/frontend/app/controllers/MemberOnlyContent.scala
+++ b/frontend/app/controllers/MemberOnlyContent.scala
@@ -7,9 +7,11 @@ import com.netaporter.uri.Uri
 import com.netaporter.uri.dsl._
 import configuration.Config
 import model._
+import play.api.mvc.Results.InternalServerError
 import play.api.mvc._
 import services.{GuardianContentService, _}
 import views.support.PageInfo
+
 import scala.concurrent.{ExecutionContext, Future}
 
 class MemberOnlyContent(contentApiService: GuardianContentService, commonActions: CommonActions, implicit val executionContext: ExecutionContext, override protected val controllerComponents: ControllerComponents) extends BaseController {
@@ -47,8 +49,8 @@ class MemberOnlyContent(contentApiService: GuardianContentService, commonActions
             Redirect(routes.Joiner.tierChooser())
           )
       }.recoverWith {
-          case GuardianContentApiError(404, _, _) => Future.successful(NotFound)
-          case _ => Future.successful(InternalServerError)
+          case GuardianContentApiError(404, _, _) => Future.successful(NotFound(views.html.error404()))
+          case ex => Future.successful(InternalServerError(views.html.error500(ex)))
         }
     }
   }


### PR DESCRIPTION
## Why are you doing this?
If you navigate to a page like [this](https://membership.theguardian.com/membership-content?referringContent=news/2019/jan/14/looking-back-public-health&membershipAccess=PaidMembersOnly) it's possible to access some special members only content.

In order to serve these pages on the membership site, we are making API calls to CAPI (based on the referringContent query param). Currently if you attempt to hit:

https://membership.theguardian.com/membership-content?referringContent=capiCannotFindMe&membershipAccess=PaidMembersOnly

CAPI will respond with a 404, which results in an unhandled exception in the membership code. Eventually this ends up leading to us serving a 500. We should be serving 404s not 500s in these cases, so this PR fixes that behaviour.

We get sporadic alerts due to this bug, so this PR also allows us to cut down on the noise. 

## Trello card: [Here](https://trello.com/c/3IjkgRib/60-stop-membership-throwing-500s-on-capi-404s)

## Changes
* Handle 404 from CAPI gracefully instead of allowing Play to throw a 500 due to the unhandled exception.