### PR TITLE
Remove references to expired certificate

### DIFF
--- a/nginx/membership.conf
+++ b/nginx/membership.conf
@@ -3,8 +3,8 @@ server {
     server_name mem.thegulocal.com;
 
     ssl on;
-    ssl_certificate wildcard-thegulocal-com-exp2019-01-09.crt; ## Supplied by https://github.com/guardian/identity-platform#setup-nginx-for-local-development
-    ssl_certificate_key wildcard-thegulocal-com-exp2019-01-09.key; ## ditto
+    ssl_certificate STAR_thegulocal_com_exp2020-01-09.crt; ## Supplied by https://github.com/guardian/identity-platform#setup-nginx-for-local-development
+    ssl_certificate_key STAR_thegulocal_com_exp2020-01-09.key; ## ditto
 
     ssl_session_timeout 5m;
 
@@ -15,6 +15,6 @@ server {
     location / {
         proxy_http_version 1.1; # this is essential for chunked responses to work
         proxy_pass http://localhost:9100/;
-        proxy_set_header Host $http_host;
+            proxy_set_header Host $http_host;
     }
 }


### PR DESCRIPTION
## Why are you doing this?
To improve the local development experience.
