### PR TITLE
Consent banner

### DIFF
--- a/frontend/app/views/fragments/consentBanner/consentBanner.scala.html
+++ b/frontend/app/views/fragments/consentBanner/consentBanner.scala.html
@@ -1,4 +1,4 @@
-<div class="component-consent-banner-consent-banner"><div class="component-consent-banner-consent-banner__copy"><svg width="36" height="36" viewBox="0 0 36 36" class="component-consent-banner-consent-banner__roundel" xmlns="http://www.w3.org/2000/svg"><path fill="#FFF" d="M18 0a18 18 0 1 0 0 36 18 18 0 0 0 0-36"></path>
+<div class="component-consent-banner-consent-banner js-consent-banner"><div class="component-consent-banner-consent-banner__copy"><svg width="36" height="36" viewBox="0 0 36 36" class="component-consent-banner-consent-banner__roundel" xmlns="http://www.w3.org/2000/svg"><path fill="#FFF" d="M18 0a18 18 0 1 0 0 36 18 18 0 0 0 0-36"></path>
     <path fill="#333" d="M21.2 4.4c2.3.4 5.3 2 6.3 3.1v5.2H27L21.2 5v-.6zm-2.2.4c-4 0-6.3 5.6-6.3 13.2 0 7.7 2.2 13.3 6.3 13.3v.6c-6 .4-14.4-4.2-14-13.8A13.3 13.3 0 0 1 19 4v.7zm10.4 14.4l-1.9.9v8.6c-1 1-3.8 2.6-6.3 3.1V19.9l-2.2-.7v-.6h10.4v.6z"></path></svg>
     <div class="component-consent-banner-consent-banner__text component-text"><h2 class="component-text__heading">Your privacy</h2>
         <p>We use cookies to improve your experience on our site and to show you personalised advertising.</p>
@@ -6,8 +6,13 @@
                 &nbsp;and&nbsp;
             <a href="https://www.theguardian.com/info/cookies">cookie policy</a>
             .</p></div>
-    <div class="component-consent-banner-consent-banner__actions"><button class="component-button component-button--primary component-button--hasicon-left" type="button"><span class="component-button__content">I'm OK with that</span>
-        <svg width="10.79" height="8.61" viewBox="0 0 10.79 8.608" xmlns="http://www.w3.org/2000/svg"><path d="M2.99 6.58L10.24 0l.55.53-7.8 8.08h-.26L0 4.79l.55-.55 2.44 2.33z"></path></svg></button>
+    <div class="component-consent-banner-consent-banner__actions">
+        <button class="component-button component-button--primary component-button--hasicon-left js-consent-banner-accept" type="button">
+            <span class="component-button__content">I'm OK with that</span>
+            <svg width="10.79" height="8.61" viewBox="0 0 10.79 8.608" xmlns="http://www.w3.org/2000/svg">
+                <path d="M2.99 6.58L10.24 0l.55.53-7.8 8.08h-.26L0 4.79l.55-.55 2.44 2.33z"></path>
+            </svg>
+        </button>
         <a href="https://profile.theguardian.com/privacy-settings">My options</a>
     </div>
 </div>

--- a/frontend/app/views/fragments/consentBanner/consentBanner.scala.html
+++ b/frontend/app/views/fragments/consentBanner/consentBanner.scala.html
@@ -1,0 +1,14 @@
+<div class="component-consent-banner-consent-banner"><div class="component-consent-banner-consent-banner__copy"><svg width="36" height="36" viewBox="0 0 36 36" class="component-consent-banner-consent-banner__roundel" xmlns="http://www.w3.org/2000/svg"><path fill="#FFF" d="M18 0a18 18 0 1 0 0 36 18 18 0 0 0 0-36"></path>
+    <path fill="#333" d="M21.2 4.4c2.3.4 5.3 2 6.3 3.1v5.2H27L21.2 5v-.6zm-2.2.4c-4 0-6.3 5.6-6.3 13.2 0 7.7 2.2 13.3 6.3 13.3v.6c-6 .4-14.4-4.2-14-13.8A13.3 13.3 0 0 1 19 4v.7zm10.4 14.4l-1.9.9v8.6c-1 1-3.8 2.6-6.3 3.1V19.9l-2.2-.7v-.6h10.4v.6z"></path></svg>
+    <div class="component-consent-banner-consent-banner__text component-text"><h2 class="component-text__heading">Your privacy</h2>
+        <p>We use cookies to improve your experience on our site and to show you personalised advertising.</p>
+        <p>To find out more, read our&nbsp;<a href="https://www.theguardian.com/help/privacy-policy">privacy policy</a>
+                &nbsp;and&nbsp;
+            <a href="https://www.theguardian.com/info/cookies">cookie policy</a>
+            .</p></div>
+    <div class="component-consent-banner-consent-banner__actions"><button class="component-button component-button--primary component-button--hasicon-left" type="button"><span class="component-button__content">I'm OK with that</span>
+        <svg width="10.79" height="8.61" viewBox="0 0 10.79 8.608" xmlns="http://www.w3.org/2000/svg"><path d="M2.99 6.58L10.24 0l.55.53-7.8 8.08h-.26L0 4.79l.55-.55 2.44 2.33z"></path></svg></button>
+        <a href="https://profile.theguardian.com/privacy-settings">My options</a>
+    </div>
+</div>
+</div>

--- a/frontend/app/views/main.scala.html
+++ b/frontend/app/views/main.scala.html
@@ -130,7 +130,7 @@
                 @content
             }
         </div>
-
+        @fragments.consentBanner.consentBanner()
         @fragments.global.footer(pageInfo, footer, None, countryGroup)
         @fragments.javaScriptRequireJS()
         @fragments.analytics.googleRemarketing()

--- a/frontend/assets/javascripts/src/main.js
+++ b/frontend/assets/javascripts/src/main.js
@@ -27,7 +27,8 @@ require([
     'src/modules/memstatus',
     'src/modules/faq',
     'src/modules/landingBundles',
-    'src/modules/bundlesLanding'
+    'src/modules/bundlesLanding',
+    'src/modules/consentBanner'
 ], function(
     ajax,
     raven,
@@ -57,7 +58,8 @@ require([
     memstatus,
     faq,
     landingBundles,
-    bundlesLanding
+    bundlesLanding,
+    consentBanner
 ) {
     'use strict';
 
@@ -107,4 +109,6 @@ require([
     memstatus.init();
 
     faq.init();
+
+    consentBanner.init();
 });

--- a/frontend/assets/javascripts/src/modules/analytics/setup.js
+++ b/frontend/assets/javascripts/src/modules/analytics/setup.js
@@ -5,14 +5,16 @@ define([
     'src/modules/analytics/krux',
     'src/modules/analytics/facebook',
     'src/modules/analytics/uet',
-    'src/modules/analytics/campaignCode'
+    'src/modules/analytics/campaignCode',
+    'src/modules/analytics/thirdPartyTracking'
 ], function (
     cookie,
     ga,
     krux,
     facebook,
     uet,
-    campaignCode
+    campaignCode,
+    thirdPartyTracking
 ) {
     'use strict';
 
@@ -32,14 +34,16 @@ define([
         !cookie.getCookie('ANALYTICS_OFF_KEY')
     );
 
+    const thirdPartyTrackingEnabled = thirdPartyTracking.thirdPartyTrackingEnabled();
+
     function setupAnalytics() {
         ga.init();
-        uet.init();
     }
 
     function setupThirdParties() {
         krux.init();
         facebook.init();
+        uet.init();
     }
 
     function init() {
@@ -49,7 +53,7 @@ define([
             setupAnalytics();
         }
 
-        if(analyticsEnabled && !guardian.isDev) {
+        if(analyticsEnabled && thirdPartyTrackingEnabled && !guardian.isDev) {
             setupThirdParties();
         }
     }

--- a/frontend/assets/javascripts/src/modules/analytics/thirdPartyTracking.js
+++ b/frontend/assets/javascripts/src/modules/analytics/thirdPartyTracking.js
@@ -1,0 +1,27 @@
+
+import { getCookie, setCookie } from '../../utils/cookie';
+
+const ConsentCookieName = 'GU_TK';
+const DaysToLive = 30 * 18;
+
+const OptedIn = 'OptedIn';
+const OptedOut = 'OptedOut';
+const Unset = 'Unset';
+
+const getTrackingConsent = () => {
+    const cookieVal = getCookie(ConsentCookieName);
+    if (cookieVal && cookieVal.split('.')[0] === '1') { return OptedIn; }
+    if (cookieVal && cookieVal.split('.')[0] === '0') { return OptedOut; }
+    return Unset;
+};
+
+const thirdPartyTrackingEnabled = () => getTrackingConsent() !== OptedOut;
+
+const writeTrackingConsentCookie = (trackingConsent) => {
+    if (trackingConsent !== Unset) {
+        const cookie = [trackingConsent === OptedIn ? '1' : '0', Date.now()].join('.');
+        setCookie(ConsentCookieName, cookie, DaysToLive);
+    }
+};
+
+export { getTrackingConsent, writeTrackingConsentCookie, thirdPartyTrackingEnabled, OptedIn, OptedOut, Unset, ConsentCookieName };

--- a/frontend/assets/javascripts/src/modules/consentBanner.js
+++ b/frontend/assets/javascripts/src/modules/consentBanner.js
@@ -1,0 +1,42 @@
+import {
+    getTrackingConsent,
+    OptedIn,
+    Unset,
+    writeTrackingConsentCookie,
+} from './analytics/thirdPartyTracking';
+
+const BANNER = 'js-consent-banner';
+const ACCEPT_BUTTON = 'js-consent-banner-accept';
+
+function bindHandlers(elements) {
+    elements.acceptButton.addEventListener('click', () => {
+        writeTrackingConsentCookie(OptedIn);
+        setBannerVisibility(elements);
+    });
+
+}
+
+function setBannerVisibility(elements) {
+    if (getTrackingConsent() === Unset){
+        elements.banner.style.display = 'block';
+    } else {
+        elements.banner.style.display = 'none';
+    }
+
+}
+
+function getElements() {
+    return {
+        banner: document.getElementsByClassName(BANNER)[0],
+        acceptButton: document.getElementsByClassName(ACCEPT_BUTTON)[0]
+    }
+}
+
+export function init() {
+    const elements = getElements();
+    bindHandlers(elements);
+    setBannerVisibility(elements);
+}
+
+
+

--- a/frontend/assets/javascripts/src/utils/cookie.js
+++ b/frontend/assets/javascripts/src/utils/cookie.js
@@ -2,16 +2,15 @@ define(['src/utils/decodeBase64'], function (decodeBase64) {
     'use strict';
 
     // Trim subdomains for prod, code and dev.
-    const getShortDomain = () => {
-
-        const domain = document.domain || '';
+    function  getShortDomain(){
+        var domain = document.domain || '';
         return domain.replace(/^(membership|m\.code|m|mem)\./, '.');
-    };
+    }
 
-    const getDomainAttribute = () => {
-        const shortDomain = getShortDomain();
-        return shortDomain === 'localhost' ? '' : ` domain=${shortDomain};`;
-    };
+    function getDomainAttribute(){
+        var shortDomain = getShortDomain();
+        return shortDomain === 'localhost' ? '' : ' domain=' + shortDomain;
+    }
 
     /*
      Cookie functions originally from http://www.quirksmode.org/js/cookies.html
@@ -30,7 +29,7 @@ define(['src/utils/decodeBase64'], function (decodeBase64) {
             expires = '';
         }
 
-        document.cookie = `${name}=${value}; path=/; ${secureCookieString} ${expires};${getDomainAttribute()}`;
+        document.cookie = [name, '=', value, expires, '; path=/; ', secureCookieString, getDomainAttribute()].join('');
     }
 
     function getCookie(name) {

--- a/frontend/assets/javascripts/src/utils/cookie.js
+++ b/frontend/assets/javascripts/src/utils/cookie.js
@@ -1,6 +1,18 @@
 define(['src/utils/decodeBase64'], function (decodeBase64) {
     'use strict';
 
+    // Trim subdomains for prod, code and dev.
+    const getShortDomain = () => {
+
+        const domain = document.domain || '';
+        return domain.replace(/^(membership|m\.code|m|mem)\./, '.');
+    };
+
+    const getDomainAttribute = () => {
+        const shortDomain = getShortDomain();
+        return shortDomain === 'localhost' ? '' : ` domain=${shortDomain};`;
+    };
+
     /*
      Cookie functions originally from http://www.quirksmode.org/js/cookies.html
      */
@@ -8,7 +20,7 @@ define(['src/utils/decodeBase64'], function (decodeBase64) {
         var date;
         var expires;
         // used for testing purposes, cookies are secure by default
-        var secureCookieString = isUnSecure ? '' : '; secure';
+        var secureCookieString = isUnSecure ? '' : 'secure;';
 
         if (days) {
             date = new Date();
@@ -18,7 +30,7 @@ define(['src/utils/decodeBase64'], function (decodeBase64) {
             expires = '';
         }
 
-        document.cookie = [name, '=', value, expires, '; path=/', secureCookieString ].join('');
+        document.cookie = `${name}=${value}; path=/; ${secureCookieString} ${expires};${getDomainAttribute()}`;
     }
 
     function getCookie(name) {

--- a/frontend/assets/stylesheets/components/_consentBanner.scss
+++ b/frontend/assets/stylesheets/components/_consentBanner.scss
@@ -1,0 +1,122 @@
+$gu-cta-height: 42px;
+
+.component-consent-banner-consent-banner {
+    z-index: 99;
+    position: fixed;
+    bottom: 0px;
+    width: 100%;
+
+    padding: ($gs-baseline / 2) 0 $gs-baseline * 2;
+    background: $c-neutral1;
+
+    a {
+        color: $white;
+        text-decoration: none !important;
+        border-bottom: 0.0625rem solid $white;
+        transition: border-color .15s ease-out;
+    }
+}
+
+
+.component-consent-banner-consent-banner__copy {
+    position: relative;
+    margin: 0 $gs-gutter/2;
+
+    @include mq($from: (gs-span(10) +gs-span(1) + $gs-gutter/2)) {
+        margin: auto;
+        max-width: gs-span(10);
+        padding-left: gs-span(1) + $gs-gutter;
+    }
+
+    @include mq($from: desktop) {
+        .component-consent-banner-consent-banner__roundel {
+            display: block;
+        }
+        max-width: gs-span(11);
+        padding-left: gs-span(1) + $gs-gutter;
+    }
+
+    @include mq($from: mem-full) {
+        max-width: gs-span(13);
+        padding-left: gs-span(1) + $gs-gutter;
+    }
+
+    @include mq($from: wide) {
+        max-width: gs-span(14);
+        padding-left: gs-span(2) + $gs-gutter;
+    }
+}
+
+.component-consent-banner-consent-banner__roundel {
+    position: absolute;
+    display: none;
+    left: 0;
+    top: 0;
+}
+
+.component-consent-banner-consent-banner__text {
+    max-width: gs-span(8);
+}
+
+.component-consent-banner-consent-banner__copy, .component-consent-banner-consent-banner__text {
+    color: $white;
+}
+
+.component-consent-banner-consent-banner__actions {
+    margin-top: $gs-baseline * 2;
+    @include fs-textSans(4);
+    font-weight: bold;
+}
+
+.component-consent-banner-consent-banner__actions a {
+    color: currentColor;
+    text-decoration: underline;
+    text-decoration-color: rgba(255,255,255,.5);
+}
+
+.component-consent-banner-consent-banner__actions button {
+    margin-right: $gs-gutter/2;
+}
+
+.component-button {
+    @include fs-textSans(4);
+    display: inline-flex;
+    align-items: center;
+    text-decoration: none;
+    font-weight: bold;
+    height: $gu-cta-height;
+    min-height: $gu-cta-height;
+    padding: 0 ($gu-cta-height / 2);
+    border: none;
+    border-radius: $gu-cta-height / 2;
+    box-sizing: border-box;
+    background: transparent;
+    cursor: pointer;
+    justify-content: space-between;
+    position: relative;
+    &:hover, &:focus {
+        outline: 0;
+    }
+
+    &[disabled], &[data-disabled] {
+        background-color: $white;
+        opacity: .5;
+        pointer-events: none;
+    }
+}
+
+.component-button--primary {
+    background-color: #FFE500;
+    color: #121212;
+    &:hover, &:focus {
+        background-color: #FFBB50;
+    }
+}
+
+.component-button--hasicon-left {
+    flex-direction: row-reverse;
+
+    svg {
+        margin: 0 ($gu-cta-height / 4) 0 (-$gu-cta-height / 8);
+    }
+}

--- a/frontend/assets/stylesheets/style.scss
+++ b/frontend/assets/stylesheets/style.scss
@@ -119,6 +119,7 @@
 @import 'components/promo-code';
 @import 'components/paypal-error-page';
 @import 'components/contributions';
+@import 'components/consentBanner';
 
 // =============================================================================
 // Scopes


### PR DESCRIPTION
## Why are you doing this?
<!--
Please do not forget to log the amount of hours you spent in this PR here:
https://docs.google.com/spreadsheets/d/1DO24_EkHI3emwTSXpnkwWGhKf7n_9VDcGu0g4kdfUD0/edit#gid=0
-->

Add a consent banner to the site for users who haven't opted in or out of third party tracking

We will now check for the existence of the GU_TK cookie which stores a user's third party tracking settings (for this browser) and store these settings in the common state in Redux.

If this cookie is not present then we show this consent banner asking them to opt in or out:
![Screenshot 2019-03-19 at 17 04 49](https://user-images.githubusercontent.com/181371/54626639-79fa9e80-4a69-11e9-8b19-32d8bad487aa.png)

If they choose to accept then we write the GU_TK cookie to record this choice and hide the banner.
