### PR TITLE
Don't show consent banner during post deploy tests

### DIFF
--- a/frontend/assets/javascripts/src/modules/consentBanner.js
+++ b/frontend/assets/javascripts/src/modules/consentBanner.js
@@ -4,6 +4,7 @@ import {
     Unset,
     writeTrackingConsentCookie,
 } from './analytics/thirdPartyTracking';
+import { getCookie } from '../utils/cookie';
 
 const BANNER = 'js-consent-banner';
 const ACCEPT_BUTTON = 'js-consent-banner-accept';
@@ -17,7 +18,10 @@ function bindHandlers(elements) {
 }
 
 function setBannerVisibility(elements) {
-    if (getTrackingConsent() === Unset){
+    const visible = getCookie('_post_deploy_user') !== 'true' &&
+        getTrackingConsent() === Unset;
+
+    if (visible){
         elements.banner.style.display = 'block';
     } else {
         elements.banner.style.display = 'none';

--- a/frontend/test/acceptance/util/TestUser.scala
+++ b/frontend/test/acceptance/util/TestUser.scala
@@ -13,6 +13,7 @@ class TestUser {
   private def addTestUserCookies(testUsername: String) = {
     Driver.addCookie("ANALYTICS_OFF_KEY", "true")
     Driver.addCookie("pre-signin-test-user", testUsername)
+    Driver.addCookie(name = "_post_deploy_user", value = "true")
   }
 
   val username = testUsers.generate()


### PR DESCRIPTION
## Why are you doing this?
The consent banner introduced in #1876 breaks a post deploy test, this PR prevents it being shown during them.
