### PR TITLE
Use t3.small instances

### DIFF
--- a/cloud-formation/membership-app.cf.yaml
+++ b/cloud-formation/membership-app.cf.yaml
@@ -32,10 +32,8 @@ Parameters:
     Description: EC2 instance type
     Type: String
     AllowedValues:
-    - t2.micro
     - t2.small
-    - t2.medium
-    - m3.medium
+    - t3.small
     ConstraintDescription: must be a valid EC2 instance type.
   ImageId:
     Description: AMI ID


### PR DESCRIPTION
## Why are you doing this?
We are moving to [t3 instances](https://aws.amazon.com/ec2/instance-types/t3/).

## Trello card: [Here](https://trello.com/c/ihXGzPyy/2313-work-to-support-aws-instance-reservations)

## Changes
* Add t3.small as an allowed instance type (and then update Cloudformation via the console in order to modify this app's launch configuration to actually use t3.smalls)
