### PR TITLE
use latest libthrift (binary substitutuion only)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -40,13 +40,14 @@ object Dependencies {
     ExclusionRule(organization = "org.scalactic")
   )
   val googleAuth = "com.gu" %% "play-googleauth" % "0.7.6"
+  val libthrift = "org.apache.thrift" % "libthrift" % "0.12.0"
   //projects
 
   val frontendDependencies =  Seq(googleAuth, scalaUri, membershipCommon, enumPlay,
     contentAPI, playWS, playFilters, playCache, playIteratees, sentryRavenLogback, awsSimpleEmail, scalaz, pegdown,
     PlayImport.specs2 % "test", specs2Extra, identityPlayAuth, catsCore, scalaLogging, kinesisLogbackAppender, logstash, dataFormat,
     jacksonDataType, jacksonDataBind, jacksonAnnotations, jacksonCore,
-    acquisitionEventProducer, bcprovJdk15on)
+    acquisitionEventProducer, bcprovJdk15on, libthrift)
 
   val acceptanceTestDependencies = Seq(scalaTest, selenium, seleniumManager)
 


### PR DESCRIPTION
## Why are you doing this?

Snyk has poicked up an issue with libthrift https://app.snyk.io/vuln/SNYK-JAVA-ORGAPACHETHRIFT-173706
We are using it via capi client and the ophan event model, but upgrading either of those causes compile errors.  Since I'm not going to have time to update those before next week, I have just done the version patch.

This could cause some binary incompatibilities, but I managed to check out locally with supporter membership with the patch.  So i think it should be ok, but it should be kept an eye on when it goes out.

## Trello card: [Here](https://trello.com/c/AmhavlkB/2366-snyk-work)
