### PR TITLE
Bump capi to v14.2

### DIFF
--- a/frontend/app/controllers/MemberOnlyContent.scala
+++ b/frontend/app/controllers/MemberOnlyContent.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import actions.CommonActions
-import com.gu.contentapi.client.GuardianContentApiError
+import com.gu.contentapi.client.model.ContentApiError
 import com.gu.i18n.CountryGroup._
 import com.netaporter.uri.Uri
 import com.netaporter.uri.dsl._
@@ -49,7 +49,7 @@ class MemberOnlyContent(contentApiService: GuardianContentService, commonActions
             Redirect(routes.Joiner.tierChooser())
           )
       }.recoverWith {
-          case GuardianContentApiError(404, _, _) => Future.successful(NotFound(views.html.error404()))
+          case ContentApiError(404, _, _) => Future.successful(NotFound(views.html.error404()))
           case ex => Future.successful(InternalServerError(views.html.error500(ex)))
         }
     }

--- a/frontend/app/services/GuardianContentService.scala
+++ b/frontend/app/services/GuardianContentService.scala
@@ -3,9 +3,9 @@ package services
 import java.time.Instant
 
 import akka.actor.ActorSystem
-import com.gu.contentapi.client.model.{ItemQuery, SearchQuery}
+import com.gu.contentapi.client.model.{ContentApiError, ItemQuery, SearchQuery}
 import com.gu.contentapi.client.model.v1._
-import com.gu.contentapi.client.{GuardianContentApiError, GuardianContentClient}
+import com.gu.contentapi.client.GuardianContentClient
 import com.gu.memsub.util.ScheduledTask
 import configuration.Config
 import org.joda.time.DateTime
@@ -104,7 +104,7 @@ trait GuardianContent {
 
   val logAndRecord: PartialFunction[Try[_], Unit] = {
     case Success(_) =>
-    case Failure(GuardianContentApiError(status, message, _)) =>
+    case Failure(ContentApiError(status, message, _)) =>
       SafeLogger.error(scrub"Error response from Content API $status")
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "2.5"
   val membershipCommon = "com.gu" %% "membership-common" % "0.527"
-  val contentAPI = "com.gu" %% "content-api-client" % "14.1"
+  val contentAPI = "com.gu" %% "content-api-client-default" % "14.1"
   val playWS = PlayImport.ws
   val playFilters = PlayImport.filters
   val playCache = PlayImport.ehcache

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "2.5"
   val membershipCommon = "com.gu" %% "membership-common" % "0.527"
-  val contentAPI = "com.gu" %% "content-api-client" % "11.40"
+  val contentAPI = "com.gu" %% "content-api-client" % "14.2"
   val playWS = PlayImport.ws
   val playFilters = PlayImport.filters
   val playCache = PlayImport.ehcache

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "2.5"
   val membershipCommon = "com.gu" %% "membership-common" % "0.527"
-  val contentAPI = "com.gu" %% "content-api-client" % "14.2"
+  val contentAPI = "com.gu" %% "content-api-client" % "14.1"
   val playWS = PlayImport.ws
   val playFilters = PlayImport.filters
   val playCache = PlayImport.ehcache


### PR DESCRIPTION
## Why are you doing this?

We need to upgrade our thrift dependencies to the latest version used in Scrooge (don't ask), because it currently impairs our ability to freely evolve the CAPI model. Last time we tried, it broke frontend badly. So we are in the process of upgrading across our whole codebase. I have noticed that upgrading CAPI consumers posed no problem as long as we did not change the model. So that's what I'm doing with this PR.