### PR TITLE
Remove requirement to update hosts file

### DIFF
--- a/nginx/README.md
+++ b/nginx/README.md
@@ -8,15 +8,6 @@ Membership depends on Identity, so **you'll need to perform the**
 
 ## Membership-specific setup
 
-#### Update your hosts file
-
-Add the following local development domains to your hosts file in `/etc/hosts`:
-
-```
-127.0.0.1   mem.thegulocal.com
-127.0.0.1   profile.thegulocal.com
-```
-
 #### Run Membership's Nginx setup script
 
 Run the Membership-specific [setup.sh](setup.sh) script from the root


### PR DESCRIPTION
## Why are you doing this?
Removing mention of changing your hosts file when setting up nginx because we are setting up DNS for *.thegulocal.com.  In the medium term we'll look to replace thegulocal.com, but that will come separately.