### PR TITLE
use latest membership-common etc backend libs

### DIFF
--- a/frontend/app/controllers/TierController.scala
+++ b/frontend/app/controllers/TierController.scala
@@ -90,7 +90,7 @@ class TierController(
     val sub = subscriber.subscription
 
     (for {
-      country <- EitherT(memberService.country(subscriber.contact).map(\/.right))
+      country <- EitherT(memberService.country(subscriber.contact))
       paymentMethod <- EitherT(paymentService.getPaymentMethod(sub.accountId).map(_ \/>[MemberError] NoCardError(sub.name)))
       preview <- EitherT(memberService.previewUpgradeSubscription(subscriber, targetChoice))
     } yield PaidToPaidUpgradeSummary(preview, sub, targetChoice.productRatePlanId, paymentMethod)(c)).run

--- a/frontend/app/services/api/MemberService.scala
+++ b/frontend/app/services/api/MemberService.scala
@@ -26,7 +26,7 @@ trait MemberService {
 
   type ZuoraSubName = String
 
-  def country(contact: GenericSFContact)(implicit i: IdentityRequest): Future[Country]
+  def country(contact: GenericSFContact)(implicit i: IdentityRequest): Future[MemberError \/ Country]
 
   def createMember(user: IdUser,
                    formData: JoinForm,
@@ -102,5 +102,8 @@ object MemberService {
   }
   case class NoCardError(name: S.Name) extends MemberError {
     override def getMessage = s"Subscription ${name.get} has no card"
+  }
+  case class NoIdentityId() extends MemberError {
+    override def getMessage = s"SF Contact has no identity id"
   }
 }

--- a/frontend/test/services/DestinationServiceTest.scala
+++ b/frontend/test/services/DestinationServiceTest.scala
@@ -32,7 +32,7 @@ class DestinationServiceTest extends Specification {
     def createRequestWithSession(newSessions: (String, String)*) = {
 
       val testMember = Contact(
-        identityId= "id",
+        identityId= Some("id"),
         regNumber= None,
         title = None,
         firstName= Some("fn"),
@@ -44,7 +44,8 @@ class DestinationServiceTest extends Specification {
         mailingCity= None,
         mailingState= None,
         mailingPostcode= None,
-        mailingCountry= None
+        mailingCountry= None,
+        recordTypeId = None
       )
       val partnerCharge: PaidCharge[Partner.type, Month.type] = PaidCharge[Partner.type, Month.type](Partner, Month, PricingSummary(Map(GBP -> Price(0.1f, GBP))), ProductRatePlanChargeId("prpcId"),SubscriptionRatePlanChargeId("srpcid"))
       val testSub: Subscription[SubscriptionPlan.Member] = new Subscription[SubscriptionPlan.Partner](

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,13 +4,13 @@ import sbt._
 object Dependencies {
 
   //versions
-  val awsClientVersion = "1.11.564"
-  val jacksonVersion = "2.9.9"
+  val awsClientVersion = "1.11.594"
+  val (jacksonVersion, jacksonVersionBump) = ("2.9.9", "2.9.9.1")
   //libraries
   val sentryRavenLogback = "io.sentry" % "sentry-logback" % "1.7.5"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "2.5"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.527"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.549"
   val contentAPI = "com.gu" %% "content-api-client-default" % "14.1"
   val playWS = PlayImport.ws
   val playFilters = PlayImport.filters
@@ -24,14 +24,14 @@ object Dependencies {
   val specs2Extra = "org.specs2" %% "specs2-matcher-extra" % "3.8.6" % "test"
   val pegdown = "org.pegdown" % "pegdown" % "1.6.0"
   val enumPlay = "com.beachape" %% "enumeratum-play" % "1.5.14"
-  val catsCore = "org.typelevel" %% "cats-core" % "1.0.1"
+  val catsCore = "org.typelevel" %% "cats-core" % "1.6.1"
   val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2"
   val kinesisLogbackAppender = "com.gu" % "kinesis-logback-appender" % "1.4.0"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "4.9"
   val dataFormat = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion
   val bcprovJdk15on = "org.bouncycastle" % "bcprov-jdk15on" % "1.60"  //-- added explicitly - snyk report avoid logback vulnerability
   // This is required to force aws libraries to use the latest version of jackson
-  val jacksonDataBind =  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion
+  val jacksonDataBind =  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersionBump
   val jacksonAnnotations = "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion
   var jacksonCore = "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion
   var jacksonDataType = "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.2
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ logLevel := Level.Warn
 
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.21")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.23")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
 


### PR DESCRIPTION
## Why are you doing this?
Update dependencies inclusing the jackson databind issue found by snyk.  Also update play, membership-common, sbt, cats, aws client

https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-450917
https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-450207

I have already added dummy keys
identity.apiUrl
identity.apiToken
to the dev/code/prod config in s3 as per this pr:
https://github.com/guardian/membership-common/pull/591/files
Otherwise it will fail in prod when deployed.  This shouldn't be used , so I have included a dummy token.  cc @twrichards  on this as he helped me to decide how to deal with this error.