### PR TITLE
Synchronous authentication via identity API

### DIFF
--- a/frontend/app/actions/ActionRefiners.scala
+++ b/frontend/app/actions/ActionRefiners.scala
@@ -52,7 +52,7 @@ class ActionRefiners(authenticationService: AuthenticationService, parser: BodyP
   }
 
   def authenticated(onUnauthenticated: RequestHeader => Result = chooseRegister(_))(implicit bodyParser: BodyParser[AnyContent]): ActionBuilder[AuthRequest, AnyContent] =
-    new AuthenticatedBuilder(authenticationService.authenticateUser, bodyParser, onUnauthenticated)
+    new AuthenticatedBuilder(authenticationService.authenticatedUserFor, bodyParser, onUnauthenticated)
 
   val PlannedOutageProtection = new ActionFilter[Request] {
 

--- a/frontend/app/actions/TouchpointActionRefiners.scala
+++ b/frontend/app/actions/TouchpointActionRefiners.scala
@@ -43,7 +43,7 @@ class TouchpointActionRefiners(authenticationService: AuthenticationService, tou
     val FreeSubscriber = MemSubscriber[Subscription[SubscriptionPlan.FreeMember]] _
     val PaidSubscriber = MemSubscriber[Subscription[SubscriptionPlan.PaidMember]] _
     (for {
-      user <- OptionEither.liftFutureEither(authenticationService.authenticateUser(request))
+      user <- OptionEither.liftFutureEither(authenticationService.authenticatedUserFor(request))
       authRequest = new AuthenticatedRequest(user, request)
       tp = authRequest.touchpointBackend
       member <- OptionEither(authRequest.forMemberOpt)

--- a/frontend/app/actions/TouchpointCommonActions.scala
+++ b/frontend/app/actions/TouchpointCommonActions.scala
@@ -33,7 +33,7 @@ class TouchpointCommonActions(
     override def executionContext = TouchpointCommonActions.this.executionContext
 
     override protected def transform[A](request: Request[A]): Future[OptionallyAuthenticatedRequest[A]] = {
-      val user = authenticationService.authenticateUser(request)
+      val user = authenticationService.authenticatedUserFor(request)
       val touchpointBackend = user.fold(touchpointBackends.Normal)(u => touchpointBackends.forUser(u.minimalUser))
       Future.successful(OptionallyAuthenticatedRequest[A](touchpointBackend,user,request))
     }

--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -1,7 +1,6 @@
 package configuration
 import com.gu.config._
 import com.gu.i18n.Country
-import com.gu.identity.cookie.{PreProductionKeys, ProductionKeys}
 import com.gu.memsub.auth.common.MemSub.Google._
 import com.gu.salesforce.Tier
 import com.gu.zuora.api.{InvoiceTemplate, InvoiceTemplates}
@@ -62,8 +61,6 @@ object Config {
 
   def idWebAppProfileUrl =
     idWebAppUrl / "membership"/ "edit"
-
-  val idKeys = if (config.getBoolean("identity.production.keys")) new ProductionKeys else new PreProductionKeys
 
   val idApiUrl = config.getString("identity.api.url")
   val idApiClientToken = config.getString("identity.api.client.token")

--- a/frontend/app/controllers/Info.scala
+++ b/frontend/app/controllers/Info.scala
@@ -202,7 +202,7 @@ class Info(
 
 
   def feedback = NoCacheAction.async { implicit request =>
-    val authenticatedUser = authenticationService.authenticateUser(request)
+    val authenticatedUser = authenticationService.authenticatedUserFor(request)
     val name = authenticatedUser.flatMap(_.minimalUser.displayName)
 
     val identityUser = authenticatedUser.map { user => identityService.getFullUserDetails(user.minimalUser)(IdentityRequest(request)) }
@@ -217,7 +217,7 @@ class Info(
 
   def submitFeedback = NoCacheAction.async { implicit request =>
 
-    val userOpt = authenticationService.authenticateUser(request).map(_.minimalUser)
+    val userOpt = authenticationService.authenticatedUserFor(request).map(_.minimalUser)
     val uaOpt = request.headers.get(USER_AGENT)
 
     val identityUser = userOpt.map { user => identityService.getFullUserDetails(user)(IdentityRequest(request)) }

--- a/frontend/app/model/Identity.scala
+++ b/frontend/app/model/Identity.scala
@@ -2,6 +2,8 @@ package model
 
 // Code in this file ported over from identity-play-auth which is deprecated.
 
+import java.time.{Clock, Duration}
+
 import com.gu.identity.model.cookies.{CookieDescription, CookieDescriptionList}
 import play.api.mvc.Cookie
 // import Writes type classes required to generate Writes instances for case classes defined in this file
@@ -56,3 +58,36 @@ object AccessCredentials {
 }
 case class IdMinimalUser(id: String, displayName: Option[String])
 case class AuthenticatedIdUser(credentials: AccessCredentials, minimalUser: IdMinimalUser)
+
+// identity-play-auth (which previously provided CookieBuilder) has been deprecated in favour of identity-auth-play:
+// - old library: https://github.com/guardian/identity-play-auth
+// - new library: https://github.com/guardian/identity/pull/1571
+//
+// As part of this migration, only the key features of identity-play-auth were kept
+// i.e. authenticating a user from a Play RequestHeader
+//
+// Therefore, to preserve the CookieBuilder functionality,
+// the code has been copy and pasted from the old identity-play-auth.
+object CookieBuilder {
+
+  def cookiesFromDescription(
+    // Description of the cookies to set, as specified by the identity API.
+    cookieDescriptionList: CookieDescriptionList,
+    domain: Option[String] = None
+  )(implicit clock: Clock = Clock.systemUTC()): Seq[Cookie] = {
+
+    val maxAge = Duration.between(clock.instant(), cookieDescriptionList.expiresAt).getSeconds.toInt
+
+    for (cookieDescription <- cookieDescriptionList.values) yield {
+      val isSecure = cookieDescription.key.startsWith("SC_")
+      val maxAgeOpt = if (cookieDescription.sessionCookie.contains(true)) None else Some(maxAge)
+      Cookie(
+        cookieDescription.key,
+        cookieDescription.value,
+        maxAge = maxAgeOpt,
+        secure = true, // as of https://github.com/guardian/identity-frontend/pull/196
+        httpOnly = isSecure, // ideally this would come from the Cookie Description
+        domain = domain)
+    }
+  }
+}

--- a/frontend/app/services/AuthenticationService.scala
+++ b/frontend/app/services/AuthenticationService.scala
@@ -1,36 +1,85 @@
 package services
 
-import com.gu.identity.play.AccessCredentials.{Cookies, Token}
-import com.gu.identity.play.AuthenticatedIdUser.Provider
-import configuration.Config
+import java.util.concurrent.Executors
+
+import com.gu.identity.auth.UserCredentials
+import com.gu.identity.model.User
+import com.gu.identity.play.IdentityPlayAuthService
+import com.gu.identity.play.IdentityPlayAuthService.UserCredentialsMissingError
+import com.gu.monitoring.SafeLogger
+import com.gu.monitoring.SafeLogger._
 import model.{AccessCredentials, AuthenticatedIdUser, IdMinimalUser}
+import org.http4s.Uri
 import play.api.mvc.RequestHeader
 
-object AuthenticationService extends com.gu.identity.play.AuthenticationService {
-  def idWebAppSigninUrl(returnUrl: String) = Config.idWebAppSigninUrl(returnUrl)
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
 
-  val identityKeys = Config.idKeys
+// Class used to authenticate a user. Authentication is done by calling back to identity API.
+// This is so session invalidation can be taken into account when authenticating a user.
+// See comments on IdentityPlayAuthService for more information.
+class AuthenticationService private (identityPlayAuthService: IdentityPlayAuthService) {
 
-  override lazy val authenticatedIdUserProvider: Provider =
-    Cookies.authProvider(identityKeys).withDisplayNameProvider(Token.authProvider(identityKeys, "membership"))
+  import AuthenticationService._
 
-}
-
-
-class AuthenticationService {
-
-  private def copyAccessCredentials(accessCredentials: com.gu.identity.play.AccessCredentials): AccessCredentials =
-    accessCredentials match {
-      case com.gu.identity.play.AccessCredentials.Cookies(scGuU, guU) => AccessCredentials.Cookies(scGuU, guU)
-      case com.gu.identity.play.AccessCredentials.Token(tokenText) => AccessCredentials.Token(tokenText)
+  // Even though a request to identity API is made when this method is called,
+  // the IO instance returned by getUserFromRequest() is executed synchronously,
+  // as changing the result type to Future would result in a very complicated diff.
+  // The analogous PR gives an idea:
+  // https://github.com/guardian/subscriptions-frontend/pull/1265
+  //
+  // It was deemed that the risk of a bug being introduced by refactoring to use Futures
+  // was greater than the risk of a user getting a slower than normal response
+  // (as a result of all threads available to execute this method call being blocked).
+  // The latter was considered low risk, since the membership-frontend app is low traffic
+  // and a dedicated thread pool of 30 threads has been reserved
+  // to execute these blocking calls (c.f. Authentication.unsafeInit()).
+  // The fact that membership-frontend is a deprecated application also factored into the decision.
+  def authenticatedUserFor(request: RequestHeader): Option[AuthenticatedIdUser] = {
+    identityPlayAuthService.getUserFromRequest(request)
+      .map { case (credentials, user) => buildAuthenticatedUser(credentials, user) }
+      .attempt
+      .unsafeRunTimed(limit = 5.seconds) // fairly arbitrary
+      .flatMap {
+      case Left(err) =>
+        logUserAuthenticationError(err)
+        None
+      case Right(user) => Some(user)
     }
-
-  def authenticateUser(request: RequestHeader): Option[AuthenticatedIdUser] =
-    AuthenticationService.authenticatedUserFor(request)
-      .map { authenticatedIdUser =>
-        AuthenticatedIdUser(
-          copyAccessCredentials(authenticatedIdUser.credentials),
-          IdMinimalUser(authenticatedIdUser.user.id, authenticatedIdUser.user.displayName)
-        )
-      }
+  }
 }
+
+object AuthenticationService {
+
+  def unsafeInit(identityApiEndpoint: String, accessToken: String): AuthenticationService = {
+    // See comment above for why dedicated blocking execution context is used.
+    implicit val blockingExecutionContext: ExecutionContext =
+      ExecutionContext.fromExecutor(Executors.newFixedThreadPool(30))
+    val identityApiUri = Uri.unsafeFromString(identityApiEndpoint)
+    // Target client not relevant; only applicable to crypto access tokens,
+    // which aren't used to authenticate requests for this application
+    // (crypto access tokens only used to authenticate requests from native apps).
+    val identityPlayAuthService = IdentityPlayAuthService.unsafeInit(identityApiUri, accessToken, targetClient = None)
+    new AuthenticationService(identityPlayAuthService)
+  }
+
+  def buildAuthenticatedUser(credentials: UserCredentials, user: User): AuthenticatedIdUser = {
+    val accessCredentials = credentials match {
+      case UserCredentials.SCGUUCookie(value) => AccessCredentials.Cookies(scGuU = value)
+      case UserCredentials.CryptoAccessToken(value, _) => AccessCredentials.Token(tokenText = value)
+    }
+    AuthenticatedIdUser(accessCredentials, IdMinimalUser(user.id, user.publicFields.displayName))
+  }
+
+  // Logs failure to authenticate a user.
+  // User shouldn't necessarily be signed in,
+  // in which case, don't log failure to authenticate as an error.
+  // All other failures are considered errors.
+  def logUserAuthenticationError(error: Throwable): Unit =
+    error match {
+      // Utilises the custom error introduced in: https://github.com/guardian/identity/pull/1578
+      case _: UserCredentialsMissingError => SafeLogger.info(s"unable to authorize user - $error")
+      case _ => SafeLogger.error(scrub"unable to authorize user", error)
+    }
+}
+

--- a/frontend/app/services/checkout/identitystrategy/NewUser.scala
+++ b/frontend/app/services/checkout/identitystrategy/NewUser.scala
@@ -2,9 +2,8 @@ package services.checkout.identitystrategy
 
 import cats.data.EitherT
 import cats.implicits._
-import com.gu.identity.play.CookieBuilder.cookiesFromDescription // TODO
-import model.CreateIdUser
-import com.gu.identity.model.{User => IdUser, PublicFields}
+import model.{CookieBuilder, CreateIdUser}
+import com.gu.identity.model.{PublicFields, User => IdUser}
 import configuration.Config
 import controllers.IdentityRequest
 import forms.MemberForm.{CommonForm, PaidMemberJoinForm}
@@ -30,7 +29,7 @@ case class NewUser(creationCommand: CreateIdUser)(implicit idReq: IdentityReques
   def ensureIdUser(checkoutFunc: (IdUser) => Future[Result])(implicit executionContext: ExecutionContext) = (for {
     userRegAndAuthResponse <- identityService.createUser(creationCommand)
     result <- EitherT.right[String](checkoutFunc(userRegAndAuthResponse.user))
-  } yield result.withCookies(cookiesFromDescription(userRegAndAuthResponse.cookies.get, Some(Config.guardianShortDomain)): _*)
+  } yield result.withCookies(CookieBuilder.cookiesFromDescription(userRegAndAuthResponse.cookies.get, Some(Config.guardianShortDomain)): _*)
     ).valueOr { error => Results.InternalServerError(error) }
 
 }

--- a/frontend/app/services/checkout/identitystrategy/Strategy.scala
+++ b/frontend/app/services/checkout/identitystrategy/Strategy.scala
@@ -14,7 +14,7 @@ class StrategyDecider(authenticationService: AuthenticationService) {
     implicit val idService = identityService
     implicit val idRequest = IdentityRequest(request)
 
-    (for (user <- authenticationService.authenticateUser(request))
+    (for (user <- authenticationService.authenticatedUserFor(request))
       yield ExistingSignedInUser(user.minimalUser, form)).getOrElse(NewUser.strategyFrom(form).get)
   }
 }

--- a/frontend/app/utils/TestUsers.scala
+++ b/frontend/app/utils/TestUsers.scala
@@ -57,7 +57,7 @@ class TestUsers(authenticationService: AuthenticationService) {
   def isTestUser[C](permittedAltCredentialType: TestUserCredentialType[C], altCredentialSource: C)(implicit request: RequestHeader)
   : Option[TestUserCredentialType[_]] = {
 
-    authenticationService.authenticateUser(request).map(_.minimalUser).fold[Option[TestUserCredentialType[_]]] {
+    authenticationService.authenticatedUserFor(request).map(_.minimalUser).fold[Option[TestUserCredentialType[_]]] {
       permittedAltCredentialType.passes(altCredentialSource)
     }(SignedInUsername.passes)
   }

--- a/frontend/app/wiring/AppComponents.scala
+++ b/frontend/app/wiring/AppComponents.scala
@@ -49,7 +49,8 @@ trait AppComponents
   private lazy val eventbriteCollectiveServices = new EventbriteCollectiveServices(defaultCacheApi, guardianLiveEventService, masterclassEventService)
   private lazy val membersDataAPI = new MembersDataAPI(executionContext)
 
-  private lazy val authenticationService = new AuthenticationService
+  private lazy val authenticationService: AuthenticationService =
+    AuthenticationService.unsafeInit(identityApiEndpoint = Config.idApiUrl, accessToken = Config.idApiClientToken)
   private lazy val testUsers = new TestUsers(authenticationService)
   private lazy val strategyDecider = new StrategyDecider(authenticationService)
 

--- a/frontend/conf/CODE.public.conf
+++ b/frontend/conf/CODE.public.conf
@@ -6,3 +6,5 @@ stage="CODE"
 
 google.oauth.callback="https://membership.code.dev-theguardian.com/oauth2callback"
 identity.webapp.url="https://profile.code.dev-theguardian.com"
+
+membership.url = "https://membership.code.dev-theguardian.com"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,8 +9,8 @@ object Dependencies {
   //libraries
   val sentryRavenLogback = "io.sentry" % "sentry-logback" % "1.7.5"
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
-  val identityPlayAuth = "com.gu.identity" %% "identity-play-auth" % "2.6"
-  val identityModelPlay = "com.gu.identity" %% "identity-model-play" % "3.184-M7"
+  val identityAuthPlay = "com.gu.identity" %% "identity-auth-play" % "3.184-M7"
+  val identityTestUsers = "com.gu" %% "identity-test-users" % "0.6"
   val membershipCommon = "com.gu" %% "membership-common" % "0.549"
   val contentAPI = "com.gu" %% "content-api-client-default" % "14.1"
   val playWS = PlayImport.ws
@@ -46,7 +46,7 @@ object Dependencies {
 
   val frontendDependencies =  Seq(googleAuth, scalaUri, membershipCommon, enumPlay,
     contentAPI, playWS, playFilters, playCache, playIteratees, sentryRavenLogback, awsSimpleEmail, scalaz, pegdown,
-    PlayImport.specs2 % "test", specs2Extra, identityPlayAuth, identityModelPlay, catsCore, scalaLogging, kinesisLogbackAppender, logstash, dataFormat,
+    PlayImport.specs2 % "test", specs2Extra, identityAuthPlay, identityTestUsers, catsCore, scalaLogging, kinesisLogbackAppender, logstash, dataFormat,
     jacksonDataType, jacksonDataBind, jacksonAnnotations, jacksonCore,
     acquisitionEventProducer, bcprovJdk15on, libthrift)
 


### PR DESCRIPTION
Follow up to #1896; authenticate a user by calling out to identity API so that session invalidation is respected.

The request to identity API is made synchronously. The reasoning behind this is the same as subscriptions frontend ([#1274](https://github.com/guardian/subscriptions-frontend/pull/1274)).