### PR TITLE
Update membership common to support complementary readertype

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
   val identityAuthPlay = "com.gu.identity" %% "identity-auth-play" % "3.184-M7"
   val identityTestUsers = "com.gu" %% "identity-test-users" % "0.6"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.549"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.550"
   val contentAPI = "com.gu" %% "content-api-client-default" % "14.1"
   val playWS = PlayImport.ws
   val playFilters = PlayImport.filters


### PR DESCRIPTION
Bumping ```membership-common``` version following guardian/membership-common#601 to allow for `Complementary` subscriptions as a `ReaderType` to FIX `MatchError`