### PR TITLE
Use dev-nginx to handle ssl

### DIFF
--- a/nginx/BrewFile
+++ b/nginx/BrewFile
@@ -1,0 +1,2 @@
+tap "guardian/devtools"
+brew "guardian/devtools/dev-nginx"

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -1,24 +1,8 @@
 # Membership NGINX
 
-## Setup Nginx for `Identity-Platform`
-
-Membership depends on Identity, so **you'll need to perform the**
-[**Nginx setup for identity-platform**](https://github.com/guardian/identity-platform/tree/master/nginx)
-**first**, before you do anything else.
-
-## Membership-specific setup
-
-#### Run Membership's Nginx setup script
-
-Run the Membership-specific [setup.sh](setup.sh) script from the root
-of the `membership-frontend` project:
-
-```
-./nginx/setup.sh
-```
-
-The script doesn't start Nginx. To manually start it run `sudo nginx` or `sudo systemctl start nginx`
-depending on your system.
+1. `cd nginx`
+1. Install dependencies `brew bundle`
+2. Run `./setup.sh`
 
 #### NGINX error messages
 

--- a/nginx/membership.conf
+++ b/nginx/membership.conf
@@ -1,10 +1,9 @@
 server {
-    listen 443;
+    listen 443 ssl;
     server_name mem.thegulocal.com;
 
-    ssl on;
-    ssl_certificate STAR_thegulocal_com_exp2020-01-09.crt; ## Supplied by https://github.com/guardian/identity-platform#setup-nginx-for-local-development
-    ssl_certificate_key STAR_thegulocal_com_exp2020-01-09.key; ## ditto
+    ssl_certificate mem.thegulocal.com.crt;
+    ssl_certificate_key mem.thegulocal.com.key;
 
     ssl_session_timeout 5m;
 

--- a/nginx/setup.sh
+++ b/nginx/setup.sh
@@ -1,9 +1,9 @@
-#!/bin/bash -x
+#!/bin/bash
+
+set -e
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-NGINX_HOME=$(nginx -V 2>&1 | grep 'configure arguments:' | sed 's#.*conf-path=\([^ ]*\)/nginx\.conf.*#\1#g')
 
-echo "\n\nUsing NGINX_HOME=$NGINX_HOME"
-
-sudo mkdir -p $NGINX_HOME/sites-enabled
-sudo ln -fs $DIR/membership.conf $NGINX_HOME/sites-enabled/membership.conf
+dev-nginx setup-cert mem.thegulocal.com
+dev-nginx link-config $DIR/membership.conf
+dev-nginx restart-nginx


### PR DESCRIPTION
## Why are you doing this?
All the Reader Revenue sites are now using dev-nginx to handle ssl certs for dev however this repo had not been updated. This PR does that update