### PR TITLE
Decommision acquisition

### DIFF
--- a/frontend/app/controllers/FrontPage.scala
+++ b/frontend/app/controllers/FrontPage.scala
@@ -1,13 +1,8 @@
 package controllers
 
 import actions.CommonActions
-import com.gu.i18n.CountryGroup._
-import com.gu.memsub.images.{Grid, ResponsiveImageGenerator, ResponsiveImageGroup}
-import model.OrientatedImages
-import model.RichEvent.EventBrandCollection
 import play.api.mvc.{BaseController, ControllerComponents}
 import services._
-import views.support.{Asset, PageInfo}
 
 class FrontPage(eventbriteService: EventbriteCollectiveServices, touchpointBackends: TouchpointBackends, commonActions: CommonActions, override protected val controllerComponents: ControllerComponents) extends BaseController {
 
@@ -17,111 +12,10 @@ class FrontPage(eventbriteService: EventbriteCollectiveServices, touchpointBacke
   val masterclassEvents = eventbriteService.masterclassEventService
 
   def index = CachedAction { implicit request =>
-    implicit val countryGroup = UK
-
-    val heroImages = OrientatedImages(
-      portrait = ResponsiveImageGroup(availableImages =
-        ResponsiveImageGenerator("5f18c6428e9f31394b14215fe3c395b8f7b4238a/1124_117_1721_1722", Seq(1721, 1000, 500))),
-      landscape = ResponsiveImageGroup(availableImages =
-        ResponsiveImageGenerator("5f18c6428e9f31394b14215fe3c395b8f7b4238a/0_0_2878_999", Seq(2000, 1000, 500))))
-
-    val eventCollections = EventBrandCollection(
-      liveEvents.getSortedByCreationDate.take(3),
-      masterclassEvents.getSortedByCreationDate.take(3)
-    )
-
-    val pageImages = Seq(
-      ResponsiveImageGroup(
-        name=Some("patrons"),
-        metadata=Some(Grid.Metadata(Some("Patrons of The Guardian"), None, None)),
-        availableImages=ResponsiveImageGenerator(
-          id="a0b637e4dc13627ead9644f8ec9bd2cc8771f17d/0_0_2000_1200",
-          sizes=List(500)
-        )
-      )
-    )
-
-    Ok(views.html.index(
-      heroImages,
-      touchpointBackends.Normal.catalog,
-      pageImages,
-      eventCollections))
+    Redirect(routes.WhatsOn.list().url, request.queryString, MOVED_PERMANENTLY)
   }
 
   def welcome = CachedAction { implicit request =>
-    val slideShowImages = Seq(
-      ResponsiveImageGroup(
-        metadata=Some(Grid.Metadata(
-          description = Some("RIP Rock and Roll? (Guardian Live event): Emmy the Great"),
-          byline = None, credit = None
-        )),
-        availableImages=ResponsiveImageGenerator(
-          id="3d2be6485a6b8f5948ba39519ceb0f76007ae8d8/0_0_2280_1368",
-          sizes=List(1000, 500)
-        )
-      ),
-      ResponsiveImageGroup(
-        metadata=Some(Grid.Metadata(
-          description = Some("A Life in Music - George Clinton (Guardian Live event)"),
-          byline = None, credit = None
-        )),
-        availableImages=ResponsiveImageGenerator(
-          id="234dff81b39968199f501f4108189efab263a668/0_0_2280_1368",
-          sizes=List(1000, 500)
-        )
-      ),
-      ResponsiveImageGroup(
-        metadata=Some(Grid.Metadata(
-          description = Some("Guardian Live with Russell Brand"),
-          byline = None, credit = None
-        )),
-        availableImages=ResponsiveImageGenerator(
-          id="ecd5ccb67c093394c51f3db6779b044e3056f50c/0_0_2280_1368",
-          sizes=List(1000, 500)
-        )
-      ),
-      ResponsiveImageGroup(
-        metadata=Some(Grid.Metadata(
-          description = Some("A Life in Politics - Ken Clarke (Guardian Live event)"),
-          byline = None, credit = None
-        )),
-        availableImages=ResponsiveImageGenerator(
-          id="192469f1bbd69247b066a202defb23ee166ede4d/0_0_2279_1368",
-          sizes=List(1000, 500)
-        )
-      ),
-      ResponsiveImageGroup(
-        metadata=Some(Grid.Metadata(
-          description = Some("Guardian Live event: Pussy Riot - art, sex and disobedience"),
-          byline = None, credit = None
-        )),
-        availableImages=ResponsiveImageGenerator(
-          id="eab86e9c81414932e0d50a1cd609dccfc20ca5d2/0_0_2279_1368",
-          sizes=List(1000, 500)
-        )
-      ),
-      ResponsiveImageGroup(
-        metadata=Some(Grid.Metadata(
-          description = Some("A Life in Music - George Clinton (Guardian Live event)"),
-          byline = None, credit = None
-        )),
-        availableImages=ResponsiveImageGenerator(
-          id="eccf14ef0f9f4b672b3a7cc594676aa498827f4a/0_0_2280_1368",
-          sizes=List(1000, 500)
-        )
-      ),
-      ResponsiveImageGroup(
-        metadata=Some(Grid.Metadata(
-          description = Some("Behind the Headlines - What's all the fuss about feminism? (Guardian Live event): Bonnie Greer"),
-          byline = None, credit = None
-        )),
-        availableImages=ResponsiveImageGenerator(
-          id="99c490b1a0863b3d30718e9985693a3ddcc4dc75/0_0_2280_1368",
-          sizes=List(1000, 500)
-        )
-      )
-    )
-
-    Ok(views.html.welcome(PageInfo(title = "Welcome", url = request.path), slideShowImages))
+    Redirect(routes.WhatsOn.list().url, request.queryString, MOVED_PERMANENTLY)
   }
 }

--- a/frontend/app/controllers/Info.scala
+++ b/frontend/app/controllers/Info.scala
@@ -106,28 +106,7 @@ class Info(
   }
 
   def supporterFor(implicit countryGroup: CountryGroup) = CachedAndOutageProtected { implicit request =>
-
-    val heroImage = heroImageFor(countryGroup)
-    val heroOrientated = OrientatedImages(portrait = heroImage, landscape = heroImage)
-
-    val detailImage = detailImageFor(countryGroup)
-    val detailImageOrientated = OrientatedImages(portrait = detailImage, landscape = detailImage)
-
-    val template = countryGroup match {
-      case US => views.html.info.supporterUSA.apply _
-      case Australia => views.html.info.supporterAustralia.apply _
-      case _ => views.html.info.supporter.apply _
-    }
-
-    Ok(template(
-      heroOrientated,
-      touchpointBackends.Normal.catalog.supporter,
-      PageInfo(
-        title = CopyConfig.copyTitleSupporters,
-        url = request.path,
-        description = Some(CopyConfig.copyDescriptionSupporters)
-      ),
-      detailImageOrientated))
+    Redirect(s"https://support.theguardian.com/${countryGroup.id}/support", request.queryString, MOVED_PERMANENTLY)
   }
 
   def patron() = CachedAndOutageProtected { implicit request =>

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -154,47 +154,8 @@ class Joiner(
 
   def enterPaidDetails(
     tier: PaidTier,
-    countryGroup: CountryGroup) = OptionallyAuthenticatedNonMemberAction(tier).async { implicit request =>
-    val userOpt = authenticationService.authenticatedUserFor(request)
-    implicit val resolution: TouchpointBackend.Resolution =
-      touchpointBackend.forRequest(PreSigninTestCookie, request.cookies)
-
-    implicit val tpBackend = resolution.backend
-
-    implicit val backendProvider: BackendProvider = new BackendProvider {
-      override def touchpointBackend(implicit tpbs: TouchpointBackends) = tpBackend
-    }
-    implicit val c = catalog
-
-    val identityRequest = IdentityRequest(request)
-
-    (for {
-      identityUserOpt <- userOpt.map(user => identityService.getIdentityUserView(user.minimalUser, identityRequest).map(Option(_))).getOrElse(Future.successful[Option[IdentityUser]](None))
-    } yield {
-
-      for (identityUser <- identityUserOpt) {
-        SafeLogger.info(s"signed-in-enter-details tier=${tier.slug} testUser=${identityUser.isTestUser} passwordExists=${identityUser.passwordExists} ${ABTest.allTests.map(_.describeParticipation).mkString(" ")}")
-      }
-      val plans = catalog.findPaid(tier)
-      val supportedCurrencies = plans.allPricing.map(_.currency).toSet
-      val pageInfo = PageInfo(
-        stripeUKMembershipPublicKey = Some(stripeUKMembershipService.publicKey),
-        stripeAUMembershipPublicKey = Some(stripeAUMembershipService.publicKey),
-        payPalEnvironment = Some(tpBackend.payPalService.config.payPalEnvironment),
-        initialCheckoutForm = CheckoutForm.forIdentityUser(identityUserOpt.flatMap(_.country), plans, Some(countryGroup)),
-        abTests = abtests.ABTest.allocations(request)
-      )
-
-      val countryCurrencyWhitelist = CountryWithCurrency.whitelisted(supportedCurrencies, GBP)
-
-      Ok(views.html.joiner.form.payment(
-        plans,
-        countryCurrencyWhitelist,
-        identityUserOpt,
-        pageInfo,
-        countryGroup,
-        resolution))
-    }).andThen { case Failure(e) => SafeLogger.error(scrub"User ${userOpt.map(_.minimalUser.id)} could not enter details for paid tier ${tier.name}: ${identityRequest.trackingParameters}", e)}
+    countryGroup: CountryGroup) = OptionallyAuthenticatedNonMemberAction(tier) { implicit request =>
+    Redirect(routes.Redirects.supportRedirect())
   }
 
   def enterFriendDetails = NonMemberAction(Tier.friend).async { implicit request =>

--- a/frontend/app/controllers/Redirects.scala
+++ b/frontend/app/controllers/Redirects.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import actions.CommonActions
+import com.gu.i18n.CountryGroup
 import configuration.Links
 import play.api.mvc._
 
@@ -14,5 +15,7 @@ class Redirects(commonActions: CommonActions, override protected val controllerC
     MovedPermanently(routes.Info.supporterRedirect(None).path)
   }
 
-  def supportRedirect = CachedAction(MovedPermanently("https://support.theguardian.com/"))
+  def supportRedirect = CachedAction{ implicit request =>
+    Redirect("https://support.theguardian.com/", request.queryString, MOVED_PERMANENTLY)
+  }
 }

--- a/frontend/app/model/Nav.scala
+++ b/frontend/app/model/Nav.scala
@@ -19,11 +19,11 @@ object Nav {
   }
 
   val primaryNavigation = List(
-    NavItem("support the guardian", "https://support.theguardian.com/?acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentId%22%3A%22become_a_supporter_link_on_membership_site%22%7D", "Support The Guardian"),
     NavItem("events", routes.WhatsOn.list.url, "Events", subNav = Seq(
       NavItem("archive", routes.WhatsOn.listArchive.url, "Archive")
     )),
     NavItem("masterclasses", "/masterclasses", "Masterclasses"),
+    NavItem("support the guardian", "https://support.theguardian.com/?acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentId%22%3A%22become_a_supporter_link_on_membership_site%22%7D", "Support The Guardian"),
     NavItem("patrons", Links.patrons, "Patrons"),
     NavItem("feedback", "/feedback", "Feedback")
   )

--- a/frontend/app/views/event/eventsList.scala.html
+++ b/frontend/app/views/event/eventsList.scala.html
@@ -49,6 +49,4 @@
             @fragments.eventListings.listing(eventsToShow, Some("Sorry, no matching events were found."), isLead=true, isFilterable=false)
         </div>
     </main>
-
-    @fragments.tier.joinListing(catalog)
 }

--- a/frontend/app/views/event/masterclassesList.scala.html
+++ b/frontend/app/views/event/masterclassesList.scala.html
@@ -80,6 +80,4 @@
         </div>
 
     </main>
-
-    @fragments.tier.joinListing(catalog)
 }

--- a/frontend/app/views/fragments/global/primaryNavigation.scala.html
+++ b/frontend/app/views/fragments/global/primaryNavigation.scala.html
@@ -14,14 +14,6 @@
 <nav role="navigation" class="global-navigation js-global-nav">
     <div class="global-navigation__scroll l-constrained">
         <ul class="global-navigation__list">
-            @if(!countryGroup.contains(CountryGroup.Australia)) {
-                <li class="global-navigation__item global-navigation__item--home">
-                    <a href="@if(isMembershipBranded) {/} else {http://theguardian.com/}" class="global-navigation__link js-nav-link-home">
-                        @fragments.inlineIcon("home")
-                        <span class="u-h">Home</span>
-                    </a>
-                </li>
-            }
             @for(navItem <- pageInfo.navigation if !navItem.isPrivate) {
                 <li class="global-navigation__item">
                     <a href="@navItem.href" class="global-navigation__link" id="qa-nav-@navItem.id">@navItem.title</a>
@@ -32,11 +24,6 @@
                     </li>
                 }
             }
-            <li class="global-navigation__item global-navigation__item--right">
-                @if(isMembershipBranded && !countryGroup.contains(CountryGroup.Australia)){
-                    <a href="@Links.membershipFront" class="global-navigation__link global-navigation__link--last js-members-area is-hidden">Members' Area</a>
-                }
-            </li>
         </ul>
     </div>
 </nav>

--- a/frontend/app/views/info/offersAndCompetitions.scala.html
+++ b/frontend/app/views/info/offersAndCompetitions.scala.html
@@ -57,6 +57,4 @@
 
 
     </main>
-
-    @fragments.tier.joinListing(catalog)
 }

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -89,7 +89,7 @@ GET         /tier/change/:tier/summary                 controllers.TierControlle
 # Information
 GET         /patrons                                   controllers.Info.patronsRedirect
 GET         /supporter                                 controllers.Info.supporterRedirect(countryGroup: Option[CountryGroup])
-GET         /about/supporter                           controllers.Redirects.supporterRedirect
+GET         /about/supporter                           controllers.Redirects.supportRedirect
 GET         /:countryGroup/supporter                   controllers.Info.supporterFor(countryGroup: CountryGroup)
 GET         /help                                      controllers.Info.help
 GET            /feedback                              controllers.Info.feedback

--- a/start-frontend.sh
+++ b/start-frontend.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-sbt -Djava.awt.headless=true "project frontend" "devrun"
+sbt -mem 2048 -Djava.awt.headless=true "project frontend" "devrun"


### PR DESCRIPTION
## Why are you doing this?
Now we are no longer promoting membership as a product we want to close down the acquisition paths, this PR does the following:
- Redirects the homepage to /events - this was chosen as it is the most visited page on the site 
- Remove link to the members area from the header
- Remove the 'Become a supporter' component from the bottom of all pages
- Tweak the navigation to fit the new information architecture 
  - remove the home button as it is now a duplicate of the events button
  - move 'Support the Guardian' after events & masterclasses

## Screenshots
### The old header and navigation bar
![Screen Shot 2020-01-10 at 14 29 02](https://user-images.githubusercontent.com/181371/72160289-fd4cfe00-33b5-11ea-97c0-b49268bfdbf9.png)
![Screen Shot 2020-01-10 at 14 28 56](https://user-images.githubusercontent.com/181371/72160290-fd4cfe00-33b5-11ea-956a-70a5a8fb52ba.png)
### The new header and navigation bar
![Screen Shot 2020-01-10 at 14 28 28](https://user-images.githubusercontent.com/181371/72160291-fd4cfe00-33b5-11ea-9c42-fc648c02d504.png)
![Screen Shot 2020-01-10 at 14 28 01](https://user-images.githubusercontent.com/181371/72160292-fde59480-33b5-11ea-9e33-a3ee3c498675.png)


