### PR TITLE
Reinstate acquisition

### DIFF
--- a/frontend/app/controllers/SiteMap.scala
+++ b/frontend/app/controllers/SiteMap.scala
@@ -15,33 +15,15 @@ class SiteMap(commonActions: CommonActions, override protected val controllerCom
   def sitemap() = CachedAction { implicit request =>
     val foo = <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
                       xmlns:xhtml="http://www.w3.org/1999/xhtml">
-      {supporterPages}
       <url>
-        <loc>{routes.FrontPage.index.absoluteURL(secure = true)}</loc>
-        <priority>0.8</priority>
+        <loc>{routes.WhatsOn.list().absoluteURL(secure = true)}</loc>
+        <priority>1</priority>
+      </url>
+      <url>
+        <loc>{routes.WhatsOn.masterclassesList().absoluteURL(secure = true)}</loc>
+        <priority>1</priority>
       </url>
     </urlset>
     Ok(foo)
-  }
-
-  def supporterPages()(implicit req: RequestHeader): Iterable[Elem] = for {
-    countryGroup <- CountryGroupLang.langByCountryGroup.keys
-  } yield {
-    <url>
-      <loc>
-        {routes.Info.supporterFor(countryGroup).absoluteURL(secure = true)}
-      </loc>
-      <priority>1.0</priority>
-      {alternatePages()}
-    </url>
-  }
-
-  def alternatePages()(implicit req: RequestHeader) = for {
-    (countrySpecificGroup, lang) <- CountryGroupLang.langByCountryGroup
-  } yield {
-      <xhtml:link
-      rel="alternate"
-      hreflang={lang}
-      href={routes.Info.supporterFor(countrySpecificGroup).absoluteURL(secure = true)}/>
   }
 }

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -5,7 +5,7 @@ Disallow: /whats-on
 Disallow: /join-challenger
 Disallow: /bundles
 Disallow: /monthly-contribution
-Disallow: /masterclasses
+Disallow: /choose-tier
 
 Allow: /
 


### PR DESCRIPTION
## Why are you doing this?
We want to leave acquisition pages available for Customer Service Representatives in case users who have lapsed want to sign up again for membership and for some reason refuse to switch to a digital subscription or recurring contribution

This PR also removes the acquisition pages from the site map and disallows the `/choose-tier` page to robots.text

## Trello card: [Here](https://trello.com/c/BPfW1xsi/2850-reinstate-membership-acquisition-pages-%F0%9F%98%AD)
