### PR TITLE
Add a verification file to allow us to access search console

### DIFF
--- a/frontend/public/google30b9d2c5743afc06.html
+++ b/frontend/public/google30b9d2c5743afc06.html
@@ -1,0 +1,1 @@
+google-site-verification: google30b9d2c5743afc06.html


### PR DESCRIPTION
## Why are you doing this?
In order to be able to access the Google search console for members.theguardian.com we need to add a verification file to the site, this PR does that.
