### PR TITLE
Include VAT in the fees we display for events

### DIFF
--- a/frontend/app/model/Eventbrite.scala
+++ b/frontend/app/model/Eventbrite.scala
@@ -111,17 +111,18 @@ object Eventbrite {
    * https://developer.eventbrite.com/docs/ticket-class-object/
    */
   case class EBTicketClass(id: String,
-                           name: String,
-                           description: Option[String],
-                           free: Boolean,
-                           quantity_total: Int,
-                           quantity_sold: Int,
-                           on_sale_status: Option[String], // Currently undocumented, so treating as optional. "SOLD_OUT", "AVAILABLE", "UNAVAILABLE"
-                           cost: Option[EBPricing],
-                           fee: Option[EBPricing],
-                           sales_end: Instant,
-                           sales_start: Option[Instant],
-                           hidden: Option[Boolean]) extends EBObject {
+    name: String,
+    description: Option[String],
+    free: Boolean,
+    quantity_total: Int,
+    quantity_sold: Int,
+    on_sale_status: Option[String], // Currently undocumented, so treating as optional. "SOLD_OUT", "AVAILABLE", "UNAVAILABLE"
+    cost: Option[EBPricing],
+    fee: Option[EBPricing],
+    tax: Option[EBPricing],
+    sales_end: Instant,
+    sales_start: Option[Instant],
+    hidden: Option[Boolean]) extends EBObject {
     val isHidden = hidden.contains(true)
 
     val isGuestList = isHidden && name.toLowerCase.contains("guestlist")
@@ -135,7 +136,10 @@ object Eventbrite {
     val feeInPence = fee.map(_.value).getOrElse(0)
     val priceValue = formatPrice(priceInPence)
     val priceText = cost.map(_.formattedPrice).getOrElse("Free")
-    val feeText = fee.filter(_.value>0).map(_.formattedPrice)
+    val feeText = fee
+      .filter(_.value > 0)
+      .map(theFee => EBPricing(theFee.value + tax.map(_.value).getOrElse(0)))
+      .map(_.formattedPrice)
     val totalCost = cost.map(c => c add fee.getOrElse(EBPricing(0)))
     val currencyCode = GBP.toString
   }

--- a/frontend/test/model/EBEventTest.scala
+++ b/frontend/test/model/EBEventTest.scala
@@ -3,6 +3,7 @@ package model
 import com.netaporter.uri.Uri
 import model.Eventbrite._
 import model.EventbriteDeserializer._
+import org.joda.time.Instant
 import play.api.test.PlaySpecification
 import utils.Resource
 
@@ -105,6 +106,30 @@ class EBEventTest extends PlaySpecification {
     }
     "be pleasantly formatted as whole pounds if there are no pence" in {
       EBPricing(123400).formattedPrice mustEqual("£1234")
+    }
+  }
+
+  "feeText" should {
+    "include tax" in {
+      val ticketClass = EBTicketClass(
+        id = "",
+        name = "",
+        description = None,
+        free = false,
+        quantity_total = 1,
+        quantity_sold = 0,
+        on_sale_status = None,
+        cost = None,
+        fee = Some(EBPricing(600)),
+        tax = Some(EBPricing(130)),
+        sales_end = Instant.now(),
+        sales_start = None,
+        hidden = None
+      )
+
+      ticketClass.feeText must beSome("£7.30")
+      ticketClass.copy(tax = None).feeText must beSome("£6")
+      ticketClass.copy(fee = None, tax = None).feeText must beNone
     }
   }
 

--- a/frontend/test/model/EventbriteTestObjects.scala
+++ b/frontend/test/model/EventbriteTestObjects.scala
@@ -12,7 +12,7 @@ object EventbriteTestObjects {
   def eventDescription(description: String = "Event Description") = new EBRichText(description, "")
   def eventLocation = new EBAddress(None, None, None, None, None, None)
   def eventVenue = new EBVenue(Option(eventLocation), None)
-  def eventTicketClass = EBTicketClass("", "", None, false, 0, 0, None, None, None, eventTime.toInstant, None, None)
+  def eventTicketClass = EBTicketClass("", "", None, false, 0, 0, None, None, None, None, eventTime.toInstant, None, None)
   def eventWithName(name: String = "") = EBEvent(eventName(name), Option(eventDescription()), "", name, eventTime, eventTime + 2.hours, (eventTime - 1.month).toInstant, eventVenue, 0, Seq(eventTicketClass), "live")
 
   case class TestRichEvent(event: EBEvent) extends RichEvent {


### PR DESCRIPTION
## Why are you doing this?
Eventbrite changed their fees to be exclusive some time ago so now when they add their fee to a sale it will appear higher than we currently have displayed on our sales page. 

EG... where it says £249 plus £6.50 booking fee below we MUST display the full fee including VAT amount eg £7.80 fee. This is a legal requirement by ad standards.

![unnamed](https://user-images.githubusercontent.com/181371/74053161-296a9780-49d3-11ea-987b-3dc121b2f2a2.png)



## Trello card: [Here](https://trello.com/c/0WQdpyrv/2880-membership-events-are-displaying-fees-excluding-tax-which-is-non-compliant-with-advertising-standards)
