### PR TITLE
move away from idapi api display name

### DIFF
--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -32,7 +32,7 @@ import services.{GuardianContentService, _}
 import tracking.AcquisitionTracking
 import utils.RequestCountry._
 import utils.TestUsers.{NameEnteredInForm, PreSigninTestCookie, isTestUser}
-import utils.{Feature, ReferralData, TestUsers, TierChangeCookies}
+import utils.{Feature, ReferralData, TestUsers, TierChangeCookies, DisplayName}
 import views.support
 import views.support.MembershipCompat._
 import views.support.Pricing._
@@ -120,7 +120,7 @@ class Joiner(
       case Some(user) => for {
         fullUser <- identityService.getFullUserDetails(user.minimalUser)(IdentityRequest(request))
         primaryEmailAddress = fullUser.primaryEmailAddress
-        displayName = fullUser.publicFields.displayName
+        displayName = DisplayName(fullUser)
         avatarUrl = fullUser.privateFields.socialAvatarUrl
       } yield
         Ok(views.html.joiner.staff(catalog, StaffEmails(request.user.email, Some(primaryEmailAddress)), displayName, avatarUrl, flashMsgOpt))
@@ -274,7 +274,7 @@ class Joiner(
       salesforceService.metrics.putAttemptedSignUp(tier)
       memberService.createMember(user, formData, eventId, tier, ipCountry, referralData).map {
         case CreateMemberResult(sfContactId, zuoraSubName) =>
-          val minimalUser = IdMinimalUser(user.id, user.publicFields.displayName)
+          val minimalUser = IdMinimalUser(user.id, DisplayName(user))
           SafeLogger.info(s"make-member-success ${tier.name} ${ABTest.allTests.map(_.describeParticipationFromCookie).mkString(" ")} ${identityStrategy.getClass.getSimpleName} user=${user.id} testUser=${isTestUser(minimalUser)} suppliedNewPassword=${formData.password.isDefined} sub=$zuoraSubName")
           if (formData.marketingConsent)
             identityService.consentEmail(user.primaryEmailAddress, IdentityRequest(request))

--- a/frontend/app/services/AuthenticationService.scala
+++ b/frontend/app/services/AuthenticationService.scala
@@ -11,6 +11,7 @@ import com.gu.monitoring.SafeLogger._
 import model.{AccessCredentials, AuthenticatedIdUser, IdMinimalUser}
 import org.http4s.Uri
 import play.api.mvc.RequestHeader
+import utils.DisplayName
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
@@ -68,7 +69,7 @@ object AuthenticationService {
       case UserCredentials.SCGUUCookie(value) => AccessCredentials.Cookies(scGuU = value)
       case UserCredentials.CryptoAccessToken(value, _) => AccessCredentials.Token(tokenText = value)
     }
-    AuthenticatedIdUser(accessCredentials, IdMinimalUser(user.id, user.publicFields.displayName))
+    AuthenticatedIdUser(accessCredentials, IdMinimalUser(user.id, DisplayName(user)))
   }
 
   // Logs failure to authenticate a user.

--- a/frontend/app/services/checkout/identitystrategy/NewUser.scala
+++ b/frontend/app/services/checkout/identitystrategy/NewUser.scala
@@ -19,7 +19,7 @@ object NewUser {
   } yield NewUser(CreateIdUser(
     paidMemberJoinForm.email,
     password,
-    PublicFields(displayName = Some(s"${form.name.first} ${form.name.last}")),
+    PublicFields(),
     Some(IdentityService.privateFieldsFor(form)))
   )
 }

--- a/frontend/app/utils/DisplayName.scala
+++ b/frontend/app/utils/DisplayName.scala
@@ -1,0 +1,14 @@
+package utils
+
+import com.gu.identity.model.User
+
+object DisplayName {
+  def apply(user: User): Option[String] = user.publicFields.username.orElse(user.privateFields.firstName)
+  def fallbackFullName(user: User): Option[String] = {
+    val fullName = for {
+      firstName <- user.privateFields.firstName
+      lastName <- user.privateFields.secondName
+    } yield s"$firstName $lastName"
+    user.publicFields.username.orElse(fullName)
+  }
+}

--- a/frontend/app/views/fragments/joiner/signedInAs.scala.html
+++ b/frontend/app/views/fragments/joiner/signedInAs.scala.html
@@ -3,7 +3,7 @@
 
 @import configuration.Config.idWebAppSignOutThenRegisterUrl
 
-@for(displayName <- user.publicFields.displayName) {
+@for(displayName <- user.displayName) {
     <p class="text-note">
         You're signed in as <strong class="qa-user-displayname">@displayName</strong>.
     @if(!inline) {

--- a/frontend/app/views/support/IdentityUser.scala
+++ b/frontend/app/views/support/IdentityUser.scala
@@ -31,7 +31,7 @@ case class IdentityUser(publicFields: PublicFields, privateFields: PrivateFields
     postCode =      privateFields.billingPostcode.mkString,
     countryName =   privateFields.billingCountry.mkString
   )
-
+  def displayName: Option[String] = publicFields.username.orElse(privateFields.firstName)
   def isTestUser: Boolean = privateFields.firstName.exists(TestUsers.isTestUser)
 }
 

--- a/frontend/test/utils/DisplayNameTest.scala
+++ b/frontend/test/utils/DisplayNameTest.scala
@@ -1,0 +1,47 @@
+package utils
+
+import com.gu.identity.model.{PrivateFields, PublicFields, User}
+import org.scalatest.{FlatSpec, Matchers}
+
+class DisplayNameTest extends FlatSpec with Matchers {
+  val username = "username"
+  val firstName = "firstName"
+  val secondName = "secondName"
+
+  "apply" should "create a display name using an Identity user's username" in {
+    val user = User(
+      "email@email.com",
+      "userId",
+      publicFields = PublicFields(username = Some(username)),
+      privateFields = PrivateFields(firstName = Some(firstName), secondName = Some(secondName))
+    )
+    DisplayName(user) should be(Some(username))
+  }
+  "apply" should "fallback to first name" in {
+    val user = User(
+      "email@email.com",
+      "userId",
+      publicFields = PublicFields(username = None),
+      privateFields = PrivateFields(firstName = Some(firstName), secondName = Some(secondName))
+    )
+    DisplayName(user) should be(Some(firstName))
+  }
+  "fallbackFullName" should "default to username" in {
+    val user = User(
+      "email@email.com",
+      "userId",
+      publicFields = PublicFields(username = Some(username)),
+      privateFields = PrivateFields(firstName = Some(firstName), secondName = Some(secondName))
+    )
+    DisplayName.fallbackFullName(user) should be(Some(username))
+  }
+  "fallbackFullName" should "fallback to first name and last name" in {
+    val user = User(
+      "email@email.com",
+      "userId",
+      publicFields = PublicFields(username = None),
+      privateFields = PrivateFields(firstName = Some(firstName), secondName = Some(secondName))
+    )
+    DisplayName.fallbackFullName(user) should be(Some("firstName secondName"))
+  }
+}


### PR DESCRIPTION
## Why are you doing this?

We are planning on removing displayName from the identity api

## Changes

displayName is now generated using the user's username, falling back to the first name or 'firstname secondname' where it seems appropriate
