### PR TITLE
Make `events.json` accessible to any domain

### DIFF
--- a/frontend/app/controllers/rest/EventApi.scala
+++ b/frontend/app/controllers/rest/EventApi.scala
@@ -17,13 +17,13 @@ object EventApi {
 
 class EventApi(eventbriteService: EventbriteCollectiveServices, commonActions: CommonActions, override protected val controllerComponents: ControllerComponents) extends BaseController {
 
-  import commonActions.CachedAction
+  import commonActions.CorsPublicCachedAction
   import EventApi._
 
   /**
     * @return for now, only Guardian Live Events - other types may be added in the future
     */
-  def events = CachedAction {
+  def events = CorsPublicCachedAction {
     Ok(toJson(EventsResponse(eventbriteService.guardianLiveEventService.events.map(Event.forRichEvent(_)))))
   }
 }


### PR DESCRIPTION
## Why are you doing this?
<!--
Please do not forget to log the amount of hours you spent in this PR here:
https://docs.google.com/spreadsheets/d/1DO24_EkHI3emwTSXpnkwWGhKf7n_9VDcGu0g4kdfUD0/edit#gid=0
-->
This endpoint needs to be used for generating events adverts from within
iframes, requiring `Access-Control-Allow-Origin: *`. 
<!--
Remember, PRs are documentation for future contributors

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Trello card: [Here](https://trello.com/c/WHMOPLcQ/686-look-into-making-a-test-native-template-that-uses-the-existing-live-events-api)

## Changes
* Set `EventAPI` to use `CorsPublicCachedAction`

<!--
If you are making heavy client-side changes, consider manual test the following
critical flow before merging
## Tested in
| Browser | Supporter Stripe checkout | Supporter Paypal checkout | Stripe Monthly Contribution |  Paypal Monthly Contribution| Upgrade from Friend to Supporter  |
|---------|---------------------------|---------------------------|-----------------------------|-----------------------------|-----------------------------------|
| IE      |                           |                           |                             |                             |                                   |
| Firefox |                           |                           |                             |                             |                                   |
| Safari  |                           |                           |                             |                             |                                   |
| Chrome  |                           |                           |                             |                             |                                   |

-->

