### PR TITLE
Revise additional COVID text so it appears only on the masterclass page

### DIFF
--- a/frontend/app/views/event/eventsList.scala.html
+++ b/frontend/app/views/event/eventsList.scala.html
@@ -31,7 +31,8 @@
         <div class="l-constrained">
             @* Temporary COVID-19 message *@
             @fragments.event.headerBarCovid(
-                twitterLink="https://twitter.com/guardianlive"
+                twitterLink="https://twitter.com/guardianlive",
+                showFormLink=false
             )
         </div>
 

--- a/frontend/app/views/event/masterclassesList.scala.html
+++ b/frontend/app/views/event/masterclassesList.scala.html
@@ -21,7 +21,8 @@
         <div class="l-constrained">
             @* Temporary COVID-19 message *@
             @fragments.event.headerBarCovid(
-                twitterLink="https://twitter.com/guardianclasses"
+                twitterLink="https://twitter.com/guardianclasses",
+                showFormLink=true
             )
         </div>
 

--- a/frontend/app/views/fragments/event/headerBarCovid.scala.html
+++ b/frontend/app/views/fragments/event/headerBarCovid.scala.html
@@ -4,12 +4,11 @@
     <h2 class="header-bar__title">
         Given the growing concerns over public health and safety due to the developing Coronavirus (COVID-19)
         situation, we have suspended our events programme until 31 May 2020. For updates please follow us on
-        @if(showFormLink == true) {
+        @if(showFormLink) {
             <a href="@twitterLink">Twitter</a>,
             <a href="https://www.theguardian.com/guardian-masterclasses/2015/jan/19/sign-up-to-the-guardian-masterclasses-newsletter">sign up to our newsletter</a>,
             or express your interest in future events <a href="https://guardiannewsampampmedia.formstack.com/forms/masterclasses__express_your_interest_in_this_course">here</a>.
-        }
-        @if(showFormLink == false) {
+        } else {
             <a href="@twitterLink">Twitter</a> or
             <a href="https://www.theguardian.com/guardian-masterclasses/2015/jan/19/sign-up-to-the-guardian-masterclasses-newsletter">sign up to our newsletter</a>.
         }

--- a/frontend/app/views/fragments/event/headerBarCovid.scala.html
+++ b/frontend/app/views/fragments/event/headerBarCovid.scala.html
@@ -1,11 +1,17 @@
-@(twitterLink: String)
+@(twitterLink: String, showFormLink: Boolean)
 
 <section class="header-bar">
     <h2 class="header-bar__title">
         Given the growing concerns over public health and safety due to the developing Coronavirus (COVID-19)
         situation, we have suspended our events programme until 31 May 2020. For updates please follow us on
-        <a href="@twitterLink">Twitter</a>,
-        <a href="https://www.theguardian.com/guardian-masterclasses/2015/jan/19/sign-up-to-the-guardian-masterclasses-newsletter">sign up to our newsletter</a>,
-        or express your interest in future events <a href="https://guardiannewsampampmedia.formstack.com/forms/masterclasses__express_your_interest_in_this_course">here</a>.
+        @if(showFormLink == true) {
+            <a href="@twitterLink">Twitter</a>,
+            <a href="https://www.theguardian.com/guardian-masterclasses/2015/jan/19/sign-up-to-the-guardian-masterclasses-newsletter">sign up to our newsletter</a>,
+            or express your interest in future events <a href="https://guardiannewsampampmedia.formstack.com/forms/masterclasses__express_your_interest_in_this_course">here</a>.
+        }
+        @if(showFormLink == false) {
+            <a href="@twitterLink">Twitter</a> or
+            <a href="https://www.theguardian.com/guardian-masterclasses/2015/jan/19/sign-up-to-the-guardian-masterclasses-newsletter">sign up to our newsletter</a>.
+        }
     </h2>
 </section>


### PR DESCRIPTION
## Why are you doing this?
This is a fix to a previous piece of work. There is an additional link to a form for people to express interest in future masterclasses, and this should appear only on the masterclass page, and not the events page.

Here is a link to the PR that introduced the error: https://github.com/guardian/membership-frontend/pull/1920

## Screenshots
![localhost_9100_events(desktop) (1)](https://user-images.githubusercontent.com/16781258/78267231-a2332f00-74fe-11ea-9e24-83c15ef80a3c.png)

![localhost_9100_masterclasses(desktop)](https://user-images.githubusercontent.com/16781258/78267254-a9f2d380-74fe-11ea-88a2-9eeddf9a1320.png)
