### PR TITLE
make nginx hit membership on http as well as https

### DIFF
--- a/nginx/membership.conf
+++ b/nginx/membership.conf
@@ -1,4 +1,13 @@
 server {
+  server_name mem.thegulocal.com;
+
+  location / {
+    proxy_pass http://localhost:9100/;
+      proxy_set_header Host $http_host;
+  }
+}
+
+server {
     listen 443 ssl;
     server_name mem.thegulocal.com;
 


### PR DESCRIPTION
## Why are you doing this?
I was getting promo instead of membership when running with dev nginx locally.
This is because nginx defaults to the first server block if it can't match host AND proto.  And we only had https defined and I was hitting http.

https://github.com/guardian/dev-nginx/pull/17 has more info