### PR TITLE
Temporarily remove event healthcheck

### DIFF
--- a/frontend/app/controllers/Healthcheck.scala
+++ b/frontend/app/controllers/Healthcheck.scala
@@ -19,7 +19,7 @@ class BoolTest(name: String, exec: () => Boolean) extends Test {
 class Healthcheck(eventbriteService: EventbriteCollectiveServices, touchpointBackends: TouchpointBackends, override protected val controllerComponents: ControllerComponents) extends BaseController {
 
   def tests = Seq(
-    new BoolTest("Events", () => eventbriteService.guardianLiveEventService.events.nonEmpty),
+    //new BoolTest("Events", () => eventbriteService.guardianLiveEventService.events.nonEmpty),
     new BoolTest("CloudWatch", () => CloudWatchHealth.hasPushedMetricSuccessfully),
     new BoolTest("ZuoraPing", () => touchpointBackends.Normal.zuoraSoapClient.lastPingTimeWithin(2.minutes)),
     new BoolTest("Salesforce", () => touchpointBackends.Normal.salesforceService.isAuthenticated)


### PR DESCRIPTION
## Why are you doing this?
<!--
Please do not forget to log the amount of hours you spent in this PR here:
https://docs.google.com/spreadsheets/d/1DO24_EkHI3emwTSXpnkwWGhKf7n_9VDcGu0g4kdfUD0/edit#gid=0
-->
To bring back membership frontend while we're running no live events.
<!--
Remember, PRs are documentation for future contributors

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Trello card: [Here](https://trello.com)

## Changes
* Change 1
* Change 2

<!--
If you are making heavy client-side changes, consider manual test the following
critical flow before merging
## Tested in
| Browser | Supporter Stripe checkout | Supporter Paypal checkout | Stripe Monthly Contribution |  Paypal Monthly Contribution| Upgrade from Friend to Supporter  |
|---------|---------------------------|---------------------------|-----------------------------|-----------------------------|-----------------------------------|
| IE      |                           |                           |                             |                             |                                   |
| Firefox |                           |                           |                             |                             |                                   |
| Safari  |                           |                           |                             |                             |                                   |
| Chrome  |                           |                           |                             |                             |                                   |

-->

## Screenshots
