### PR TITLE
remove doc to log your hours from the template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,4 @@
 ## Why are you doing this?
-<!--
-Please do not forget to log the amount of hours you spent in this PR here:
-https://docs.google.com/spreadsheets/d/1DO24_EkHI3emwTSXpnkwWGhKf7n_9VDcGu0g4kdfUD0/edit#gid=0
--->
 
 <!--
 Remember, PRs are documentation for future contributors


### PR DESCRIPTION
## Why are you doing this?
This was introduced at the time of the membership play upgrade to try to make a case to turn this off, but it's not really being used, so it's just causing extra hassle!
