### PR TITLE
Increase specificity of membership event element

### DIFF
--- a/frontend/assets/stylesheets/event-card.scss
+++ b/frontend/assets/stylesheets/event-card.scss
@@ -21,6 +21,9 @@
     }
     .membership-event__action {
         padding-top: 0;
+        .membership-event__button{
+            color: $white;
+        }
     }
     .membership-event__header {
         color: $white;


### PR DESCRIPTION
## Why are you doing this?
The `.membership-event__button` was being incorrectly styled on some
pages due to `frontend` styling having a higher specificity than the
`membership-frontend` CSS. This increases the specificity of the event
card button so that its font colouring is correct.
<!--
Remember, PRs are documentation for future contributors

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Trello card: [Here](https://trello.com/c/HmR3E6wW/831-broken-styling-on-membership-events-aside)

## Changes
* Update CSS to increase specificity

<!--
If you are making heavy client-side changes, consider manual test the following
critical flow before merging
## Tested in
| Browser | Supporter Stripe checkout | Supporter Paypal checkout | Stripe Monthly Contribution |  Paypal Monthly Contribution| Upgrade from Friend to Supporter  |
|---------|---------------------------|---------------------------|-----------------------------|-----------------------------|-----------------------------------|
| IE      |                           |                           |                             |                             |                                   |
| Firefox |                           |                           |                             |                             |                                   |
| Safari  |                           |                           |                             |                             |                                   |
| Chrome  |                           |                           |                             |                             |                                   |

-->

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/9122944/83282351-5d133c80-a1d1-11ea-9b1e-118c4c58bbb2.png)

### After
![image](https://user-images.githubusercontent.com/9122944/83282256-3a812380-a1d1-11ea-8434-d7cea6b4cb68.png)
