### PR TITLE
Add privacy policy link alongside terms and conditions

### DIFF
--- a/frontend/app/views/fragments/event/terms.scala.html
+++ b/frontend/app/views/fragments/event/terms.scala.html
@@ -1,3 +1,4 @@
 @(event: model.RichEvent.RichEvent)
+@import configuration.Links
 
-By proceeding, you agree to the @event.metadata.title <a href="@event.metadata.termsUrl" target="_blank">Terms and Conditions</a>
+By proceeding, you agree to the @event.metadata.title <a href="@event.metadata.termsUrl" target="_blank">Terms and Conditions</a>. To find out what personal data we collect and how we use it, please visit our <a href="@Links.guardianPrivacyPolicy" target="_blank">Privacy Policy</a>.


### PR DESCRIPTION
## Why are you doing this?

Trello: https://trello.com/c/EedY0f8J/3025-add-privacy-link-to-masterclass-events

This PR adds our "Privacy Policy" link alongside the terms and conditions in the template `terms.scala.html`. `terms.scala.html` is imported as `@fragments.event.terms(event)` by `eventDetail.scala.html` and `infoPanel.scala.html`.

The required URL is already exposed as `@Links.guardianPrivacyPolicy`

## Screenshots

**Event details: desktop**

<img width="1142" alt="Screenshot 2020-06-02 at 15 45 13" src="https://user-images.githubusercontent.com/1590704/83535336-c785ee80-a4e9-11ea-816f-9c5f13029cec.png">

**Event details: tablet**

<img width="557" alt="Screenshot 2020-06-02 at 15 46 50" src="https://user-images.githubusercontent.com/1590704/83535376-cf459300-a4e9-11ea-95b7-774c26eae932.png">

**Event details: mobile**

<img width="394" alt="Screenshot 2020-06-02 at 15 46 09" src="https://user-images.githubusercontent.com/1590704/83535420-d5d40a80-a4e9-11ea-84e6-40db46c5947d.png">

**Info panel**

<img width="300" alt="Screenshot 2020-06-02 at 15 48 19" src="https://user-images.githubusercontent.com/1590704/83535444-dc628200-a4e9-11ea-8255-cbd8a1cd15ca.png">

