### PR TITLE
Disable feature warnings

### DIFF
--- a/frontend/app/services/TouchpointBackend.scala
+++ b/frontend/app/services/TouchpointBackend.scala
@@ -63,7 +63,7 @@ object TouchpointBackend {
     // extendedRunner sets the configurable read timeout, which is used for the createSubscription call.
     val extendedRunner = RequestRunners.configurableFutureRunner(20.seconds)
 
-    val zuoraSoapClient = new ClientWithFeatureSupplier(FeatureChoice.codes, config.zuoraSoap, runner, extendedRunner)
+    val zuoraSoapClient = new ClientWithFeatureSupplier(Set.empty, config.zuoraSoap, runner, extendedRunner)
     val discounter = new Discounter(Config.discountRatePlanIds(config.zuoraEnvName))
     val zuoraSoapService = new ZuoraSoapServiceImpl(zuoraSoapClient)
     val zuoraRestService = new ZuoraRestService[Future]


### PR DESCRIPTION
Related PR: https://github.com/guardian/membership-common/pull/616

This is related to [`ZuoraSoapService#getFeatures`](https://github.com/guardian/membership-common/blob/436462503fed218800bdb0989c37b5aef24abf15/src/main/scala/com/gu/zuora/ZuoraSoapService.scala#L236) which seems to be [dead](https://github.com/search?q=org%3Aguardian+getFeatures&type=Code) and removing it would result in simplifications of membership-common, in particular weakening dependency on 

```
"com.typesafe.akka" %% "akka-agent" % "2.5.30"
```

which is deprecated.


https://github.com/guardian/membership-common/blob/436462503fed218800bdb0989c37b5aef24abf15/src/main/scala/com/gu/zuora/soap/ClientWithFeatureSupplier.scala#L28


```
class ClientWithFeatureSupplier(
    featureCodes: Set[Code],
    apiConfig: ZuoraSoapConfig,
    httpClient: FutureHttpClient,
    extendedHttpClient: FutureHttpClient,
    metrics: ZuoraMetrics = NoOpZuoraMetrics
)(implicit actorSystem: ActorSystem, ec: ExecutionContext)
  extends Client(apiConfig, httpClient, extendedHttpClient, metrics) {

  val featuresSupplier = new FutureSupplier[Seq[Feature]](getFeatures)
  actorSystem.scheduler.schedule(30.minutes, 30.minutes)(featuresSupplier.refresh())

  private def getFeatures: Future[Seq[Feature]] = {
    val featuresF = query[Feature](SimpleFilter("Status", "Active"))
    featuresF.foreach { features =>
      val diff = featureCodes &~ features.map(_.code).toSet
      if (diff.nonEmpty) {
        SafeLogger.error(scrub"Zuora ${apiConfig.envName} is missing the following product features: ${diff.mkString(", ")}. Please update configuration ASAP!")
      }
    }
    featuresF
  }
}
```



