### PR TITLE
actually bump scala uri, also fix EB rate limit and dates

### DIFF
--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -4,8 +4,8 @@ import com.gu.i18n.Country
 import com.gu.memsub.auth.common.MemSub.Google._
 import com.gu.salesforce.Tier
 import com.gu.zuora.api.{InvoiceTemplate, InvoiceTemplates}
-import com.netaporter.uri.Uri
-import com.netaporter.uri.dsl._
+import io.lemonlabs.uri.Uri
+import io.lemonlabs.uri.dsl._
 import com.typesafe.config.ConfigFactory
 import model.Eventbrite.EBEvent
 import services._
@@ -30,7 +30,7 @@ object Config {
 
   val membershipUrl = config.getString("membership.url")
   val membershipSupporterUrl = config.getString("membership.supporter.url")
-  val membershipHost = Uri.parse(Config.membershipUrl).host.get
+  val membershipHost = Uri.parse(Config.membershipUrl).toUrl.hostOption.get
 
   val membersDataAPIUrl = config.getString("members-data-api.url")
 

--- a/frontend/app/configuration/Links.scala
+++ b/frontend/app/configuration/Links.scala
@@ -3,7 +3,7 @@ package configuration
 import com.gu.i18n.CountryGroup
 import com.gu.i18n.CountryGroup.{UK,US,Australia}
 import controllers.routes
-import com.netaporter.uri.dsl._
+import io.lemonlabs.uri.dsl._
 
 object Links {
   val guardianCookiePolicy = "http://www.theguardian.com/info/cookies"

--- a/frontend/app/configuration/Videos.scala
+++ b/frontend/app/configuration/Videos.scala
@@ -1,7 +1,7 @@
 package configuration
 
 import com.gu.memsub.images.{ResponsiveImageGenerator, ResponsiveImageGroup}
-import com.netaporter.uri.dsl._
+import io.lemonlabs.uri.dsl._
 import model.Video
 
 object Videos {

--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -4,8 +4,8 @@ import _root_.services._
 import actions.Fallbacks._
 import actions.{ActionRefiners, CommonActions, OAuthActions, Subscriber, SubscriptionRequest, TouchpointActionRefiners, TouchpointCommonActions}
 import com.gu.googleauth.GoogleAuthConfig
-import com.netaporter.uri.Uri
-import com.netaporter.uri.dsl._
+import io.lemonlabs.uri.Uri
+import io.lemonlabs.uri.dsl._
 import com.gu.monitoring.SafeLogger
 import model.EmbedSerializer._
 import model.Eventbrite.{EBCode, EBEvent}
@@ -145,7 +145,7 @@ class Event(
 
   private def addEventBriteGACrossDomainParam(uri: Uri)(implicit req: RequestHeader): Uri = {
     // https://www.eventbrite.co.uk/support/articles/en_US/Troubleshooting/how-to-enable-cross-domain-and-ecommerce-tracking-with-google-universal-analytics
-    req.cookies.get("_ga").map(_.value.replaceFirst("GA\\d+\\.\\d+\\.", "")).fold(uri)(value => uri & ("_eboga", value))
+    req.cookies.get("_ga").map(_.value.replaceFirst("GA\\d+\\.\\d+\\.", "")).fold(uri)(value => uri.toUrl & ("_eboga", value))
   }
 
   private def redirectMemberToEventbrite(event: RichEvent)(implicit req: SubscriptionRequest[AnyContent] with Subscriber): Future[Result] = {

--- a/frontend/app/controllers/Joiner.scala
+++ b/frontend/app/controllers/Joiner.scala
@@ -15,7 +15,7 @@ import com.gu.salesforce._
 import com.gu.stripe.Stripe
 import com.gu.stripe.Stripe.Serializer._
 import com.gu.zuora.soap.models.errors._
-import com.netaporter.uri.dsl._
+import io.lemonlabs.uri.dsl._
 import com.gu.monitoring.SafeLogger
 import com.gu.monitoring.SafeLogger._
 import configuration.{Config, CopyConfig}

--- a/frontend/app/controllers/MemberOnlyContent.scala
+++ b/frontend/app/controllers/MemberOnlyContent.scala
@@ -3,8 +3,8 @@ package controllers
 import actions.CommonActions
 import com.gu.contentapi.client.model.ContentApiError
 import com.gu.i18n.CountryGroup._
-import com.netaporter.uri.Uri
-import com.netaporter.uri.dsl._
+import io.lemonlabs.uri.Uri
+import io.lemonlabs.uri.dsl._
 import configuration.Config
 import model._
 import play.api.mvc.Results.InternalServerError
@@ -23,7 +23,7 @@ class MemberOnlyContent(contentApiService: GuardianContentService, commonActions
   def membershipContent(referringContentOpt: Option[String] = None) = CachedAction.async { implicit request =>
     referringContentOpt.fold(Future(Redirect((routes.Info.supporterRedirect(None))))){
         referringContent =>
-        contentApiService.contentItemQuery(Uri.parse(referringContent).path.stripPrefix("/")).map { response =>
+        contentApiService.contentItemQuery(Uri.parse(referringContent).path.toString().stripPrefix("/")).map { response =>
           val signInUrl = ((Config.idWebAppUrl / "signin") ? ("returnUrl" -> ("https://theguardian.com/" + referringContent)) ? ("skipConfirmation" -> "true")).toString
           implicit val countryGroup = UK
 

--- a/frontend/app/controllers/MembershipStatus.scala
+++ b/frontend/app/controllers/MembershipStatus.scala
@@ -11,7 +11,7 @@ import forms.MemberForm.supportForm
 import play.api.libs.json.{JsArray, JsString, Json}
 import play.api.mvc._
 import services.{AuthenticationService, TouchpointBackend}
-import com.netaporter.uri.dsl._
+import io.lemonlabs.uri.dsl._
 import play.api.libs.ws.WSClient
 import views.support.{TestTrait, _}
 

--- a/frontend/app/controllers/VanityUrl.scala
+++ b/frontend/app/controllers/VanityUrl.scala
@@ -2,7 +2,7 @@ package controllers
 
 import actions.CommonActions
 import play.api.mvc.{BaseController, ControllerComponents}
-import com.netaporter.uri.dsl._
+import io.lemonlabs.uri.dsl._
 import tracking.RedirectWithCampaignCodes.internalCampaignCode
 
 class VanityUrl(commonActions: CommonActions, override protected val controllerComponents: ControllerComponents) extends BaseController {

--- a/frontend/app/controllers/rest/package.scala
+++ b/frontend/app/controllers/rest/package.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import org.joda.time.DateTimeZone.UTC
 import org.joda.time.format.ISODateTimeFormat.dateTimeNoMillis
 import org.joda.time.DateTime

--- a/frontend/app/filters/RedirectMembersFilter.scala
+++ b/frontend/app/filters/RedirectMembersFilter.scala
@@ -4,7 +4,7 @@ package filters
 import javax.inject.Inject
 
 import akka.stream.Materializer
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import configuration.Config
 import play.api.http.Status.FOUND
 import play.api.mvc.Results.Redirect
@@ -17,7 +17,7 @@ class RedirectMembersFilter(implicit val mat: Materializer) extends Filter {
 
   def apply(nextFilter: RequestHeader => Future[Result])(requestHeader: RequestHeader): Future[Result] = {
     if (requestHeader.host.toLowerCase.startsWith("members.")) {
-      val requestUri = Uri.parse(requestHeader.uri)
+      val requestUri = Uri.parse(requestHeader.uri).toUrl
       val redirectUri = requestUri.query.param(internalCampaignCode) match {
         case None => requestUri.addParam(internalCampaignCode, "MEMBERS_DOMAIN_REDIRECT")
         case _ => requestUri

--- a/frontend/app/model/Destination.scala
+++ b/frontend/app/model/Destination.scala
@@ -1,6 +1,6 @@
 package model
 
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import model.RichEvent.RichEvent
 
 sealed trait Destination

--- a/frontend/app/model/Eventbrite.scala
+++ b/frontend/app/model/Eventbrite.scala
@@ -4,8 +4,8 @@ import com.github.nscala_time.time.Imports._
 import com.gu.i18n.Currency.GBP
 import com.gu.memsub.Price
 import com.gu.salesforce.Tier
-import com.netaporter.uri.Uri
-import com.netaporter.uri.dsl._
+import io.lemonlabs.uri.{Uri, Url}
+import io.lemonlabs.uri.dsl._
 import configuration.Config
 import org.joda.time.Instant
 import org.joda.time.format.ISODateTimeFormat
@@ -33,7 +33,7 @@ object Eventbrite {
     "18882606384" -> "19223927284"
   )
 
-  val googleMapsUri = Uri.parse("https://maps.google.com/")
+  val googleMapsUri = Uri.parse("https://maps.google.com/").toUrl
 
   trait EBObject
 
@@ -258,10 +258,10 @@ object Eventbrite {
       else None
     }
 
-    val mainImageUrl: Option[Uri] = for {
+    val mainImageUrl: Option[Url] = for {
       m <- """\smain-image:\s*(.*?)\s""".r.findFirstMatchIn(ebDescription.description)
       uri <- Try(Uri.parse(m.group(1))) match {
-        case Success(uri) => Some(uri)
+        case Success(uri) => Some(uri.toUrl)
         case Failure(e) =>
           SafeLogger.error(scrub"Event ${ebEvent.id} - can't parse main-image url from text '${m.matched}'", e)
           None

--- a/frontend/app/model/PackagePromo.scala
+++ b/frontend/app/model/PackagePromo.scala
@@ -1,5 +1,5 @@
 package model
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 
 object PackagePromo {
 

--- a/frontend/app/model/ResponsiveImageGroup.scala
+++ b/frontend/app/model/ResponsiveImageGroup.scala
@@ -3,7 +3,7 @@ package model
 import com.gu.contentapi.client.model.v1.{Content, Element}
 import com.gu.memsub.images.{ResponsiveImage, ResponsiveImageGroup => RIG}
 import model.RichEvent.GridImage
-import com.netaporter.uri.dsl._
+import io.lemonlabs.uri.dsl._
 
 case class OrientatedImages(portrait: RIG, landscape: RIG)
 

--- a/frontend/app/model/Video.scala
+++ b/frontend/app/model/Video.scala
@@ -1,7 +1,7 @@
 package model
 
 case class Video(
-  srcUrl: com.netaporter.uri.Uri,
+  srcUrl: io.lemonlabs.uri.Uri,
   posterImage: Option[com.gu.memsub.images.ResponsiveImageGroup],
   autoplay: Boolean = false,
   loop: Boolean = false

--- a/frontend/app/services/DestinationService.scala
+++ b/frontend/app/services/DestinationService.scala
@@ -1,6 +1,6 @@
 package services
 import com.gu.memsub.Subscriber.Member
-import com.netaporter.uri.dsl._
+import io.lemonlabs.uri.dsl._
 import configuration.Config
 import model.Eventbrite.EBCode
 import model.RichEvent.RichEvent
@@ -34,8 +34,8 @@ class DestinationService[M[+_] : Monad](
     * then lets find the bit of content they want to see and send them back to it
     */
   def contentDestinationFor(session: Session): M[Option[ContentDestination]] = (for {
-    guardianReferrer <- OptionT(session.get(DestinationService.JoinReferrer).filter(_.host.contains(Config.guardianHost)).point[M])
-    contentItem <- OptionT(capiItemQuery(guardianReferrer.path).map(resp => resp.content.map(ContentItem).map(ContentDestination)))
+    guardianReferrer <- OptionT(session.get(DestinationService.JoinReferrer).map(_.toUrl).filter(_.hostOption.map(_.value).contains(Config.guardianHost)).point[M])
+    contentItem <- OptionT(capiItemQuery(guardianReferrer.path.toString()).map(resp => resp.content.map(ContentItem).map(ContentDestination)))
   } yield contentItem).run
 
   /**

--- a/frontend/app/services/GridService.scala
+++ b/frontend/app/services/GridService.scala
@@ -2,19 +2,21 @@ package services
 
 import java.util.concurrent.atomic.AtomicReference
 import java.util.function.UnaryOperator
+
 import com.gu.memsub.images.Grid
 import com.gu.memsub.images.Grid.{Export, GridObject, GridResult}
 import com.gu.memsub.images.GridDeserializer._
 import com.gu.memsub.util.WebServiceHelper
 import com.gu.okhttp.RequestRunners
 import com.gu.okhttp.RequestRunners.FutureHttpClient
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.{Uri, Url}
 import com.gu.monitoring.SafeLogger
 import com.gu.monitoring.SafeLogger._
 import configuration.Config
 import model.RichEvent.GridImage
 import okhttp3.Request
 import play.api.libs.json.Json
+
 import scala.concurrent.{ExecutionContext, Future}
 
 object GridService {
@@ -26,9 +28,9 @@ object GridService {
   object ImageIdWithCrop {
     implicit val writesImageIdWithCrop = Json.writes[ImageIdWithCrop]
 
-    def fromGuToolsUri(uri: Uri): Option[ImageIdWithCrop] =
+    def fromGuToolsUri(uri: Url): Option[ImageIdWithCrop] =
       for {
-        imageId <- uri.path.split("/").lastOption
+        imageId <- uri.path.toString().split("/").lastOption
         crop <-  uri.query.param(CropQueryParam)
         if uri.toString().startsWith(gridUrl)
       } yield ImageIdWithCrop(imageId, crop)

--- a/frontend/app/services/TouchpointBackend.scala
+++ b/frontend/app/services/TouchpointBackend.scala
@@ -18,7 +18,7 @@ import com.gu.zuora.api.ZuoraService
 import com.gu.zuora.rest.{SimpleClient, ZuoraRestService}
 import com.gu.zuora.soap.ClientWithFeatureSupplier
 import com.gu.zuora.{soap, ZuoraSoapService => ZuoraSoapServiceImpl}
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import com.gu.monitoring.SafeLogger
 import com.gu.monitoring.SafeLogger._
 import configuration.Config

--- a/frontend/app/views/support/Dates.scala
+++ b/frontend/app/views/support/Dates.scala
@@ -44,7 +44,8 @@ object Dates {
   def prettyDate(dt: DateTime): String = dt.toString("d MMMMM YYYY")
   def prettyDate(dt: LocalDate): String = dt.toString("d MMMMM YYYY")
   def prettyDateNoYear(dt: DateTime): String = dt.withZone(DateTimeZone.forID("Europe/London")).toString("d MMMMM")
-  def prettyTime(dt: DateTime): String = dt.toString(if (dt.getMinuteOfHour==0) "h" else "h.mm") + dt.toString("a").toLowerCase + " " + dt.toString("z")
+  def prettyTime(dt: DateTime): String = dt.toString(if (dt.getMinuteOfHour==0) "h" else "h.mm") + dt.toString("a").toLowerCase
+  def timezone(dt: DateTime): String = " " + dt.toString("z")
 
   def prettyDateWithTime(dt: DateTime): String = prettyDate(dt) + ", " + prettyTime(dt)
   def prettyDateNoYearTime(dt: DateTime): String = prettyDateNoYear(dt) + ", " + prettyTime(dt)
@@ -101,7 +102,7 @@ object Dates {
 
   def dateTimeRange(interval: Interval): String = {
     if (interval.isSameDay) {
-      prettyDateWithTimeAndDayName(interval.start) + "–" + prettyTime(interval.end)
+      prettyDateWithTimeAndDayName(interval.start) + "–" + prettyTime(interval.end) + timezone(interval.start)
     } else {
       val range = multiDateRangeFormatter(interval, "EEEE d MMMMM YYYY")
       range.start + "–" + range.end

--- a/frontend/app/views/support/PackagePromo.scala
+++ b/frontend/app/views/support/PackagePromo.scala
@@ -2,8 +2,8 @@ package views.support
 
 import com.gu.i18n.CountryGroup
 import com.gu.salesforce.{FreeTier, PaidTier, Tier}
-import com.netaporter.uri.Uri
-import com.netaporter.uri.dsl._
+import io.lemonlabs.uri.Uri
+import io.lemonlabs.uri.dsl._
 import controllers.routes
 import model.PackagePromo.CtaButton
 import play.twirl.api.Html
@@ -17,8 +17,8 @@ object PackagePromo {
   def forCountryTier(t: Tier, cg: CountryGroup, promoCode: Option[String]) = {
 
     val link = (t match {
-      case p: PaidTier => Uri.parse(routes.Joiner.enterPaidDetails(p).url)
-      case _: FreeTier => Uri.parse(routes.Joiner.enterFriendDetails().url)
+      case p: PaidTier => Uri.parse(routes.Joiner.enterPaidDetails(p).url).toUrl
+      case _: FreeTier => Uri.parse(routes.Joiner.enterFriendDetails().url).toUrl
     }) ? ("countryGroup" -> cg.id) & ("promoCode" -> promoCode)
 
     val attrs = Map[String, String](

--- a/frontend/conf/CODE.public.conf
+++ b/frontend/conf/CODE.public.conf
@@ -8,3 +8,6 @@ google.oauth.callback="https://membership.code.dev-theguardian.com/oauth2callbac
 identity.webapp.url="https://profile.code.dev-theguardian.com"
 
 membership.url = "https://membership.code.dev-theguardian.com"
+
+eventbrite.api.refresh-time-seconds=3599
+eventbrite.api.refresh-time-priority-events-seconds=3501

--- a/frontend/conf/DEV.public.conf
+++ b/frontend/conf/DEV.public.conf
@@ -54,3 +54,6 @@ google.adwords.joiner.conversion {
     partner=""
     patron=""
 }
+
+eventbrite.api.refresh-time-seconds=3599
+eventbrite.api.refresh-time-priority-events-seconds=3501

--- a/frontend/conf/PROD.public.conf
+++ b/frontend/conf/PROD.public.conf
@@ -52,3 +52,6 @@ google.adwords.joiner.conversion {
 }
 
 logstash.enabled=false
+
+eventbrite.api.refresh-time-seconds=299
+eventbrite.api.refresh-time-priority-events-seconds=119

--- a/frontend/conf/application.conf
+++ b/frontend/conf/application.conf
@@ -27,8 +27,6 @@ eventbrite.url="https://www.eventbrite.co.uk"
 eventbrite.api.url="https://eventbrite-proxy.guardianapis.com/v3"
 
 eventbrite.api.iframe-url="https://www.eventbrite.com/tickets-external?ref=etckt&v=2"
-eventbrite.api.refresh-time-seconds=59
-eventbrite.api.refresh-time-priority-events-seconds=29
 eventbrite.waitlist.url="https://www.eventbrite.co.uk/waitlist"
 eventbrite.limitedAvailabilityCutoff=15
 

--- a/frontend/test/model/EBEventTest.scala
+++ b/frontend/test/model/EBEventTest.scala
@@ -1,6 +1,6 @@
 package model
 
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import model.Eventbrite._
 import model.EventbriteDeserializer._
 import org.joda.time.Instant

--- a/frontend/test/services/DestinationServiceTest.scala
+++ b/frontend/test/services/DestinationServiceTest.scala
@@ -45,7 +45,8 @@ class DestinationServiceTest extends Specification {
         mailingState= None,
         mailingPostcode= None,
         mailingCountry= None,
-        recordTypeId = None
+        recordTypeId = None,
+        deliveryInstructions = None
       )
       val partnerCharge: PaidCharge[Partner.type, Month.type] = PaidCharge[Partner.type, Month.type](Partner, Month, PricingSummary(Map(GBP -> Price(0.1f, GBP))), ProductRatePlanChargeId("prpcId"),SubscriptionRatePlanChargeId("srpcid"))
       val testSub: Subscription[SubscriptionPlan.Member] = new Subscription[SubscriptionPlan.Partner](

--- a/frontend/test/services/GridServiceTest.scala
+++ b/frontend/test/services/GridServiceTest.scala
@@ -1,7 +1,7 @@
 package services
 
-import com.netaporter.uri.Uri
-import com.netaporter.uri.dsl._
+import io.lemonlabs.uri.{Uri, Url}
+import io.lemonlabs.uri.dsl._
 import com.gu.memsub.images.Grid.GridResult
 import com.gu.memsub.images.GridDeserializer._
 import org.specs2.concurrent.ExecutionEnv
@@ -12,7 +12,7 @@ import utils.Resource
 class GridServiceTest(implicit ev: ExecutionEnv) extends Specification {
   import GridService.ImageIdWithCrop
 
-  val validGridUrl: Uri = "https://media.gutools.co.uk/images/aef2fb1db22f7cd20683548719a2849b3c9962ec?crop=0_19_480_288"
+  val validGridUrl: Url = "https://media.gutools.co.uk/images/aef2fb1db22f7cd20683548719a2849b3c9962ec?crop=0_19_480_288".toUrl
 
   "ImageIdWithCrop" should {
     "build only from valid urls" in {

--- a/frontend/test/views/support/DatesTest.scala
+++ b/frontend/test/views/support/DatesTest.scala
@@ -8,20 +8,20 @@ class DatesTest extends Specification {
 
   "prettyTime" should {
     "respect Guardian style: 1am, 6.30pm, etc" in {
-      Dates.prettyTime(new DateTime(2015, 3, 22,  1,  0)) mustEqual "1am GMT"
-      Dates.prettyTime(new DateTime(2015, 3, 22, 18, 30)) mustEqual "6.30pm GMT"
+      Dates.prettyTime(new DateTime(2015, 3, 22,  1,  0)) mustEqual "1am"
+      Dates.prettyTime(new DateTime(2015, 3, 22, 18, 30)) mustEqual "6.30pm"
     }
   }
 
   "dateRange" should {
     "respect Guardian style on date ranges" in {
       val interval = new Interval(new DateTime(2015, 3, 22, 14, 45),  new DateTime(2015, 3, 22, 17,  0))
-      Dates.dateTimeRange(interval) mustEqual "Sunday 22 March 2015, 2.45pm GMT–5pm GMT"
+      Dates.dateTimeRange(interval) mustEqual "Sunday 22 March 2015, 2.45pm–5pm GMT"
     }
 
     "merge date if both dates are on the same day" in {
       val interval = new Interval(new DateTime(2014, 11, 6, 10, 20),  new DateTime(2014, 11, 6, 12, 30))
-      Dates.dateTimeRange(interval) mustEqual "Thursday 6 November 2014, 10.20am GMT–12.30pm GMT"
+      Dates.dateTimeRange(interval) mustEqual "Thursday 6 November 2014, 10.20am–12.30pm GMT"
     }
 
     "merge month and year if both are the same" in {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   val scalaUri = "io.lemonlabs" %% "scala-uri" % "2.2.2"
   val identityAuthPlay = "com.gu.identity" %% "identity-auth-play" % "3.184-M7"
   val identityTestUsers = "com.gu" %% "identity-test-users" % "0.6"
-  val membershipCommon = "com.gu" %% "membership-common" % "0.550"
+  val membershipCommon = "com.gu" %% "membership-common" % "0.567"
   val contentAPI = "com.gu" %% "content-api-client-default" % "14.1"
   val playWS = PlayImport.ws
   val playFilters = PlayImport.filters


### PR DESCRIPTION
## Why are you doing this?

second attempt at scala uri bump, the old one was still being picked up from membership-common as the package names and maven artifact names are different, so it didn't evict the old one and kept using it.

first attempt here: https://github.com/guardian/membership-frontend/pull/1939

I also tweaked the dates a bit more based on further comments.
![image](https://user-images.githubusercontent.com/7304387/84410756-fdbc2000-ac05-11ea-83d8-3dcbaeba2859.png)


I have also reduced the refresh time for event brite to try to improve the rate limit errors.  It will refresh every 5 mins instead of every minute.