### PR TITLE
Set up geocountry route on membership-frontend

### DIFF
--- a/frontend/app/controllers/GeoCountry.scala
+++ b/frontend/app/controllers/GeoCountry.scala
@@ -1,0 +1,15 @@
+package controllers
+
+import actions.CommonActions
+import play.api.mvc.{BaseController, ControllerComponents}
+import utils.RequestCountry._
+
+class GeoCountry(commonActions: CommonActions,  override protected val controllerComponents: ControllerComponents) extends BaseController {
+  import commonActions.NoCacheAction
+
+  def getCountry () = NoCacheAction {
+    request =>
+      Ok(request.getFastlyCountry.map(_.alpha2).getOrElse("Missing Country"))
+
+  }
+}

--- a/frontend/app/wiring/AppComponents.scala
+++ b/frontend/app/wiring/AppComponents.scala
@@ -115,7 +115,8 @@ trait AppComponents
       new PricingApi(touchpointBackends, commonActions, controllerComponents),
       new Giraffe(commonActions, controllerComponents),
       new MembershipStatus(wsClient, defaultBodyParser, executionContext, googleAuthConfig, commonActions, controllerComponents),
-      new PayPal(touchpointBackends, executionContext, commonActions, controllerComponents)
+      new PayPal(touchpointBackends, executionContext, commonActions, controllerComponents),
+      new GeoCountry(commonActions, controllerComponents)
     )
   }
 

--- a/frontend/build-tc.sh
+++ b/frontend/build-tc.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 echo ${BUILD_NUMBER:-DEV} > conf/build.txt
 
+export NVM_DIR="$HOME/.nvm"
+[[ -s "$NVM_DIR/nvm.sh" ]] && . "$NVM_DIR/nvm.sh"  # This loads nvm
+
+nvm install
+nvm use
+
 # put the init-instance.sh script into the riff-raff package so that it ends up in S3 ready
 # to be fetched by the instance on boot
 # the special ##teamcity command causes teamcity to write it to the build output

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -141,3 +141,6 @@ POST        /paypal/setup-payment                      controllers.PayPal.setupP
 POST        /paypal/create-agreement                   controllers.PayPal.createAgreement
 GET         /paypal/return                             controllers.PayPal.returnUrl
 GET         /paypal/cancel                             controllers.PayPal.cancelUrl
+
+# Geo Country
+GET         /geocountry                              controllers.GeoCountry.getCountry()


### PR DESCRIPTION
## Why are you doing this?

This PR introduces a new `/geocountry` route to membership frontend, this is required so we can retrieve the users' country code, which is necessary for knowing which CMP to present them with.