### PR TITLE
remove bing tracking pixel from twirl template

### DIFF
--- a/frontend/app/views/fragments/javaScriptLaterSteps.scala.html
+++ b/frontend/app/views/fragments/javaScriptLaterSteps.scala.html
@@ -14,4 +14,3 @@
         }
     };
 </script>
-<noscript><img src="//bat.bing.com/action/0?ti=5039324&Ver=2" height="0" width="0" style="display:none; visibility: hidden;" /></noscript>


### PR DESCRIPTION
## Why are you doing this?

This PR removes the Bing Ads tracking pixel dropped in the event this `<noscript>` tag is used. Without JS being enabled we can't say whether the user has consented to tracking pixels related to personalised advertising, so we should assume they haven't consented and not drop this pixel. The rest of the Bing Ads implementation is already behind a consent check in the client-side code.