### PR TITLE
Add twitter:image meta tag

### DIFF
--- a/frontend/app/views/main.scala.html
+++ b/frontend/app/views/main.scala.html
@@ -44,6 +44,9 @@
         <meta property="fb:app_id" content="@Config.facebookAppId"/>
         <meta name="twitter:site" content="@@@Social.twitterUsername"/>
         <meta name="twitter:card" content="summary"/>
+        @for(pageImage <- pageInfo.image) {
+            <meta property="twitter:image" content="@pageImage"/>
+        }
         <meta name="google-site-verification" content="qf7V0ceP_mY_0jTl7R7C1wZSKn2gK7TlharWVLr8Ea0" />
         <meta name="google-site-verification" content="usCUaIJGNg9ijq-htmMAU6yEhAwNm7wdyb_fk_s2LTQ" />
 


### PR DESCRIPTION
## Why are you doing this?

Include the `twitter:image` meta tag to enhance twitter cards for membership pages, as recommended here: https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/summary

The implementation is a copy of the technique used in the same template for the `og:image` meta tag, here: https://github.com/guardian/membership-frontend/blob/1dae3e0d0e6d3489a65af4ca913690d1d515c856/frontend/app/views/main.scala.html#L38

Hopefully this will enhance tweets for these pages with the image, compared to what we see at the moment:

<img width="457" alt="Screenshot 2020-08-03 at 12 57 33" src="https://user-images.githubusercontent.com/1590704/89180097-f28fcb80-d588-11ea-8828-853a807ffd00.png">

