### PR TITLE
correct reference to CD branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ These are browser driving Selenium tests.
 
 ## Deployment
 
-We use continuous deployment of the `master` branch to Production (https://membership.theguardian.com/).
+We use continuous deployment of the `main` branch to Production (https://membership.theguardian.com/).
 See [fix-a-failed-deploy.md](https://github.com/guardian/riff-raff/blob/master/riff-raff/public/docs/howto/fix-a-failed-deploy.md)
 for what to do if a deploy goes bad.
 


### PR DESCRIPTION
I have been changing the default branch to "main" and this is an out of date reference in the readme.
instructions here:
https://docs.google.com/document/d/1nqC5Uk6n3y7S79m1yiG6oqT8NtXWpDcsS-uLI_RK7Mg/edit#

This PR is also useful to test the release pipeline still works!