### PR TITLE
Disable tracking/conversion pixels

### DIFF
--- a/frontend/app/views/fragments/analytics/appNexusPixel.scala.html
+++ b/frontend/app/views/fragments/analytics/appNexusPixel.scala.html
@@ -1,7 +1,7 @@
 @(parameterName: String, appNexusID: Option[Int])
 @for(id <- appNexusID){
     <!-- Segment Pixel - Jan17 - DO NOT MODIFY -->
-    <img class="app-nexus-pixel" src="https://secure.adnxs.com/px?@parameterName=@id&t=2" width="1" height="1"/>
+    <!--img class="app-nexus-pixel" src="https://secure.adnxs.com/px?@parameterName=@id&t=2" width="1" height="1"/ -->
     <!-- End of Segment Pixel -->
 }
 

--- a/frontend/app/views/fragments/analytics/facebookEventTicketSale.scala.html
+++ b/frontend/app/views/fragments/analytics/facebookEventTicketSale.scala.html
@@ -3,7 +3,7 @@
 @import configuration.Config
 
 @if(Config.stage == "PROD") {
-    <script>
+    <!-- <script>
         (function() {
             var _fbq = window._fbq || (window._fbq = []);
             if (!_fbq.loaded) {
@@ -20,8 +20,7 @@
             'value': '0.00',
             'currency': 'GBP'
         }]);
-    </script>
-    <noscript><img height="1" width="1" alt="" style="display:none" src="https://www.facebook.com/tr?ev=@Config.facebookEventTicketSaleTrackingId&amp;cd[value]=0.00&amp;cd[currency]=GBP&amp;noscript=1" />
-    </noscript>
-
+    </script> -->
+    <!-- <noscript><img height="1" width="1" alt="" style="display:none" src="https://www.facebook.com/tr?ev=@Config.facebookEventTicketSaleTrackingId&amp;cd[value]=0.00&amp;cd[currency]=GBP&amp;noscript=1" />
+    </noscript> -->
 }

--- a/frontend/app/views/fragments/analytics/facebookJoinerConversion.scala.html
+++ b/frontend/app/views/fragments/analytics/facebookJoinerConversion.scala.html
@@ -1,9 +1,9 @@
 @(tier: com.gu.salesforce.Tier)
 
 @import configuration.Config
-    
+
 @for(trackingId <- Config.facebookJoinerConversionTrackingId.get(tier) if Config.stage == "PROD") {
-    <script>
+    <!-- <script>
         (function() {
             var _fbq = window._fbq || (window._fbq = []);
             if (!_fbq.loaded) {
@@ -18,5 +18,5 @@
         window._fbq = window._fbq || [];
         window._fbq.push(['track', '@trackingId', {'value': '0.00', 'currency': 'GBP'}]);
     </script>
-    <noscript><img height="1" width="1" alt="" style="display:none" src="https://www.facebook.com/tr?ev=@trackingId&amp;cd[value]=0.00&amp;cd[currency]=GBP&amp;noscript=1" /></noscript>
+    <noscript><img height="1" width="1" alt="" style="display:none" src="https://www.facebook.com/tr?ev=@trackingId&amp;cd[value]=0.00&amp;cd[currency]=GBP&amp;noscript=1" /></noscript> -->
 }

--- a/frontend/app/views/fragments/analytics/googleEventPurchaseConversion.scala.html
+++ b/frontend/app/views/fragments/analytics/googleEventPurchaseConversion.scala.html
@@ -1,7 +1,7 @@
 @import configuration.Config
 
 @if(Config.stage == "PROD") {
-    <div class="is-hidden">
+    <!-- <div class="is-hidden">
         <script type="text/javascript">
             var google_conversion_id = 967211513;
             var google_conversion_language = "en";
@@ -17,5 +17,5 @@
                 <img height="1" width="1" style="border-style : none ;" alt="" src="//www.googleadservices.com/pagead/conversion/967211513/?label=vQrdCNWe2VYQ-fOZzQM&amp;guid=ON&amp;script=0"/>
             </div>
         </noscript>
-    </div>
+    </div> -->
 }

--- a/frontend/app/views/fragments/analytics/googleJoinerConversion.scala.html
+++ b/frontend/app/views/fragments/analytics/googleJoinerConversion.scala.html
@@ -3,7 +3,7 @@
 @import configuration.Config
 
 @for(label <- Config.googleAdwordsJoinerConversionLabel.get(tier) if Config.stage == "PROD") {
-    <div class="is-hidden">
+    <!-- <div class="is-hidden">
         <script type="text/javascript">
             var google_conversion_id = 967211513;
             var google_conversion_language = "en";
@@ -18,5 +18,5 @@
                 <img height="1" width="1" style="border-style:none;" alt="" src="//www.googleadservices.com/pagead/conversion/967211513/?label=@label&amp;guid=ON&amp;script=0"/>
             </div>
         </noscript>
-    </div>
+    </div> -->
 }


### PR DESCRIPTION
## Why are you doing this?

https://github.com/guardian/membership-frontend/pull/1956 deprecated the membership acquisitions flows by redirecting to support.theguardian.com.

This means we should no longer need the tracking/conversion pixels dropped on the membership acquisitions pages. We also no longer take event bookings on this platform, users book off-platform using eventbrite and do not return to the site to see a confirmation screen. We therefore no-longer need the event-specific tracking/conversion pixels.

This PR comments out references to these tracking/pixels for now. Eventually we should remove all templates/files no longer used. I'm doing this to be sure they're not dropped as these old implementations are not behind consent.