### PR TITLE
Add FAQ links to footer

### DIFF
--- a/frontend/Gruntfile.js
+++ b/frontend/Gruntfile.js
@@ -208,7 +208,7 @@ module.exports = function (grunt) {
                 }
             },
             compile_images: {
-                files: ['<%= dirs.assets.images %>/**/*'],
+                files: ['<%= dirs.assets.images %>/**/*', '!<%= dirs.assets.images %>/inline-svgs/*'],
                 tasks: ['compile:images'],
                 options: {
                     atBegin: true

--- a/frontend/app/configuration/Links.scala
+++ b/frontend/app/configuration/Links.scala
@@ -12,6 +12,9 @@ object Links {
   val guardianLiveTerms = "http://www.theguardian.com/info/2014/sep/09/guardian-live-events-terms-and-conditions"
   val guardianMasterclassesTerms = "http://www.theguardian.com/guardian-masterclasses/terms-and-conditions"
 
+  val guardianLiveFAQs = "https://www.theguardian.com/guardian-masterclasses/2020/aug/27/guardian-live-online-faqs"
+  val guardianMasterclassesFAQs = "https://www.theguardian.com/guardian-masterclasses/2020/jul/20/guardian-masterclasses-faqs"
+
   val membershipFront = "http://www.theguardian.com/membership"
 
   def membershipTerms(countryGroup: Option[CountryGroup] = None) = {

--- a/frontend/app/model/Nav.scala
+++ b/frontend/app/model/Nav.scala
@@ -33,9 +33,9 @@ object Nav {
   )
 
   def footerNavigation(countryGroup: Option[CountryGroup] = None) = List(
-    NavItem("help", routes.Info.help().toString, "Help"),
+    NavItem("masterclassesFAQ", Links.guardianMasterclassesFAQs, "Masterclass FAQ"),
+    NavItem("liveFAQ", Links.guardianLiveFAQs, "GuardianLive FAQ"),
     NavItem("contact", Links.membershipContact, "Contact us"),
-    NavItem("feedback", routes.Info.feedback().toString, "Feedback"),
     NavItem("terms", Links.membershipTerms(countryGroup), "Terms & conditions"),
     NavItem("privacy", Links.guardianPrivacyPolicy, "Privacy policy"),
     NavItem("cookies", Links.guardianCookiePolicy, "Cookie policy")


### PR DESCRIPTION
## Why are you doing this?

We need to add links to the specific FAQ pages for Masterclasses and GuardianLive to the footer, and remove the Help and Feedback links.

## Trello card: [Here](https://trello.com/c/oihkyTrg)

## Changes
* Add the two FAQs links and remove the Help and Feedback links
* Fix `grunt watch` task that was looping due to the SVG minification

## Screenshots

![Screenshot 2020-09-03 at 14 40 20](https://user-images.githubusercontent.com/29146931/92124156-552cef00-edf5-11ea-8ce4-7b8c6e9c04cd.png)

![Screenshot 2020-09-03 at 14 40 48](https://user-images.githubusercontent.com/29146931/92124160-56f6b280-edf5-11ea-80ed-77ec3d622488.png)

![Screenshot 2020-09-03 at 14 33 55](https://user-images.githubusercontent.com/29146931/92124151-54945880-edf5-11ea-8a44-d7fc2df4c93c.png)