### PR TITLE
TCFv2 - Privacy settings link in footer

### DIFF
--- a/frontend/app/views/fragments/global/footer.scala.html
+++ b/frontend/app/views/fragments/global/footer.scala.html
@@ -25,6 +25,9 @@
                         <a class="colophon__link" id="qa-footer-link-@item.id" href="@item.href">@item.title</a>
                     </li>
                 }
+                <li class="colophon__item">
+                    <button class="fake-link colophon__link is-hidden js-privacy-settings-link" id="qa-footer-link-privacySettings">Privacy Settings</button>
+                </li>
             </ul>
             <small class="global-footer__copyright">
                 &copy; @{new DateTime().year.getAsText} Guardian News and Media Limited or its affiliated companies.

--- a/frontend/app/views/fragments/global/footer.scala.html
+++ b/frontend/app/views/fragments/global/footer.scala.html
@@ -26,7 +26,9 @@
                     </li>
                 }
                 <li class="colophon__item">
-                    <button class="fake-link colophon__link is-hidden js-privacy-settings-link" id="qa-footer-link-privacySettings">Privacy Settings</button>
+                    <button class="fake-link colophon__link u-hidden-non-js js-privacy-settings-link" id="qa-footer-link-privacySettings">
+                        Privacy Settings
+                    </button>
                 </li>
             </ul>
             <small class="global-footer__copyright">

--- a/frontend/assets/javascripts/src/modules/analytics/cmp.es6
+++ b/frontend/assets/javascripts/src/modules/analytics/cmp.es6
@@ -38,7 +38,9 @@ const registerCallbackOnConsentChange = (fn) => onConsentChange(fn);
 
 const createPrivacySettingsLink = () => {
     const privacySettingsButton = document.querySelector(PRIVACY_SETTINGS_SELECTOR);
-    privacySettingsButton.addEventListener('click', cmp.showPrivacyManager);
+    if (privacySettingsButton) {
+        privacySettingsButton.addEventListener('click', cmp.showPrivacyManager);
+    }
 }
 
 export { getConsentForVendors, checkAllTCFv2PurposesAreOptedIn, checkCCPA, registerCallbackOnConsentChange, createPrivacySettingsLink };

--- a/frontend/assets/javascripts/src/modules/analytics/cmp.es6
+++ b/frontend/assets/javascripts/src/modules/analytics/cmp.es6
@@ -1,6 +1,5 @@
 import { onConsentChange, cmp } from '@guardian/consent-management-platform';
 
-const HIDDEN_CLASS = 'is-hidden';
 const PRIVACY_SETTINGS_SELECTOR ='.js-privacy-settings-link';
 
 const getConsentForVendors = (cmpVendorIds) => new Promise((resolve) => {
@@ -39,7 +38,6 @@ const registerCallbackOnConsentChange = (fn) => onConsentChange(fn);
 
 const createPrivacySettingsLink = () => {
     const privacySettingsButton = document.querySelector(PRIVACY_SETTINGS_SELECTOR);
-    privacySettingsButton.classList.remove(HIDDEN_CLASS);
     privacySettingsButton.addEventListener('click', cmp.showPrivacyManager);
 }
 

--- a/frontend/assets/javascripts/src/modules/analytics/cmp.es6
+++ b/frontend/assets/javascripts/src/modules/analytics/cmp.es6
@@ -1,4 +1,7 @@
-import { onConsentChange } from '@guardian/consent-management-platform';
+import { onConsentChange, cmp } from '@guardian/consent-management-platform';
+
+const HIDDEN_CLASS = 'is-hidden';
+const PRIVACY_SETTINGS_SELECTOR ='.js-privacy-settings-link';
 
 const getConsentForVendors = (cmpVendorIds) => new Promise((resolve) => {
     if (!Array.isArray(cmpVendorIds)) {
@@ -34,4 +37,10 @@ const checkCCPA = () => new Promise((resolve) => {
 
 const registerCallbackOnConsentChange = (fn) => onConsentChange(fn);
 
-export { getConsentForVendors, checkAllTCFv2PurposesAreOptedIn, checkCCPA, registerCallbackOnConsentChange };
+const createPrivacySettingsLink = () => {
+    const privacySettingsButton = document.querySelector(PRIVACY_SETTINGS_SELECTOR);
+    privacySettingsButton.classList.remove(HIDDEN_CLASS);
+    privacySettingsButton.addEventListener('click', cmp.showPrivacyManager);
+}
+
+export { getConsentForVendors, checkAllTCFv2PurposesAreOptedIn, checkCCPA, registerCallbackOnConsentChange, createPrivacySettingsLink };

--- a/frontend/assets/javascripts/src/modules/analytics/setup.js
+++ b/frontend/assets/javascripts/src/modules/analytics/setup.js
@@ -73,6 +73,7 @@ define([
     }
 
     function init() {
+        cmp.createPrivacySettingsLink();
         if (analyticsEnabled && !guardian.isDev) {
             cmp.registerCallbackOnConsentChange(loadTrackers);
         }


### PR DESCRIPTION
## Why are you doing this?

We need a way for users to surface the privacy settings modal and amend their preferences at any time.

## Trello card: [Here](https://trello.com/c/dg5nTUPE)

## Changes
* Added button to footer that surfaces the privacy settings modal

## Screenshots

**Mobile**
![Screenshot 2020-09-04 at 17 05 22](https://user-images.githubusercontent.com/29146931/92261699-d063d300-eed1-11ea-929f-28d336f90248.png)

**Tablet**
![Screenshot 2020-09-04 at 17 05 57](https://user-images.githubusercontent.com/29146931/92261710-d2c62d00-eed1-11ea-9a99-019dcf0959f2.png)

**Desktop**
![Screenshot 2020-09-04 at 17 04 17](https://user-images.githubusercontent.com/29146931/92261709-d2c62d00-eed1-11ea-93c0-21a383d3d8ae.png)

**Desktop - no Javascript**
![Screenshot 2020-09-04 at 17 23 48](https://user-images.githubusercontent.com/29146931/92262812-94ca0880-eed3-11ea-945e-cb7ed40755df.png)
