### PR TITLE
Fixing GA to load when all consents have been agreed to

### DIFF
--- a/frontend/assets/javascripts/src/modules/analytics/cmp.es6
+++ b/frontend/assets/javascripts/src/modules/analytics/cmp.es6
@@ -11,7 +11,7 @@ const getConsentForVendors = (cmpVendorIds) => new Promise((resolve) => {
          * vendor specific consent from state.
          */
         resolve(cmpVendorIds.reduce((accumulator, vendorId) => {
-            const consented = state.tcfv2 && state.tcfv2.vendorConsents ? state.tcfv2.vendorConsents[vendorId] : undefined;
+            const consented = state.tcfv2 && state.tcfv2.vendorConsents ? state.tcfv2.vendorConsents[vendorId] : null;
             return {
                 ...accumulator,
                 [vendorId]: consented,

--- a/frontend/assets/javascripts/src/modules/analytics/cmp.es6
+++ b/frontend/assets/javascripts/src/modules/analytics/cmp.es6
@@ -11,7 +11,7 @@ const getConsentForVendors = (cmpVendorIds) => new Promise((resolve) => {
          * vendor specific consent from state.
          */
         resolve(cmpVendorIds.reduce((accumulator, vendorId) => {
-            const consented = state.tcfv2 && state.tcfv2.vendorConsents && state.tcfv2.vendorConsents[vendorId] || false;
+            const consented = state.tcfv2 && state.tcfv2.vendorConsents ? state.tcfv2.vendorConsents[vendorId] : undefined;
             return {
                 ...accumulator,
                 [vendorId]: consented,

--- a/frontend/assets/javascripts/src/modules/analytics/ga.es6
+++ b/frontend/assets/javascripts/src/modules/analytics/ga.es6
@@ -90,6 +90,9 @@ export function wrappedGa(a,b,c){
 
 export function init() {
     let guardian = window.guardian;
+
+    console.log('Loading Google Analytics');
+
     create();
 
     wrappedGa('require', 'linker');

--- a/frontend/assets/javascripts/src/modules/analytics/ga.es6
+++ b/frontend/assets/javascripts/src/modules/analytics/ga.es6
@@ -91,8 +91,6 @@ export function wrappedGa(a,b,c){
 export function init() {
     let guardian = window.guardian;
 
-    console.log('Loading Google Analytics');
-
     create();
 
     wrappedGa('require', 'linker');

--- a/frontend/assets/javascripts/src/modules/analytics/setup.js
+++ b/frontend/assets/javascripts/src/modules/analytics/setup.js
@@ -63,6 +63,8 @@ define([
                 if (allPurposesAgreed) {
                     campaignCode.init()
                     if (typeof(vendorConsents[ga.cmpVendorId]) === 'undefined') {
+                        console.log('Google Analytics has not been configured as a vendor yet, but all purposes have been ' +
+                            'agreed so we\'re loading it.');
                         ga.init();
                     }
                 }

--- a/frontend/assets/javascripts/src/modules/analytics/setup.js
+++ b/frontend/assets/javascripts/src/modules/analytics/setup.js
@@ -60,7 +60,12 @@ define([
                     vendorConsents[tracker.cmpVendorId] ?
                         tracker.init() : reportTagLoadFail(tracker, allPurposesAgreed)
                 })
-                allPurposesAgreed && campaignCode.init()
+                if (allPurposesAgreed) {
+                    campaignCode.init()
+                    if (typeof(vendorConsents[ga.cmpVendorId]) === 'undefined') {
+                        ga.init();
+                    }
+                }
             }
         });
     }


### PR DESCRIPTION
## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

Fixing GA to load when all consents have been agreed to. This is whilst we wait for GA to be properly set up as a vendor.