### PR TITLE
track conversion on buy button click

### DIFF
--- a/frontend/assets/javascripts/src/modules/analytics/remarketing.js
+++ b/frontend/assets/javascripts/src/modules/analytics/remarketing.js
@@ -1,6 +1,22 @@
 
 import { loadScript } from 'src/utils/loadScript';
 
+const bindBuyButtonClickHandlers = () => {
+    const buyButtonClassName = 'js-ticket-cta';
+    const buyButtons = document.getElementsByClassName(buyButtonClassName);
+
+    [...buyButtons].forEach(buyButton => {
+        buyButton.addEventListener('click', () => {
+            window.google_trackConversion({
+                google_conversion_id: 618113903,
+                google_conversion_label: 'iIHRCLLc--UBEO_W3qYC',
+                google_custom_params: window.google_tag_params,
+                google_remarketing_only: true,
+            });
+        })
+    });
+}
+
 export function init() {
     if (window.sideLoad && window.sideLoad.paths) {
         const { remarketing } = window.sideLoad.paths;
@@ -12,6 +28,8 @@ export function init() {
                     google_custom_params: window.google_tag_params,
                     google_remarketing_only: true,
                 });
+
+                bindBuyButtonClickHandlers();
             });
         }
     }


### PR DESCRIPTION
## Why are you doing this?

This PR adds GA conversion tracking to the membership site in order to track 'Book ticket' button clicks. The remarketing module is already behind a consent check, so these clicks will only be tracked if consent has been granted.

Trello: https://trello.com/c/V1kSIA1x/3426-track-ga-conversion-tag-on-membership-site-buy-button-clicks
