### PR TITLE
Honour consent state in Australia

### DIFF
--- a/frontend/assets/javascripts/src/modules/analytics/cmp.es6
+++ b/frontend/assets/javascripts/src/modules/analytics/cmp.es6
@@ -34,6 +34,12 @@ const checkCCPA = () => new Promise((resolve) => {
     })
 });
 
+const checkAus = () => new Promise((resolve) => {
+    onConsentChange(state => {
+        resolve(state.aus ? state.ccpa.personalisedAdvertising : null);
+    })
+});
+
 const registerCallbackOnConsentChange = (fn) => onConsentChange(fn);
 
 const createPrivacySettingsLink = () => {
@@ -43,4 +49,4 @@ const createPrivacySettingsLink = () => {
     }
 }
 
-export { getConsentForVendors, checkAllTCFv2PurposesAreOptedIn, checkCCPA, registerCallbackOnConsentChange, createPrivacySettingsLink };
+export { getConsentForVendors, checkAllTCFv2PurposesAreOptedIn, checkCCPA, checkAus, registerCallbackOnConsentChange, createPrivacySettingsLink };

--- a/frontend/assets/javascripts/src/modules/analytics/setup.js
+++ b/frontend/assets/javascripts/src/modules/analytics/setup.js
@@ -46,6 +46,7 @@ define([
 
         Promise.allSettled([
             cmp.checkCCPA(),
+            cmp.checkAus(),
             cmp.getConsentForVendors(vendorIds),
             cmp.checkAllTCFv2PurposesAreOptedIn(),
         ]).then(results => {

--- a/frontend/assets/javascripts/src/modules/analytics/setup.js
+++ b/frontend/assets/javascripts/src/modules/analytics/setup.js
@@ -50,9 +50,9 @@ define([
             cmp.getConsentForVendors(vendorIds),
             cmp.checkAllTCFv2PurposesAreOptedIn(),
         ]).then(results => {
-            const [ccpaConsent, vendorConsents, allPurposesAgreed] = results.map(promise => promise.value);
+            const [ccpaConsent, ausConsent, vendorConsents, allPurposesAgreed] = results.map(promise => promise.value);
 
-            if (ccpaConsent) {
+            if (ccpaConsent || ausConsent) {
                 trackers.forEach(tracker => tracker.init());
                 campaignCode.init();
             } else {


### PR DESCRIPTION
## Why are you doing this?

In https://github.com/guardian/membership-frontend/pull/1981 we enabled the new Australian CMP. The state returned when in Australian mode by the `@guardian/consent-management-platform` library `onConsentChange` now looks like:

```js
{
  aus: {
    personalisedAdvertising: true
  }
}
```

We therefore need to update the consent checks to handle `state` if it looks like this.
