### PR TITLE
Ensuring Identity ID is not passed to GA

### DIFF
--- a/frontend/assets/javascripts/src/modules/analytics/ga.es6
+++ b/frontend/assets/javascripts/src/modules/analytics/ga.es6
@@ -9,7 +9,7 @@ const dimensions = {
     ophanPageViewId: 'dimension3', // Hit
     ophanBrowserId: 'dimension4', // User
     platform: 'dimension5', // Hit
-    identityId: 'dimension6', // User
+    // Removed -- identityId: 'dimension6', // User
     isLoggedOn: 'dimension7', // Hit
     stripeId: 'dimension8', // Session
     zouraId: 'dimension9', // Session
@@ -113,9 +113,6 @@ export function init() {
 
     if (guardian.abTests) {
         wrappedGa('set', dimensions.experience, Object.keys(guardian.abTests).map(function(k){return k+"="+guardian.abTests[k]}).join(","));
-    }
-    if (isLoggedIn) {
-        wrappedGa('set', dimensions.identityId, u.id);
     }
     if (ophan) {
         wrappedGa('set', dimensions.ophanPageViewId, ophan.viewId);


### PR DESCRIPTION
## Why are you doing this?
The Identity ID is no longer needed in GA and the Support site stopped sending Identity IDs to GA ages ago. 

As part of our data minimisation work, poor @NathanielBennett has been sending off repeated deletion requests to Google whilst this site has been adding new ones back in! Hopefully that will end now.
