### PR TITLE
[CMP] Add pubData for Sourcepoint Reporting

### DIFF
--- a/frontend/assets/javascripts/src/main.js
+++ b/frontend/assets/javascripts/src/main.js
@@ -61,7 +61,7 @@ require([
     landingBundles,
     bundlesLanding,
     cmp,
-    ophan
+    ophan,
 ) {
     'use strict';
 
@@ -76,7 +76,7 @@ require([
         cmp.cmp.init({
             pubData: {
                 platform: 'membership',
-                pageViewId: ophan.viewId
+                pageViewId: ophan.viewId,
             },
             country: responseCountryCode
         });

--- a/frontend/assets/javascripts/src/main.js
+++ b/frontend/assets/javascripts/src/main.js
@@ -75,6 +75,7 @@ require([
     }).then(responseCountryCode => {
         cmp.cmp.init({
             pubData: {
+                platform: 'membership',
                 pageViewId: ophan.viewId
             },
             country: responseCountryCode

--- a/frontend/assets/javascripts/src/main.js
+++ b/frontend/assets/javascripts/src/main.js
@@ -28,7 +28,8 @@ require([
     'src/modules/faq',
     'src/modules/landingBundles',
     'src/modules/bundlesLanding',
-    '@guardian/consent-management-platform'
+    '@guardian/consent-management-platform',
+    'ophan-tracker-js/build/ophan.membership',
 ], function(
     ajax,
     raven,
@@ -59,7 +60,8 @@ require([
     faq,
     landingBundles,
     bundlesLanding,
-    cmp
+    cmp,
+    ophan
 ) {
     'use strict';
 
@@ -72,6 +74,9 @@ require([
         }
     }).then(responseCountryCode => {
         cmp.cmp.init({
+            pubData: {
+                pageViewId: ophan.viewId
+            },
             country: responseCountryCode
         });
     }).catch(err => {


### PR DESCRIPTION
## Why are you doing this?

In order to join consent signals with browsers, we need to send the page view id to Sourcepoint.

## Changes
* Imported `ophan.viewId`
* Added the `pubData` object to `cmp.init`
* Added `pageViewId` and `platform` params
