### PR TITLE
[CMP] fix linting

### DIFF
--- a/frontend/assets/javascripts/src/main.js
+++ b/frontend/assets/javascripts/src/main.js
@@ -61,7 +61,7 @@ require([
     landingBundles,
     bundlesLanding,
     cmp,
-    ophan,
+    ophan
 ) {
     'use strict';
 


### PR DESCRIPTION
## Why are you doing this?

#1986 broke the build’s linting.

## Changes
* removed trailing comma