### PR TITLE
More GA custom dimensions to remove

### DIFF
--- a/frontend/assets/javascripts/src/modules/analytics/ga.es6
+++ b/frontend/assets/javascripts/src/modules/analytics/ga.es6
@@ -6,14 +6,14 @@ const tracker = 'membershipPropertyTracker';
 const dimensions = {
     signedIn: 'dimension1', // User
     signedOut: 'dimension2', // User
-    ophanPageViewId: 'dimension3', // Hit
-    ophanBrowserId: 'dimension4', // User
+    // Removed -- ophanPageViewId: 'dimension3', // Hit
+    // Removed -- ophanBrowserId: 'dimension4', // User
     platform: 'dimension5', // Hit
     // Removed -- identityId: 'dimension6', // User
     isLoggedOn: 'dimension7', // Hit
-    stripeId: 'dimension8', // Session
+    // Never sent -- stripeId: 'dimension8', // Session
     zouraId: 'dimension9', // Session
-    membershipNumber: 'dimension10', // User
+    // Removed -- membershipNumber: 'dimension10', // User
     productPurchased: 'dimension11', // Session
     intcmp: 'dimension12', // Session
     customerAgent: 'dimension13', // Session
@@ -114,9 +114,7 @@ export function init() {
     if (guardian.abTests) {
         wrappedGa('set', dimensions.experience, Object.keys(guardian.abTests).map(function(k){return k+"="+guardian.abTests[k]}).join(","));
     }
-    if (ophan) {
-        wrappedGa('set', dimensions.ophanPageViewId, ophan.viewId);
-    }
+
     // The hash on the url is set in identity-federation-api to indicate user has come via facebook login, this identifies that and stops the referrer being counted as www.facebook.com
     if(document.location.hash === '#fbLogin') {
         wrappedGa('set', 'referrer', null);
@@ -125,14 +123,12 @@ export function init() {
 
     if("productData" in guardian) {
 
-        wrappedGa('set',dimensions.membershipNumber,guardian.productData.regNumber);
         wrappedGa('set',dimensions.productPurchased,guardian.productData.tier);
         wrappedGa('set',dimensions.paymentMethod,guardian.productData.paymentMethod);
         // Send analytics after acquisition (on thank you page).
         acquisitionEvent();
 
     }
-    wrappedGa('set', dimensions.ophanBrowserId, cookie.getCookie('bwid'));
 
     let intcmp = new RegExp('INTCMP=([^&]*)').exec(location.search);
     if (intcmp && intcmp[1]){


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Personal identifiers and dimensions with infinite cardinality (Ophan page view ID, Ophan Browser ID, Membership Number etc) should not be being set as GA Custom Dimensions. This change removes them as they are not used in any GA reports and will soon be made inactive historical values will be deleted. See https://docs.google.com/spreadsheets/d/1MmWHNeeiQE_dzekImIP9Tv4beLx_8JzWx3rOtCp4PGg/edit#gid=1460779756

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
1) Browse the site, no Ophan identifiers should be being set anymore.
1) Browse the checkout in test user mode, accepting tracking in the CMP. Make a test membership. On the thank-you page no more Membership Number will be sent.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
No more of these identifiers should be being sent to GA.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
Risk of continuing to collect these custom dimensions is higher than impact on them no longer being in reports in GA. Risks are low as this site is mainly used by Customer Service representatives.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
N/A