### PR TITLE
Patch in necessary permissions for wazuh

### DIFF
--- a/cloud-formation/membership-app.cf.yaml
+++ b/cloud-formation/membership-app.cf.yaml
@@ -259,6 +259,7 @@ Resources:
   WazuhSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
+      GroupDescription: Allow outbound traffic from wazuh agent to manager
       VpcId:
         Ref: VpcId
       SecurityGroupEgress:

--- a/cloud-formation/membership-app.cf.yaml
+++ b/cloud-formation/membership-app.cf.yaml
@@ -93,6 +93,7 @@ Resources:
         Ref: ImageId
       SecurityGroups:
       - Ref: InstanceSecurityGroup
+      - Ref: WazuhSecurityGroup
       InstanceType: t4g.small
       IamInstanceProfile:
         Ref: MembershipAppInstanceProfile
@@ -169,6 +170,21 @@ Resources:
               Fn::FindInMap: [ StageVariables, { Ref: Stage }, DynamoDBTables ]
       ManagedPolicyArns:
             - !Sub arn:aws:iam::${AWS::AccountId}:policy/guardian-ec2-role-for-ssm
+  DescribeEC2Policy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: describe-ec2-policy
+      PolicyDocument:
+        Statement:
+        - Effect: Allow
+          Resource: "*"
+          Action:
+          - ec2:DescribeTags
+          - ec2:DescribeInstances
+          - autoscaling:DescribeAutoScalingGroups
+          - autoscaling:DescribeAutoScalingInstances
+      Roles:
+      - !Ref MembershipAppRole
   MembershipAppInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
@@ -239,6 +255,16 @@ Resources:
       - IpProtocol: tcp
         FromPort: 443
         ToPort: 443
+        CidrIp: 0.0.0.0/0
+  WazuhSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      VpcId:
+        Ref: VpcId
+      SecurityGroupEgress:
+      - IpProtocol: tcp
+        FromPort: 1514
+        ToPort: 1515
         CidrIp: 0.0.0.0/0
   FrontendELBDNSrecord:
     Type: AWS::Route53::RecordSet


### PR DESCRIPTION
## What are you doing in this PR?

* Open ports 1514 and 1515 for outbound traffic
* Give permission to the instance to call describe-tags,
   so the agent can identify itself in a human readable way with 
   the wazuh server.

## Why are you doing this?

There's currently a major review of the guardian's security practices under the cyber security programme. One of the projects in this programme is to install a vulnerability scanner called Wazuh in guardian ec2 instances.

The scanner has already been installed in the ami image, but it's attempt to connect with the central server is being block by the instance security group. Hopefully this will fix it, otherwise I'll have to review network ACLs!

## Testing

Works in code ✅
