### PR TITLE
Use SSM tunnel for SSH access

### DIFF
--- a/cloud-formation/membership-app.cf.yaml
+++ b/cloud-formation/membership-app.cf.yaml
@@ -242,7 +242,7 @@ Resources:
   InstanceSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: Enable HTTP access on the configured
+      GroupDescription: Open up ssh access and enable HTTP access on the configured
         port
       VpcId:
         Ref: VpcId

--- a/cloud-formation/membership-app.cf.yaml
+++ b/cloud-formation/membership-app.cf.yaml
@@ -129,9 +129,18 @@ Resources:
           - Effect: Allow
             Action: s3:GetObject
             Resource: arn:aws:s3:::membership-private/*
+      - PolicyName: SSMTunnel
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
           - Effect: Allow
-            Action: s3:GetObject
-            Resource: arn:aws:s3:::github-public-keys/Membership-and-Subscriptions/*
+            Action:
+            - ssm:UpdateInstanceInformation
+            - ssmmessages:CreateControlChannel
+            - ssmmessages:CreateDataChannel
+            - ssmmessages:OpenControlChannel
+            - ssmmessages:OpenDataChannel
+            Resource: '*'
       - PolicyName: SendingEmail
         PolicyDocument:
           Version: '2012-10-17'
@@ -233,15 +242,11 @@ Resources:
   InstanceSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: Open up ssh access and enable HTTP access on the configured
+      GroupDescription: Enable HTTP access on the configured
         port
       VpcId:
         Ref: VpcId
       SecurityGroupIngress:
-      - IpProtocol: tcp
-        FromPort: '22'
-        ToPort: '22'
-        CidrIp: 77.91.248.0/21
       - IpProtocol: tcp
         FromPort: '9000'
         ToPort: '9000'

--- a/cloud-formation/membership-app.cf.yaml
+++ b/cloud-formation/membership-app.cf.yaml
@@ -248,6 +248,10 @@ Resources:
         Ref: VpcId
       SecurityGroupIngress:
       - IpProtocol: tcp
+        FromPort: '22'
+        ToPort: '22'
+        CidrIp: 77.91.248.0/21
+      - IpProtocol: tcp
         FromPort: '9000'
         ToPort: '9000'
         CidrIp: 77.91.248.0/21


### PR DESCRIPTION
Co-authored with @rupertbates and @lucymonie 

## Why are you doing this?

This updates the Cloudformation template to remove SSH access via Github keys and switch to using SSM
https://github.com/guardian/ssm-scala#enabling-ssm-tunnel

## Trello card: [Here](https://trello.com/c/GE0BcT4l)
