### PR TITLE
Read currency from Eventbrite

### DIFF
--- a/frontend/app/model/Eventbrite.scala
+++ b/frontend/app/model/Eventbrite.scala
@@ -95,8 +95,8 @@ object Eventbrite {
     if (priceInPounds.isWhole) f"$priceInPounds%.0f" else f"$priceInPounds%.2f"
   }
 
-  def formatPriceWithCurrency(priceInPence: Double, currency: String): String = {
-    Currency.fromString(currency).getOrElse(GBP).glyph + formatPrice(priceInPence)
+  def formatPriceWithCurrency(priceInPence: Double, currencyCode: String): String = {
+    Currency.fromString(currencyCode).getOrElse(GBP).glyph + formatPrice(priceInPence)
   }
 
   case class EBPricing(value: Int, currency: String) extends EBObject {

--- a/frontend/app/model/Schema.scala
+++ b/frontend/app/model/Schema.scala
@@ -1,7 +1,7 @@
 package model
 
 import model.RichEvent.RichEvent
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, Writes}
 
 object LocationSchema {
   implicit val writesSchema = Json.writes[LocationSchema]

--- a/frontend/app/model/Schema.scala
+++ b/frontend/app/model/Schema.scala
@@ -1,7 +1,7 @@
 package model
 
 import model.RichEvent.RichEvent
-import play.api.libs.json.{Json, Writes}
+import play.api.libs.json.Json
 
 object LocationSchema {
   implicit val writesSchema = Json.writes[LocationSchema]

--- a/frontend/test/model/EBEventTest.scala
+++ b/frontend/test/model/EBEventTest.scala
@@ -1,5 +1,6 @@
 package model
 
+import com.gu.i18n.Currency.{GBP, USD}
 import io.lemonlabs.uri.Uri
 import model.Eventbrite._
 import model.EventbriteDeserializer._
@@ -122,10 +123,13 @@ class EBEventTest extends PlaySpecification {
 
   "getPrice" should {
     "be pleasantly formatted with pence if the value is not whole pounds" in {
-      EBPricing(123425).formattedPrice mustEqual("£1234.25")
+      EBPricing(123425, GBP.iso).formattedPrice mustEqual("£1234.25")
     }
     "be pleasantly formatted as whole pounds if there are no pence" in {
-      EBPricing(123400).formattedPrice mustEqual("£1234")
+      EBPricing(123400, GBP.iso).formattedPrice mustEqual("£1234")
+    }
+    "Display the correct currency" in {
+      EBPricing(123400, USD.iso).formattedPrice mustEqual("$1234")
     }
   }
 
@@ -140,8 +144,8 @@ class EBEventTest extends PlaySpecification {
         quantity_sold = 0,
         on_sale_status = None,
         cost = None,
-        fee = Some(EBPricing(600)),
-        tax = Some(EBPricing(130)),
+        fee = Some(EBPricing(600, GBP.iso)),
+        tax = Some(EBPricing(130, GBP.iso)),
         sales_end = Instant.now(),
         sales_start = None,
         hidden = None


### PR DESCRIPTION
## Why are you doing this?

Previously we ignored the currency information returned from Eventbrite and hardcoded '£' in all pricing information on our site. This PR makes use of the currency information from the API to display prices correctly.

## Trello card: [Here](https://trello.com/c/88h9Xk84/3662-fix-incorrect-currency-display-on-membership-site)

## Screenshots
![Screen Shot 2021-04-19 at 17 05 09](https://user-images.githubusercontent.com/181371/115268142-dbeace00-a131-11eb-96e1-581f50bfd10e.png)
![Screen Shot 2021-04-19 at 17 04 55](https://user-images.githubusercontent.com/181371/115268146-dd1bfb00-a131-11eb-8e69-b28ff7a30e4b.png)
