### PR TITLE
Sort out separate headers for masterclasses and events

### DIFF
--- a/frontend/app/views/event/eventsList.scala.html
+++ b/frontend/app/views/event/eventsList.scala.html
@@ -29,10 +29,8 @@
     @main("Events", pageInfo = pageInfo, header = LiveHeader, footer = LiveFooter) {
     <main>
         <div class="l-constrained">
-            @* Temporary COVID-19 message *@
-            @fragments.event.headerBarCovid(
-                twitterLink="https://twitter.com/guardianlive",
-                showFormLink=false
+            @fragments.event.headerBar(
+                title = "Join us as we mark 200 years of The Guardian with a special digital festival. See our full lineup of online events below."
             )
         </div>
 

--- a/frontend/app/views/event/masterclassesList.scala.html
+++ b/frontend/app/views/event/masterclassesList.scala.html
@@ -19,11 +19,10 @@
     <main>
 
         <div class="l-constrained">
-            @* Temporary COVID-19 message *@
-            @fragments.event.headerBarCovid(
-                twitterLink="https://twitter.com/guardianclasses",
-                showFormLink=true
-            )
+        @fragments.event.headerBarWithLinks(
+            twitterLink="https://twitter.com/guardianlive",
+            showFormLink=true
+        )
         </div>
 
         <div class="event-filters">

--- a/frontend/app/views/fragments/event/headerBarCovid.scala.html
+++ b/frontend/app/views/fragments/event/headerBarCovid.scala.html
@@ -1,8 +1,0 @@
-@(twitterLink: String, showFormLink: Boolean)
-
-<section class="header-bar">
-    <h2 class="header-bar__title">
-        Join us as we mark 200 years of The Guardian with a special digital festival! 
-        <a href="https://www.theguardian.com/membership/2021/apr/28/the-guardian-at-200-announcing-a-digital-festival">See our full lineup of online events here.</a>
-    </h2>
-</section>

--- a/frontend/app/views/fragments/event/headerBarWithLinks.scala.html
+++ b/frontend/app/views/fragments/event/headerBarWithLinks.scala.html
@@ -1,0 +1,14 @@
+@(twitterLink: String, showFormLink: Boolean)
+<section class="header-bar">
+    <h2 class="header-bar__title">
+        For updates on future live and online events please follow us on
+        @if(showFormLink) {
+            <a href="@twitterLink">Twitter</a>,
+            <a href="https://www.theguardian.com/guardian-masterclasses/2015/jan/19/sign-up-to-the-guardian-masterclasses-newsletter">sign up to our newsletter</a>,
+            or express your interest in future events <a href="https://guardiannewsampampmedia.formstack.com/forms/masterclasses__express_your_interest_in_this_course">here</a>.
+        } else {
+            <a href="@twitterLink">Twitter</a> or
+            <a href="https://www.theguardian.com/guardian-masterclasses/2015/jan/19/sign-up-to-the-guardian-masterclasses-newsletter">sign up to our newsletter</a>.
+        }
+    </h2>
+</section>


### PR DESCRIPTION
## Why are you doing this?
#2000 added special header wording for the 20th anniversary. 

Unfortunately masterclasses do not want that heading on their page as it doesn't really make sense in that context.

This PR reverts the masterclasses header to the original text and tweaks the wording slightly on the events page.

## Trello card: [Here](https://trello.com/c/Gdc5TYYG/3697-header-tweaks-for-membership)

## Screenshots
![Screen Shot 2021-05-06 at 15 01 53](https://user-images.githubusercontent.com/181371/117311405-11a2ed00-ae7c-11eb-9cac-8cbeb14b349f.png)
![Screen Shot 2021-05-06 at 15 01 34](https://user-images.githubusercontent.com/181371/117311415-136cb080-ae7c-11eb-9ece-52a58de8f49c.png)
