### PR TITLE
only download the required file for deploy

### DIFF
--- a/frontend/instance/frontend/init-instance.sh
+++ b/frontend/instance/frontend/init-instance.sh
@@ -5,7 +5,7 @@
 CONF_DIR=/etc/frontend
 # download dist
 mkdir /dist
-aws --region $region s3 cp --recursive s3://membership-dist/${stack}/${stage}/frontend/ /dist
+aws --region $region s3 cp s3://membership-dist/${stack}/${stage}/frontend/frontend_1.0-SNAPSHOT_all.deb /dist
 # download private for this stage
 mkdir /etc/gu
 aws --region $region s3 cp s3://membership-private/${stage}/membership.private.conf /etc/gu


### PR DESCRIPTION
The deploys are failing because we do a recursive download.   However we only actually need a single file.
![image](https://user-images.githubusercontent.com/7304387/124460461-4f8e9580-dd87-11eb-9410-079ebdc592ba.png)


```
aws --region $region s3 cp --recursive s3://membership-dist/${stack}/${stage}/frontend/ /dist
fatal error: An error occurred (AccessDenied) when calling the ListObjectsV2 operation: Access Denied
```
So I have changed it so it only download the file it needs, meaning we don't need to extend the permissions.