### PR TITLE
remove the G200 header and revert to requested copy

### DIFF
--- a/frontend/app/views/event/eventsList.scala.html
+++ b/frontend/app/views/event/eventsList.scala.html
@@ -29,9 +29,9 @@
     @main("Events", pageInfo = pageInfo, header = LiveHeader, footer = LiveFooter) {
     <main>
         <div class="l-constrained">
-            @fragments.event.headerBar(
-                title = "Guardian Live brings you closer to the big stories, award-winning journalists, and leading thinkers in livestreamed and interactive events that you can access from wherever you are in the world. To stay informed, <a href="https://www.theguardian.com/guardian-masterclasses/2015/jan/19/sign-up-to-the-guardian-masterclasses-newsletter">sign up to our newsletter here</a>."
-            )
+            <section class="header-bar">
+                <h1 class="header-bar__title">Guardian Live brings you closer to the big stories, award-winning journalists, and leading thinkers in livestreamed and interactive events that you can access from wherever you are in the world. To stay informed, <a href="https://www.theguardian.com/guardian-masterclasses/2015/jan/19/sign-up-to-the-guardian-masterclasses-newsletter">sign up to our newsletter here</a>.</h1>
+            </section>
         </div>
 
         @fragments.eventListings.eventsFilters(

--- a/frontend/app/views/event/eventsList.scala.html
+++ b/frontend/app/views/event/eventsList.scala.html
@@ -30,7 +30,7 @@
     <main>
         <div class="l-constrained">
             @fragments.event.headerBar(
-                title = "Join us as we mark 200 years of The Guardian with a special digital festival. See our full lineup of online events below."
+                title = "Guardian Live brings you closer to the big stories, award-winning journalists, and leading thinkers in livestreamed and interactive events that you can access from wherever you are in the world. To stay informed, <a href="https://www.theguardian.com/guardian-masterclasses/2015/jan/19/sign-up-to-the-guardian-masterclasses-newsletter">sign up to our newsletter here</a>."
             )
         </div>
 


### PR DESCRIPTION
This PR changes the previously requested events page header to the new requested header copy.
![image](https://user-images.githubusercontent.com/7304387/124754820-8d73f100-df22-11eb-9a84-cf08986f5789.png)
