### PR TITLE
Update change password link in top pop-out menu

### DIFF
--- a/frontend/app/configuration/Links.scala
+++ b/frontend/app/configuration/Links.scala
@@ -49,7 +49,7 @@ object ProfileLinks {
 
   val emailPreferences =  Config.idWebAppUrl / "email-prefs" ? Config.idMember
 
-  val changePassword =  Config.idWebAppUrl / "password/change" ? Config.idMember
+  val changePassword =  Config.idWebAppUrl / "reset" ? Config.idMember
 
   def signOut(path: String) = {
     Config.idWebAppUrl / "signout" ? Config.idMember ? ("returnUrl" -> (Config.membershipUrl + path))


### PR DESCRIPTION
## Why are you doing this?
This updates the change password link in the top pop-out menu to point to the correct password reset page. The page the link is currently pointing at will shortly be removed to reduce duplication and ensure we are adhering to security best practice.