### PR TITLE
update to version 1.5.6 of SBT

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.5.6


### PR DESCRIPTION
## Why are you doing this?

we want to move to 1.5.6 just in case of the log4j vulnerability
