### PR TITLE
Update identity-auth-play to 3.254

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   //libraries
   val sentryRavenLogback = "io.sentry" % "sentry-logback" % "1.7.30"
   val scalaUri = "io.lemonlabs" %% "scala-uri" % "2.2.2"
-  val identityAuthPlay = "com.gu.identity" %% "identity-auth-play" % "3.251"
+  val identityAuthPlay = "com.gu.identity" %% "identity-auth-play" % "3.254"
   val identityTestUsers = "com.gu" %% "identity-test-users" % "0.8"
   val membershipCommon = "com.gu" %% "membership-common" % "0.608"
   val contentAPI = "com.gu" %% "content-api-client-default" % "17.22"


### PR DESCRIPTION
## Why are you doing this?

Upgrading identity-auth-play to mitigate a critical vulnerability. More details here https://github.com/guardian/identity/pull/2106