### PR TITLE
Add LinkedIn tracking pixel 

### DIFF
--- a/frontend/assets/javascripts/src/modules/analytics/linkedin.js
+++ b/frontend/assets/javascripts/src/modules/analytics/linkedin.js
@@ -8,9 +8,9 @@ export function init() {
         window.lintrk = (a, b) => window.lintrk.q.push([a, b]);
         window.lintrk.q = [];
     }
-    var s = document.getElementsByTagName('script')[0];
+    const s = document.getElementsByTagName('script')[0];
 
-    var b = document.createElement('script');
+    let b = document.createElement('script');
 
     b.type = 'text/javascript';
     b.async = true;

--- a/frontend/assets/javascripts/src/modules/analytics/linkedin.js
+++ b/frontend/assets/javascripts/src/modules/analytics/linkedin.js
@@ -1,0 +1,23 @@
+export function init() {
+    const _linkedin_partner_id = '2929546';
+
+    window._linkedin_data_partner_ids = window._linkedin_data_partner_ids || [];
+    window._linkedin_data_partner_ids.push(_linkedin_partner_id);
+
+    if (!window.lintrk) {
+        window.lintrk = (a, b) => window.lintrk.q.push([a, b]);
+        window.lintrk.q = [];
+    }
+    var s = document.getElementsByTagName('script')[0];
+
+    var b = document.createElement('script');
+
+    b.type = 'text/javascript';
+    b.async = true;
+    b.src = 'https://snap.licdn.com/li.lms-analytics/insight.min.js';
+
+    s.parentNode.insertBefore(b, s);
+}
+
+export const vendorName = 'LinkedIn Pixel';
+export const cmpVendorId = '5ed0eb688a76503f1016578f';

--- a/frontend/assets/javascripts/src/modules/analytics/setup.js
+++ b/frontend/assets/javascripts/src/modules/analytics/setup.js
@@ -6,7 +6,8 @@ define([
     'src/modules/analytics/uet',
     'src/modules/analytics/campaignCode',
     'src/modules/analytics/cmp',
-    'src/modules/analytics/remarketing'
+    'src/modules/analytics/remarketing',
+    'src/modules/analytics/linkedin'
 ], function (
     cookie,
     ga,
@@ -14,7 +15,8 @@ define([
     uet,
     campaignCode,
     cmp,
-    remarketing) {
+    remarketing,
+    linkedin) {
     'use strict';
 
     /*
@@ -40,7 +42,7 @@ define([
     }
 
     function loadTrackers() {
-        const trackers = [ga, facebook, uet, remarketing];
+        const trackers = [ga, facebook, uet, remarketing, linkedin];
         const vendorIds = trackers.map(tracker => tracker.cmpVendorId);
 
         Promise.allSettled([

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@babel/runtime": "^7.12.5",
     "@emotion/core": "^10.0.21",
-    "@guardian/consent-management-platform": "^6.7.4",
+    "@guardian/consent-management-platform": "^10.5.0",
     "@guardian/src-button": "^2.0.0",
     "@guardian/src-foundations": "^2.0.0",
     "@guardian/src-icons": "^2.0.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -934,10 +934,17 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
-"@guardian/consent-management-platform@^6.7.4":
-  version "6.7.4"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.7.4.tgz#ae75775c40f8234a2e2774c126a688e9a98f5df4"
-  integrity sha512-f/XieB0dOyGYZDhP/UmyrHiyuehETt2L1GKqacsySFdcD/++fKe7LLcXbza4NE54MHyS0wbvd+Qh4avjG4IPLg==
+"@guardian/consent-management-platform@^10.5.0":
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-10.5.0.tgz#5195abd5cf6d940dbdfb7c27b05165913999ed0e"
+  integrity sha512-oxCcHLalyMMIMneolgX7d/n5NM+e7cVYhPwITmYdw2dyM6zpmsZsUENEVnno49HpU0MamD7YzNrhE4HT2w2YIA==
+  dependencies:
+    "@guardian/libs" "1.6.1 - 3.3.0"
+
+"@guardian/libs@1.6.1 - 3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-3.3.0.tgz#fa98c7b8216ab35b8cf3087cd9ba336958fac99a"
+  integrity sha512-XB9o8qtDOg+KlPh1sjEr4u+Ai3RFTRr2riZ/HJpdlh8Cu4ZpYjCSGUZXSGkxp1CwFWT9sduANnsWSqZ97iBloQ==
 
 "@guardian/src-button@^2.0.0":
   version "2.1.0"


### PR DESCRIPTION
This adds LinkedIn's Insight tracking pixel to the site when a user has consented via the cmp.  The `@guardian/consent-management-platform` library has also been bumped from `6.7.4` to `10.5.0` in the process.

Trello card: [Here](https://trello.com/c/uS3wNu9C/344-add-linkedin-pixel-to-the-membership-site)