### PR TITLE
Updated sentry-logback to 6.5.0

### DIFF
--- a/frontend/app/monitoring/SentryLogging.scala
+++ b/frontend/app/monitoring/SentryLogging.scala
@@ -30,7 +30,7 @@ object SentryLogging {
       case Success(dsn) =>
         SafeLogger.info(s"Initialising Sentry logging.")
         Try {
-          val sentryClient = Sentry.init(dsn)
+           Sentry.init(dsn)
 
           val sentryAppender = new SentryAppender {
             addFilter(SentryFilters.errorLevelFilter)
@@ -40,7 +40,7 @@ object SentryLogging {
 
           val buildInfo: Map[String, String] = app.BuildInfo.toMap.view.mapValues(_.toString).toMap
           val tags = Map("stage" -> Config.stage.toString) ++ buildInfo
-          sentryClient.setTags(tags.asJava)
+          tags.foreach {case (key, value) => Sentry.setTag(key, value) }
 
           LoggerFactory.getLogger(ROOT_LOGGER_NAME).asInstanceOf[Logger].addAppender(sentryAppender)
         } match {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val awsClientVersion = "1.12.319"
   val jacksonVersion = "2.11.4"
   //libraries
-  val sentryRavenLogback = "io.sentry" % "sentry-logback" % "1.7.30"
+  val sentryRavenLogback = "io.sentry" % "sentry-logback" % "6.5.0"
   val scalaUri = "io.lemonlabs" %% "scala-uri" % "2.3.1"
   val identityAuthPlay = "com.gu.identity" %% "identity-auth-play" % "3.255"
   val identityTestUsers = "com.gu" %% "identity-test-users" % "0.8"


### PR DESCRIPTION
## Why are you doing this?
Update Scala dependency sentry-logback from 1.7.30 to 6.5.0 for membership-frontend

We are five major versions behind, and automated Scala Steward PRs are failing for this dependency, so we need to manually update
Refer :
Scala steward PR on membership-frontend failed:
 [guardian/membership-frontend: Pull Request 2244](https://github.com/guardian/membership-frontend/pull/2244)
Latest 
 [guardian/membership-frontend: Pull Request 2293](https://github.com/guardian/membership-frontend/pull/2293)

## Trello card: (https://trello.com/c/OQDb66kV/684-membership-frontend-update-sentry-logback-to-641)


<!--
If you are making heavy client-side changes, consider manual test the following
critical flow before merging
## Tested in
| Browser | Supporter Stripe checkout | Supporter Paypal checkout | Stripe Monthly Contribution |  Paypal Monthly Contribution| Upgrade from Friend to Supporter  |
|---------|---------------------------|---------------------------|-----------------------------|-----------------------------|-----------------------------------|
| IE      |                           |                           |                             |                             |                                   |
| Firefox |                           |                           |                             |                             |                                   |
| Safari  |                           |                           |                             |                             |                                   |
| Chrome  |                           |                           |                             |                             |                                   |

-->

