### PR TITLE
Remove misleading ticket info from Events pages

### DIFF
--- a/frontend/app/views/event/eventDetail.scala.html
+++ b/frontend/app/views/event/eventDetail.scala.html
@@ -36,9 +36,11 @@
             </div>
             @for(internalTicketing <- event.underlying.internalTicketing) {
                 <div class="event-ticket@if(internalTicketing.isFree) { event-ticket--free} u-cf">
-                    <div class="event-ticket__item event-ticket__details">
-                        @fragments.pricing.priceInfoEvent(event, isPrimary=true)
-                    </div>
+                    @if(event.metadata.identifier == "masterclasses") {
+                        <div class="event-ticket__item event-ticket__details">
+                            @fragments.pricing.priceInfoEvent(event, isPrimary=true)
+                        </div>
+                    }
                     @if(event.underlying.isBookable) {
                         <div class="event-ticket__item event-ticket__action">
                             @fragments.event.ticketCta(event, List("qa-event-detail-booking-action"))

--- a/frontend/app/views/fragments/event/infoPanel.scala.html
+++ b/frontend/app/views/fragments/event/infoPanel.scala.html
@@ -24,8 +24,10 @@
         </div>
 
          @for(ticketing <- event.underlying.internalTicketing) {
-            @fragments.pricing.priceInfoEvent(event, showLimited=true)
-            @if(event.underlying.isBookable) {
+             @if(event.metadata.identifier == "masterclasses") {
+                 @fragments.pricing.priceInfoEvent(event, showLimited=true)
+             }
+             @if(event.underlying.isBookable) {
                 <div class="u-margin-vertical">
                     @fragments.event.ticketCta(event)
                 </div>

--- a/frontend/app/views/fragments/event/stats.scala.html
+++ b/frontend/app/views/fragments/event/stats.scala.html
@@ -15,7 +15,7 @@
 </div>
 
 @* Event locations *@
-@if(event.underlying.ebEvent.venue.name && event.underlying.ebEvent.venue.address) {
+@if(event.underlying.ebEvent.venue.addressDefaultLine.isDefined || event.underlying.ebEvent.venue.googleMapsLink.isDefined) {
     <div class="stat-item">
         <div class="stat-item__first">
         @fragments.inlineIcon("location", List("icon-inline--medium", "icon-inline--top", "icon-inline--neutral"))

--- a/frontend/app/views/fragments/event/stats.scala.html
+++ b/frontend/app/views/fragments/event/stats.scala.html
@@ -15,24 +15,26 @@
 </div>
 
 @* Event locations *@
-<div class="stat-item">
-    <div class="stat-item__first">
+@if(event.underlying.ebEvent.venue.name && event.underlying.ebEvent.venue.address) {
+    <div class="stat-item">
+        <div class="stat-item__first">
         @fragments.inlineIcon("location", List("icon-inline--medium", "icon-inline--top", "icon-inline--neutral"))
+        </div>
+        <div class="stat-item__second copy">
+            @for(addressDefaultLine <- event.underlying.ebEvent.venue.addressDefaultLine) {
+                @addressDefaultLine
+            }
+            @for(googleMapsLink <- event.underlying.ebEvent.venue.googleMapsLink) {
+                <div class="stat-item__supplementary copy">
+                    <a href="@googleMapsLink">Google map</a>
+                </div>
+            }
+        </div>
     </div>
-    <div class="stat-item__second copy">
-        @for(addressDefaultLine <- event.underlying.ebEvent.venue.addressDefaultLine) {
-            @addressDefaultLine
-        }
-        @for(googleMapsLink <- event.underlying.ebEvent.venue.googleMapsLink) {
-            <div class="stat-item__supplementary copy">
-                <a href="@googleMapsLink">Google map</a>
-            </div>
-        }
-    </div>
-</div>
+}
 
 @* Event ticket sale dates *@
-@if(showTicketSales && event.canHavePriorityBooking) {
+@if(showTicketSales && event.canHavePriorityBooking && event.metadata.identifier == "masterclasses") {
     @for(ticketing <- event.underlying.internalTicketing if event.underlying.isBookable) {
         <div class="stat-item">
             <div class="stat-item__first">


### PR DESCRIPTION
## Why are you doing this?

The request was to remove the following sections from Guardian Live event pages. The templates that contain these elements are shared with Masterclass event pages, and these sections need to remain on those pages. I've therefore wrapped the elements in conditional checks `event.metadata.identifier == "masterclasses"`

<img width="1488" alt="Screenshot 2022-10-26 at 15 16 54" src="https://user-images.githubusercontent.com/1590704/198050784-d9847c88-79d5-41be-8f9c-ef70f9bb7249.png">

I've also made an additional change to only render the location map element if an address or venue name is available. Almost all events are virtual now so these are often `None` which leads a useless element being rendered...

<img width="312" alt="Screenshot 2022-10-25 at 17 13 05" src="https://user-images.githubusercontent.com/1590704/198051656-48ea37c5-7e39-4018-a59c-a34574a68110.png">

[Trello](https://trello.com/c/sB1KQPPA/756-remove-confusing-copy-from-events-pages)

## Screenshots

### Desktop: Before

<img width="1143" alt="Screenshot 2022-10-26 at 17 47 07" src="https://user-images.githubusercontent.com/1590704/198086647-d4cfa316-e2fd-492a-8f97-f717ddfef247.png">

### Desktop: After

<img width="1137" alt="Screenshot 2022-10-26 at 16 03 58" src="https://user-images.githubusercontent.com/1590704/198086916-a3c9235c-8321-4bff-94e9-e8b8249d63a4.png">

### Tablet: Before

<img width="1050" alt="Screenshot 2022-10-26 at 17 46 26" src="https://user-images.githubusercontent.com/1590704/198086749-31f9e87e-cad2-4d11-985e-1f1f1ee71d98.png">

### Tablet: After

<img width="1050" alt="Screenshot 2022-10-26 at 17 45 48" src="https://user-images.githubusercontent.com/1590704/198086836-893d1165-1c7c-4b09-aa1f-da175aff0529.png">

### Mobile: Before

<img width="392" alt="Screenshot 2022-10-26 at 17 46 53" src="https://user-images.githubusercontent.com/1590704/198086680-acc7658b-775b-40b9-8d47-86d65d52b0a3.png">

### Mobile: After

<img width="371" alt="Screenshot 2022-10-26 at 16 04 29" src="https://user-images.githubusercontent.com/1590704/198086889-b44239b0-3ebf-4bba-9022-7519b08f4bb8.png">
