### PR TITLE
Updated the event schema markup

### DIFF
--- a/frontend/app/model/Schema.scala
+++ b/frontend/app/model/Schema.scala
@@ -54,16 +54,14 @@ object EventSchema {
   }
 
   private def locationOpt(event: RichEvent): Option[LocationSchema] = {
-    if (event.underlying.ebEvent.venue.name.isEmpty) {
-      if (!event.underlying.isSoldOut)
-        Some(LocationSchema(None,Some(event.underlying.ebEvent.memUrl),None,None,"VirtualLocation"))
-      else
-        Some(LocationSchema(None, Some(Config.eventbriteWaitlistUrl(event.underlying.ebEvent)), None, None,"VirtualLocation"))
+    event.underlying.ebEvent.venue.name match {
+      case None => if (!event.underlying.isSoldOut)
+          Some(LocationSchema(None, Some(event.underlying.ebEvent.memUrl), None, None, "VirtualLocation"))
+        else
+          Some(LocationSchema(None, Some(Config.eventbriteWaitlistUrl(event.underlying.ebEvent)), None, None, "VirtualLocation"))
+      case Some(name) =>
+        Some(LocationSchema(Some(name), None, event.underlying.ebEvent.venue.addressLine, event.underlying.ebEvent.venue.googleMapsLink, "Place"))
     }
-    else
-      event.underlying.ebEvent.venue.name.map { name =>
-        LocationSchema(Some(name),None, event.underlying.ebEvent.venue.addressLine, event.underlying.ebEvent.venue.googleMapsLink,"Place")
-      }
   }
 
   private def offerOpt(event: RichEvent): Option[OfferSchema] = {

--- a/frontend/app/model/Schema.scala
+++ b/frontend/app/model/Schema.scala
@@ -9,11 +9,11 @@ object LocationSchema {
 }
 
 case class LocationSchema(
-                           name: Option[String],
-                           url:Option[String],
-                           address: Option[String],
-                           hasMap: Option[String],
-                           `@type`: String
+ name: Option[String],
+ url:Option[String],
+ address: Option[String],
+ hasMap: Option[String],
+ `@type`: String
                          )
 
 object OfferSchema {
@@ -21,28 +21,26 @@ object OfferSchema {
 }
 
 case class OfferSchema(
-                        url: String,
-                        category: String,
-                        price: String,
-                        priceCurrency: String,
-                        availability: Option[String],
-                        `@type`: String = "Offer"
-                      )
+ url: String,
+ category: String,
+ price: String,
+ priceCurrency: String,
+ availability: Option[String],
+ `@type`: String = "Offer")
 
 case class EventSchema(
-                        name: String,
-                        description: String,
-                        startDate: String,
-                        endDate: String,
-                        url: String,
-                        image: Option[String],
-                        eventAttendanceMode:String,
-                        eventStatus:String,
-                        location: Option[LocationSchema],
-                        offers: Option[OfferSchema],
-                        `@context`: String = "http://schema.org",
-                        `@type`: String = "Event"
-                      )
+ name: String,
+ description: String,
+ startDate: String,
+ endDate: String,
+ url: String,
+ image: Option[String],
+ eventAttendanceMode:String,
+ eventStatus:String,
+ location: Option[LocationSchema],
+ offers: Option[OfferSchema],
+ `@context`: String = "http://schema.org",
+ `@type`: String = "Event")
 
 object EventSchema {
 

--- a/frontend/app/model/Schema.scala
+++ b/frontend/app/model/Schema.scala
@@ -1,7 +1,5 @@
 package model
 
-
-import controllers.routes
 import model.RichEvent.RichEvent
 import play.api.libs.json.Json
 import configuration.{Config, CopyConfig}

--- a/frontend/app/model/Schema.scala
+++ b/frontend/app/model/Schema.scala
@@ -1,53 +1,73 @@
 package model
 
+
+import controllers.routes
 import model.RichEvent.RichEvent
 import play.api.libs.json.Json
+import configuration.{Config, CopyConfig}
 
 object LocationSchema {
   implicit val writesSchema = Json.writes[LocationSchema]
 }
 
 case class LocationSchema(
-  name: String,
-  address: Option[String],
-  hasMap: Option[String],
-  `@type`: String = "Place"
-)
+                           name: Option[String],
+                           url:Option[String],
+                           address: Option[String],
+                           hasMap: Option[String],
+                           `@type`: String
+                         )
 
 object OfferSchema {
   implicit val writesSchema = Json.writes[OfferSchema]
 }
 
 case class OfferSchema(
-  url: String,
-  category: String,
-  price: String,
-  priceCurrency: String,
-  availability: Option[String],
-  `@type`: String = "Offer"
-)
+                        url: String,
+                        category: String,
+                        price: String,
+                        priceCurrency: String,
+                        availability: Option[String],
+                        `@type`: String = "Offer"
+                      )
 
 case class EventSchema(
-  name: String,
-  description: String,
-  startDate: String,
-  endDate: String,
-  url: String,
-  image: Option[String],
-  location: Option[LocationSchema],
-  offers: Option[OfferSchema],
-  `@context`: String = "http://schema.org",
-  `@type`: String = "Event"
-)
+                        name: String,
+                        description: String,
+                        startDate: String,
+                        endDate: String,
+                        url: String,
+                        image: Option[String],
+                        eventAttendanceMode:String,
+                        eventStatus:String,
+                        location: Option[LocationSchema],
+                        offers: Option[OfferSchema],
+                        `@context`: String = "http://schema.org",
+                        `@type`: String = "Event"
+                      )
 
 object EventSchema {
 
   implicit val writesSchema = Json.writes[EventSchema]
 
+  private def eventAttendanceMode(event:RichEvent)={
+    if (event.underlying.ebEvent.venue.name.isEmpty)
+      "https://schema.org/OnlineEventAttendanceMode"
+    else
+      "https://schema.org/OfflineEventAttendanceMode"
+  }
+
   private def locationOpt(event: RichEvent): Option[LocationSchema] = {
-    event.underlying.ebEvent.venue.name.map { name =>
-      LocationSchema(name, event.underlying.ebEvent.venue.addressLine, event.underlying.ebEvent.venue.googleMapsLink)
+    if (event.underlying.ebEvent.venue.name.isEmpty) {
+      if (!event.underlying.isSoldOut)
+        Some(LocationSchema(None,Some(event.underlying.ebEvent.memUrl),None,None,"VirtualLocation"))
+      else
+        Some(LocationSchema(None, Some(Config.eventbriteWaitlistUrl(event.underlying.ebEvent)), None, None,"VirtualLocation"))
     }
+    else
+      event.underlying.ebEvent.venue.name.map { name =>
+        LocationSchema(Some(name),None, event.underlying.ebEvent.venue.addressLine, event.underlying.ebEvent.venue.googleMapsLink,"Place")
+      }
   }
 
   private def offerOpt(event: RichEvent): Option[OfferSchema] = {
@@ -56,6 +76,8 @@ object EventSchema {
     }
   }
 
+
+
   def from(event: RichEvent): EventSchema = EventSchema(
     event.underlying.ebEvent.name.text,
     event.underlying.ebDescription.cleanHtml,
@@ -63,7 +85,10 @@ object EventSchema {
     event.underlying.ebEvent.end.toString,
     event.underlying.ebEvent.memUrl,
     event.socialImgUrl,
+    eventAttendanceMode(event),
+    event.underlying.ebEvent.status,
     locationOpt(event),
-    offerOpt(event)
+    offerOpt(event),
   )
 }
+

--- a/frontend/app/model/Schema.scala
+++ b/frontend/app/model/Schema.scala
@@ -50,7 +50,7 @@ object EventSchema {
     if (event.underlying.ebEvent.venue.name.isEmpty)
       "https://schema.org/OnlineEventAttendanceMode"
     else
-      "https://schema.org/OfflineEventAttendanceMode"
+      "https://schema.org/MixedEventAttendanceMode"
   }
 
   private def locationOpt(event: RichEvent): Option[LocationSchema] = {


### PR DESCRIPTION
## Why are you doing this?

To update event schema markup to event pages on the membership site, to enable Guardian events to show in the Google event carousel listings and dramatically increase organic traffic to our live events.

## Trello card: [https://trello.com/c/Zbl0J4P1/345-add-event-schema-markup-html-to-event-pages-on-the-membership-site]()

## Changes
* Added url as a new property under LocationSchema to add “[VirtualLocation](https://schema.org/VirtualLocation)” as a Location Type
* Changes to locationOpt method to check for the locationType and pass values to Schema accordingly .Also modified it to change the url links for “IsSoldOut” cases as well.If events are  “Sold Out” , the users must be able to see the waiting list url
* Added eventStatus and eventAttendanceMode as  new properties to  Event Schema.

