### PR TITLE
Event schema updated for organizer,validFrom and breadcrumbs

### DIFF
--- a/frontend/app/model/Schema.scala
+++ b/frontend/app/model/Schema.scala
@@ -25,8 +25,17 @@ case class OfferSchema(
  category: String,
  price: String,
  priceCurrency: String,
+ validFrom:String,
  availability: Option[String],
  `@type`: String = "Offer")
+object OrganizerSchema {
+  implicit val writesSchema = Json.writes[OrganizerSchema]
+}
+
+case class OrganizerSchema(
+                        url: String,
+                        name: String,
+                        `@type`: String = "Organization")
 
 case class EventSchema(
  name: String,
@@ -39,6 +48,7 @@ case class EventSchema(
  eventStatus:String,
  location: Option[LocationSchema],
  offers: Option[OfferSchema],
+ organizer:Option[OrganizerSchema],
  `@context`: String = "http://schema.org",
  `@type`: String = "Event")
 
@@ -66,10 +76,13 @@ object EventSchema {
 
   private def offerOpt(event: RichEvent): Option[OfferSchema] = {
     event.underlying.generalReleaseTicket.map { ticket =>
-      OfferSchema(event.underlying.ebEvent.memUrl, "primary", ticket.priceValue, ticket.currencyCode, event.underlying.statusSchema)
+      OfferSchema(event.underlying.ebEvent.memUrl, "primary", ticket.priceValue, ticket.currencyCode,ticket.sales_start.getOrElse(None).toString, event.underlying.statusSchema)
     }
   }
 
+  private def organizerOpt(event: RichEvent): Option[OrganizerSchema] = {
+      Some(OrganizerSchema(event.underlying.ebEvent.memUrl, "Guardian Members"))
+  }
 
 
   def from(event: RichEvent): EventSchema = EventSchema(
@@ -83,6 +96,7 @@ object EventSchema {
     event.underlying.ebEvent.status,
     locationOpt(event),
     offerOpt(event),
+    organizerOpt(event),
   )
 }
 

--- a/frontend/app/model/Schema.scala
+++ b/frontend/app/model/Schema.scala
@@ -10,7 +10,7 @@ object LocationSchema {
 
 case class LocationSchema(
  name: Option[String],
- url:Option[String],
+ url: Option[String],
  address: Option[String],
  hasMap: Option[String],
  `@type`: String
@@ -25,17 +25,18 @@ case class OfferSchema(
  category: String,
  price: String,
  priceCurrency: String,
- validFrom:String,
+ validFrom: String,
  availability: Option[String],
  `@type`: String = "Offer")
+
 object OrganizerSchema {
   implicit val writesSchema = Json.writes[OrganizerSchema]
 }
 
 case class OrganizerSchema(
-                        url: String,
-                        name: String,
-                        `@type`: String = "Organization")
+ url: String,
+ name: String,
+ `@type`: String = "Organization")
 
 case class EventSchema(
  name: String,
@@ -44,11 +45,11 @@ case class EventSchema(
  endDate: String,
  url: String,
  image: Option[String],
- eventAttendanceMode:String,
- eventStatus:String,
+ eventAttendanceMode: String,
+ eventStatus: String,
  location: Option[LocationSchema],
  offers: Option[OfferSchema],
- organizer:Option[OrganizerSchema],
+ organizer: Option[OrganizerSchema],
  `@context`: String = "http://schema.org",
  `@type`: String = "Event")
 
@@ -56,7 +57,7 @@ object EventSchema {
 
   implicit val writesSchema = Json.writes[EventSchema]
 
-  private def eventAttendanceMode(event:RichEvent)={
+  private def eventAttendanceMode(event: RichEvent) = {
     if (event.underlying.ebEvent.venue.name.isEmpty)
       "https://schema.org/OnlineEventAttendanceMode"
     else
@@ -66,9 +67,9 @@ object EventSchema {
   private def locationOpt(event: RichEvent): Option[LocationSchema] = {
     event.underlying.ebEvent.venue.name match {
       case None => if (!event.underlying.isSoldOut)
-          Some(LocationSchema(None, Some(event.underlying.ebEvent.memUrl), None, None, "VirtualLocation"))
-        else
-          Some(LocationSchema(None, Some(Config.eventbriteWaitlistUrl(event.underlying.ebEvent)), None, None, "VirtualLocation"))
+        Some(LocationSchema(None, Some(event.underlying.ebEvent.memUrl), None, None, "VirtualLocation"))
+      else
+        Some(LocationSchema(None, Some(Config.eventbriteWaitlistUrl(event.underlying.ebEvent)), None, None, "VirtualLocation"))
       case Some(name) =>
         Some(LocationSchema(Some(name), None, event.underlying.ebEvent.venue.addressLine, event.underlying.ebEvent.venue.googleMapsLink, "Place"))
     }
@@ -76,12 +77,12 @@ object EventSchema {
 
   private def offerOpt(event: RichEvent): Option[OfferSchema] = {
     event.underlying.generalReleaseTicket.map { ticket =>
-      OfferSchema(event.underlying.ebEvent.memUrl, "primary", ticket.priceValue, ticket.currencyCode,ticket.sales_start.getOrElse(None).toString, event.underlying.statusSchema)
+      OfferSchema(event.underlying.ebEvent.memUrl, "primary", ticket.priceValue, ticket.currencyCode, ticket.sales_start.getOrElse(None).toString, event.underlying.statusSchema)
     }
   }
 
   private def organizerOpt(event: RichEvent): Option[OrganizerSchema] = {
-      Some(OrganizerSchema(event.underlying.ebEvent.memUrl, "Guardian Members"))
+    Some(OrganizerSchema(event.underlying.ebEvent.memUrl, "Guardian Members"))
   }
 
 

--- a/frontend/app/views/main.scala.html
+++ b/frontend/app/views/main.scala.html
@@ -67,9 +67,37 @@
 
         @for(schema <- pageInfo.schemaOpt) {
             <script type="application/ld+json">
+         {
+                "@@context": "https://schema.org",
+                "@@type": "BreadcrumbList",
+                "description":"Breadcrumbs list",
+                "name": "Breadcrumbs",
+                "itemListElement": [{
+                "@@type": "ListItem",
+                "position": 1,
+                "name": "Home",
+                "item": [{
+                "@@type": "WebPage",
+                "id":"https://membership.theguardian.com"
+                }]},{
+                "@@type": "ListItem",
+                "position": 2,
+                "name": "Events",
+                "item":[{
+                "@@type": "WebPage",
+                "id":"https://membership.theguardian.com/events"
+                }]},{
+                "@@type": "ListItem",
+                "position": 3,
+                "name":"@Html(schema.name)",
+                "item":[
                 @Html(Json.toJson(schema).toString)
+                ]
+                }]
+                }
             </script>
         }
+
 
         @fragments.javaScriptFirstSteps(pageInfo)
 

--- a/frontend/app/views/main.scala.html
+++ b/frontend/app/views/main.scala.html
@@ -82,13 +82,6 @@
                 }]},{
                 "@@type": "ListItem",
                 "position": 2,
-                "name": "Events",
-                "item":[{
-                "@@type": "WebPage",
-                "id":"https://membership.theguardian.com/events"
-                }]},{
-                "@@type": "ListItem",
-                "position": 3,
                 "name":"@Html(schema.name)",
                 "item":[
                 @Html(Json.toJson(schema).toString)


### PR DESCRIPTION
## Why are you doing this?
To update event schema markup on the membership site  to add  BreadcrumbList and fix non-critical issues  like ‘validFrom’ and 'organizer' in order to optimise it for events to appear in Google search results 

## Trello card: [https://trello.com/c/1gLDHTx9/885-membership-site-update-event-schema](https://trello.com/c/1gLDHTx9/885-membership-site-update-event-schema)

