### PR TITLE
Masterclasses black friday promo

### DIFF
--- a/frontend/app/views/event/masterclassesList.scala.html
+++ b/frontend/app/views/event/masterclassesList.scala.html
@@ -21,7 +21,7 @@
         <div class="l-constrained">
             <section class="header-bar">
                 <h1 class="header-bar__title">
-                    Our <strong>Black Friday sale is now on</strong> across all Guardian Masterclasses. To be the first to hear about our courses and save 20% on any full price standard ticket, <a href="https://www.theguardian.com/guardian-masterclasses/2015/jan/19/sign-up-to-the-guardian-masterclasses-newsletter">sign up to our newsletter here</a>. But hurry, offer ends Friday 2 December 2022.
+                    Our <strong>Black Friday sale is now on</strong> across all Guardian Masterclasses. To be the first to hear about our courses and save 20% on any full price standard ticket, <a href="https://www.theguardian.com/guardian-masterclasses/2015/jan/19/sign-up-to-the-guardian-masterclasses-newsletter">sign up to our newsletter here</a>. But hurry, offer ends Friday 2 December.
                 </h1>
             </section>
         </div>

--- a/frontend/app/views/event/masterclassesList.scala.html
+++ b/frontend/app/views/event/masterclassesList.scala.html
@@ -20,8 +20,10 @@
 
         <div class="l-constrained">
             <section class="header-bar">
-                <h1 class="header-bar__title">Guardian Masterclasses offers a range of practical, expert-led online workshops in journalism, creative writing, business skills and personal development. To be the first to hear about new events, <a href="https://www.theguardian.com/guardian-masterclasses/2015/jan/19/sign-up-to-the-guardian-masterclasses-newsletter">sign up to our newsletter here</a>.</h1>
-            </section>            
+                <h1 class="header-bar__title">
+                    Our <strong>Black Friday sale is now on</strong> across all Guardian Masterclasses. To be the first to hear about our courses and save 20% on any full price standard ticket, <a href="https://www.theguardian.com/guardian-masterclasses/2015/jan/19/sign-up-to-the-guardian-masterclasses-newsletter">sign up to our newsletter here</a>. But hurry, offer ends Friday 2 December 2022.
+                </h1>
+            </section>
         </div>
 
         <div class="event-filters">


### PR DESCRIPTION
## Why are you doing this?

Updates the copy at the top of Masterclasses pages to promote a Black Friday offer. 

### Before
<img width="1140" alt="Screenshot 2022-11-24 at 16 02 15" src="https://user-images.githubusercontent.com/1590704/203826682-82ebc36a-f24e-4e67-b54d-97a73d1c992c.png">

### After
<img width="1145" alt="Screenshot 2022-11-24 at 15 32 46" src="https://user-images.githubusercontent.com/1590704/203826391-058b3c6c-1d49-47e5-99a7-1f2363d58279.png">
