### PR TITLE
Modify breadcrumb list of event schema 

### DIFF
--- a/frontend/app/views/main.scala.html
+++ b/frontend/app/views/main.scala.html
@@ -83,11 +83,15 @@
                 "@@type": "ListItem",
                 "position": 2,
                 "name":"@Html(schema.name)",
-                "item":[
-                @Html(Json.toJson(schema).toString)
-                ]
+                "item":[{
+                "@@type": "WebPage",
+                "id":"@Html(schema.url)"
+                }]
                 }]
                 }
+            </script>
+            <script type="application/ld+json">
+            @Html(Json.toJson(schema).toString)
             </script>
         }
 

--- a/frontend/app/views/main.scala.html
+++ b/frontend/app/views/main.scala.html
@@ -88,7 +88,7 @@
                 "id":"@Html(schema.url)"
                 }]
                 }]
-                }
+         }
             </script>
             <script type="application/ld+json">
             @Html(Json.toJson(schema).toString)


### PR DESCRIPTION
## Why are you doing this?

The event schema markup on the membership site to be updated with 'id' in  BreadcrumbList  in order to optimise it for events to appear in Google search results.The breadcrumb list to be updated similar to what we have in pages of https://patrons.theguardian.com/events/ 


## Changes
* Taking events out of the Breadcrumb list
* Adding id to Breadcrumb list for individual events and masterclasses

After the change (Breadcrumbs from Membership site)
<img width="1081" alt="image" src="https://user-images.githubusercontent.com/73653255/204790249-9e832870-1f2e-4615-81eb-779355f5add2.png">

After the change (Events from Membership site) 
<img width="331" alt="image" src="https://user-images.githubusercontent.com/73653255/204832337-93ac24c3-ad4a-4bb6-9692-6d3fd35e16d4.png">


Breadcrumbs from Patrons (for example)
<img width="458" alt="image" src="https://user-images.githubusercontent.com/73653255/204815973-e2f313d2-7123-4b07-a668-b18eadad6cc6.png">

