### PR TITLE
Update specs2-matcher-extra to 4.19.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
   val awsSimpleEmail = "com.amazonaws" % "aws-java-sdk-ses" % awsClientVersion
   val scalaTest =  "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % "test"
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.3.7"
-  val specs2Extra = "org.specs2" %% "specs2-matcher-extra" % "4.5.1" % "test"
+  val specs2Extra = "org.specs2" %% "specs2-matcher-extra" % "4.19.0" % "test"
   val pegdown = "org.pegdown" % "pegdown" % "1.6.0"
   val enumPlay = "com.beachape" %% "enumeratum-play" % "1.7.0"
   val catsCore = "org.typelevel" %% "cats-core" % "2.9.0"


### PR DESCRIPTION
## Why are you doing this?

Update specs2-matcher-extra manually as  it failed checks during automated update from 4.5.1 to 4.19.0 
## Trello card: [Here](https://trello.com/c/nq2DIBpQ/744-membership-frontend-update-specs2-matcher-extra-to-4190)

