### PR TITLE
Update scala-uri to 4.0.3

### DIFF
--- a/frontend/app/configuration/Config.scala
+++ b/frontend/app/configuration/Config.scala
@@ -5,7 +5,7 @@ import com.gu.memsub.auth.common.MemSub.Google._
 import com.gu.salesforce.Tier
 import com.gu.zuora.api.{InvoiceTemplate, InvoiceTemplates}
 import io.lemonlabs.uri.Uri
-import io.lemonlabs.uri.dsl._
+import io.lemonlabs.uri.typesafe.dsl._
 import com.typesafe.config.ConfigFactory
 import model.Eventbrite.EBEvent
 import services._
@@ -48,16 +48,16 @@ object Config {
   def facebookSigninUrl = oauthWebAppSigninUrl("facebook")(_)
 
   private def oauthWebAppSigninUrl(socialProvider: String)(uri: String): String =
-    ("https://oauth.theguardian.com" / socialProvider / "signin") ? ("returnUrl" -> s"$membershipUrl$uri") & idSkipConfirmation & idMember
+    (("https://oauth.theguardian.com" / socialProvider / "signin") ? ("returnUrl" -> s"$membershipUrl$uri") & idSkipConfirmation & idMember).toString()
 
   def idWebAppSigninUrl(uri: String): String =
-    (idWebAppUrl / "signin") ? ("returnUrl" -> s"$membershipUrl$uri") & idSkipConfirmation & idMember
+    ((idWebAppUrl / "signin") ? ("returnUrl" -> s"$membershipUrl$uri") & idSkipConfirmation & idMember).toString()
 
   def idWebAppRegisterUrl(uri: String): String =
-    (idWebAppUrl / "register") ? ("returnUrl" -> s"$membershipUrl$uri") & idSkipConfirmation & idMember
+    ((idWebAppUrl / "register") ? ("returnUrl" -> s"$membershipUrl$uri") & idSkipConfirmation & idMember).toString()
 
   def idWebAppSignOutThenRegisterUrl(uri: String): String =
-    (idWebAppUrl / "signout") ? ("returnUrl" -> (idWebAppUrl / "register") ? ("returnUrl" -> s"$membershipUrl$uri" & idSkipConfirmation & idMember))
+    ((idWebAppUrl / "signout") ? ("returnUrl" -> (idWebAppUrl / "register").toString())? ("returnUrl" -> s"$membershipUrl$uri" & idSkipConfirmation & idMember)).toString()
 
   def idWebAppProfileUrl =
     idWebAppUrl / "membership"/ "edit"
@@ -77,7 +77,7 @@ object Config {
   val eventbriteLimitedAvailabilityCutoff = config.getInt("eventbrite.limitedAvailabilityCutoff")
 
   def eventbriteWaitlistUrl(event: EBEvent): String =
-    eventbriteWaitlistUrl ? ("eid" -> event.id) & ("tid" -> 0)
+    (eventbriteWaitlistUrl ? ("eid" -> event.id) & ("tid" -> 0)).toString()
 
   val eventOrderingJsonUrl = config.getString("event.ordering.json")
 

--- a/frontend/app/configuration/Links.scala
+++ b/frontend/app/configuration/Links.scala
@@ -3,7 +3,7 @@ package configuration
 import com.gu.i18n.CountryGroup
 import com.gu.i18n.CountryGroup.{UK,US,Australia}
 import controllers.routes
-import io.lemonlabs.uri.dsl._
+import io.lemonlabs.uri.typesafe.dsl._
 
 object Links {
   val guardianCookiePolicy = "http://www.theguardian.com/info/cookies"

--- a/frontend/app/configuration/Videos.scala
+++ b/frontend/app/configuration/Videos.scala
@@ -1,7 +1,7 @@
 package configuration
 
 import com.gu.memsub.images.{ResponsiveImageGenerator, ResponsiveImageGroup}
-import io.lemonlabs.uri.dsl._
+import io.lemonlabs.uri.typesafe.dsl._
 import model.Video
 
 object Videos {

--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -5,7 +5,7 @@ import actions.Fallbacks._
 import actions.{ActionRefiners, CommonActions, OAuthActions, Subscriber, SubscriptionRequest, TouchpointActionRefiners, TouchpointCommonActions}
 import com.gu.googleauth.GoogleAuthConfig
 import io.lemonlabs.uri.Uri
-import io.lemonlabs.uri.dsl._
+import io.lemonlabs.uri.typesafe.dsl._
 import com.gu.monitoring.SafeLogger
 import model.EmbedSerializer._
 import model.Eventbrite.{EBCode, EBEvent}
@@ -161,7 +161,7 @@ class Event(
 
   def eventbriteRedirect(event: RichEvent, discountCodeOpt: Option[EBCode])(implicit req: RequestHeader) = {
     val eventUrl = discountCodeOpt.fold(Uri.parse(event.underlying.ebEvent.url))(c => event.underlying.ebEvent.url ? ("discount" -> c.code))
-    Found(addEventBriteGACrossDomainParam(eventUrl)).withCookies(Cookie(eventCookie(event), "", Some(3600)))
+    Found(addEventBriteGACrossDomainParam(eventUrl).toString()).withCookies(Cookie(eventCookie(event), "", Some(3600)))
   }
 
   def thankyouPixel(id: String) = NoCacheAction { implicit request =>

--- a/frontend/app/controllers/VanityUrl.scala
+++ b/frontend/app/controllers/VanityUrl.scala
@@ -2,7 +2,7 @@ package controllers
 
 import actions.CommonActions
 import play.api.mvc.{BaseController, ControllerComponents}
-import io.lemonlabs.uri.dsl._
+import io.lemonlabs.uri.typesafe.dsl._
 import tracking.RedirectWithCampaignCodes.internalCampaignCode
 
 class VanityUrl(commonActions: CommonActions, override protected val controllerComponents: ControllerComponents) extends BaseController {
@@ -10,6 +10,6 @@ class VanityUrl(commonActions: CommonActions, override protected val controllerC
   import commonActions.CachedAction
 
   def redirect = CachedAction { implicit request =>
-    MovedPermanently(routes.FrontPage.index().url ? (internalCampaignCode -> "pap_233874"))
+    MovedPermanently((routes.FrontPage.index().url ? (internalCampaignCode -> "pap_233874")).toString())
   }
 }

--- a/frontend/app/model/Eventbrite.scala
+++ b/frontend/app/model/Eventbrite.scala
@@ -6,7 +6,7 @@ import com.gu.i18n.Currency.GBP
 import com.gu.memsub.Price
 import com.gu.salesforce.Tier
 import io.lemonlabs.uri.{Uri, Url}
-import io.lemonlabs.uri.dsl._
+import io.lemonlabs.uri.typesafe.dsl._
 import configuration.Config
 import org.joda.time.Instant
 import org.joda.time.format.ISODateTimeFormat
@@ -82,7 +82,7 @@ object Eventbrite {
     lazy val addressShortLine = seqToLine(Seq(name, address.flatMap(_.city)).flatten)
     lazy val addressDefaultLine = seqToLine(Seq(name, address.flatMap(_.city), address.flatMap(_.postal_code)).flatten)
     lazy val googleMapsLink: Option[String] = {
-      addressLine.map(al => googleMapsUri ? ("q" -> (name.map(_ + ", ").mkString + al)))
+      addressLine.map(al => (googleMapsUri ? ("q" -> (name.map(_ + ", ").mkString + al))).toString())
     }
   }
 

--- a/frontend/app/model/ResponsiveImageGroupModel.scala
+++ b/frontend/app/model/ResponsiveImageGroupModel.scala
@@ -3,7 +3,7 @@ package model
 import com.gu.contentapi.client.model.v1.{Content, Element}
 import com.gu.memsub.images.{ResponsiveImage, ResponsiveImageGroup => RIG}
 import model.RichEvent.GridImage
-import io.lemonlabs.uri.dsl._
+import io.lemonlabs.uri.typesafe.dsl._
 
 case class OrientatedImages(portrait: RIG, landscape: RIG)
 

--- a/frontend/app/views/support/PackagePromo.scala
+++ b/frontend/app/views/support/PackagePromo.scala
@@ -3,7 +3,7 @@ package views.support
 import com.gu.i18n.CountryGroup
 import com.gu.salesforce.{FreeTier, PaidTier, Tier}
 import io.lemonlabs.uri.Uri
-import io.lemonlabs.uri.dsl._
+import io.lemonlabs.uri.typesafe.dsl._
 import controllers.routes
 import model.PackagePromo.CtaButton
 import play.twirl.api.Html

--- a/frontend/test/services/GridServiceTest.scala
+++ b/frontend/test/services/GridServiceTest.scala
@@ -1,7 +1,7 @@
 package services
 
 import io.lemonlabs.uri.{Uri, Url}
-import io.lemonlabs.uri.dsl._
+import io.lemonlabs.uri.typesafe.dsl._
 import com.gu.memsub.images.Grid.GridResult
 import com.gu.memsub.images.GridDeserializer._
 import org.specs2.concurrent.ExecutionEnv

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val jacksonVersion = "2.11.4"
   //libraries
   val sentryRavenLogback = "io.sentry" % "sentry-logback" % "6.9.1"
-  val scalaUri = "io.lemonlabs" %% "scala-uri" % "2.3.1"
+  val scalaUri = "io.lemonlabs" %% "scala-uri" % "4.0.3"
   val identityAuthPlay = "com.gu.identity" %% "identity-auth-play" % "3.255"
   val identityTestUsers = "com.gu" %% "identity-test-users" % "0.8"
   val membershipCommon = "com.gu" %% "membership-common" % "0.622"


### PR DESCRIPTION
## Why are you doing this?
Update scala-uri to 4.0.3 manually as the automated upgrade fails on version upgrade from 2.3.1 to 4.0.3.

## Trello card: [Here](https://trello.com/c/RG0yALYz/683-membership-frontend-update-scala-uri-to-402)
