### PR TITLE
Routing change to force the correct path prefix for Event Details page

### DIFF
--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -84,7 +84,7 @@ class Event(
   def details(slug: String) = CachedAction { implicit request =>
     detailsResult(slug)((event: RichEvent) => {
       if (event.isInstanceOf[LiveEvent] || event.isInstanceOf[MasterclassEvent]) {
-        // the slug is not canonical so 302 to the correct one
+        // the url prefix is not canonical so 302 to the correct one
         Redirect(event.detailsUrl)
       } else {
         // event is neither LiveEvent or Masterclass (should never happen!)
@@ -101,7 +101,7 @@ class Event(
       if (slug == correctEvent.underlying.ebEvent.slug) {
         correctAction(correctEvent)
       } else {
-        // the slug is not correct capitalisation, or canonical
+        // the slug is not correct capitalisation, or canonical so 302 to the correct one
         Redirect(correctEvent.detailsUrl)
       }
     }

--- a/frontend/app/controllers/Event.scala
+++ b/frontend/app/controllers/Event.scala
@@ -64,7 +64,7 @@ class Event(
       if (event.isInstanceOf[MasterclassEvent]) {
         eventDetail(event)
       } else {
-        // the url prefix or slug are not canonical so 302 to the correct one
+        // the url prefix is not canonical so 302 to the correct one
         Redirect(event.detailsUrl)
       }
     });
@@ -75,7 +75,7 @@ class Event(
       if (event.isInstanceOf[LiveEvent]) {
         eventDetail(event)
       } else {
-        // the url prefix or slug are not canonical so 302 to the correct one
+        // the url prefix is not canonical so 302 to the correct one
         Redirect(event.detailsUrl)
       }
     });

--- a/frontend/app/model/RichEvent.scala
+++ b/frontend/app/model/RichEvent.scala
@@ -103,7 +103,7 @@ object RichEvent {
     image: Option[GridImage],
     contentOpt: Option[Content]
   ) extends RichEvent {
-    val detailsUrl = routes.Event.details(underlying.ebEvent.slug).url
+    val detailsUrl = routes.Event.detailsLive(underlying.ebEvent.slug).url
     val hasLargeImage = true
     val canHavePriorityBooking = true
     val imgOpt = image.flatMap(model.ResponsiveImageGroup.fromGridImage)
@@ -143,7 +143,7 @@ object RichEvent {
     underlying: EventWithDescription,
     data: Option[MasterclassData]
   ) extends RichEvent {
-    val detailsUrl = routes.Event.details(underlying.ebEvent.slug).url
+    val detailsUrl = routes.Event.detailsMasterclass(underlying.ebEvent.slug).url
     val hasLargeImage = false
     val canHavePriorityBooking = false
     val imgOpt = data.flatMap(_.images)

--- a/frontend/app/views/fragments/event/item.scala.html
+++ b/frontend/app/views/fragments/event/item.scala.html
@@ -34,7 +34,7 @@
     </div>
 }
 
-<a href="@routes.Event.details(event.underlying.ebEvent.slug).url" class="@RenderClasses(Map(
+<a href="@event.detailsUrl" class="@RenderClasses(Map(
     ("event-item", true),
     ("event-item--hero", isFeatured),
     ("qa-available-event-item", event.underlying.isBookable),

--- a/frontend/app/views/fragments/event/itemList.scala.html
+++ b/frontend/app/views/fragments/event/itemList.scala.html
@@ -1,6 +1,6 @@
 @(event: model.RichEvent.RichEvent, classes: Seq[String] = Seq.empty)
 
-<a href="@routes.Event.details(event.underlying.ebEvent.slug)"
+<a href="@event.detailsUrl"
    class="event-item event-item--list @if(event.underlying.isBookable){ qa-available-event-item} @classes.mkString(" ")">
     @for(img <- event.imgOpt) {
         <div class="event-item__media">

--- a/frontend/conf/routes
+++ b/frontend/conf/routes
@@ -59,6 +59,8 @@ GET         /masterclasses/:tag/:subTag                controllers.WhatsOn.maste
 
 # Event Details
 GET         /event/:id                                 controllers.Event.details(id)
+GET         /live/:id                                  controllers.Event.detailsLive(id)
+GET         /masterclass/:id                           controllers.Event.detailsMasterclass(id)
 GET         /event/:id/embed                           controllers.Event.embedData(id)
 GET         /event/:id/buy                             controllers.Event.buy(id)
 GET         /event/:id/thankyou/pixel                  controllers.Event.thankyouPixel(id)


### PR DESCRIPTION
## Why are you doing this?
Making a small routing change to force the correct path prefix (/masterclass/ or /live/) when showing an Event details page. This makes it much easier for a human to identify that pageview counts are for masterclass or live event traffic at a glance in Google Analytics etc

Before: 

A Masterclass URL would look like:

https://events.theguardian.com/event/kickstart-your-writing-year-an-online-retreat-with-guardian-masterclasses-474635275887 

Now, the above path redirects to:

https://events.theguardian.com/masterclass/kickstart-your-writing-year-an-online-retreat-with-guardian-masterclasses-474635275887

This should improve the Behaviour > Site Content listing in Google Analytics, which often shows a confusing mix of Masterclass and Live Event pages:

<img width="1229" alt="Screenshot 2023-01-20 at 09 35 24" src="https://user-images.githubusercontent.com/1515970/213664588-4624ed6c-33af-43cf-ae5d-fcfaa92fa11b.png">

This change will let the team setup partitioned views.

## Trello card: [Here](https://trello.com)
https://trello.com/c/6Bt9vjVh

## Testing

- [x] Tested on CODE  (https://membership.code.dev-theguardian.com/)

cc @GHaberis 