### PR TITLE
Enable Dependabot Version Updates for Membership-frontend

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+    - package-ecosystem: "npm"
+      directory: "/frontend"
+      schedule:
+          interval: "daily"
+    - package-ecosystem: 'github-actions'
+      directory: '/'
+      schedule:
+          interval: 'daily'


### PR DESCRIPTION
## Why are you doing this?
Create dependabot.yml for membership-frontend

This introduces a `dependabot.yml` file which is necessary for enabling [Dependabot Version & Security Updates](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates).

This targets npm  package-ecosystems that Dependabot will monitor for new versions.

We have a  `package.json` files (aka dependency manifests)  in `/frontend` folder 
We can also keep our [Github Actions](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot) up to date with Dependabot. Actions are often updated with bug fixes and new features to make automated processes more reliable, faster, and safer.  Enabling Dependabot version updates for GitHub Actions will help ensure that references to actions in a repository's workflow.yml file are kept up to date. 

## Why are you doing this?

For keeping dependency updates and security vulnerabilities in our NPM modules and Github Actions up to date.

## Trello card: [[Enable Dependabot version updates on membership-frontend](https://trello.com/c/pMYuFOYy/1162-enable-dependabot-version-updates-on-membership-frontend)]




