### PR TITLE
Fixing header link so that clicking on Guardian Masterclasses doesn't redirect to Live Events page

### DIFF
--- a/frontend/app/views/fragments/global/defaultHeader.scala.html
+++ b/frontend/app/views/fragments/global/defaultHeader.scala.html
@@ -1,9 +1,10 @@
 @import model.SVG.Logos
+@import model.Nav.NavItem
 @import views.support.PageInfo
 @import com.gu.i18n.CountryGroup
 @import configuration.Config
 
-@(pageInfo: PageInfo, countryGroup: Option[CountryGroup], innerHeaderClass: String = "", svg: model.SVG.SVGImage = Logos.membersLogo)
+@(pageInfo: PageInfo, countryGroup: Option[CountryGroup], innerHeaderClass: String = "", svg: model.SVG.SVGImage = Logos.membersLogo, homepage: Option[NavItem] = None)
 
 <header class="global-header hidden-print js-header" role="banner">
     <div class="global-header__inner @innerHeaderClass">
@@ -13,7 +14,7 @@
             </div>
             @* Branding *@
             <div class="global-header__logo">
-	            <a href="/" class="global-header__logo__link" id="qa-header-logo">
+	            <a href="@homepage.map(_.href).getOrElse("/")" class="global-header__logo__link" id="qa-header-logo">
                     <span class="u-h">@Config.siteTitle</span>
                     @fragments.common.inlineSvgImage(svg, List("global-header__logo__image"))
                 </a>

--- a/frontend/app/views/fragments/global/header.scala.html
+++ b/frontend/app/views/fragments/global/header.scala.html
@@ -12,10 +12,10 @@
         @fragments.global.guardianHeader(pageInfo, countryGroup)
     }
     case MasterClassesHeader => {
-        @fragments.global.defaultHeader(pageInfo, countryGroup, "master-classes-header__inner", Logos.guardianMasterclassesHeader)
+        @fragments.global.defaultHeader(pageInfo, countryGroup, "master-classes-header__inner", Logos.guardianMasterclassesHeader, pageInfo.navigation.find(_.id == "masterclasses"))
     }
     case LiveHeader => {
-        @fragments.global.defaultHeader(pageInfo, countryGroup, "live-header__inner", Logos.guardianLiveHeader)
+        @fragments.global.defaultHeader(pageInfo, countryGroup, "live-header__inner", Logos.guardianLiveHeader, pageInfo.navigation.find(_.id == "events"))
     }
     case _ => { @fragments.global.defaultHeader(pageInfo, countryGroup) }
 }


### PR DESCRIPTION
## Why are you doing this?
Fixing header link so that clicking on Guardian Masterclasses doesn't redirect to Live Events page.

This issue was reported by the Masterclasses marketing team.

## Screenshots

Before - see that it just links to the `membership.theguardian.com` domain:
<img width="829" alt="Screenshot 2023-03-27 at 17 27 31" src="https://user-images.githubusercontent.com/1515970/228040206-0caa814a-0bb5-4fe0-9009-87c7ac8772d3.png">

After - it now links to `/masterclasses` on the Masterclass pages (and, not in screenshot, /events in the Live Events pages):
<img width="913" alt="Screenshot 2023-03-27 at 17 27 06" src="https://user-images.githubusercontent.com/1515970/228040437-2885962b-6e6f-4ee6-bf23-a6c3c9af5b8f.png">
