### PR TITLE
Upgrade to ubuntu jammy

### DIFF
--- a/frontend/conf/riff-raff.yaml
+++ b/frontend/conf/riff-raff.yaml
@@ -7,7 +7,7 @@ deployments:
     parameters:
       templatePath: cfn.yaml
       amiTags:
-        Recipe: bionic-membership-ARM
+        Recipe: jammy-membership-java8
         AmigoStage: PROD
       amiParameter: ImageId
       amiEncrypted: true


### PR DESCRIPTION
## Why are you doing this?
Upgrade Ubuntu version in membership-frontend’s Amigo bake


We have to upgrade any services using Ubuntu 18.04 to versions 20.04 or 22.04 as 18.04 will soon [leave standard support](https://ubuntu.com/about/release-cycle).

## Trello card: [Here](https://trello.com/c/O9BFuw8u/1186-upgrade-ubuntu-version-in-membership-frontends-amigo-bake-by-31-03)

## Result
Tested in CODE.

<img width="1679" alt="Screenshot 2023-03-27 at 17 47 09" src="https://user-images.githubusercontent.com/73653255/228010798-347d692a-fe7b-4ca9-a079-ea410dc66f66.png">

