### PR TITLE
Updating the list of Masterclass category tags + promo copy

### DIFF
--- a/frontend/app/model/RichEvent.scala
+++ b/frontend/app/model/RichEvent.scala
@@ -164,14 +164,11 @@ object RichEvent {
     case class tagItem(categoryName: String, subCategories: Seq[String] = Seq())
 
     val tags = Seq(
-      tagItem("Writing", Seq("Copywriting", "Creative writing", "Research", "Fiction", "Non-fiction")),
-      tagItem("Publishing"),
-      tagItem("Journalism"),
       tagItem("Business"),
-      tagItem("Digital"),
-      tagItem("Culture"),
-      tagItem("Food and drink"),
-      tagItem("Media")
+      tagItem("Creative writing"),
+      tagItem("Journalism"),
+      tagItem("Lifestyle"),
+      tagItem("Personal development")
     )
 
     // if a tag is hyphenated (Non-fiction) then weirdness/duplication happens here

--- a/frontend/app/views/event/masterclassesList.scala.html
+++ b/frontend/app/views/event/masterclassesList.scala.html
@@ -20,8 +20,8 @@
 
         <div class="l-constrained">
             <section class="header-bar">
-                <h1 class="header-bar__title">Guardian Masterclasses offers a range of practical, expert-led online workshops in journalism, creative writing, business skills and personal development. To be the first to hear about new events, <a href="https://www.theguardian.com/guardian-masterclasses/2015/jan/19/sign-up-to-the-guardian-masterclasses-newsletter">sign up to our newsletter here</a>.</h1>
-            </section>            
+                <h1 class="header-bar__title">Save 15% on all full price standard tickets by entering the code SPRINGSALE15 at checkout, subject to availability. Hurry, this offer ends on Monday 17 April 2023. To be the first to hear about new events, <a href="https://www.theguardian.com/guardian-masterclasses/2015/jan/19/sign-up-to-the-guardian-masterclasses-newsletter">sign up to our newsletter here</a>.</h1>
+            </section>
         </div>
 
         <div class="event-filters">


### PR DESCRIPTION
## Why are you doing this?
Updating the list of Masterclass category tags as the old list is way out of date and messing up how the MC team want to present their portfolio.

Also adding some promo copy.

<!--
Remember, PRs are documentation for future contributors

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Screenshots

Before:
<img width="508" alt="Screenshot 2023-03-28 at 11 26 57" src="https://user-images.githubusercontent.com/1515970/228208168-daf484ce-6a5d-4a2f-add6-a6b587e3bb11.png">

After:
<img width="634" alt="Screenshot 2023-03-28 at 11 30 08" src="https://user-images.githubusercontent.com/1515970/228208667-f83ef84c-592b-44ee-8404-ff43e0cf16b5.png">
