### PR TITLE
Update com.typesafe.play to 2.8.16

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ logLevel := Level.Warn
 
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.8")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.16")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
 


### PR DESCRIPTION
## Why are you doing this?

Upgrade com.typesafe.play:play_2.13 to 2.8.16 or higher. as it came up as a 'High Risk' vulnerability in Snaky

## Trello card: [Here](https://trello.com/c/p80LYx8h/1283-membership-frontend-comtypesafeplayplay213-snyk-high)

