### PR TITLE
Update com.google.oauth-client to fix Snyk-reported vulnerability

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,7 +25,7 @@ object Dependencies {
   val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5"
   val kinesisLogbackAppender = "com.gu" % "kinesis-logback-appender" % "1.4.4"
   val logstash = "net.logstash.logback" % "logstash-logback-encoder" % "7.3"
-  val googleAuth = "com.gu.play-googleauth" %% "play-v28" % "2.1.1"
+  val googleAuth = "com.gu.play-googleauth" %% "play-v28" % "2.2.7"
   // vvv below here. All the dependencies are to force upgrades to versions of the libs without vulnerabilities
   val libthrift = "org.apache.thrift" % "libthrift" % "0.17.0"
   // ^^^ above here

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ logLevel := Level.Warn
 
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.8")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.19")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
 


### PR DESCRIPTION
## Why are you doing this?

The transitive dependency on com.google.oauth-client was identified as a high-level vulnerability by Snyk.

Trello card: https://trello.com/c/vJmb7fLI/1281-membership-frontend-comgoogleoauth-clientgoogle-oauth-client-snyk-high

## Changes

### Use sonatypeOssRepos over sonatypeRepo

This fixes a deprecation warning in the sbt output.

### Update play-googleauth to the newest version

This is newer than required but will hopefully reduce work required in future.

### Update play to newest version (via sbt-plugin)

The existing version was incompatible with the newer version of play-googleauth.

## Screenshots

The homepage loads:

<img width="2056" alt="Screenshot 2023-05-24 at 09 26 17" src="https://github.com/guardian/membership-frontend/assets/23191049/0f5c61e2-10d8-4ce1-8208-faffc3b69d3c">

Sign-in still works:

<img width="2056" alt="Screenshot 2023-05-24 at 09 31 35" src="https://github.com/guardian/membership-frontend/assets/23191049/b42d6781-3c90-412f-9aba-b49e799f05ca">
