### PR TITLE
Update jackson-databind to 2.15.1

### DIFF
--- a/frontend/build.sbt
+++ b/frontend/build.sbt
@@ -109,7 +109,6 @@ libraryDependencies ++= frontendDependencies.map {
 dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion
 dependencyOverrides += "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.15.1"
 
-
 addCommandAlias("devrun", "run 9100")
 
 dependencyOverrides += "org.scala-lang.modules" %% "scala-xml" % "2.1.0"

--- a/frontend/build.sbt
+++ b/frontend/build.sbt
@@ -107,6 +107,8 @@ libraryDependencies ++= frontendDependencies.map {
 }
 
 dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion
+dependencyOverrides += "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.15.1"
+
 
 addCommandAlias("devrun", "run 9100")
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,6 +6,7 @@ object Dependencies {
   //versions
   val awsClientVersion = "1.12.460"
   val jacksonVersion = "2.15.1"
+  val jacksonDatabindVersion = "2.15.1"
   //libraries
   val sentryRavenLogback = "io.sentry" % "sentry-logback" % "6.18.1"
   val scalaUri = "io.lemonlabs" %% "scala-uri" % "2.3.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,6 @@ object Dependencies {
   //versions
   val awsClientVersion = "1.12.460"
   val jacksonVersion = "2.15.1"
-  val jacksonDatabindVersion = "2.15.1"
   //libraries
   val sentryRavenLogback = "io.sentry" % "sentry-logback" % "6.18.1"
   val scalaUri = "io.lemonlabs" %% "scala-uri" % "2.3.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
 
   //versions
   val awsClientVersion = "1.12.460"
-  val jacksonVersion = "2.11.4"
+  val jacksonVersion = "2.15.1"
   //libraries
   val sentryRavenLogback = "io.sentry" % "sentry-logback" % "6.18.1"
   val scalaUri = "io.lemonlabs" %% "scala-uri" % "2.3.1"

--- a/project/MembershipCommonDependencies.scala
+++ b/project/MembershipCommonDependencies.scala
@@ -30,7 +30,7 @@ object MembershipCommonDependencies {
   val libPhoneNumber = "com.googlecode.libphonenumber" % "libphonenumber" % "8.13.4"
   val dynamoDB = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion
   val scalaXml = "org.scala-lang.modules" %% "scala-xml" % "2.1.0"
-  val jacksonDatabind = "com.fasterxml.jackson.core" % "jackson-databind" % "2.14.2"
+  val jacksonDatabind = "com.fasterxml.jackson.core" % "jackson-databind" % "2.15.1"
 
   val dependencies = Seq(
     scalaUri,


### PR DESCRIPTION
## Why are you doing this?

Upgrade com.fasterxml.jackson.core:jackson-databind to 2.15.1 (latest version). as it came up as a 'High Risk' vulnerability in Snyk

## Trello card: [Here](https://trello.com/c/Nyt8dZh4/1280-membership-frontend-comfasterxmljacksoncorejackson-databind-snyk-high)

<img width="1178" alt="image" src="https://github.com/guardian/membership-frontend/assets/73653255/6b193a24-99aa-4491-afa8-740057bd5489">


### Changes
The  artifacts  are updated to versions 
1.jacksonVersion updated to [2.15.1](https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind/2.15.1) from 2.11.4
2 jackson-module-scala updated to [2.15.1](https://mvnrepository.com/artifact/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.1)

Updating jackson-module-scala as well because of the below error ( if only jackson-databind  is updated to 2.15.1 )
<img width="1317" alt="image" src="https://github.com/guardian/membership-frontend/assets/73653255/feed3d60-9b8a-4e7a-8a1d-34a87074fb5b">

