### PR TITLE
Better validation for ZBillingPeriod

### DIFF
--- a/membership-common/src/main/scala/com/gu/memsub/subsv2/Plan.scala
+++ b/membership-common/src/main/scala/com/gu/memsub/subsv2/Plan.scala
@@ -53,16 +53,7 @@ object EndDateCondition {
   implicit val reads: Reads[EndDateCondition] = ZuoraEnum.getReads(values, "invalid end date condition value")
 }
 
-sealed trait ZBillingPeriod extends ZuoraEnum {
-  def toBillingPeriod: BillingPeriod = this match {
-    case ZYear => Year
-    case ZTwoYears => TwoYears
-    case ZThreeYears => ThreeYears
-    case ZMonth => Month
-    case ZQuarter => Quarter
-    case  _ => throw new IllegalArgumentException("Zuora billing period not supported")
-  }
-}
+sealed trait ZBillingPeriod extends ZuoraEnum
 
 case object ZYear extends ZBillingPeriod {
   override val id = "Annual"


### PR DESCRIPTION
## Why are you doing this?
The `readSupporterPlusV2ChargeList` ChargeListReads object was quite loose in the type of charges it would match which meant that some subscriptions could be mistakenly identified as supporter plus subs.

This PR tightens the deserialisation up so that it only matches charges with billing periods which are valid for supporter plus subscriptions.

original change in https://github.com/guardian/members-data-api/pull/1033