### PR TITLE
bump cmp from 13.5 to 13.6.1

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@babel/runtime": "^7.12.5",
     "@emotion/core": "^10.3.1",
-    "@guardian/consent-management-platform": "^13.5.0",
+    "@guardian/consent-management-platform": "^13.6.1",
     "@guardian/libs": "^14.0.0",
     "@guardian/src-button": "^2.0.0",
     "@guardian/src-foundations": "^2.0.0",


### PR DESCRIPTION
## Why are you doing this?

Bumping consent-management-platform from 13.5 to 13.6.1 to re-include redplanet.
co-authored-by @akinsola-guardian 