### PR TITLE
Update to actions/setup-node@v3

### DIFF
--- a/.github/workflows/membership-frontend-build.yml
+++ b/.github/workflows/membership-frontend-build.yml
@@ -32,8 +32,9 @@ jobs:
 
         # (Respects .nvmrc)
             - name: Setup Node
-              uses: guardian/actions-setup-node@v2.4.1
+              uses: actions/setup-node@v3
               with:
+                  node-version-file: '.nvmrc'
                   cache: "yarn"
                   cache-dependency-path: frontend/yarn.lock
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1046,10 +1046,10 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@guardian/consent-management-platform@^13.5.0":
-  version "13.5.0"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-13.5.0.tgz#61a97c823f6b18f62a6517a3374f6e7bdfca121d"
-  integrity sha512-9iz04lyonWAbUeZ7B+fNp0KbgAervsWDO3A4CE/3e+d876AQj0I3TwU7W4jpWxI4tthcA6UVk7Y6faaS8l+lFw==
+"@guardian/consent-management-platform@^13.6.1":
+  version "13.6.1"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-13.6.1.tgz#528ed9193b1bd96e9f84964a5a1a080de43e29c1"
+  integrity sha512-5KQ4dZrqIBKuJCSJ/TTWXZ4F0WXY9ecpMnfOfvNIU9tXF1LAeT+LNv7hfV8eC5qMJskj2yvZZUi7hlwWD+Nq/A==
 
 "@guardian/libs@^14.0.0":
   version "14.0.0"


### PR DESCRIPTION
## What are you doing in this PR?

Github Actions: Stop using guardian/actions-setup-node and use actions/setup-node instead

[**Trello Card**](https://trello.com/c/dlZA1kOt/1546-github-actions-stop-using-guardian-actions-setup-node-and-use-actions-setup-node-instead)

## Why are you doing this?

The [actions-setup-node repo ] (https://github.com/guardian/actions-setup-node) says that  has been archived by the owner on Dec 5, 2022 and will not be updated.

The official Github [actions/setup-node](https://github.com/marketplace/actions/setup-node-js-environment) now has [some support for node version files](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#node-version-file).

You should use that instead.