### PR TITLE
bump cmp from 13.6.1 to 13.7.0 for vendor changes

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@babel/runtime": "^7.12.5",
     "@emotion/core": "^10.3.1",
-    "@guardian/consent-management-platform": "^13.6.1",
+    "@guardian/consent-management-platform": "^13.7.0",
     "@guardian/libs": "^14.0.0",
     "@guardian/src-button": "^2.0.0",
     "@guardian/src-foundations": "^2.0.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1046,10 +1046,10 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@guardian/consent-management-platform@^13.6.1":
-  version "13.6.1"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-13.6.1.tgz#528ed9193b1bd96e9f84964a5a1a080de43e29c1"
-  integrity sha512-5KQ4dZrqIBKuJCSJ/TTWXZ4F0WXY9ecpMnfOfvNIU9tXF1LAeT+LNv7hfV8eC5qMJskj2yvZZUi7hlwWD+Nq/A==
+"@guardian/consent-management-platform@^13.7.0":
+  version "13.7.0"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-13.7.0.tgz#c5f6511b822a3f16c3a78337653204f072396416"
+  integrity sha512-GQPhLOch8FIKko9muw8Fsm28+f+KubLGNbNfUxX4slg9+0jM4J57Kajr75RTqdtzWmKkp0cdYI9QDIVsbhgcuQ==
 
 "@guardian/libs@^14.0.0":
   version "14.0.0"


### PR DESCRIPTION
## Why are you doing this?

Bumping to the current version of consent-management-platform that updates the vendors.
[consent-management-platform 13.7.0 Release Notes](https://github.com/guardian/consent-management-platform/releases/tag/v13.7.0)