### PR TITLE
Bump CMP to 13.7.1

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@babel/runtime": "^7.12.5",
     "@emotion/core": "^10.3.1",
-    "@guardian/consent-management-platform": "^13.6.1",
+    "@guardian/consent-management-platform": "^13.7.1",
     "@guardian/libs": "^14.0.0",
     "@guardian/src-button": "^2.0.0",
     "@guardian/src-foundations": "^2.0.0",
@@ -84,6 +84,9 @@
     "lodash.mergewith": "^4.6.2"
   },
   "snyk": true,
-  "browserslist": ["> 1%", "last 2 versions", "IE 9"]
-
+  "browserslist": [
+    "> 1%",
+    "last 2 versions",
+    "IE 9"
+  ]
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1046,10 +1046,10 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@guardian/consent-management-platform@^13.6.1":
-  version "13.6.1"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-13.6.1.tgz#528ed9193b1bd96e9f84964a5a1a080de43e29c1"
-  integrity sha512-5KQ4dZrqIBKuJCSJ/TTWXZ4F0WXY9ecpMnfOfvNIU9tXF1LAeT+LNv7hfV8eC5qMJskj2yvZZUi7hlwWD+Nq/A==
+"@guardian/consent-management-platform@^13.7.1":
+  version "13.7.1"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-13.7.1.tgz#ba38f32de023775e615e79cfa97a3425f144eb89"
+  integrity sha512-BtUNkuCqd++A0Wkk9CA4kI95yVZJk1YMjPdppEnmq3cG/ros4ElXN4cNG7pWifeTR5cUtJflAiRRO4L5ewASpQ==
 
 "@guardian/libs@^14.0.0":
   version "14.0.0"


### PR DESCRIPTION
## Why are you doing this?
Bump version of consent-management-platform to 13.7.1 in order to keep the vendor list up to date.
<!--
Remember, PRs are documentation for future contributors

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Trello card: [Here](https://trello.com)

## Changes
* Update @guardian/consent-management-platform to 13.7.1

This has been tested in CODE.

<!--
If you are making heavy client-side changes, consider manual test the following
critical flow before merging
## Tested in
| Browser | Supporter Stripe checkout | Supporter Paypal checkout | Stripe Monthly Contribution |  Paypal Monthly Contribution| Upgrade from Friend to Supporter  |
|---------|---------------------------|---------------------------|-----------------------------|-----------------------------|-----------------------------------|
| IE      |                           |                           |                             |                             |                                   |
| Firefox |                           |                           |                             |                             |                                   |
| Safari  |                           |                           |                             |                             |                                   |
| Chrome  |                           |                           |                             |                             |                                   |

-->

