### PR TITLE
Filter out Football Weekly events from Featured Events section too

### DIFF
--- a/frontend/app/services/EventbriteService.scala
+++ b/frontend/app/services/EventbriteService.scala
@@ -229,7 +229,11 @@ object EventbriteServiceHelpers {
 
   def getFeaturedEvents(orderedIds: Seq[String], events: Seq[RichEvent]): Seq[RichEvent] = {
     val (orderedEvents, normalEvents) = events.partition { event => orderedIds.contains(event.underlying.ebEvent.id) }
-    orderedEvents.sortBy { event => orderedIds.indexOf(event.underlying.ebEvent.id) } ++ normalEvents.filter(!_.underlying.isSoldOut).take(4 - orderedEvents.length)
+    orderedEvents.sortBy { event => orderedIds.indexOf(event.underlying.ebEvent.id) } ++ normalEvents
+      .filterNot(_.underlying.isSoldOut)
+      // Manual override to remove the Football Weekly Live tour events which have their own sale page on www
+      .filterNot(_.underlying.ebEvent.name.text.contains("Football Weekly Live tour"))
+      .take(4 - orderedEvents.length)
   }
 }
 


### PR DESCRIPTION
## Why are you doing this?
Just like I filtered out Football Weekly events from the main listings in https://github.com/guardian/membership-frontend/pull/2511, this change also filters it out of Featured Events too

<!--
Remember, PRs are documentation for future contributors

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Screenshots
Before:
<img width="1151" alt="Screenshot 2023-11-06 at 12 53 23" src="https://github.com/guardian/membership-frontend/assets/1515970/7fca0d35-f8c0-48af-8e50-07c61b076aec">

After:
<img width="1241" alt="Screenshot 2023-11-06 at 12 22 06" src="https://github.com/guardian/membership-frontend/assets/1515970/1e31e4a9-f377-45e1-a69e-76306bc09c1b">

