### PR TITLE
Reduce the number of Eventbrite API calls by slowing the refresh schedule for the archive

### DIFF
--- a/frontend/app/services/EventbriteService.scala
+++ b/frontend/app/services/EventbriteService.scala
@@ -83,7 +83,7 @@ abstract class EventbriteService(ebAccount: EBAccount)(
   // goal here is to keep the downstream cache warm (AWS CloudFront - ttl 61s).
   lazy val eventsTask = eventsTaskFor("live", 1.second, Config.eventbriteRefreshTime.seconds)
 
-  lazy val archivedEventsTask = eventsTaskFor("ended", 29.seconds, 3600.seconds)
+  lazy val archivedEventsTask = eventsTaskFor("ended", 29.seconds, 7200.seconds)
 
   lazy val draftEventsTask =  eventsTaskFor("draft", 59.seconds, Config.eventbriteRefreshTime.seconds)
 


### PR DESCRIPTION
## Why are you doing this?
Reduce the number of Eventbrite API calls by slowing the refresh schedule for the archive. This will hopefully give space to let other ETL jobs complete.

<!--
Remember, PRs are documentation for future contributors

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->